### PR TITLE
Fix QuickStart navigation regression

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -261,17 +261,17 @@
                 ]
               },
               {
-                "group": "QuickStart",
-                "pages": [
-                  "docs-main/appdev/quickstart/index",
-                  "docs-main/appdev/quickstart/prerequisites",
-                  "docs-main/appdev/quickstart/project-structure",
-                  "docs-main/appdev/quickstart/running-the-demo"
-                ]
-              },
-              {
                 "group": "Module 4: Full-Stack Application Development",
                 "pages": [
+                  {
+                    "group": "QuickStart",
+                    "pages": [
+                      "docs-main/appdev/quickstart/index",
+                      "docs-main/appdev/quickstart/prerequisites",
+                      "docs-main/appdev/quickstart/project-structure",
+                      "docs-main/appdev/quickstart/running-the-demo"
+                    ]
+                  },
                   "docs-main/appdev/modules/m4-building-apps-intro",
                   "docs-main/appdev/modules/m4-app-architecture",
                   "docs-main/appdev/modules/m4-sdks-apis",
@@ -336,17 +336,17 @@
                 ]
               },
               {
-                "group": "QuickStart",
-                "pages": [
-                  "docs-main/appdev/quickstart/index",
-                  "docs-main/appdev/quickstart/prerequisites",
-                  "docs-main/appdev/quickstart/project-structure",
-                  "docs-main/appdev/quickstart/running-the-demo"
-                ]
-              },
-              {
                 "group": "Module 4: Full-Stack Application Development",
                 "pages": [
+                  {
+                    "group": "QuickStart",
+                    "pages": [
+                      "docs-main/appdev/quickstart/index",
+                      "docs-main/appdev/quickstart/prerequisites",
+                      "docs-main/appdev/quickstart/project-structure",
+                      "docs-main/appdev/quickstart/running-the-demo"
+                    ]
+                  },
                   "docs-main/appdev/modules/m4-building-apps-intro",
                   "docs-main/appdev/modules/m4-app-architecture",
                   "docs-main/appdev/modules/m4-sdks-apis",
@@ -411,17 +411,17 @@
                 ]
               },
               {
-                "group": "QuickStart",
-                "pages": [
-                  "docs-main/appdev/quickstart/index",
-                  "docs-main/appdev/quickstart/prerequisites",
-                  "docs-main/appdev/quickstart/project-structure",
-                  "docs-main/appdev/quickstart/running-the-demo"
-                ]
-              },
-              {
                 "group": "Module 4: Full-Stack Application Development",
                 "pages": [
+                  {
+                    "group": "QuickStart",
+                    "pages": [
+                      "docs-main/appdev/quickstart/index",
+                      "docs-main/appdev/quickstart/prerequisites",
+                      "docs-main/appdev/quickstart/project-structure",
+                      "docs-main/appdev/quickstart/running-the-demo"
+                    ]
+                  },
                   "docs-main/appdev/modules/m4-building-apps-intro",
                   "docs-main/appdev/modules/m4-app-architecture",
                   "docs-main/appdev/modules/m4-sdks-apis",


### PR DESCRIPTION
## Summary
- Restores QuickStart as a nested sub-group inside Module 4, matching the structure from PR #24
- PR #25 inadvertently flattened QuickStart into a standalone group between Module 3 and Module 4