### PR TITLE
Week 4 - Module 3: Daml Smart Contracts

### DIFF
--- a/docs-main/appdev/modules/m3-authorization.mdx
+++ b/docs-main/appdev/modules/m3-authorization.mdx
@@ -3,4 +3,216 @@ title: "Authorization Model"
 description: "Understand Daml's authorization model - signatories, observers, and controllers"
 ---
 
-Content coming soon.
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/parties.rst" hash="5d3e37a1" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/parties.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+# Parties and authority
+
+Daml is designed for distributed applications involving mutually distrusting parties. In a well-constructed contract model, all parties have strong guarantees that nobody cheats or circumvents the rules laid out by templates and choices.
+
+In this section you will learn about Daml's authorization rules and how to develop contract models that give all parties the required guarantees. In particular, you'll learn how to:
+
+- Pass authority from one contract to another
+- Write advanced choices
+- Reason through Daml's Authorization model
+
+<Tip>
+Remember that you can load all the code for this section into a folder called `intro-parties` by running `dpm new intro-parties  --template daml-intro-parties`
+</Tip>
+
+## Prevent IOU revocation
+
+The `SimpleIou` contract from `choices` and `constraints` has one major problem: The contract is only signed by the `issuer`. The signatories are the parties with the power to create and archive contracts. If Alice gave Bob a `SimpleIou` for \$100 in exchange for some goods, she could just archive it after receiving the goods. Bob would have a record of such actions, but would have to resort to off-ledger means to get his money back:
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+For a party to have any guarantees that only those transformations specified in the choices are actually followed, they either need to be a signatory themselves, or trust one of the signatories to not agree to transactions that archive and re-create contracts in unexpected ways. To make the `SimpleIou` safe for Bob, you need to add him as a signatory:
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+There's a new problem here: There is no way for Alice to issue or transfer this `Iou` to Bob. To get an `Iou` with Bob's signature as `owner` onto the ledger, his authority is needed:
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+This may seem awkward, but notice that the `ensure` clause is gone from the `Iou` again. The above `Iou` can contain negative values so Bob should be glad that `Alice` cannot put his signature on any `Iou`.
+
+You'll now learn a couple of common ways of building issuance and transfer workflows for the above `Iou`, before diving into the authorization model in full.
+
+## Use Propose-Accept workflow for one-off authorization
+
+If there is no standing relationship between Alice and Bob, Alice can propose the issuance of an Iou to Bob, giving him the choice to accept. You can do so by introducing a proposal contract `IouProposal`:
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+Note how we have used the fact that templates are records here to store the `Iou` in a single field:
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+The `IouProposal` contract carries the authority of `iou.issuer` by virtue of them being a signatory. By exercising the `IouProposal_Accept` choice, Bob adds his authority to that of Alice, which is why an `Iou` with both signatories can be created in the context of that choice.
+
+The choice is called `IouProposal_Accept`, not `Accept`, because propose-accept patterns are very common. In fact, you'll see another one just below. As each choice defines a record type, you cannot have two choices of the same name in scope. It's a good idea to qualify choice names to ensure uniqueness.
+
+The above solves issuance, but not transfers. You can solve transfers exactly the same way, though, by creating a `TransferProposal`:
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+In addition to defining the signatories of a contract, `signatory` can also be used to extract the signatories from another contract. Instead of writing `signatory (signatory iou)`, you could write `signatory iou.issuer, iou.owner`.
+
+The `IouProposal` had a single signatory so it could be cancelled easily by archiving it. Without a `Cancel` choice, the `newOwner` could abuse an open TransferProposal as an option. The triple `Accept`, `Reject`, `Cancel` is common to most proposal templates.
+
+To allow an `iou.owner` to create such a proposal, you need to give them the choice to propose a transfer on the `Iou` contract. The choice looks just like the above `Transfer` choice, except that a `IouTransferProposal` is created instead of an `Iou`:
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+Bob can now transfer his `Iou`. The transfer workflow can even be used for issuance:
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+## Use role contracts for ongoing authorization
+
+Many actions, like the issuance of assets or their transfer, can be pre-agreed. You can represent this succinctly in Daml through relationship or role contracts.
+
+Jointly, an `owner` and `newOwner` can transfer an asset, as demonstrated in the script above. In `compose`, you will see how to compose the `ProposeTransfer` and `IouTransferProposal_Accept` choices into a single new choice, but for now, here is a different way. You can give them the joint right to transfer an IOU:
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+Up to now, the controllers of choices were known from the current contract. Here, the `newOwner` variable is part of the choice arguments, not the `Iou`.
+
+This is also the first time we have shown a choice with more than one controller. If multiple controllers are specified, the authority of *all* the controllers is needed. Here, neither `owner`, nor `newOwner` can execute a transfer unilaterally, hence the name `Mutual_Transfer`.
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+The above `IouSender` contract now gives one party, the `sender` the right to send `Iou` contracts with positive amounts to a `receiver`. The `nonconsuming` keyword on the choice `Send_Iou` changes the behaviour of the choice so that the contract it's exercised on does not get archived when the choice is exercised. That way the `sender` can use the contract to send multiple Ious.
+
+Here it is in action:
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+## Daml's authorization model
+
+Hopefully, the above will have given you a good intuition for how authority is passed around in Daml. In this section you'll learn about the formal authorization model to allow you to reason through your contract models. This will allow you to construct them in such a way that you don't run into authorization errors at runtime, or, worse still, allow malicious transactions.
+
+In `choices` you learned that a transaction is, equivalently, a tree of transactions, or a forest of actions, where each transaction is a list of actions, and each action has a child-transaction called its consequences.
+
+Each action has a set of *required authorizers* -- the parties that must authorize that action -- and each transaction has a set of *authorizers* -- the parties that did actually authorize the transaction.
+
+The authorization rule is that the required authorizers of every action are a subset of the authorizers of the parent transaction.
+
+The required authorizers of actions are:
+
+- The required authorizers of an **exercise action** are the controllers on the corresponding choice. Remember that `Archive` and `archive` are just an implicit choice with the signatories as controllers.
+- The required authorizers of a **create action** are the signatories of the contract.
+- The required authorizers of a **fetch action** (which also includes `fetchByKey`) are somewhat dynamic and covered later.
+
+The authorizers of transactions are:
+
+- The root transaction of a commit is authorized by the submitting party.
+- The consequences of an exercise action are authorized by the actors of that action plus the signatories of the contract on which the action was taken.
+
+### An authorization example
+
+Consider the transaction from the script above where Bob sends an `Iou` to Charlie using a `Send_Iou` contract. It is authorized as follows, ignoring fetches:
+
+- Bob submits the transaction so he's the authorizer on the root transaction.
+- The root transaction has a single action, which is to exercise `Send_Iou` on a `IouSender` contract with Bob as `sender` and Charlie as `receiver`. Since the controller of that choice is the `sender`, Bob is the required authorizer.
+- The consequences of the `Send_Iou` action are authorized by its actors, Bob, as well as signatories of the contract on which the action was taken. That's Charlie in this case, so the consequences are authorized by both Bob and Charlie.
+- The consequences contain a single action, which is a `Mutual_Transfer` with Charlie as `newOwner` on an `Iou` with `issuer` Alice and `owner` Bob. The required authorizers of the action are the `owner`, Bob, and the `newOwner`, Charlie, which matches the parent's authorizers.
+- The consequences of `Mutual_Transfer` are authorized by the actors (Bob and Charlie), as well as the signatories on the Iou (Alice and Bob).
+- The single action on the consequences, the creation of an Iou with `issuer` Alice and `owner` Charlie has required authorizers Alice and Charlie, which is a proper subset of the parent's authorizers.
+
+You can see the graph of this transaction in the transaction view of the IDE:
+
+``` none
+TX 12 1970-01-01T00:00:00Z (Parties:276:3)
+#12:0
+│   disclosed to (since): 'Bob' (12), 'Charlie' (12)
+└─> 'Bob' exercises Send_Iou on #10:0 (Parties:IouSender)
+          with
+            iouCid = #11:3
+    children:
+    #12:1
+    │   disclosed to (since): 'Bob' (12), 'Charlie' (12), 'Alice' (12)
+    └─> 'Alice' and 'Bob' fetch #11:3 (Parties:Iou)
+
+    #12:2
+    │   disclosed to (since): 'Bob' (12), 'Charlie' (12), 'Alice' (12)
+    └─> 'Bob' and 'Charlie' exercise Mutual_Transfer on #11:3 (Parties:Iou)
+                            with
+                              newOwner = 'Charlie'
+        children:
+        #12:3
+        │   disclosed to (since): 'Bob' (12), 'Charlie' (12), 'Alice' (12)
+        └─> 'Alice' and 'Charlie' create Parties:Iou
+                                  with
+                                    issuer = 'Alice';
+                                    owner = 'Charlie';
+                                    cash =
+                                      (Parties:Cash with
+                                        currency = "USD"; amount = 100.0000000000)
+```
+
+Note that authority is not automatically transferred transitively.
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+```daml
+-- Code from: daml/daml-intro-parties/daml/Parties.daml
+-- [Insert snippet here]
+```
+
+The consequences of `TryB` are authorized by both Alice and Bob, but the action `TryA` only has Alice as an actor and Alice is the only signatory on the contract.
+
+Therefore, the consequences of `TryA` are only authorized by Alice. Bob's authority is now missing to create the flipped `NonTransitive` so the transaction fails.
+
+## Next up
+
+In `compose` you will put everything you have learned together to build a simple asset holding and trading model akin to that in the `/app-dev/bindings-java/quickstart`. In that context you'll learn a bit more about the `Update` action and how to use it to compose transactions, as well as about privacy on Daml ledgers.
+
+
+{/* COPIED_END */}

--- a/docs-main/appdev/modules/m3-building-packaging.mdx
+++ b/docs-main/appdev/modules/m3-building-packaging.mdx
@@ -1,0 +1,129 @@
+---
+title: "Building and Packaging"
+description: "Build Daml projects, manage dependencies, and package DAR files for deployment"
+---
+
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/dependencies.rst" hash="da2790f4" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/dependencies.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+# Work with dependencies
+
+The application from `compose` is a complete and secure model for atomic swaps of assets, but there is plenty of room for improvement. However, one can't implement all features before going live with an application so it's important to understand how to change already running code. There are fundamentally two types of change one may want to make:
+
+1.  Upgrades, which change existing logic. For example, one might want the `Asset` template to have multiple signatories.
+2.  Extensions, which merely add new functionality through additional templates.
+
+Upgrades are covered in their own section outside this introduction to Daml: [smart contract upgrades](https://docs.digitalasset.com/build/3.4/sdk/explanations/smart-contract-upgrades),
+so in this section we will extend the `compose` model with a simple second workflow: a multi-leg trade. In doing so, you'll learn about:
+
+- The software architecture of the Daml stack
+- Dependencies and data dependencies
+- Identifiers
+
+Since we are extending `compose`, the setup for this chapter is slightly more complex:
+
+1.  In a base directory, load the `compose` project using `dpm new intro-compose  --template daml-intro-compose`. The directory `intro7` here is important as it'll be referenced by the other project we are creating.
+2.  In the same directory, load this chapter's project using `dpm new intro-9  --template daml-intro-9`.
+
+`Dependencies` contains a new module `Intro.Asset.MultiTrade` and a corresponding test module `Test.Intro.Asset.MultiTrade`.
+
+## DAR files, Daml-LF, and the engine
+
+In `compose` you already learnt a little about projects, Daml-LF, DAR files, and dependencies. In this chapter we will actually need to have dependencies from the current project to the `compose` project so it's time to learn a little more about all this.
+
+Let's have a look inside the DAR file of `compose`. DAR files, like Java JAR files, are just ZIP archives, but the SDK also has a utility to inspect DARs out of the box:
+
+1.  Navigate into the `intro7` directory.
+2.  Build using `dpm build -o assets.dar`
+3.  Run `dpm damlc inspect-dar assets.dar`
+
+You'll get a whole lot of output. Under the header "DAR archive contains the following files:" you'll see that the DAR contains:
+
+1.  `*.dalf` files for the project and all its dependencies
+2.  The original Daml source code
+3.  `*.hi` and `*.hie` files for each `*.daml` file
+4.  Some meta-inf and config files
+
+The first file is something like `intro7-1.0.0-887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625.dalf` which is the actual compiled package for the project. `*.dalf` files contain Daml-LF, which is Daml's intermediate language. The file contents are a binary encoded protobuf message from the [daml-lf schema](https://github.com/digital-asset/daml/tree/main/daml-lf/archive). Daml-LF is evaluated on the ledger by the Daml Engine, which is a JVM component that is part of tools like the IDE's script runner, the Sandbox, or proper production ledgers. If Daml-LF is to Daml what Java Bytecode is to Java, the Daml Engine is to Daml what the JVM is to Java.
+
+## Hashes and identifiers
+
+Under the heading "DAR archive contains the following packages:" you get a similar looking list of package names, paired with only the long random string repeated. That hexadecimal string, `887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625` in this case, is the package hash and the primary and only identifier for a package that's guaranteed to be available and preserved. Meta information like name ("intro7") and version ("1.0.0") help make it human readable but should not be relied upon. You may not always get DAR files from your compiler, but be loading them from a running ledger, or get them from an artifact repository.
+
+We can see this in action. When a DAR file gets deployed to a ledger, not all meta information is preserved.
+
+1.  Note down your main package hash from running `inspect-dar` above
+2.  Start the project by running a ledger and uploading the `assets.dar` DAR:
+
+```bash
+cat <<EOF
+canton.parameters.enable-alpha-state-via-config = yes
+canton.parameters.state-refresh-interval = 5s
+canton.participants.sandbox.alpha-dynamic.dars = [
+  { location = "./assets.dar" }
+]
+EOF > config.conf
+
+dpm sandbox -c config.conf
+```
+
+3.  Open another terminal and use the gRPC Ledger API to download the dar, making sure to replace the hash with the appropriate one
+
+```bash
+grpcurl  localhost:6866 com.digitalasset.canton.admin.participant.v30.PackageService.GetDar \
+  -d '{"mainPackageId": "887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625"}' \
+  -plaintext | jq -r '.payload' | base64 --decode > assets_ledger.dar
+```
+
+4.  Run `dpm damlc inspect-dar assets_ledger.dar`
+
+You'll notice two things. Firstly, a lot of the dependencies have lost their names, they are now only identifiable by hash. We could of course also create a second project `intro7-1.0.0` with completely different contents so even when name and version are available, package hash is the only safe identifier.
+
+That's why over the Ledger API, all types, like templates and records are identified by the triple `(entity name, module name, package hash)`. Your client application should know the package hashes it wants to interact with. To aid that, `inspect-dar` also provides a machine-readable format for the information it emits: `dpm damlc inspect-dar --json assets_ledger.dar`. The `main_package_id` field in the resulting JSON payload is the package hash of our project.
+
+Secondly, you'll notice that all the `*.daml`, `*.hi` and `*.hie` files are gone. This leads us to data dependencies.
+
+## Dependencies and data dependencies
+
+Dependencies under the `daml.yaml` `dependencies` group rely on the `*.hi` files. The information in these files is crucial for dependencies like the Daml standard library, which provide functions, types, and typeclasses.
+
+However, as you can see above, this information isn't preserved. Furthermore, preserving this information may not even be desirable. Imagine we had built `intro7` with SDK 1.100.0, and are building `intro9` with SDK 1.101.0. All the typeclasses and instances on the inbuilt types may have changed and are now present twice -- once from the current SDK and once from the dependency. This gets messy fast, which is why the SDK does not support `dependencies` across SDK versions. For dependencies on contract models that were fetched from a ledger, or come from an older SDK version, there is a simpler kind of dependency called `data-dependencies`. The syntax for `data-dependencies` is the same, but they only rely on the "binary" `*.dalf` files. The name tries to confer that the main purpose of such dependencies is to handle data: Records, Choices, Templates. The stuff one needs to use contract composability across projects.
+
+For an extension model like this one,`data-dependencies` are appropriate, so the current project includes `compose` that way:
+
+{/* TODO: Fix or remove this literal include — the RST source used a literal-include directive pointing to daml.yaml */}
+
+You'll notice a module `Test.Intro.Asset.TradeSetup`, which is almost a carbon copy of the `compose` trade setup Scripts. `data-dependencies` is designed to use existing contracts and data types. Daml Script is not imported. In practice, we also shouldn't expect that the DAR file we download from the ledger using the Ledger API to contain test scripts. For larger projects it's good practice to keep them separate and only deploy templates to the ledger.
+
+## About project structures
+
+As you've seen here, identifiers depend on the package as a whole and packages always bring all their dependencies with them. Thus changing anything in a complex dependency graph can have significant repercussions. It is therefore advisable to keep dependency graphs simple, and to separate concerns which are likely to change at different rates into separate packages.
+
+For example, in all our projects in this intro, including this chapter, our scripts are in the same project as our templates. In practice, that means changing a test changes all identifiers, which is not desirable. It's better for maintainability to separate tests from main templates. If we had done that in [Design Patterns](/docs-main/appdev/modules/m3-design-patterns), that would also have saved us from copying those modules.
+
+Similarly, we included `Trade` in the same project as `Asset` in [Design Patterns](/docs-main/appdev/modules/m3-design-patterns), even though `Trade` is a pure extension to the core `Asset` model. If we expect `Trade` to need more frequent changes, it may be a good idea to split it out into a separate project from the start.
+
+## Next up
+
+The `MultiTrade` model has more complex control flow and data handling than previous models. In [Language Fundamentals](/docs-main/appdev/modules/m3-language-fundamentals) you'll learn how to write more advanced logic: control flow, folds, common typeclasses, custom functions, and the Daml standard library. We'll be using the same projects so don't delete your folders just yet.
+
+
+{/* COPIED_END */}
+
+## Building with dpm
+
+When working on Canton Network projects, use the `dpm` tool for all build operations:
+
+- `dpm build` — Compile your Daml project and produce a DAR file
+- `dpm build --all` — Build all packages in a multi-package project
+- `dpm test` — Run all Daml Script tests in the current package
+- `dpm codegen-java` — Generate Java bindings from your Daml model
+- `dpm codegen-js` — Generate TypeScript/JavaScript bindings from your Daml model
+- `dpm sandbox` — Start a local Canton sandbox for integration testing
+
+The `dpm` tool wraps the Daml compiler and build system with Canton Network defaults, handling SDK versioning and dependency resolution automatically.

--- a/docs-main/appdev/modules/m3-choices.mdx
+++ b/docs-main/appdev/modules/m3-choices.mdx
@@ -3,4 +3,237 @@ title: "Choices"
 description: "Learn how to add behavior to Daml contracts using choices - the methods that transform contract state"
 ---
 
-Content coming soon.
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/choices.rst" hash="9b87bfb6" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/choices.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+## Introduction
+
+In the previous section, you saw how to change data on a contract by archiving it and re-creating it with updated data. But what if you wanted to allow another party to make specific changes? Or if you wanted to provide a convenient way to transform contract data?
+
+In this section you will learn about how to define simple data transformations using *choices* and how to delegate the right to *exercise* these choices to other parties.
+
+<Tip>
+You can load the code for this section by running `dpm new intro-choices --template daml-intro-choices`
+</Tip>
+
+## Choices as methods
+
+If you think of templates as classes and contracts as objects, where are the methods?
+
+Take as an example a `Contact` contract on which the contact owner wants to be able to change the telephone number, just like on the `Account` in [Contract Templates](/docs-main/appdev/modules/m3-contract-templates). Rather than requiring them to manually look up the contract, archive the old one, and create a new one, you can provide them a convenience method on `Contact`:
+
+```daml
+template Contact
+  with
+    owner : Party
+    party : Party
+    address : Text
+    telephone : Text
+  where
+    signatory owner
+    observer party
+
+    choice UpdateTelephone
+      : ContractId Contact
+      with
+        newTelephone : Text
+      controller owner
+      do
+        create this with
+          telephone = newTelephone
+```
+
+The above defines a *choice* called `UpdateTelephone`. Choices are part of a contract template. They're permissioned functions that result in an `Update`. Using choices, authority can be passed around, allowing the construction of complex transactions.
+
+Let's unpack the code snippet above:
+
+- The first line, `choice UpdateTelephone` indicates a choice definition, `UpdateTelephone` is the name of the choice. It starts a new block in which that choice is defined.
+
+- `: ContractId Contact` is the return type of the choice.
+
+  This particular choice archives the current `Contact`, and creates a new one. What it returns is a reference to the new contract, in the form of a `ContractId Contact`
+
+- The following `with` block is that of a record. Just like with templates, in the background, a new record type is declared: `data UpdateTelephone = UpdateTelephone with`
+
+- The line `controller owner` says that this choice is *controlled* by `owner`, meaning `owner` is the only party that is allowed to *exercise* them.
+
+- The `do` starts a block defining the action the choice should perform when exercised. In this case a new `Contact` is created.
+
+- The new `Contact` is created using `this with`. `this` is a special value available within the `where` block of templates and takes the value of the current contract's arguments.
+
+There is nothing here explicitly saying that the current `Contact` should be archived. That's because choices are *consuming* by default. That means when the above choice is exercised on a contract, that contract is archived.
+
+As mentioned in `data`, within a choice we use `create` instead of `createCmd`. Whereas `createCmd` builds up a list of commands to be sent to the ledger, `create` builds up a more flexible `Update` that is executed directly by the ledger. You might have noticed that `create` returns an `Update (ContractId Contact)`, not a `ContractId Contact`. As a `do` block always returns the value of the last statement within it, the whole `do` block returns an `Update`, but the return type on the choice is just a `ContractId Contact`. This is a convenience. Choices *always* return an `Update` so for readability it's omitted on the type declaration of a choice.
+
+Now to exercise the new choice in a script:
+
+```daml
+choice_test = do
+  owner <- allocateParty "Alice"
+  party <- allocateParty "Bob"
+
+  contactCid <- submit owner do
+     createCmd Contact with
+      owner
+      party
+      address = "1 Bobstreet"
+      telephone = "012 345 6789"
+
+  -- Bob can't change his own telephone number as Alice controls
+  -- that choice.
+  submitMustFail party do
+    exerciseCmd contactCid UpdateTelephone with
+      newTelephone = "098 7654 321"
+
+  newContactCid <- submit owner do
+    exerciseCmd contactCid UpdateTelephone with
+      newTelephone = "098 7654 321"
+```
+
+You exercise choices using the `exercise` function, which takes a `ContractId a`, and a value of type `c`, where `c` is a choice on template `a`. Since `c` is just a record, you can also just fill in the choice parameters using the `with` syntax you are already familiar with.
+
+`exerciseCmd` returns a `Commands r` where `r` is the return type specified on the choice, allowing the new `ContractId Contact` to be stored in the variable `newContactCid`. Just like for `createCmd` and `create`, there is also `exerciseCmd` and `exercise`. The versions with the `cmd` suffix is always used on the client side to build up the list of commands on the ledger. The versions without the suffix are used within choices and are executed directly on the server.
+
+There is also `createAndExerciseCmd` and `createAndExercise` which we have seen in the previous section. This allows you to create a new contract with the given arguments and immediately exercise a choice on it. For a consuming choice, this archives the contract so the contract is created and archived within the same transaction.
+
+## Choices as delegation
+
+Up to this point all the contracts only involved one party. `party` may have been stored as `Party` field in the above, which suggests they are actors on the ledger, but they couldn't see the contracts, nor change them in any way. It would be reasonable for the party for which a `Contact` is stored to be able to update their own address and telephone number. In other words, the `owner` of a `Contact` should be able to *delegate* the right to perform a certain kind of data transformation to `party`.
+
+The below demonstrates this using an `UpdateAddress` choice and corresponding extension of the script:
+
+```daml
+    choice UpdateAddress
+      : ContractId Contact
+      with
+        newAddress : Text
+      controller party
+      do
+        create this with
+          address = newAddress
+```
+
+```daml
+  newContactCid <- submit party do
+    exerciseCmd newContactCid UpdateAddress with
+      newAddress = "1-10 Bobstreet"
+
+  Some newContact <- queryContractId owner newContactCid
+
+  assert (newContact.address == "1-10 Bobstreet")
+```
+
+If you open the script view in the IDE, you will notice that Bob sees the `Contact`. This is because `party` is specified as an `observer` in the template, and in this case Bob is the `party`. More on *observers* later, but in short, they get to see any changes to the contract.
+
+## Choices in the ledger model
+
+In [Contract Templates](/docs-main/appdev/modules/m3-contract-templates) you learned about the high-level structure of a Daml ledger. With choices and the `exercise` function, you have the next important ingredient to understand the structure of the ledger and transactions.
+
+A *transaction* is a list of *actions*, and there are three kinds of action: `create`, `exercise` and `fetch`.
+
+- A `create` action creates a new contract with the given arguments and sets its status to *active*.
+- A `fetch` action checks the existence and activeness of a contract.
+- An `exercise` action exercises a choice on a contract resulting in a transaction (list of sub-actions) called the *consequences*. Exercises come in two kinds called `consuming` and `nonconsuming`. `consuming` is the default kind and changes the contract's status from *active* to *archived*.
+
+Each action can be visualized as a tree, where the action is the root node, and its children are its consequences. Every consequence may have further consequences. As `fetch`, `create` has no consequences, it is always a leaf node. You can see the actions and their consequences in the transaction view of the above script:
+
+``` none
+Transactions:
+  TX 0 1970-01-01T00:00:00Z (Contact:46:17)
+  #0:0
+  │   consumed by: #2:0
+  │   referenced by #2:0
+  │   disclosed to (since): 'Alice' (0), 'Bob' (0)
+  └─> 'Alice' creates Contact:Contact
+              with
+                owner = 'Alice'; party = 'Bob'; address = "1 Bobstreet"; telephone = "012 345 6789"
+
+  TX 1 1970-01-01T00:00:00Z
+    mustFailAt actAs: {'Bob'} readAs: {} (Contact:55:3)
+
+  TX 2 1970-01-01T00:00:00Z (Contact:59:20)
+  #2:0
+  │   disclosed to (since): 'Alice' (2), 'Bob' (2)
+  └─> 'Alice' exercises UpdateTelephone on #0:0 (Contact:Contact)
+              with
+                newTelephone = "098 7654 321"
+      children:
+      #2:1
+      │   consumed by: #3:0
+      │   referenced by #3:0
+      │   disclosed to (since): 'Alice' (2), 'Bob' (2)
+      └─> 'Alice' creates Contact:Contact
+                  with
+                    owner = 'Alice'; party = 'Bob'; address = "1 Bobstreet"; telephone = "098 7654 321"
+
+  TX 3 1970-01-01T00:00:00Z (Contact:69:20)
+  #3:0
+  │   disclosed to (since): 'Alice' (3), 'Bob' (3)
+  └─> 'Bob' exercises UpdateAddress on #2:1 (Contact:Contact)
+            with
+              newAddress = "1-10 Bobstreet"
+      children:
+      #3:1
+      │   disclosed to (since): 'Alice' (3), 'Bob' (3)
+      └─> 'Alice' creates Contact:Contact
+                  with
+                    owner = 'Alice';
+                    party = 'Bob';
+                    address = "1-10 Bobstreet";
+                    telephone = "098 7654 321"
+
+Active contracts:  #3:1
+
+Return value: {}
+```
+
+There are four commits corresponding to the four `submit` statements in the script. Within each commit, we see that it's actually actions that have IDs of the form `#commit_number:action_number`. Contract IDs are just the ID of their `create` action.
+
+So commits `#2` and `#3` contain `exercise` actions with IDs `#2:0` and `#3:0`. The `create` actions of the updated `Contact` contracts, `#2:1` and `#3:1`, are indented and found below a line reading `children:`, making the tree structure apparent.
+
+### The archive choice
+
+You may have noticed that there is no archive action. That's because `archive cid` is just shorthand for `exercise cid Archive`, where `Archive` is a choice implicitly added to every template, with the signatories as controllers.
+
+## A simple cash model
+
+With the power of choices, you can build your first interesting model: issuance of cash IOUs (I owe you). The model presented here is simpler than the one in [Language Fundamentals](/docs-main/appdev/modules/m3-language-fundamentals) as it's not concerned with the location of the physical cash, but merely with liabilities:
+
+```daml
+data Cash = Cash with
+  currency : Text
+  amount : Decimal
+    deriving (Eq, Show)
+
+template SimpleIou
+  with
+    issuer : Party
+    owner : Party
+    cash : Cash
+  where
+    signatory issuer
+    observer owner
+
+    choice Transfer
+      : ContractId SimpleIou
+      with
+        newOwner : Party
+      controller owner
+      do
+        create this with owner = newOwner
+```
+
+The above model is fine as long as everyone trusts Dora. Dora could revoke the `SimpleIou` at any point by archiving it. However, the provenance of all transactions would be on the ledger so the owner could *prove* that Dora was dishonest and cancelled her debt.
+
+## Next up
+
+You can now store and transform data on the ledger, even giving other parties specific write access through choices.
+
+In [Authorization Model](/docs-main/appdev/modules/m3-authorization), you will learn more about the authorization rules that govern who can create, exercise, and archive contracts.
+
+{/* COPIED_END */}

--- a/docs-main/appdev/modules/m3-contract-keys.mdx
+++ b/docs-main/appdev/modules/m3-contract-keys.mdx
@@ -1,6 +1,132 @@
 ---
 title: "Contract Keys"
-description: "Using contract keys in Daml"
+description: "Use contract keys for stable references to contracts, lookups, and uniqueness constraints"
 ---
 
-Content coming soon.
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/contract-keys.rst" hash="85971992" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/contract-keys.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+# Reference: Contract Keys
+
+<Warning>
+Contract keys are not supported in this release of Canton 3.x. Support for **non-unique contract keys** will come in a future release of Canton 3.x. Unique contract keys are not planned be supported in Canton 3.x, as there are no known good solutions for enforcing uniqueness constraints at the infrastructure level when there are multiple independent subnetworks that can be (dis)connected at any point in time.
+
+The documentation below is kept for completeness, but can be ignored for this release of Canton 3.x.
+</Warning>
+
+## Unsupported feature
+
+Contract keys are an optional addition to templates. They let you specify a way of uniquely identifying contracts, using the parameters to the template - similar to a primary key for a database.
+
+Contract keys do not change and can be used to refer to a contract even when the contract id changes.
+
+Here's an example of setting up a contract key for a bank account, to act as a bank account ID:
+
+```daml
+-- Code from: code-snippets/Account.daml
+-- [Include actual code example here]
+```
+
+## What Can Be a Contract Key
+
+The key can be an arbitrary serializable expression that does **not** contain contract IDs. However, it **must** include every party that you want to use as a `maintainer` (see [Specify Maintainers](#specify-maintainers) below).
+
+It's best to use simple types for your keys like `Text` or `Int`, rather than a list or more complex type.
+
+## Specify Maintainers
+
+If you specify a contract key for a template, you must also specify a `maintainer` or maintainers, in a similar way to specifying signatories or observers. The maintainers "own" the key in the same way the signatories "own" a contract. Just like signatories of contracts prevent double spends or use of false contract data, maintainers of keys prevent double allocation or incorrect lookups. Since the key is part of the contract, the maintainers **must** be signatories of the contract. However, maintainers are computed from the `key` instead of the template arguments. In the example above, the `bank` is ultimately the maintainer of the key.
+
+Uniqueness of keys is guaranteed per template. Since multiple templates may use the same key type, some key-related functions must be annotated using the `@ContractType` as shown in the examples below.
+
+When you are writing Daml models, the maintainers matter since they affect authorization -- much like signatories and observers. You don't need to do anything to "maintain" the keys. In the above example, it is guaranteed that there can only be one `Account` with a given `number` at a given `bank`.
+
+Checking of the keys is done automatically at execution time, by the Daml execution engine: if someone tries to create a new contract that duplicates an existing contract key, the execution engine will cause that creation to fail.
+
+## Contract Lookups
+
+The primary purpose of contract keys is to provide a stable, and possibly meaningful, identifier that can be used in Daml to fetch contracts. There are two functions to perform such lookups: `fetchbykey` and `lookupbykey`. Both types of lookup are performed at interpretation time on the submitting Participant Node, on a best-effort basis. Currently, that best-effort means lookups only return contracts if the submitting Party is a stakeholder of that contract.
+
+In particular, the above means that if multiple commands are submitted simultaneously, all using contract lookups to find and consume a given contract, there will be contention between these commands, and at most one will succeed. For more information, see the section on avoiding contention in the [Canton documentation](https://docs.digitalasset.com/canton/usermanual/performance/index.html).
+
+Limiting key usage to stakeholders also means that keys cannot be used to access a divulged contract, i.e. there can be cases where `fetch` succeeds and `fetchByKey` does not. See the example at the end of this section for details.
+
+### fetchByKey
+
+`(fetchedContractId, fetchedContract) <- fetchByKey @ContractType contractKey`
+
+Use `fetchByKey` to fetch the ID and data of the contract with the specified key. It is an alternative to `fetch` and behaves the same in most ways.
+
+It returns a tuple of the ID and the contract object (containing all its data).
+
+Like `fetch`, `fetchByKey` needs to be authorized by at least one stakeholder.
+
+`fetchByKey` fails and aborts the transaction if:
+
+- The submitting Party is not a stakeholder on a contract with the given key, or
+- A contract was found, but the `fetchByKey` violates the authorization rule, meaning no stakeholder authorized the `fetch`.
+
+This means that if it fails, it doesn't guarantee that a contract with that key doesn't exist, just that the submitting Party doesn't know about it, or there are issues with authorization.
+
+### visibleByKey
+
+`boolean <- visibleByKey @ContractType contractKey`
+
+Use `visibleByKey` to check whether you can see an active contract for the given key with the current authorizations. If the contract exists and you have permission to see it, returns `True`, otherwise returns `False`.
+
+To clarify, ignoring contention:
+
+1.  `visibleByKey` will return `True` if all of these are true: there exists a contract for the given key, the submitter is a stakeholder on that contract, and at the point of call we have the authorization of **all** of the maintainers of the key.
+2.  `visibleByKey` will return `False` if all of those are true: there is no contract for the given key, and at the point of call we have authorization from **all** the maintainers of the key.
+3.  `visibleByKey` will abort the transaction at interpretation time if, at the point of call, we are missing the authorization from any one maintainer of the key.
+4.  `visibleByKey` will fail at validation time (after returning `False` at interpretation time) if all of these are true: at the point of call, we have the authorization of **all** the maintainers, and a valid contract exists for the given key, but the submitter is not a stakeholder on that contract.
+
+While it may at first seem too restrictive to require **all** maintainers to authorize the call, this is actually required in order to validate negative lookups. In the positive case, when you can see the contract, it's easy for the transaction to mention which contract it found, and therefore for validators to check that this contract does indeed exist, and is active as of the time of executing the transaction.
+
+For the negative case, however, the transaction submitted for execution cannot say *which* contract it has not found (as, by definition, it has not found it, and it may not even exist). Still, validators have to be able to reproduce the result of not finding the contract, and therefore they need to be able to look for it, which means having the authorization to ask the maintainers about it.
+
+### lookupByKey
+
+`optionalContractId <- lookupByKey @ContractType contractKey`
+
+Use `lookupByKey` to check whether a contract with the specified key exists. If it does exist, `lookupByKey` returns the `Some contractId`, where `contractId` is the ID of the contract; otherwise, it returns `None`.
+
+`lookupByKey` is conceptually equivalent to
+
+```daml
+lookupByKey : forall c k. (HasFetchByKey c k) => k -> Update (Optional (ContractId c))
+lookupByKey k = do
+  visible <- visibleByKey @c k
+  if visible then do
+    (contractId, _ignoredContract) <- fetchByKey @c k
+    return $ Some contractId
+  else
+    return None
+```
+
+Therefore, `lookupByKey` needs all the same authorizations as `visibleByKey`, for the same reasons, and fails in the same cases.
+
+To get the data from the contract once you've confirmed it exists, you'll still need to use `fetch`.
+
+## exerciseByKey
+
+`exerciseByKey @ContractType contractKey`
+
+Use `exerciseByKey` to exercise a choice on a contract identified by its `key` (compared to `exercise`, which lets you exercise a contract identified by its `ContractId`). Just like `exercise`, running `exerciseByKey` requires visibility of the contract (either through divulgence, `readAs` or being a stakeholder) and authorization from the controllers of the choice.
+
+## Example
+
+A complete example of possible success and failure scenarios of `fetchByKey` and `lookupByKey` is shown below.
+
+```daml
+-- Code from: code-snippets/Keys.daml
+-- [Include actual code example here]
+```
+
+
+{/* COPIED_END */}

--- a/docs-main/appdev/modules/m3-contract-templates.mdx
+++ b/docs-main/appdev/modules/m3-contract-templates.mdx
@@ -3,4 +3,83 @@ title: "Contract Templates"
 description: "Learn how to define Daml contract templates - the core building blocks of Canton smart contracts"
 ---
 
-Content coming soon.
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/contracts.rst" hash="9baeec6a" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/contracts.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+## Introduction
+
+To begin with, you're going to write a very small Daml template, which represents a self-issued, non-transferable token. Because it's a minimal template, it isn't actually useful on its own - you'll make it more useful later - but it's enough that it can show you the most basic concepts:
+
+- Transactions
+- Daml modules and files
+- Templates
+- Contracts
+- Signatories
+
+<Tip>
+You can load the code for this section by running `dpm new intro-contracts --template daml-intro-contracts`
+</Tip>
+
+## Daml ledger basics
+
+Like most structures called ledgers, a Daml Ledger is just a list of *commits*. When we say *commit*, we mean the final result of when a *party* successfully *submits* a *transaction* to the ledger.
+
+*Transaction* is a concept we'll cover in more detail through this introduction. The most basic examples are the creation and archival of a *contract*.
+
+A contract is *active* from the point where there is a committed transaction that creates it, up to the point where there is a committed transaction that *archives* it.
+
+Individual contracts are *immutable* in the sense that an active contract can not be changed. You can only change the *active contract set* by creating a new contract, or archiving an old one.
+
+Daml specifies what transactions are legal on a Daml Ledger. The rules the Daml code specifies are collectively called a *Daml model* or *contract model*.
+
+## Daml modules and files
+
+Each `.daml` file defines a *Daml Module* at the top:
+
+```daml
+module Token where
+```
+
+Code comments in Daml are introduced with `--`:
+
+```daml
+-- A Daml file defines a module.
+module Token where
+```
+
+## Templates
+
+A `template` defines a type of contract that can be created, and who has the right to do so. *Contracts* are instances of *templates*.
+
+```daml
+template Token
+  with
+    owner : Party
+  where
+    signatory owner
+```
+
+You declare a template starting with the `template` keyword, which takes a name as an argument.
+
+Daml is whitespace-aware and uses layout to structure *blocks*. Everything that's below the first line is indented, and thus part of the template's body.
+
+*Contracts* contain data, referred to as the *create arguments* or simply *arguments*. The `with` block defines the data type of the create arguments by listing field names and their types. The single colon `:` means "of type", so you can read this as "template `Token` with a field `owner` of type `Party`".
+
+`Token` contracts have a single field `owner` of type `Party`. The fields declared in a template's `with` block are in scope in the rest of the template body, which is contained in a `where` block.
+
+## Signatories
+
+The `signatory` keyword specifies the *signatories* of a contract. These are the parties whose *authority* is required to create the contract or archive it -- just like a real contract. Every contract must have at least one signatory.
+
+Furthermore, Daml ledgers *guarantee* that parties see all transactions where their authority is used. This means that signatories of a contract are guaranteed to see the creation and archival of that contract.
+
+## Next up
+
+In [Choices](/docs-main/appdev/modules/m3-choices), you'll learn how to add behavior to your contracts using choices.
+
+{/* COPIED_END */}

--- a/docs-main/appdev/modules/m3-design-patterns.mdx
+++ b/docs-main/appdev/modules/m3-design-patterns.mdx
@@ -1,6 +1,337 @@
 ---
 title: "Design Patterns"
-description: "Common Daml design patterns for Canton applications"
+description: "Common Daml design patterns for multi-party workflows, composition, and reusable contract models"
 ---
 
-Content coming soon.
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/compose.rst" hash="f782af8e" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/compose.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+# Compose choices
+
+It's time to put everything you've learned so far together into a complete and secure Daml model for asset issuance, management, transfer, and trading. This application will have capabilities similar to the one in `/app-dev/bindings-java/quickstart`. In the process you will learn about a few more concepts:
+
+- Daml projects, packages, and modules
+- Composition of transactions
+- Observers and stakeholders
+- Daml's execution model
+- Privacy
+
+The model in this section is not a single Daml file, but a Daml project consisting of several files that depend on each other.
+
+<Tip>
+Remember that you can load all the code for this section into a folder called `intro-compose` by running `dpm new intro-compose  --template daml-intro-compose`
+</Tip>
+
+## Daml projects
+
+Daml is organized in projects, packages, and modules. A Daml project is specified using a single `daml.yaml` file, and compiles into a package in Daml's intermediate language, or bytecode equivalent, Daml-LF. Each Daml file within a project becomes a Daml module, which is a bit like a namespace. Each Daml project has a source root specified in the `source` parameter in the project's `daml.yaml` file. The package will include all modules specified in `*.daml` files beneath that source directory.
+
+You can start a new project with a skeleton structure using `dpm new project-name` in the terminal. A minimal project would contain just a `daml.yaml` file and an empty directory of source files.
+
+> Take a look at the `daml.yaml` for the this chapter's project:
+
+```yaml
+-- Code from: daml/daml-intro-compose/daml.yaml.template
+-- [Include actual code example here]
+```
+
+You can generally set `name` and `version` freely to describe your project. `dependencies` does what the name suggests: it includes dependencies. You should always include `daml-prim` and `daml-stdlib`. The former contains internals of the compiler and the Daml Runtime, the latter gives access to the Daml standard library. `daml-script` contains the types and functions for Daml Script.
+
+You compile a Daml project by running `dpm build` from the project root directory. This creates a DAR file in `.daml/dist/dist/${project_name}-${project_version}.dar`. A DAR file is Daml's equivalent of a JAR file in Java: it's the artifact that gets deployed to a ledger to load the package and its dependencies. `dar` files are fully self-contained in that they contain all dependencies of the main package. More on all of this in [Building and Packaging](/docs-main/appdev/modules/m3-building-packaging).
+
+## Project structure
+
+This project contains an asset holding model for transferable, fungible assets and a separate trade workflow. The templates are structured in three modules: `Intro.Asset`, `Intro.Asset.Role`, and `Intro.Asset.Trade`.
+
+In addition, there are tests in modules `Test.Intro.Asset`, `Test.Intro.Asset.Role`, and `Test.Intro.Asset.Trade`.
+
+All but the last `.`-separated segment in module names correspond to paths relative to the project source directory, and the last one to a file name. The folder structure therefore looks like this:
+
+``` none
+.
+├── daml
+│   ├── Intro
+│   │   ├── Asset
+│   │   │   ├── Role.daml
+│   │   │   └── Trade.daml
+│   │   └── Asset.daml
+│   └── Test
+│       └── Intro
+│           ├── Asset
+│           │   ├── Role.daml
+│           │   └── Trade.daml
+│           └── Asset.daml
+└── daml.yaml
+```
+
+Each file contains a module header. For example, `daml/Intro/Asset/Role.daml`:
+
+```daml
+-- Code from: daml/daml-intro-compose/daml/Intro/Asset/Role.daml
+-- [Include actual code example here]
+```
+
+You can import one module into another using the `import` keyword. The `LibraryModules` module imports all six modules:
+
+```daml
+-- Code from: daml/daml-intro-compose/daml/Intro/Asset/Role.daml
+-- [Include actual code example here]
+```
+
+Imports always have to appear just below the module declaration. You can optionally add a list of names after the import to import only the selected names:
+
+```daml
+import DA.List (sortOn, groupOn)
+```
+
+If your module contains any Daml Scripts, you need to import the corresponding functionality:
+
+```daml
+import Daml.Script
+```
+
+## Project overview
+
+The project both changes and adds to the `Iou` model presented in [Authorization](/docs-main/appdev/modules/m3-authorization):
+
+- Assets are fungible in the sense that they have `Merge` and `Split` choices that allow the `owner` to manage their holdings.
+
+- Transfer proposals now need the authorities of both `issuer` and `newOwner` to accept. This makes `Asset` safer than `Iou` from the issuer's point of view.
+
+  With the `Iou` model, an `issuer` could end up owing cash to anyone as transfers were authorized by just `owner` and `newOwner`. In this project, only parties having an `AssetHolder` contract can end up owning assets. This allows the `issuer` to determine which parties may own their assets.
+
+- The `Trade` template adds a swap of two assets to the model.
+
+## Composed choices and scripts
+
+This project showcases how you can put the `Update` and `Script` actions you learned about in [Authorization](/docs-main/appdev/modules/m3-authorization) to good use. For example, the `Merge` and `Split` choices each perform several actions in their consequences.
+
+- Two create actions in case of `Split`
+- One create and one archive action in case of `Merge`
+
+```daml
+-- Code from: daml/daml-intro-compose/daml/Intro/Asset.daml
+-- [Include actual code example here]
+```
+
+The `return` function used in `Split` is available in any `Action` context. The result of `return x` is a no-op containing the value `x`. It has an alias `pure`, indicating that it's a pure value, as opposed to a value with side-effects. The `return` name makes sense when it's used as the last statement in a `do` block as its argument is indeed the "return"-value of the `do` block in that case.
+
+Taking transaction composition a step further, the `Trade_Settle` choice on `Trade` composes two `exercise` actions:
+
+```daml
+-- Code from: daml/daml-intro-compose/daml/Intro/Asset/Trade.daml
+-- [Include actual code example here]
+```
+
+The resulting transaction, with its two nested levels of consequences, can be seen in the `test_trade` script in `Test.Intro.Asset.Trade`:
+
+``` none
+TX 14 1970-01-01T00:00:00Z (Test.Intro.Asset.Trade:79:23)
+#14:0
+│   disclosed to (since): 'Alice' (14), 'Bob' (14)
+└─> 'Bob' exercises Trade_Settle on #12:0 (Intro.Asset.Trade:Trade)
+          with
+            quoteAssetCid = #9:1; baseApprovalCid = #13:1
+    children:
+    #14:1
+    │   disclosed to (since): 'Alice' (14), 'Bob' (14), 'USD_Bank' (14)
+    └─> 'Alice' and 'USD_Bank' fetch #10:1 (Intro.Asset:Asset)
+
+    #14:2
+    │   disclosed to (since): 'Alice' (14), 'Bob' (14), 'EUR_Bank' (14)
+    └─> 'Bob' and 'EUR_Bank' fetch #9:1 (Intro.Asset:Asset)
+
+    #14:3
+    │   disclosed to (since): 'Alice' (14), 'Bob' (14), 'USD_Bank' (14)
+    └─> 'Alice' and 'Bob' exercise TransferApproval_Transfer on #13:1 (Intro.Asset:TransferApproval)
+                          with
+                            assetCid = #10:1
+        children:
+        #14:4
+        │   disclosed to (since): 'Alice' (14), 'Bob' (14), 'USD_Bank' (14)
+        └─> 'Alice' and 'USD_Bank' fetch #10:1 (Intro.Asset:Asset)
+
+        #14:5
+        │   disclosed to (since): 'Alice' (14), 'Bob' (14), 'USD_Bank' (14)
+        └─> 'Alice' and 'USD_Bank' exercise Archive on #10:1 (Intro.Asset:Asset)
+
+        #14:6
+        │   disclosed to (since): 'Alice' (14), 'Bob' (14), 'USD_Bank' (14)
+        └─> 'Bob' and 'USD_Bank' create Intro.Asset:Asset
+                                 with
+                                   issuer = 'USD_Bank';
+                                   owner = 'Bob';
+                                   symbol = "USD";
+                                   quantity = 100.0000000000;
+                                   observers = []
+
+    #14:7
+    │   disclosed to (since): 'Alice' (14), 'Bob' (14), 'EUR_Bank' (14)
+    └─> 'Alice',
+        'Bob' exercises TransferApproval_Transfer on #11:1 (Intro.Asset:TransferApproval)
+              with
+                assetCid = #9:1
+        children:
+        #14:8
+        │   disclosed to (since): 'Alice' (14), 'Bob' (14), 'EUR_Bank' (14)
+        └─> 'Bob' and 'EUR_Bank' fetch #9:1 (Intro.Asset:Asset)
+
+        #14:9
+        │   disclosed to (since): 'Alice' (14), 'Bob' (14), 'EUR_Bank' (14)
+        └─> 'Bob' and 'EUR_Bank' exercise Archive on #9:1 (Intro.Asset:Asset)
+
+        #14:10
+        │   disclosed to (since): 'Alice' (14), 'Bob' (14), 'EUR_Bank' (14)
+        └─> 'Alice' and 'EUR_Bank' create Intro.Asset:Asset
+                                   with
+                                     issuer = 'EUR_Bank';
+                                     owner = 'Alice';
+                                     symbol = "EUR";
+                                     quantity = 90.0000000000;
+                                     observers = []
+```
+
+Similar to choices, you can see how the scripts in this project are built up from each other:
+
+```daml
+-- Code from: daml/daml-intro-compose/daml/Test/Intro/Asset/Role.daml
+-- [Include actual code example here]
+```
+
+In the above, the `test_issuance` script in `Test.Intro.Asset.Role` uses the output of the `setupRoles` script in the same module.
+
+The same line shows a new kind of pattern matching. Rather than writing `setupResult <- setupRoles` and then accessing the components of `setupResult` using `_1`, `_2`, etc., you can give them names. It's equivalent to writing:
+
+```daml
+setupResult <- setupRoles
+case setupResult of
+  (alice, bob, bank, aha, ahb) -> ...
+```
+
+Just writing `(alice, bob, bank, aha, ahb) <- setupRoles` would also be legal, but `setupResult` is used in the return value of `test_issuance` so it makes sense to give it a name, too. The notation with `@` allows you to give both the whole value as well as its constituents names in one go.
+
+## Daml's execution model
+
+Daml's execution model is fairly easy to understand, but has some important consequences. You can imagine the life of a transaction as follows:
+
+Command submission
+A user submits a list of commands via the Ledger API of a participant node, acting as a `Party` hosted on that node. That party is called the requester.
+
+Interpretation
+Each command corresponds to one or more actions. During this step, the `Update` corresponding to each action is evaluated in the context of the ledger to calculate all consequences, including transitive ones (consequences of consequences, etc.). The result of this is a complete transaction. Together with its requestor, this is also known as a commit.
+
+Blinding
+On ledgers with strong privacy, projections (see [Privacy Model](/docs-main/overview/learn/privacy-model)) for all involved parties are created. This is also called *projecting*.
+
+Transaction submission
+The transaction/commit is submitted to the network.
+
+Validation
+The transaction/commit is validated by the network. Who exactly validates can differ from implementation to implementation. Validation also involves scheduling and collision detection, ensuring that the transaction has a well-defined place in the (partial) ordering of commits, and no double spends occur.
+
+Commitment
+The commit is actually committed according to the commit or consensus protocol of the ledger.
+
+Confirmation
+The network sends confirmations of the commitment back to all involved participant nodes.
+
+Completion
+The user gets back a confirmation through the Ledger API of the submitting participant node.
+
+The first important consequence of the above is that all transactions are committed atomically. Either a transaction is committed as a whole and for all participants, or it fails.
+
+That's important in the context of the `Trade_Settle` choice shown above. The choice transfers a `baseAsset` one way and a `quoteAsset` the other way. Thanks to transaction atomicity, there is no chance that either party is left out of pocket.
+
+The second consequence is that the requester of a transaction knows all consequences of their submitted transaction -- there are no surprises in Daml. However, it also means that the requester must have all the information to interpret the transaction. We also refer to this as Principle 2 a bit later on this page.
+
+That's also important in the context of `Trade`. In order to allow Bob to interpret a transaction that transfers Alice's cash to Bob, Bob needs to know both about Alice's `Asset` contract, as well as about some way for `Alice` to accept a transfer -- remember, accepting a transfer needs the authority of `issuer` in this example.
+
+## Observers
+
+*Observers* are Daml's mechanism to disclose contracts to other parties. They are declared just like signatories, but using the `observer` keyword, as shown in the `Asset` template:
+
+```daml
+-- Code from: daml/daml-intro-compose/daml/Intro/Asset.daml
+-- [Include actual code example here]
+```
+
+The `Asset` template also gives the `owner` a choice to set the observers, and you can see how Alice uses it to show her `Asset` to Bob just before proposing the trade. You can try out what happens if she didn't do that by removing that transaction:
+
+```daml
+-- Code from: daml/daml-intro-compose/daml/Test/Intro/Asset/Trade.daml
+-- [Include actual code example here]
+```
+
+Observers have guarantees in Daml. In particular, they are guaranteed to see actions that create and archive the contract on which they are an observer.
+
+Since observers are calculated from the arguments of the contract, they always know about each other. That's why, rather than adding Bob as an observer on Alice's `AssetHolder` contract, and using that to authorize the transfer in `Trade_Settle`, Alice creates a one-time authorization in the form of a `TransferAuthorization`. If Alice had lots of counterparties, she would otherwise end up leaking them to each other.
+
+Choice controllers are not automatically made observers, as they can only be calculated at the point in time when the choice arguments are known.
+
+## Privacy
+
+Daml's privacy model is based on two principles:
+
+Principle 1. Parties see those actions that they have a stake in. Principle 2. Every party that sees an action sees its (transitive) consequences.
+
+Principle 2 is necessary to ensure that every party can independently verify the validity of every transaction they see.
+
+A party has a stake in an action if
+
+- they are a required authorizer of it
+- they are a signatory of the contract on which the action is performed
+- they are an observer on the contract, and the action creates or archives it
+
+What does that mean for the `exercise tradeCid Trade_Settle` action from `test_trade`?
+
+Alice is the signatory of `tradeCid` and Bob a required authorizer of the `Trade_Settled` action, so both of them see it. According to principle 2 above, that means they get to see everything in the transaction.
+
+The consequences contain, next to some `fetch` actions, two `exercise` actions of the choice `TransferApproval_Transfer`.
+
+Each of the two involved `TransferApproval` contracts is signed by a different `issuer`, which see the action on "their" contract. So the EUR_Bank sees the `TransferApproval_Transfer` action for the EUR `Asset` and the USD_Bank sees the `TransferApproval_Transfer` action for the USD `Asset`.
+
+Some Daml ledgers, like the script runner and the Sandbox, work on the principle of "data minimization", meaning nothing more than the above information is distributed. That is, the "projection" of the overall transaction that gets distributed to EUR_Bank in step 4 of `execution_model` would consist only of the `TransferApproval_Transfer` and its consequences.
+
+Other implementations, in particular those on public blockchains, may have weaker privacy constraints.
+
+### Divulgence
+
+Note that principle 2 of the privacy model means that sometimes parties see contracts that they are not signatories or observers on. If you look at the final ledger state of the `test_trade` script, for example, you may notice that both Alice and Bob now see both assets, as indicated by the Xs in their respective columns:
+
+| Alice | Bob | EUR_Bank | USD_Bank | id | status | issuer | owner | symbol | quantity |
+|-------|-----|----------|----------|----|--------|--------|-------|--------|----------|
+| X | X | - | X | #15:6 | active | USD_Bank | Bob | USD | 100.0 |
+| X | X | X | - | #15:10 | active | EUR_Bank | Alice | EUR | 90.0 |
+
+This is because the `create` action of these contracts are in the transitive consequences of the `Trade_Settle` action both of them have a stake in. This kind of disclosure is often called "divulgence" and needs to be considered when designing Daml models for privacy sensitive applications.
+
+{/* COPIED_END */}
+
+## Common Daml design patterns
+
+Beyond the composition patterns shown above, the Daml community has developed several patterns for recurring multi-party workflow challenges. These patterns provide proven solutions you can adapt in your own contracts.
+
+### Propose-Accept
+
+The Propose-Accept pattern is the most common way to get multiple parties to agree on a shared contract. One party creates a proposal contract that the other party can accept, reject, or let expire. The `IouProposal` in the authorization module is a classic example. This pattern works best for bilateral agreements where one party initiates the workflow.
+
+### Delegation
+
+The Delegation pattern gives one party the right to exercise a choice on behalf of another party. A principal creates a delegation contract that authorizes an agent to act for them. The agent can then control contracts on the ledger without the principal committing each action. This pattern models real-world custodian relationships where ownership and administration rights are separate.
+
+### Authorization
+
+The Authorization pattern verifies that a controlling party is authorized before they take certain actions. An authorization contract serves as proof that a party has the right permissions. Before performing a restricted action (like transferring an asset), the choice body checks for the existence and validity of the authorization contract.
+
+### Locking
+
+The Locking pattern prevents choices from being exercised on a contract while it is in a locked state. This models real-world scenarios like securities settlement where assets must be frozen during clearing. There are three approaches: locking by archiving (recreating the contract with a lock flag), locking by state (adding a lock field to the template), and locking by safekeeping (transferring the contract to a trusted third party).
+
+### Multiple party agreement
+
+The Multiple Party Agreement pattern collects signatures from more than two parties. A pending contract is created by one party and passed around for others to sign. Once all parties have signed, any signatory can finalize the agreement and create the actual contract. This pattern avoids the limitations of chaining bilateral Propose-Accept workflows when three or more parties need to reach consensus.

--- a/docs-main/appdev/modules/m3-dev-environment.mdx
+++ b/docs-main/appdev/modules/m3-dev-environment.mdx
@@ -3,4 +3,38 @@ title: "Development Environment Setup"
 description: "Set up your development environment for writing Daml smart contracts"
 ---
 
-Content coming soon.
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/intro.rst" hash="0f1592f4" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/intro.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+## Introduction
+
+Daml is a smart contract language designed to build composable applications on Canton ledgers.
+
+In this module, you will learn about the structure of a Daml Ledger, and how to write Daml applications that run on Canton Network, by building an asset-holding and trading application. You will gain an overview of the most important language features and how to use Daml's developer tools to write, test, compile, package and ship your application.
+
+## Prerequisites
+
+- You have installed [dpm](https://docs.digitalasset.com/canton/usermanual/dpm)
+
+## Loading Example Code
+
+Each section in this module presents a new self-contained application with more functionality than the previous section. You can load the code for each section using `dpm`. For example:
+
+```bash
+# Load the contract templates example
+dpm new intro-contracts --template daml-intro-contracts
+
+# Load the choices example
+dpm new intro-choices --template daml-intro-choices
+```
+
+{/* COPIED_END */}
+
+## Next Steps
+
+Continue to [Contract Templates](/docs-main/appdev/modules/m3-contract-templates) to learn about the basic building blocks of Daml smart contracts.

--- a/docs-main/appdev/modules/m3-exception-handling.mdx
+++ b/docs-main/appdev/modules/m3-exception-handling.mdx
@@ -1,6 +1,0 @@
----
-title: "Exception Handling"
-description: "Exception handling in Daml smart contracts"
----
-
-Content coming soon.

--- a/docs-main/appdev/modules/m3-interfaces.mdx
+++ b/docs-main/appdev/modules/m3-interfaces.mdx
@@ -1,6 +1,344 @@
 ---
 title: "Interfaces"
-description: "Using interfaces in Daml smart contracts"
+description: "Define and implement Daml interfaces for polymorphic contract behavior and cross-template interoperability"
 ---
 
-Content coming soon.
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/interfaces.rst" hash="fdeb13bb" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/interfaces.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+# Reference: Interfaces
+
+In Daml, an interface defines an abstract type together with a behavior specified by its view type, method signatures, and choices. For a template to conform to this interface, there must be a corresponding `interface instance` definition where all the methods of the interface (including the special `view` method) are implemented. This allows decoupling such behavior from its implementation, so other developers can write applications in terms of the interface instead of the concrete template.
+
+## Configuration
+
+To use this feature your Daml project must target Daml-LF version `1.15` or higher, which is the current default.
+
+If using Canton, the protocol version of the sync domain should be `4` or higher, see Canton protocol version for more details.
+
+## Interface Declaration
+
+An interface declaration is somewhat similar to a template declaration.
+
+### Interface Name
+
+```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+- This is the name of the interface.
+- It's preceded by the keyword `interface` and followed by the keyword `where`.
+- It must begin with a capital letter, like any other type name.
+
+### Implicit abstract type
+
+- Whenever an interface is defined, an abstract type is defined with the same name. "Abstract" here means:
+  - Values of this type cannot be created using a data constructor. Instead, they are constructed by applying the function `toInterface` to a template value.
+  - Values of this type cannot be inspected directly via case analysis. Instead, use functions such as `fromInterface`.
+  - See `daml-ref-interface-functions` for more information on these and other functions for interacting with interface values.
+- An interface value carries inside it the type and parameters of the template value from which it was constructed.
+- As for templates, the existence of a local binding `b` of type `I`, where `I` is an interface does not necessarily imply the existence on the ledger of a contract with the template type and parameters used to construct `b`. This can only be assumed if `b` the result of a fetch from the ledger within the same transaction.
+
+### Interface Methods
+
+```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+- An interface may define any number of methods.
+- A method definition consists of the method name and the method type, separated by a single colon `:`. The name of the method must be a valid identifier beginning with a lowercase letter or an underscore.
+- A method definition introduces a top level function of the same name:
+  - If the interface is called `I`, the method is called `m`, and the method type is `M` (which might be a function type), this introduces the function `m : I -> M`:
+
+    ```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+  - The first argument's type `I` means that the function can only be applied to values of the interface type `I` itself. Methods cannot be applied to template values, even if there exists an `interface instance` of `I` for that template. To use an interface method on a template value, first convert it using the `toInterface` function.
+
+  - Applying the function to such argument results in a value of type `M`, corresponding to the implementation of `m` in the interface instance of `I` for the underlying template type `t` (the type of the template value from which the interface value was constructed).
+- One special method, `view`, must be defined for the viewtype. (see **Viewtype** below).
+
+### Interface View Type
+
+```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+- All interface instances must implement a special `view` method which returns a value of the type declared by `viewtype`.
+- The type must be a record.
+- This type is returned by subscriptions on interfaces.
+
+### Interface Choices
+
+```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+- Interface choices work in a very similar way to template choices. Any contract of a template type for which an interface instance exists will grant the choice to the controlling party.
+- Interface choices can only be exercised on values of the corresponding interface type. To exercise an interface choice on a template value, first convert it using the `toInterface` function.
+- Interface methods can be used to define the controller of a choice (e.g. `method1`) as well as the actions that run when the choice is *exercised* (e.g. `method2` and `method3`).
+- As for template choices, the `choice` keyword can be optionally prefixed with the `nonconsuming` keyword to specify that the contract will not be consumed when the choice is exercised. If not specified, the choice will be `consuming`. Note that the `preconsuming` and `postconsuming` qualifiers are not supported on interface choices.
+- See `choices` for full reference information, but note that controller-first syntax is not supported for interface choices.
+
+### Empty Interfaces
+
+```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+- It is possible (though not necessarily useful) to define an interface without methods, precondition or choices. However, a view type must always be defined, though it can be set to unit.
+
+## Interface Instances
+
+For context, a simple template definition:
+
+```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+### `interface instance` clause
+
+```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+- To make a template an instance of an existing interface, an `interface instance` clause must be defined in the template declaration.
+- The template of the clause must match the enclosing declaration. In other words, a template `T` declaration can only contain `interface instance` clauses where the template is `T`.
+- The clause must start with the keywords `interface instance`, followed by the name of the interface, then the keyword `for` and the name of the template, and finally the keyword `where`, which introduces a block where **all** the methods of the interface must be implemented.
+- Within the clause, there's an implicit local binding `this` referring to the contract on which the method is applied, which has the type of the template's data record. The template parameters of this contract are also in scope.
+- Method implementations can be defined using the same syntax as for top level functions, including pattern matches and guards (e.g. `method3`).
+- Each method implementation must return the same type as specified for that method in the interface declaration.
+- The implementation of the special `view` method must return the type specified as the `viewtype` in the interface declaration.
+
+### Empty `interface instance` clause
+
+- If the interface has no methods, the interface instance only needs to implement the `view` method:
+
+```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+## Interface Functions
+
+### `interfaceTypeRep`
+
+<table>
+<tbody>
+<tr class="odd">
+<td>Type</td>
+<td><p><code>HasInterfaceTypeRep i =&gt;</code><br />
+<code>i -&gt; TemplateTypeRep</code></p></td>
+</tr>
+<tr class="even">
+<td>Instantiated Type</td>
+<td><code>MyInterface -&gt; TemplateTypeRep</code></td>
+</tr>
+<tr class="odd">
+<td>Notes</td>
+<td>The value of the resulting <code>TemplateTypeRep</code> indicates what template was used to construct the interface value.</td>
+</tr>
+</tbody>
+</table>
+
+### `toInterface`
+
+<table>
+<tbody>
+<tr class="odd">
+<td>Type</td>
+<td><p><code>forall i t.</code><br />
+<code>HasToInterface t i =&gt;</code><br />
+<code>t -&gt; i</code></p></td>
+</tr>
+<tr class="even">
+<td>Instantiated Type</td>
+<td><code>MyTemplate -&gt; MyInterface</code></td>
+</tr>
+<tr class="odd">
+<td>Notes</td>
+<td>Converts a template value into an interface value.</td>
+</tr>
+</tbody>
+</table>
+
+### `fromInterface`
+
+<table>
+<tbody>
+<tr class="odd">
+<td>Type</td>
+<td><p><code>HasFromInterface t i =&gt;</code><br />
+<code>i -&gt; Optional t</code></p></td>
+</tr>
+<tr class="even">
+<td>Instantiated Type</td>
+<td><code>MyInterface -&gt; Optional MyTemplate</code></td>
+</tr>
+<tr class="odd">
+<td>Notes</td>
+<td>Attempts to convert an interface value back into a template value. The result is <code>None</code> if the expected template type doesn't match the underlying template type used to construct the contract.</td>
+</tr>
+</tbody>
+</table>
+
+### `toInterfaceContractId`
+
+<table>
+<tbody>
+<tr class="odd">
+<td>Type</td>
+<td><p><code>forall i t.</code><br />
+<code>HasToInterface t i =&gt;</code><br />
+<code>ContractId t -&gt; ContractId i</code></p></td>
+</tr>
+<tr class="even">
+<td>Instantiated Type</td>
+<td><code>ContractId MyTemplate -&gt; ContractId MyInterface</code></td>
+</tr>
+<tr class="odd">
+<td>Notes</td>
+<td>Converts a template Contract ID into an Interface Contract ID.</td>
+</tr>
+</tbody>
+</table>
+
+### `fromInterfaceContractId`
+
+<table>
+<tbody>
+<tr class="odd">
+<td>Type</td>
+<td><p><code>forall t i.</code><br />
+<code>HasFromInterface t i =&gt;</code><br />
+<code>ContractId i -&gt; ContractId t</code></p></td>
+</tr>
+<tr class="even">
+<td>Instantiated Type</td>
+<td><code>ContractId MyInterface -&gt; ContractId MyTemplate</code></td>
+</tr>
+<tr class="odd">
+<td>Notes</td>
+<td>Converts an interface contract id into a template contract id. This function does not verify that the given contract id actually points to a contract of the resulting type; if that is not the case, a subsequent <code>fetch</code>, <code>exercise</code> or <code>archive</code> will fail. Therefore, this should only be used when the underlying contract is known to be of the resulting type, or when the result is immediately used by a <code>fetch</code>, <code>exercise</code> or <code>archive</code> action and a transaction failure is the desired behavior in case of mismatch. In all other cases, consider using <code>fetchFromInterface</code> instead.</td>
+</tr>
+</tbody>
+</table>
+
+### `coerceInterfaceContractId`
+
+<table>
+<tbody>
+<tr class="odd">
+<td>Type</td>
+<td><p><code>forall j i.</code><br />
+<code>(HasInterfaceTypeRep i, HasInterfaceTypeRep j) =&gt;</code><br />
+<code>ContractId i -&gt; ContractId j</code></p></td>
+</tr>
+<tr class="even">
+<td>Instantiated Type</td>
+<td><code>ContractId SourceInterface -&gt; ContractId TargetInterface</code></td>
+</tr>
+<tr class="odd">
+<td>Notes</td>
+<td>Converts an interface contract id into a contract id of a different interface. This function does not verify that the given contract id actually points to a contract of the resulting type; if that is not the case, a subsequent <code>fetch</code>, <code>exercise</code> or <code>archive</code> will fail. Therefore, this should only be used when the underlying contract is known to be of the resulting type, or when the result is immediately used by a <code>fetch</code>, <code>exercise</code> or <code>archive</code> action and a transaction failure is the desired behavior in case of mismatch.</td>
+</tr>
+</tbody>
+</table>
+
+### `fetchFromInterface`
+
+<table>
+<tbody>
+<tr class="odd">
+<td>Type</td>
+<td><p><code>forall t i.</code><br />
+<code>(HasFromInterface t i, HasFetch i) =&gt;</code><br />
+<code>ContractId i -&gt; Update (Optional (ContractId t, t))</code></p></td>
+</tr>
+<tr class="even">
+<td>Instantiated Type</td>
+<td><p><code>ContractId MyInterface -&gt;</code><br />
+<code>Update (Optional (ContractId MyTemplate, MyTemplate))</code></p></td>
+</tr>
+<tr class="odd">
+<td>Notes</td>
+<td>Attempts to fetch and convert an interface contract id into a template, returning both the converted contract and its contract id if the conversion is successful, or <code>None</code> otherwise.</td>
+</tr>
+</tbody>
+</table>
+
+## Required Interfaces
+
+```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+- An interface can depend on other interfaces. These are specified with the `requires` keyword after the interface name but before the `where` keyword, separated by commas.
+
+- For an interface declaration to be valid, its list of required interfaces must be transitively closed. In other words, an interface `I` cannot require an interface `J` without also explicitly requiring all the interfaces required by `J`. The order, however, is irrelevant.
+
+  For example, given
+
+  ```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+  This declaration for interface `Square` would cause a compiler error
+
+  ```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+  Explicitly adding `Shape` to the required interfaces fixes the error
+
+  ```daml
+-- Code from: code-snippets-dev/Interfaces.daml
+-- [Include actual code example here]
+```
+
+- For a template `T` to be a valid `interface instance` of an interface `I`, `T` must also be an `interface instance` of each of the interfaces required by `I`.
+
+### Interface Functions
+
+| Function                  | Notes                                                                                                                              |
+|---------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+| `toInterface`             | Can also be used to convert an interface value to one of its required interfaces.                                                  |
+| `fromInterface`           | Can also be used to convert a value of an interface type to one of its requiring interfaces.                                       |
+| `toInterfaceContractId`   | Can also be used to convert an interface contract id into a contract id of one of its required interfaces.                         |
+| `fromInterfaceContractId` | Can also be used to convert an interface contract id into a contract id of one of its requiring interfaces.                        |
+| `fetchFromInterface`      | Can also be used to fetch and convert an interface contract id into a contract and contract id of one of its requiring interfaces. |
+
+
+{/* COPIED_END */}
+
+## Interfaces on Canton Network
+
+Interfaces are central to interoperability across the Canton Network. Two Canton Improvement Proposals (CIPs) define standard interfaces that app developers should be aware of:
+
+- [CIP-0056 — Token Standard](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md): Defines a standard interface for fungible tokens on Canton Network. If your application issues or transfers tokens, implementing this interface ensures compatibility with wallets and other applications in the ecosystem.
+
+- [CIP-0103 — dApp Standard](https://github.com/mjuchli-da/cips/blob/cip-dapp-standard/cip-0103/cip-0103.md): Defines standard interfaces for decentralized applications. This CIP is particularly relevant for developers coming from Ethereum, as it maps familiar ERC-style patterns to Daml interfaces.
+
+When building applications on Canton Network, implementing these standard interfaces lets your contracts participate in the broader ecosystem without requiring custom integration with each counterparty.

--- a/docs-main/appdev/modules/m3-language-fundamentals.mdx
+++ b/docs-main/appdev/modules/m3-language-fundamentals.mdx
@@ -3,4 +3,502 @@ title: "Language Fundamentals"
 description: "Learn the fundamentals of Daml - a functional programming language designed for smart contracts"
 ---
 
-Content coming soon.
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/functional-101.rst" hash="57479f7e" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/functional-101.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+## Introduction
+
+In this chapter, you will learn more about expressing complex logic in a functional language like Daml. Specifically, you'll learn about:
+
+- Function signatures and functions
+- Advanced control flow (`if...else`, folds, recursion, `when`)
+
+<Note>
+There is a project template `daml-intro-functional-101` for this chapter, containing the code snippets from this section.
+</Note>
+
+## The Haskell connection
+
+The previous chapters of this introduction to Daml have mostly covered the structure of templates, and their connection to the Daml Ledger Model. The logic of what happens within the `do` blocks of choices has been kept relatively simple. In this chapter, we will dive deeper into Daml's expression language, the part that allows you to write logic inside those `do` blocks. But we can only scratch the surface here. Daml borrows a lot of its language from [Haskell](https://www.haskell.org). If you want to dive deeper, or learn about specific aspects of the language you can refer to standard literature on Haskell. Some recommendations:
+
+- [Finding Success and Failure in Haskell (Julie Moronuki, Chris Martin)](https://joyofhaskell.com/)
+- [Haskell Programming from first principles (Christopher Allen, Julie Moronuki)](http://haskellbook.com/)
+- [Learn You a Haskell for Great Good! (Miran Lipovača)](http://learnyouahaskell.com/)
+- [Programming in Haskell (Graham Hutton)](http://www.cs.nott.ac.uk/~pszgmh/pih.html)
+- [Real World Haskell (Bryan O'Sullivan, Don Stewart, John Goerzen)](http://book.realworldhaskell.org/)
+
+When comparing Daml to Haskell it's worth noting:
+
+- Haskell is a lazy language, which allows you to write things like `head [1..]`, meaning "take the first element of an infinite list". Daml by contrast is strict. Expressions are fully evaluated, which means it is not possible to work with infinite data structures.
+- Daml has a `with` syntax for records and a dot syntax for record field access, neither of which is present in Haskell. However, Daml supports Haskell's curly brace record notation.
+- Daml has a number of Haskell compiler extensions active by default.
+- Daml doesn't support all features of Haskell's type system. For example, there are no existential types or GADTs.
+- Actions are called Monads in Haskell.
+
+## Functions
+
+In `data` you learnt about one half of Daml's type system: Data types. It's now time to learn about the other, which are Function types. Function types in Daml can be spotted by looking for `->` which can be read as "maps to".
+
+For example, the function signature `Int -> Int` maps an integer to another integer. There are many such functions, but one would be:
+
+```daml
+increment : Int -> Int
+increment n = n + 1
+```
+
+You can see here that the function declaration and the function definitions are separate. The declaration can be omitted in cases where the type can be inferred by the compiler, but for top-level functions (ie ones at the same level as templates, directly under a module), it's often a good idea to include them for readability.
+
+In the case of `increment` it could have been omitted. Similarly, we could define a function `add` without a declaration:
+
+```daml
+add n m = n + m
+```
+
+If you do this, and wonder what type the compiler has inferred, you can hover over the function name in the IDE:
+
+```
+add
+  : Additive a
+  => a -> a -> a
+
+Defined at /tmp/daml-intro-9/daml/Main.daml:20:1
+add n m = n + m
+```
+
+What you see here is a slightly more complex signature:
+
+```daml
+add : Additive a => a -> a -> a
+```
+
+There are two interesting things going on here:
+
+1.  We have more than one `->`.
+2.  We have a type parameter `a` with a constraint `Additive a`.
+
+### Function application
+
+Let's start by looking at the right hand part `a -> a -> a`. The `->` is right associative, meaning `a -> a -> a` is equivalent to `a -> (a -> a)`. Using the "maps to" way of reading `->`, we get "`a` maps to a function that maps `a` to `a`".
+
+And this is indeed what happens. We can define a different version of `increment` by *partially applying* `add`:
+
+```daml
+increment2 = add 1
+```
+
+If you try this out in your IDE, you'll see that the compiler infers type `Int -> Int` again. It can do so because of the literal `1 : Int`.
+
+So if we have a function `f : a -> b -> c -> d` and a value `valA : a`, we get `f valA : b -> c -> d`, i.e. we can apply the function argument by argument. If we also had `valB : b`, we would have `f valA valB : c -> d`. What this tells you is that function *application* is left associative: `f valA valB == (f valA) valB`.
+
+### Infix functions
+
+Now `add` is clearly just an alias for `+`, but what is `+`? `+` is just a function. It's only special because it starts with a symbol. Functions that start with a symbol are *infix* by default which means they can be written between two arguments. That's why we can write `1 + 2` rather than `+ 1 2`. The rules for converting between normal and infix functions are simple. Wrap an infix function in parentheses to use it as a normal function (i.e. *prefix*), and wrap a normal function in backticks to make it infix:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+With that knowledge, we could have defined `add` more succinctly as the alias that it is:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+If we want to partially apply an infix operation we can also do that as follows:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+#### Associativity and Precedence
+
+When dealing with multiple infix operators, precedence determines how the Daml compiler should parse an expression. For example, for the expression `x + y * z`, because `\*` has a higher precedence than `+`, the expression is parsed as `x + (y * z)` instead of `(x + y) * z`. When dealing with infix operators with the same precedence, associativity determines how the Daml compiler should parse an expression. For example, because `+` and `-` are left-associative, the expression `x + y - z` is parsed as `(x + y) - z` instead of `x + (y - z)`. For built-in operators this has been predefined, for user-defined operators, it must be user-defined. See the [Daml reference on Fixity, Associativity and Precedence](https://docs.digitalasset.com/daml/reference/base.html) for details.
+
+### Type constraints
+
+The `Additive a =>` part of the signature of `add` is a type constraint on the type parameter `a`. `Additive` here is a typeclass. You already met typeclasses like `Eq` and `Show` earlier. The `Additive` typeclass says that you can add a thing, i.e. there is a function `(+) : a -> a -> a`. Now the way to read the full signature of `add` is "Given that `a` has an instance for the `Additive` typeclass, `a` maps to a function which maps `a` to `a`".
+
+Typeclasses in Daml are a bit like interfaces in other languages. To be able to add two things using the `+` function, those things need to "expose" (have an instance for) the `Additive` interface (typeclass).
+
+Unlike interfaces, typeclasses can have multiple type parameters. A good example, which also demonstrates the use of multiple constraints at the same time, is the signature of the `exercise` function:
+
+```daml
+exercise : (Template t, Choice t c r) => ContractId t -> c -> Update r
+```
+
+Let's turn this into prose: Given that `t` is the type of a template, and that `t` has a choice `c` with return type `r`, the `exercise` function maps a `ContractId` for a contract of type `t` to a function that takes the choice arguments of type `c` and returns an `Update` resulting in type `r`.
+
+That's quite a mouthful, and does require one to know what *meaning* the typeclass `Choice` gives to parameters `t` `c` and `r`, but in many cases, that's obvious from the context or names of typeclasses and variables.
+
+Using single letters, while common, is not mandatory. The above may be made a little bit clearer by expanding the type parameter names, at the cost of making the code a bit longer:
+
+```daml
+exercise : (Template template, Choice template choice result) =>
+             ContractId template -> choice -> Update result
+```
+
+### Pattern matching in arguments
+
+You met pattern matching earlier, using `case` expressions which is one way of pattern matching. However, it can also be convenient to do the pattern matching at the level of function arguments. Think about implementing the function `uncurry`:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+`uncurry` takes a function with two arguments (or more, since `c` could be a function), and turns it into a function from a 2-tuple to `c`. Here are three ways of implementing it, using tuple accessors, `case` pattern matching, and function pattern matching:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+Any pattern matching you can do in `case` you can also do at the function level, and the compiler helpfully warns you if you did not cover all cases, which is called "non-exhaustive".
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+The above will give you a warning:
+
+``` none
+warning:
+  Pattern match(es) are non-exhaustive
+  In an equation for ‘fromSome’: Patterns not matched: None
+```
+
+A function that does not cover all its cases, like `fromSome` here, is called a *partial* function. `fromSome None` will cause a runtime error.
+
+We can use function level pattern matching together with a feature called *Record Wildcards* to write the function `issueAsset`:
+
+```daml
+-- Code from: daml/daml-intro-9/daml/Test/Intro/Asset/MultiTrade.daml
+-- [Insert snippet here]
+```
+
+The `..` in the pattern match here means bind all fields from the given record to local variables, so we have local variables `issuer`, `owner`, etc.
+
+The `..` in the second to last line means fill all fields of the new record using local variables of the matching names, in this case (per the definition of `Issue_Asset`), `symbol` and `quantity`, taken from the `asset` argument to the function. In other words, this is equivalent to:
+
+```daml
+exerciseCmd ahCid Issue_Asset with symbol = asset.symbol, quantity = asset.quantity
+```
+
+because the notation `asset@(Asset with ..)` binds `asset` to the entire record, while also binding all of the fields of `asset` to local variables.
+
+### Functions everywhere
+
+You have probably already guessed it: Anywhere you can put a value in Daml you can also put a function. Even inside data types:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+More often it makes sense to define functions locally, inside a `let` clause or similar. Good examples of this are the `validate` and `transfer` functions defined locally in the `Trade_Settle` choice of the model from `dependencies`:
+
+```daml
+-- Code from: daml/daml-intro-9/daml/Intro/Asset/MultiTrade.daml
+-- [Insert snippet here]
+```
+
+You can see that the function signature is inferred from the context here. If you look closely (or hover over the function in the IDE), you'll see that it has signature
+
+```bash
+validate : (HasFetch r, Eq r, HasField "observers" r a) => (r, ContractId r) -> Update ()
+```
+
+<Note>
+Bear in mind that functions are not serializable, so you can't use them inside template arguments, as choice inputs, or as choice outputs. They also don't have instances of the `Eq` or `Show` typeclasses which one would commonly want on data types.
+</Note>
+
+The `mapA` and `mapA_` functions loop through the lists of assets and approvals, and apply the functions `validate` and `transfer` to each element of those lists, performing the resulting `Update` action in the process. We'll look at that more closely under `loops` below.
+
+### Lambdas
+
+Daml supports inline functions, called "lambda"s. They are defined using the `(\x y z -> ...)` syntax. For example, a lambda version of `increment` would be `(\n -> n + 1)`.
+
+## Control flow
+
+In this section, we will cover branches and loops, and look at a few common patterns of how to translate procedural code into functional code.
+
+### Branches
+
+Until `compose` the only real kind of control flow introduced has been `case`, which is a powerful tool for branching.
+
+#### If-else expression
+
+`constraints` also showed a seemingly self-explanatory `if ... else` expression, but didn't explain it further. Let's implement the function `boolToInt : Bool -> Int` which in typical fashion maps `True` to `1` and `False` to `0`. Here is an implementation using `case`:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+If you write this function in the IDE, you'll get a warning from the linter:
+
+``` none
+Suggestion: Use if
+Found:
+case b of
+    True -> 1
+    False -> 0
+Perhaps:
+if b then 1 else 0
+```
+
+The linter knows the equivalence and suggests a better implementation:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+In short: `if ... else` expressions are equivalent to `case` expressions, but can be easier to read.
+
+#### Control flow as expressions
+
+`case` and `if ... else` expressions really are control flow in the sense that they short-circuit:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+This function behaves as you would expect: the error only gets evaluated if an invalid text is passed in.
+
+This is different from functions, where all arguments are evaluated immediately:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+In the above, `boom` is an error.
+
+While providing proper control flow, `case` and `if ... else` expressions do result in a value when evaluated. You can actually see that in the function definitions above. Since each of the functions is defined just as a `case` or `if ... else` expression, the value of the evaluated function is just the value of the `case` or `if ... else` expression. Values have a type: the `if ... else` expression in `boolToInt2` has type `Int` as that is what the function returns; similarly, the `case` expression in `doError` has type `Bool`. To be able to give such expressions an unambiguous type, each branch needs to have the same type. The below function does not compile as one branch tries to return an `Int` and the other a `Text`:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+If we need functions that can return two (or more) types of things we need to encode that in the return type. For two possibilities, it's common to use the `Either` type:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+When you have more than two possible types (and sometimes even just for two types), it can be clearer to define your own variant type to wrap all possibilities.
+
+#### Branches in actions
+
+The most common case where this becomes important is inside `do` blocks. Say we want to create a contract of one type in one case, and of another type in another case. Let's say we have two template types and want to write a function that creates an `S` if a condition is met, and a `T` otherwise.
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+It would be tempting to write a simple `if ... else`, but it won't typecheck if each branch returns a different type:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+We have two options:
+
+1.  Use the `Either` trick from above.
+2.  Get rid of the return types.
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+The latter is so common that there is a utility function in `DA.Action` to get rid of the return type: `void : Functor f => f a -> f ()`.
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+`void` also helps express control flow of the type "Create a `T` only if a condition is met.
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+Note that we still need the `else` clause of the same type `()`. This pattern is so common, it's encapsulated in the standard library function `DA.Action.when : (Applicative f) => Bool -> f () -> f ()`.
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+Despite `when` looking like a simple function, the compiler does some magic so that it short-circuits evaluation just like `if ... else` and `case`. The following `noop` function is a no-op (i.e. "does nothing"), not an error as one might otherwise expect:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+With `case`, `if ... else`, `void` and `when`, you can express all branching. However, one additional feature you may want to learn is guards. They are not covered here, but can help avoid deeply nested `if ... else` blocks. Here's just one example. The Haskell sources at the beginning of the chapter cover this topic in more depth.
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+### Loops
+
+Other than branching, the most common form of control flow is looping. Looping is usually used to iteratively modify some state. We'll use JavaScript in this section to illustrate the procedural way of doing things.
+
+``` JavaScript
+function sum(intArr) {
+  var result = 0;
+  intArr.forEach (i => {
+    result += i;
+  });
+  return result;
+}
+```
+
+A more general loop looks like this:
+
+``` JavaScript
+function whileF(init, cont, step, finalize) {
+  var state = init();
+  while (cont(state)) {
+    state = step(state);
+  }
+  return finalize(state);
+}
+```
+
+In both cases, state is being mutated: `result` in the former, `state` in the latter. Values in Daml are immutable, so it needs to work differently. In Daml we will do this with folds and recursion.
+
+#### Folds
+
+Folds correspond to looping with an explicit iterator: `for` and `forEach` loops in procedural languages. The most common iterator is a list, as is the case in the `sum` function above. For such cases, Daml has the `foldl` function. The `l` stands for "left" and means the list is processed from the left. There is also a corresponding `foldr` which processes from the right.
+
+```daml
+foldl : (b -> a -> b) -> b -> [a] -> b
+```
+
+Let's give the type parameters semantic names. `b` is the state, `a` is an item. `foldl`s first argument is a function which takes a state and an item, and returns a new state. That's the equivalent of the inner block of the `forEach`. It then takes a state, which is the initial state, and a list of items, which is the iterator. The result is again a state. The `sum` function above can be translated to Daml almost instantly with those correspondences in mind:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+If we wanted to be more verbose, we could replace `(+)` with a lambda `(\result i -> result + i)` which makes the correspondence to `result += i` from the JavaScript clearer.
+
+Almost all loops with explicit iterators can be translated to folds, though we have to take a bit of care with performance when it comes to translating `for` loops:
+
+``` JavaScript
+function sumArrs(arr1, arr2) {
+  var l = min (arr1.length, arr2.length);
+  var result = new int[l];
+  for(var i = 0; i < l; i++) {
+    result[i] = arr1[i] + arr2[i];
+  }
+  return result;
+}
+```
+
+Translating the `for` into a `forEach` is easy if you can get your hands on an array containing values `[0..(l-1)]`. And that's how you do it in Daml, using *ranges*. `[0..(l-1)]` is shorthand for `enumFromTo 0 (l-1)`, which returns the list you'd expect.
+
+Daml also has an operator `(!!) : [a] -> Int -> a` which returns an element in a list. You may now be tempted to write `sumArrs` like this:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+Unfortunately, that's not a very good approach. Lists in Daml are linked lists, which makes access using `(!!)` too slow for this kind of iteration. A better approach in Daml is to get rid of the `i` altogether and instead merge the lists first using the `zip` function, and then iterate over the "zipped" up lists:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+`zip : [a] -> [b] -> [(a, b)]` takes two lists, and merges them into a single list where the first element is the 2-tuple containing the first element of the two input lists, and so on. It drops any left-over elements of the longer list, thus making the `min` logic unnecessary.
+
+#### Maps
+
+In effect, the lambda passed to `foldl` only "wants" to act on a single element of the (zipped-up) input list, but still has to manage the concatenation of the whole state. Acting on each element separately is a common-enough pattern that there is a specialized function for it: `map : (a -> b) -> [a] -> [b]`. Using it, we can rewrite `sumArr` to:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+As a rule, use `map` if the result has the same shape as the input and you don't need to carry state from one iteration to the next. Use folds if you need to accumulate state in any way.
+
+#### Recursion
+
+If there is no explicit iterator, you can use recursion. Let's try to write a function that reverses a list, for example. We want to avoid `(!!)` so there is no sensible iterator here. Instead, we use recursion:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+You may be tempted to make `reverseWorker` a local definition inside `reverse`, but Daml only supports recursion for top-level functions so the recursive part `recurseWorker` has to be its own top-level function.
+
+#### Folds and maps in action contexts
+
+The folds and `map` function above are pure in the sense introduced earlier: The functions used to map or process items have no side effects. If you have looked at the multi-package models, you'll have noticed `mapA`, `mapA_`, and `forA`, which seem to serve a similar role but within `Action`s . A good example is the `mapA` call in the `testMultiTrade` script:
+
+```daml
+-- Code from: daml/daml-intro-9/daml/Test/Intro/Asset/MultiTrade.daml
+-- [Insert snippet here]
+```
+
+Here we have a list of relationships (type `[Relationship]`) and a function `setupRelationship : Relationship -> Script (ContractId AssetHolder)`. We want the `AssetHolder` contracts for those relationships, i.e. something of type `[ContractId AssetHolder]`. Using the map function almost gets us there, but `map setupRelationship rels` would have type `[Update (ContractId AssetHolder)]`. This is a list of `Update` actions, each resulting in a `ContractId AssetHolder`. What we need is an `Update` action resulting in a `[ContractId AssetHolder]`. The list and `Update` are nested the wrong way around for our purposes.
+
+Intuitively, it's clear how to fix this: we want the compound action consisting of performing each of the actions in the list in turn. There's a function for that: `sequence : : Applicative m => [m a] -> m [a]`. It implements that intuition and allows us to "take the `Update` out of the list", so to speak. So we could write `sequence (map setupRelationship rels)`. This is so common that it's encapsulated in the `mapA` function, a possible implementation of which is
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+The `A` in `mapA` stands for "Action", and you'll find that many functions that have something to do with "looping" have an `A` equivalent. The most fundamental of all of these is `foldlA : Action m => (b -> a -> m b) -> b -> [a] -> m b`, a left fold with side effects. Here the inner function has a side-effect indicated by the `m` so the end result `m b` also has a side effect: the sum of all the side effects of the inner function.
+
+To improve your familiarity with these concepts, try implementing `foldlA` in terms of `foldl`, as well as `sequence` and `mapA` in terms of `foldlA`. Here is one set of possible implementations:
+
+```daml
+-- Code from: daml/daml-intro-functional-101/daml/Main.daml
+-- [Insert snippet here]
+```
+
+`forA` is just `mapA` with its arguments reversed. This is useful for readability if the list of items is already in a variable, but the function is a lengthy lambda.
+
+```daml
+-- Code from: daml/daml-intro-9/daml/Test/Intro/Asset/MultiTrade.daml
+-- [Insert snippet here]
+```
+
+Lastly, you'll have noticed that in some cases we used `mapA_`, not `mapA`. The underscore indicates that the result is not used, so `mapA_ fn xs fn == void (mapA fn xs)`. The Daml Linter will alert you if you could use `mapA_` instead of `mapA`, and similarly for `forA_`.
+
+## Next up
+
+You now know the basics of functions and control flow, both in pure and Action contexts. The multi-package example shows just how much can be done with just the tools you have encountered here, but there are many more tools at your disposal in the Daml standard library, which provides functions and typeclasses for many common circumstances.
+
+
+{/* COPIED_END */}

--- a/docs-main/appdev/modules/m3-testing.mdx
+++ b/docs-main/appdev/modules/m3-testing.mdx
@@ -1,6 +1,159 @@
 ---
-title: "Testing"
-description: "Testing Daml smart contracts"
+title: "Testing Daml Contracts"
+description: "Write and run tests for Daml smart contracts using Daml Script"
 ---
 
-Content coming soon.
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/tests.rst" hash="b7bc1096" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/tests.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+# Test Daml contracts
+
+This section is about testing and debugging the Daml contracts you've built using the tools from earlier chapters. You've already met Daml Script as a way of testing your code inside the IDE. In this chapter you'll learn about more ways to run Daml Scripts, as well as other tools you can use for testing and debugging. Specifically we will cover:
+
+- Running Daml Scripts to test and debug templates
+- The `trace` and `debug` functions
+- The choice coverage
+
+Note that this section only covers testing your Daml contracts.
+
+<Tip>
+Remember that you can load all the code for this section into a folder called `intro-test` by running `dpm new intro-test  --template daml-intro-test`
+</Tip>
+
+## Multi-package project structure
+
+In the project structures section you learned that it is important to keep the scripts and templates in separate packages. The project for this section is a multi-package build, containing all the code from `compose` and `dependencies`. The folder structure looks like this:
+
+``` none
+.
+├── asset
+├── asset-tests
+├── multi-trade
+├── multi-trade-tests
+└── multi-package.yaml
+```
+
+`asset`, `asset-tests`, `multi-trade` and `multi-trade-tests` are packages. They each contain there own `daml.yaml` file. `asset` contains the code for the `Asset` and `Trade` templates. The scripts for testing `Asset` and `Trade` are in the `asset-tests` package, which depends on `asset`. Contrary to `asset-tests`, `asset` is meant to be uploaded to a Canton ledger.
+
+Similarly `multi-trade` contains the `MultiTrade` template, and `multi-trade-tests` contains the corresponding scripts.
+
+`multi-package.yaml` is the multi-package configuration. It allows `dpm` to orchestrate the build of each sub-package. It contains the list of sub-packages:
+
+```yaml
+packages:
+- ./asset
+- ./asset-tests
+- ./multi-trade
+- ./multi-trade-tests
+```
+
+Run `dpm build --all` at the root of the multi-package project, to build all sub-packages. Or you can run `dpm build` in any of the sub-package. It detects the dependencies, and build them in the correct order. For instance, running `dpm build` in `multi-trade-tests` triggers the build of `asset`, `multi-trade` and `multi-trade-tests` in that order.
+
+## Test templates with Daml Scripts
+
+Daml Script is the main tool to test Daml contracts. In a script, you can submit commands and queries from multiple parties on a fresh, initially empty, ledger.
+
+There are two main ways to run a Daml Script: - Click the `Script results` lens in VS Code: it provides the table and transaction views, which are useful for debugging. - Run the `dpm test` command, which is useful for regression checks and coverage.
+
+### Run a script in VS Code
+
+In the earlier testing with scripts section, you learned how to write and run a Daml Script in VS Code.
+
+As a refresher, find a script in the `asset-tests` or `multi-trade-tests` and click the `Script results` lens, that appears on top of the script name. VS Code should open the table view in a side pane. The table view describes the final state of the ledger at the end of the script. It shows the list of active contracts, their data, and for each party, if it can see the contract or not. Click the `Show archived` toggle to see the list of archived contracts.
+
+In the side pane, click the `Show transaction view` button to switch to the transaction view. It shows you all the transactions, and sub-transactions, executed by the script. It also contain the failure message whenever a script fail. Try to change the submitting party of an `exerciseCmd` and see if the script is still succeeding.
+
+You can use the table and transaction views in VS Code to better understand the visibility of each contract, and authority of each party.
+
+### Run all scripts with `dpm`
+
+`dpm` can run all the scripts inside a package. This is useful for quick regression check, and their automation in the CI.
+
+Open a terminal in the `multi-trade-tests` folder and run `dpm test`. It should succeed and print the following test summary:
+
+``` none
+Test Summary
+
+daml/Intro/Asset/MultiTradeTests.daml:testMultiTrade: ok, 12 active contracts, 28 transactions.
+daml/Intro/Asset/TradeSetup.daml:setupRoles: ok, 2 active contracts, 4 transactions.
+daml/Intro/Asset/TradeSetup.daml:test_issuance: ok, 3 active contracts, 5 transactions.
+daml/Intro/Asset/TradeSetup.daml:tradeSetup: ok, 6 active contracts, 10 transactions.
+Modules internal to this package:
+- Internal templates
+  0 defined
+  0 (100.0%) created
+- Internal template choices
+  0 defined
+  0 (100.0%) exercised
+- Internal interface implementations
+  0 defined
+    0 internal interfaces
+    0 external interfaces
+- Internal interface choices
+  0 defined
+  0 (100.0%) exercised
+Modules external to this package:
+- External templates
+  7 defined
+  5 ( 71.4%) created in any tests
+  5 ( 71.4%) created in internal tests
+  0 (  0.0%) created in external tests
+- External template choices
+  27 defined
+  7 ( 25.9%) exercised in any tests
+  7 ( 25.9%) exercised in internal tests
+  0 (  0.0%) exercised in external tests
+- External interface implementations
+  0 defined
+- External interface choices
+  0 defined
+  0 (100.0%) exercised in any tests
+  0 (100.0%) exercised in internal tests
+  0 (100.0%) exercised in external tests
+```
+
+The first part of the summary is a list of each executed script. For each script, you can see the total number of transactions, and active contracts at the end of the script. For instance the `testMultiTrade` executed 28 transactions, to create 12 active contracts.
+
+The second part of the summary is the coverage report. It shows you how many templates and choices are tested by the complete set of scripts in the package, in proportion of the total number of templates and choices.
+
+To learn more about Daml test coverage, read the [Daml test coverage guide](https://docs.digitalasset.com/build/3.4/sdk/howtos/testing/test-coverage).
+
+## Debug, trace, and stacktraces
+
+The above demonstrates nicely how to test the happy path, but what if a function doesn't behave as you expected? Daml has two functions that allow you to do fine-grained printf debugging: `debug` and `trace`. Both allow you to print something to StdOut if the code is reached. The difference between `debug` and `trace` is similar to the relationship between `abort` and `error`:
+
+- `debug : Text -> m ()` maps a text to an Action that has the side-effect of printing to StdOut.
+- `trace : Text -> a -> a` prints to StdOut when the expression is evaluated.
+
+``` none
+daml> let a : Script () = debug "foo"
+daml> let b : Script () = trace "bar" (debug "baz")
+[Daml.Script:378]: "bar"
+daml> a
+[DA.Internal.Prelude:532]: "foo"
+daml> b
+[DA.Internal.Prelude:532]: "baz"
+daml>
+```
+
+If in doubt, use `debug`. It's the easier of the two to interpret the results of.
+
+The thing in the square brackets is the last location. It'll tell you the Daml file and line number that triggered the printing, but often no more than that because full stacktraces could violate subtransaction privacy quite easily. If you want to enable stacktraces for some purely functional code in your modules, you can use the machinery in the `DA.Stack` module to do so, but we won't cover that any further here.
+
+
+{/* COPIED_END */}
+
+## Local testing with dpm sandbox
+
+For integration testing beyond Daml Script, you can run a local Canton sandbox using `dpm sandbox`. This starts a local participant node with an in-memory ledger, letting you test your contracts in a more realistic environment before deploying to DevNet or TestNet.
+
+```bash
+dpm sandbox
+```
+
+The sandbox is useful for testing Ledger API interactions, codegen-based clients, and multi-participant setups that go beyond what Daml Script covers.

--- a/docs-main/appdev/modules/m3-working-with-time.mdx
+++ b/docs-main/appdev/modules/m3-working-with-time.mdx
@@ -1,6 +1,245 @@
 ---
 title: "Working with Time"
-description: "Working with time in Daml smart contracts"
+description: "Implement time-based logic in Daml contracts including expiration, deadlines, and time constraints"
 ---
 
-Content coming soon.
+{/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/smart-contracts/develop/patterns/implementing-time-constraints.rst" hash="17e57ac2" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `docs/replicated/daml/3.4/sdk/sdlc-howtos/smart-contracts/develop/patterns/implementing-time-constraints.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+# How To Implement Time Constraints
+
+Contract time constraints may be implemented using either:
+
+- ledger time primitives (i.e. isLedgerTimeLT, isLedgerTimeLE, isLedgerTimeGT and isLedgerTimeGE) or assertions (i.e. assertWithinDeadline and assertDeadlineExceeded)
+
+  > - the use of ledger time primitives and assertions do not constrain the time bound between transaction preparation and submission - e.g. they are suitable for workflows using external parties to sign transactions
+
+- or, by calling getTime
+
+  > - calls to getTime constrain transaction preparation and submission workflows to be (by default) within 1 minute.
+  > - the 1 minute value is the default value for the ledger time record time tolerance parameter (a dynamic synchronizer parameter).
+
+The next subsections demonstrate how the following Coin and TransferProposal contracts can be modified to use different types of ledger time constraints to control when parties are allowed to perform ledger writes.
+
+Coin contract
+
+```daml
+-- Code from: ./daml/SimpleCoinTransfer.daml
+-- [Include actual code example here]
+```
+
+```daml
+-- Code from: ./daml/SimpleCoinTransfer.daml
+-- [Include actual code example here]
+```
+
+TransferProposal contract
+
+```daml
+-- Code from: ./daml/SimpleCoinTransfer.daml
+-- [Include actual code example here]
+```
+
+```daml
+-- Code from: ./daml/SimpleCoinTransfer.daml
+-- [Include actual code example here]
+```
+
+```daml
+-- Code from: ./daml/SimpleCoinTransfer.daml
+-- [Include actual code example here]
+```
+
+```mermaid
+flowchart LR
+    subgraph Coin["Coin (active)"]
+        C1[owner: Alice\nissuer: Bank\nnewOwner: Bob]
+    end
+    Coin -->|"Transfer"| TP
+    subgraph TP["TransferProposal (active)"]
+        T1[newOwner: Bob\ncoin: Coin]
+    end
+    TP -->|"AcceptTransfer"| Coin2
+    subgraph Coin2["Coin (new owner)"]
+        C2[owner: Bob\nissuer: Bank]
+    end
+```
+*Simple coin transfer with consent withdrawal*
+
+## How to check that a deadline is valid
+
+This design pattern demonstrates how to limit choices so that they must occur by a given deadline.
+
+### Motivation
+
+When parties need to perform ledger writes by a given deadline.
+
+### Implementation
+
+Transfer proposals can be accepted at any point in time. To restrict this behaviour so that acceptance must occur by a fixed time, a guard for AcceptTransfer choice execution can be added.
+
+TransferProposal contract
+In the TransferProposal contract, the body of the AcceptTransfer choice is modified to assert that the contract deadline is valid.
+
+```daml
+-- Code from: ./daml/LimitedTimeCoinTransfer.daml
+-- [Include actual code example here]
+```
+
+As transfer proposals are created when a Transfer choice is executed, the time by which an AcceptTransfer can be executed needs to be passed in as a choice parameter.
+
+Coin contract
+In the Coin contract, the Transfer choice has an additional deadline argument, so that TransferProposal contracts can be given a fixed lifetime.
+
+```daml
+-- Code from: ./daml/LimitedTimeCoinTransfer.daml
+-- [Include actual code example here]
+```
+
+```mermaid
+flowchart LR
+    subgraph Coin["Coin (active)"]
+        C1[owner: Alice\nissuer: Bank]
+    end
+    Coin -->|"Transfer(deadline)"| TP
+    subgraph TP["TransferProposal"]
+        T1[newOwner: Bob\ndeadline: timestamp]
+    end
+    TP -->|"AcceptTransfer\nassert now ≤ deadline"| Coin2
+    subgraph Coin2["Coin (new owner)"]
+        C2[owner: Bob\nissuer: Bank]
+    end
+```
+*Time-limited coin ownership transfer*
+
+## How to check that a deadline has passed
+
+This design pattern demonstrates how to ensure choices only occur after a given deadline.
+
+### Motivation
+
+When parties need to perform ledger writes after a fixed time delay.
+
+### Implementation
+
+Transfer proposals can be accepted at any point in time. To restrict this behaviour so that acceptance can only occur after a fixed delay, a guard for AcceptTransfer choice execution can be added.
+
+TransferProposal contract
+In the TransferProposal contract, the body of the AcceptTransfer choice is modified to assert that the contract deadline has been exceeded or passed.
+
+```daml
+-- Code from: ./daml/DelayedCoinTransfer.daml
+-- [Include actual code example here]
+```
+
+As transfer proposals are created when a Transfer choice is executed, the delay time after which an AcceptTransfer can be executed needs to be passed in as a choice parameter.
+
+Coin contract
+In the Coin contract, the Transfer choice has an additional deadline argument, so that TransferProposal contracts can be given a delay.
+
+```daml
+-- Code from: ./daml/DelayedCoinTransfer.daml
+-- [Include actual code example here]
+```
+
+```mermaid
+flowchart LR
+    subgraph Coin["Coin (active)"]
+        C1[owner: Alice\nissuer: Bank]
+    end
+    Coin -->|"Transfer(delay)"| TP
+    subgraph TP["TransferProposal"]
+        T1[newOwner: Bob\ndelay: duration]
+    end
+    TP -->|"AcceptTransfer\nassert now > delay"| Coin2
+    subgraph Coin2["Coin (new owner)"]
+        C2[owner: Bob\nissuer: Bank]
+    end
+```
+*Delayed coin ownership transfer*
+
+## Grant time-limited writes to parties
+
+This design pattern demonstrates how to grant time-limited writes to parties.
+
+### Motivation
+
+When parties need to be able to perform ledger writes, but writes need to only be granted for a specific time window.
+
+### Implementation
+
+Transfer proposals can be accepted at any point in time. To restrict this behaviour so that acceptance can only occur within a given time window, a guard for AcceptTransfer choice execution can be added.
+
+TransferProposal contract
+In the TransferProposal contract, the body of the AcceptTransfer choice is modified to assert that the contract deadline has been exceeded or passed.
+
+```daml
+-- Code from: ./daml/CoinWithTransferWindow.daml
+-- [Include actual code example here]
+```
+
+As transfer proposals are created when a Transfer choice is executed, the interval start and end times, during which an AcceptTransfer can be executed need to be passed in as choice parameters.
+
+Coin contract
+In the Coin contract, the Transfer choice has an additional deadline argument, so that TransferProposal contracts can be given a delay.
+
+```daml
+-- Code from: ./daml/CoinWithTransferWindow.daml
+-- [Include actual code example here]
+```
+
+```mermaid
+flowchart LR
+    subgraph Coin["Coin (active)"]
+        C1[owner: Alice\nissuer: Bank]
+    end
+    Coin -->|"Transfer(start, end)"| TP
+    subgraph TP["TransferProposal"]
+        T1[newOwner: Bob\nstartTime: timestamp\nendTime: timestamp]
+    end
+    TP -->|"AcceptTransfer\nassert start ≤ now ≤ end"| Coin2
+    subgraph Coin2["Coin (new owner)"]
+        C2[owner: Bob\nissuer: Bank]
+    end
+```
+*Coin ownership transfer within a time window*
+
+## Where to use getTime
+
+For workflows that prepare and submit transactions, care needs to be taken when using calls to getTime. This is because calls to getTime cause transactions to be bound to the ledger time, and in turn constrain how sequencers may re-order transactions. Global Synchronizers are configured such that the transaction prepare and submit time window is one minute, so any workflow using getTime must prepare and submit transactions within that one-minute time window.
+
+For workflows where this constraint can not be met (e.g. workflows that sign transactions using external parties), it is recommended that workflows are designed to use the ledger time primitives and assertions.
+
+### Motivation
+
+When parties need to perform ledger writes by a given deadline, but are able to prepare and submit a transaction within 1 minute.
+
+### Implementation
+
+Transfer proposals can be accepted at any point in time. To require acceptance by a fixed time, you can add a guard for AcceptTransfer choice execution. Here you determine the current ledger time by calling getTime.
+
+TransferProposal contract
+In the TransferProposal contract, the body of the AcceptTransfer choice is modified to assert that the contract deadline is valid relative to the ledger time returned by calling getTime.
+
+```daml
+-- Code from: ./daml/GetTimeCoinTransfer.daml
+-- [Include actual code example here]
+```
+
+As transfer proposals are created when a Transfer choice is executed, the time by which an AcceptTransfer can be executed needs to be passed in as a choice parameter.
+
+Coin contract
+In the Coin contract, the Transfer choice has an additional deadline argument, so that TransferProposal contracts can be given a fixed lifetime.
+
+```daml
+-- Code from: ./daml/GetTimeCoinTransfer.daml
+-- [Include actual code example here]
+```
+
+
+{/* COPIED_END */}

--- a/docs.json
+++ b/docs.json
@@ -401,9 +401,8 @@
                   "docs-main/appdev/modules/m3-working-with-time",
                   "docs-main/appdev/modules/m3-contract-keys",
                   "docs-main/appdev/modules/m3-interfaces",
-                  "docs-main/appdev/modules/m3-exception-handling",
                   "docs-main/appdev/modules/m3-testing",
-                  "docs-main/appdev/modules/m3-building-and-packaging"
+                  "docs-main/appdev/modules/m3-building-packaging"
                 ]
               },
               {
@@ -558,9 +557,8 @@
                   "docs-main/appdev/modules/m3-working-with-time",
                   "docs-main/appdev/modules/m3-contract-keys",
                   "docs-main/appdev/modules/m3-interfaces",
-                  "docs-main/appdev/modules/m3-exception-handling",
                   "docs-main/appdev/modules/m3-testing",
-                  "docs-main/appdev/modules/m3-building-and-packaging"
+                  "docs-main/appdev/modules/m3-building-packaging"
                 ]
               },
               {
@@ -715,9 +713,8 @@
                   "docs-main/appdev/modules/m3-working-with-time",
                   "docs-main/appdev/modules/m3-contract-keys",
                   "docs-main/appdev/modules/m3-interfaces",
-                  "docs-main/appdev/modules/m3-exception-handling",
                   "docs-main/appdev/modules/m3-testing",
-                  "docs-main/appdev/modules/m3-building-and-packaging"
+                  "docs-main/appdev/modules/m3-building-packaging"
                 ]
               },
               {


### PR DESCRIPTION
## Summary

The Daml tutorial sequence. 11 files are **copied from docs-website RST** (COPIED_START/END markers, reviewer warning banners). Copied content can be skipped but diagrams should be checked. Original additions sit outside the markers.

| File | Source RST | Original additions | Needs review |
|------|-----------|-------------------|-------------|
| `m3-dev-environment` | `tutorials/.../intro.rst` | Intro, Next Steps | — |
| `m3-language-fundamentals` | `tutorials/.../functional-101.rst` | — | IDE signature screenshot replaced with **code block**. `[Insert snippet here]` placeholders throughout. |
| `m3-contract-templates` | `tutorials/.../contracts.rst` | Next Steps link | — |
| `m3-choices` | `tutorials/.../choices.rst` | Next Steps link | RST refs converted to internal links |
| `m3-authorization` | `tutorials/.../parties.rst` | — | `[Insert snippet here]` placeholders |
| `m3-design-patterns` | `tutorials/.../compose.rst` | ~20 lines: pattern summaries (Propose-Accept, Delegation, Authorization, Locking, Multi-party) | Divulgence image replaced with **markdown table** |
| `m3-working-with-time` | `sdlc-howtos/.../time-constraints.rst` | — | **4 SVG diagrams converted to mermaid flowcharts** |
| `m3-contract-keys` | `reference/.../contract-keys.rst` | — | — |
| `m3-interfaces` | `reference/.../interfaces.rst` | ~8 lines: CIP-0056 + CIP-0103 section with GitHub links | — |
| `m3-testing` | `tutorials/.../tests.rst` | ~7 lines: `dpm sandbox` testing section | — |
| `m3-building-packaging` | `tutorials/.../dependencies.rst` | ~11 lines: `dpm build` commands | — |

**Also deletes** `m3-exception-handling.mdx` (Daml exceptions deprecated).

**docs.json:** Replaces `m3-building-and-packaging` with `m3-building-packaging`.

## Review focus

The 4 SVG-to-mermaid conversions in working-with-time. The divulgence table in design-patterns. The code-block replacement in language-fundamentals. Original additions outside COPIED markers.