### PR TITLE
Week 10 - Module 6: Smart Contract Upgrades

### DIFF
--- a/docs-main/appdev/modules/m6-deployment.mdx
+++ b/docs-main/appdev/modules/m6-deployment.mdx
@@ -3,7 +3,9 @@ title: "Upgrade Deployment"
 description: "Deploying Daml package upgrades across environments with coordination, rollback, and migration strategies"
 ---
 
-Deploying an upgrade means getting v2 DAR files onto all relevant validators and transitioning workflows from v1 to v2. The distributed nature of Canton means you can't just flip a switch — you need to coordinate across organizations while keeping existing workflows running.
+Deploying an upgrade means getting newer version packages onto all relevant validators and transitioning workflows from the current version to the new version. The distributed nature of Canton means you can't just flip a switch — you need to coordinate across organizations while keeping existing workflows running.
+
+In the following discussion, the current version is `v1` and the new version is `v2`.
 
 ## Deployment Sequence
 
@@ -13,11 +15,11 @@ The deployment follows the asynchronous rollout model described in the [Overview
 
 2. **Distribute v2 DAR to counterparties** — Share the v2 DAR file with app users and other organizations. They need to upload it to their validators before v2 workflows can span multiple parties.
 
-3. **Update backends to use v2** — Point your backend's Ledger API client at the v2 package. New contracts are now created with v2. Existing v1 contracts remain usable.
+3. **Update backends to use v2** — Point your backend's Ledger API client at the v2 package. New contracts are now created with v2. Existing v1 contracts remain usable.  Note that the backend may need to work with both the v1 and v2 packages to minimize any downtime.
 
 4. **Migrate existing contracts (if needed)** — For contracts that need v2 data, run migration automation that exercises upgrade choices to archive v1 contracts and create v2 replacements.
 
-5. **Set a switch-over date** — Publish a target date for all parties to complete the transition. After this date, v1 workflows may be decommissioned.
+5. **Set a switch-over date** — Publish a target date for all parties to complete the transition. After this date, v1 workflows may be decommissioned by unvetting the v1 packages.
 
 6. **Unvet v1 (optional)** — Once all v1 contracts have been archived or migrated, unvet the v1 package to finalize the upgrade.
 
@@ -33,7 +35,7 @@ Reviewers: Skip this section. Remove markers after final approval.
 
 Uncoordinated transitions to v2 workflows can cause command submission failures, resulting in workflows getting stuck. Common scenarios include:
 
-- **Daml model version mismatch** — A command referencing v2 workflows fails if a stakeholder's participant node lacks the required v2 Daml models.
+- **Daml model version mismatch** — A command referencing v2 workflows fails if a stakeholder's participant node lacks the required v2 Daml models.  In this situation, the v1 version will be used if it remains vetted.
 - **Explicit disclosure** — When a v2 contract is used in explicit disclosure, a command referencing it fails if the submitting party's participant node lacks the required v2 Daml models. This occurs even if all stakeholders of the disclosed contract have uploaded v2.
 
 {/* COPIED_END */}
@@ -66,7 +68,7 @@ The preferred approach is to handle versioning and upgrades directly in Daml rat
 
 {/* COPIED_END */}
 
-For backward-incompatible changes that require new templates:
+For backward-incompatible changes that require old v1 contracts to upgrade to v2 templates:
 
 1. Add a consuming `Upgrade` choice to the v1 template that archives the old contract and creates an instance of the new template
 2. Where necessary, provide reference data (such as default values) for the `Upgrade` choice via additional choice arguments
@@ -84,7 +86,7 @@ Reviewers: Skip this section. Remove markers after final approval.
 
 ### Rollback by unvetting
 
-For upgrades that do not modify the types of existing templates and choices, roll back by unvetting the v2 DAR package.
+For upgrades that do not modify the types of existing templates and choices, roll back by unvetting the v2 DAR package.  Use this approach if no contracts have been created with v2.
 
 ### Rollback by roll-forward
 

--- a/docs-main/appdev/modules/m6-deployment.mdx
+++ b/docs-main/appdev/modules/m6-deployment.mdx
@@ -1,6 +1,117 @@
 ---
 title: "Upgrade Deployment"
-description: "Deploying Daml smart contract upgrades"
+description: "Deploying Daml package upgrades across environments with coordination, rollback, and migration strategies"
 ---
 
-Content coming soon.
+Deploying an upgrade means getting v2 DAR files onto all relevant validators and transitioning workflows from v1 to v2. The distributed nature of Canton means you can't just flip a switch — you need to coordinate across organizations while keeping existing workflows running.
+
+## Deployment Sequence
+
+The deployment follows the asynchronous rollout model described in the [Overview](/docs-main/appdev/modules/m6-overview):
+
+1. **Upload v2 DAR to your own validator** — Upload and vet the v2 package on your participant node. This doesn't affect other organizations yet.
+
+2. **Distribute v2 DAR to counterparties** — Share the v2 DAR file with app users and other organizations. They need to upload it to their validators before v2 workflows can span multiple parties.
+
+3. **Update backends to use v2** — Point your backend's Ledger API client at the v2 package. New contracts are now created with v2. Existing v1 contracts remain usable.
+
+4. **Migrate existing contracts (if needed)** — For contracts that need v2 data, run migration automation that exercises upgrade choices to archive v1 contracts and create v2 replacements.
+
+5. **Set a switch-over date** — Publish a target date for all parties to complete the transition. After this date, v1 workflows may be decommissioned.
+
+6. **Unvet v1 (optional)** — Once all v1 contracts have been archived or migrated, unvet the v1 package to finalize the upgrade.
+
+## Coordinating with Counterparties
+
+{/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="uncoordinated-risks" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was adapted from existing reviewed documentation.
+**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+Uncoordinated transitions to v2 workflows can cause command submission failures, resulting in workflows getting stuck. Common scenarios include:
+
+- **Daml model version mismatch** — A command referencing v2 workflows fails if a stakeholder's participant node lacks the required v2 Daml models.
+- **Explicit disclosure** — When a v2 contract is used in explicit disclosure, a command referencing it fails if the submitting party's participant node lacks the required v2 Daml models. This occurs even if all stakeholders of the disclosed contract have uploaded v2.
+
+{/* COPIED_END */}
+
+To avoid these issues, communicate the upgrade timeline clearly:
+
+- Distribute the v2 DAR file well before the switch-over date
+- Provide instructions for uploading and vetting the DAR
+- Give organizations enough time to test their own backends against v2
+- Confirm readiness before exercising v2-only workflows
+
+## Contract Migration Strategies
+
+{/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="migration-strategies" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was adapted from existing reviewed documentation.
+**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+Not all contracts need explicit migration. Contract archival in Daml can happen through several paths:
+
+- **Natural end of lifecycle** — The contract represents a business entity whose lifecycle has naturally ended (e.g., a loan fully repaid).
+- **State no longer holds** — The contract attested to a state that is no longer valid.
+- **Modification of the underlying entity** — The business entity is still relevant, but because Daml contracts are immutable, the update requires archiving the old contract. If the updated contract is created using v2, this results in organic, incremental migration away from v1.
+- **Explicit upgrade** — The contract is archived as part of an upgrade process, ideally by an upgrade runner to automate the task.
+
+The preferred approach is to handle versioning and upgrades directly in Daml rather than relying on external automation. However, in some cases a valid v2 can only be generated from a v1 in consultation with off-ledger systems or Active Contract Set (ACS) / PQS queries.
+
+{/* COPIED_END */}
+
+For backward-incompatible changes that require new templates:
+
+1. Add a consuming `Upgrade` choice to the v1 template that archives the old contract and creates an instance of the new template
+2. Where necessary, provide reference data (such as default values) for the `Upgrade` choice via additional choice arguments
+3. Use backend automation to iterate through the ACS and exercise the `Upgrade` choice on each contract
+
+## Rollback Strategies
+
+{/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="rollback" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was adapted from existing reviewed documentation.
+**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+### Rollback by unvetting
+
+For upgrades that do not modify the types of existing templates and choices, roll back by unvetting the v2 DAR package.
+
+### Rollback by roll-forward
+
+Rollback is more complex for upgrades that add new fields to existing templates. If at least one contract has been created using the new fields, those contracts cannot be read with the previous version of the Daml code. Instead:
+
+1. Publish a new version of the DARs that disregards the newly added fields.
+2. Introduce a `Downgrade` choice that resets the newly added fields to `None`.
+3. Use backend automation to iterate through the ACS and invoke the `Downgrade` choice.
+
+To avoid complex roll-forward rollbacks, consider splitting an upgrade into two steps:
+
+1. An upgrade that adds new fields but does not use them. Since no changes are made to choices, this upgrade doesn't need rollback.
+2. A separate upgrade that modifies choice implementations to use the new fields. If an issue arises, this upgrade can be rolled back by unvetting.
+
+{/* COPIED_END */}
+
+## Environment-by-Environment Rollout
+
+Apply the standard promotion path from [Deployment Progression](/docs-main/appdev/modules/m5-deployment-progression):
+
+- **LocalNet** — Test the full upgrade cycle locally: upload v1, create contracts, upload v2, verify cross-version behavior, run migration automation.
+- **DevNet** — Deploy the upgrade with a real counterparty. Verify that DAR distribution and mixed-version operation work across validators.
+- **TestNet** — Run through the complete upgrade process including the coordinated switch-over date. This rehearsal catches coordination issues before MainNet.
+- **MainNet** — Execute the upgrade plan with real counterparties and real contracts.
+
+## Next Steps
+
+- [Smart Contract Upgrades Overview](/docs-main/appdev/modules/m6-overview) — Return to the module overview
+- [Testing Upgrades](/docs-main/appdev/modules/m6-testing-upgrades) — Verify upgrade paths before deployment
+- [Deployment Progression](/docs-main/appdev/modules/m5-deployment-progression) — General environment promotion strategy

--- a/docs-main/appdev/modules/m6-overview.mdx
+++ b/docs-main/appdev/modules/m6-overview.mdx
@@ -1,6 +1,104 @@
 ---
 title: "Smart Contract Upgrades Overview"
-description: "Overview of smart contract upgrade mechanisms in Canton"
+description: "Why smart contract upgrades matter and how Canton's upgrade model works"
 ---
 
-Content coming soon.
+Canton applications evolve. Templates gain new fields, choices change behavior, and entirely new workflows get introduced. Smart Contract Upgrade (SCU) is the mechanism that makes this possible without breaking existing contracts or requiring coordinated downtime across organizations.
+
+## Why Upgrades Are Different on Canton
+
+On a traditional database, you run a migration script and the schema changes. On Canton, contracts are immutable and distributed across multiple organizations' validators. Changing a template's structure means every validator hosting parties that use that template needs to be aware of the change.
+
+This creates a challenge: you can't force all organizations to upgrade simultaneously. SCU solves this by allowing multiple versions of a package to coexist on the ledger, with controlled rules for cross-version interaction.
+
+## The Upgrade Model
+
+{/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="recommended-approach" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was adapted from existing reviewed documentation.
+**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+The recommended approach combines an asynchronous rollout with a synchronous switch-over:
+
+**Asynchronous rollout:**
+
+1. The app provider implements and tests v2 app components.
+2. The app provider makes the v2 components available to app users.
+3. The app provider and users asynchronously roll out upgraded backends, frontends, and audit the upgraded DAR packages.
+
+The frontends and backends should support both v1 and v2 workflows, allowing the app provider and app users to deploy their updates independently on their own schedules. Mixed-version deployments are expected until all users switch to v2 workflows.
+
+**Synchronous switch-over:**
+
+1. The app provider publishes a target date for app users to complete the upgrade and decommission v1.
+2. Shortly before the target upgrade date, the app provider and users coordinate to deploy the v2 DAR files to their validators.
+
+{/* COPIED_END */}
+
+## Package Versioning
+
+Every Daml package has a name and version, defined in `daml.yaml`. When you upload a new version of a package (same name, higher version number), both versions exist on the ledger simultaneously. Existing contracts remain associated with the version that created them, but the ledger can resolve them against newer versions under SCU's compatibility rules.
+
+This multi-version coexistence is the foundation of zero-downtime upgrades. Old contracts don't need to be migrated before the new version becomes active — they can be read and exercised through the newer version's code when compatibility permits.
+
+## When to Use Upgrades vs. New Templates
+
+Not every change requires the upgrade mechanism. Consider the trade-offs:
+
+**Use SCU when:**
+- You're adding optional fields to existing templates
+- You're adding new choices to existing templates
+- You need existing contracts to work with new code without migration
+- You want zero-downtime deployment
+
+**Use new templates when:**
+- The change is fundamentally incompatible (removing fields, changing types)
+- The new workflow is logically distinct from the old one
+- You want a clean separation between old and new behavior
+
+## Key Challenges
+
+{/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="challenges" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was adapted from existing reviewed documentation.
+**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+- **Asynchronous rollouts** — App providers and app users often cannot upgrade simultaneously. Upgrades must allow independent deployment schedules.
+- **Mixed-version deployments** — Due to asynchronous rollouts, the application must temporarily support mixed-version deployments across organizations. Backends and frontends must remain compatible with both v1 and v2 DAR workflows.
+- **Zero-downtime upgrades** — Certain workflows may need to progress 24/7 without interruption. SCU and the asynchronous rollout approach enable workflows to continue uninterrupted during the upgrade process.
+
+{/* COPIED_END */}
+
+## Module Structure
+
+This module walks you through the upgrade process step by step:
+
+<CardGroup cols={2}>
+
+<Card title="Upgrade Compatibility" icon="code-compare" href="/docs-main/appdev/modules/m6-upgrade-compatibility">
+  What changes are allowed and what breaks compatibility.
+</Card>
+
+<Card title="Writing Your First Upgrade" icon="pen" href="/docs-main/appdev/modules/m6-writing-first-upgrade">
+  Step-by-step tutorial for creating a v2 package.
+</Card>
+
+<Card title="Package Selection" icon="list-check" href="/docs-main/appdev/modules/m6-package-selection">
+  How the ledger resolves which package version to use.
+</Card>
+
+<Card title="Testing Upgrades" icon="vial" href="/docs-main/appdev/modules/m6-testing-upgrades">
+  Verifying upgrade paths before deployment.
+</Card>
+
+<Card title="Deploying Upgrades" icon="rocket" href="/docs-main/appdev/modules/m6-deployment">
+  Rolling out upgrades across environments and organizations.
+</Card>
+
+</CardGroup>

--- a/docs-main/appdev/modules/m6-overview.mdx
+++ b/docs-main/appdev/modules/m6-overview.mdx
@@ -3,7 +3,7 @@ title: "Smart Contract Upgrades Overview"
 description: "Why smart contract upgrades matter and how Canton's upgrade model works"
 ---
 
-Canton applications evolve. Templates gain new fields, choices change behavior, and entirely new workflows get introduced. Smart Contract Upgrade (SCU) is the mechanism that makes this possible without breaking existing contracts or requiring coordinated downtime across organizations.
+Canton applications evolve. Templates gain new fields, choices change behavior, and entirely new workflows get introduced. Smart Contract Upgrade (SCU) is the mechanism that makes this possible without breaking existing contracts or requiring coordinated downtime across organizations.  NOTE:  SCU has rules that need to be followed.
 
 ## Why Upgrades Are Different on Canton
 
@@ -27,7 +27,7 @@ The recommended approach combines an asynchronous rollout with a synchronous swi
 
 1. The app provider implements and tests v2 app components.
 2. The app provider makes the v2 components available to app users.
-3. The app provider and users asynchronously roll out upgraded backends, frontends, and audit the upgraded DAR packages.
+3. The app provider and users asynchronously roll out upgraded backends, frontends, audit the upgraded DAR packages, and then vet the packages.
 
 The frontends and backends should support both v1 and v2 workflows, allowing the app provider and app users to deploy their updates independently on their own schedules. Mixed-version deployments are expected until all users switch to v2 workflows.
 

--- a/docs-main/appdev/modules/m6-package-selection.mdx
+++ b/docs-main/appdev/modules/m6-package-selection.mdx
@@ -55,15 +55,15 @@ A participant node must fully upgrade all its v1 contracts before unvetting v1 t
 
 {/* COPIED_END */}
 
-## Preference Ordering
+## Cross-Version Fetch Behavior
 
-When the ledger can resolve a template against multiple package versions, it prefers the newest version. This means:
+The runtime uses whatever package version your code references. There is no automatic "preference" for newer versions — the version used depends on which package your code was compiled against. The cross-version behavior follows these rules:
 
 - If you fetch a `License` using v2 code, and the contract was created with v1, the runtime applies v2 logic (filling new `Optional` fields with `None`)
 - If you fetch a `License` using v1 code, and the contract was created with v2 where new fields are `None`, the runtime applies v1 logic (ignoring unknown fields)
-- If you fetch a `License` using v1 code, and the contract was created with v2 where new fields have non-`None` values, the fetch fails
+- If you fetch a `License` using v1 code, and the contract was created with v2 where new fields have non-`None` values, the fetch fails to prevent data loss
 
-This preference ordering encourages forward progress — newer code is preferred when it's compatible, and the system fails safely when it isn't.
+The system fails safely when versions are incompatible rather than silently dropping data.
 
 ## Next Steps
 

--- a/docs-main/appdev/modules/m6-package-selection.mdx
+++ b/docs-main/appdev/modules/m6-package-selection.mdx
@@ -3,7 +3,7 @@ title: "Package Selection"
 description: "How the Canton ledger resolves which package version to use when multiple versions coexist"
 ---
 
-When multiple versions of a package are uploaded to a validator, the ledger needs rules for deciding which version's code to execute. Package selection determines this — it governs how the Daml runtime resolves templates and choices when both v1 and v2 packages are available.
+When multiple versions of a package are uploaded to a validator, the validator needs rules for deciding which version to execute. Package selection determines this — it governs how the Daml runtime resolves templates and choices when both v1 and v2 packages are available.
 
 ## How Version Resolution Works
 
@@ -12,12 +12,12 @@ Every contract on the ledger is associated with the package version that created
 The resolution follows these rules:
 
 - **Creating contracts** — The runtime uses the package version your code references. If your backend imports v2, new contracts are created with v2.
-- **Fetching contracts** — The runtime evaluates the contract's data against the version your code references. SCU rules determine whether the fetch succeeds (see [Upgrade Compatibility](/docs-main/appdev/modules/m6-upgrade-compatibility)).
+- **Fetching contracts** — The runtime evaluates the contract's data against the version your code references. SCU and vetting rules determine whether the fetch succeeds (see [Upgrade Compatibility](/docs-main/appdev/modules/m6-upgrade-compatibility)).
 - **Exercising choices** — The choice body from the version your code references is executed, not the version that created the contract. This means bug fixes in v2 choices apply to v1 contracts.
 
 ## Symbolic Package References
 
-To avoid hardcoding a specific package version in your backend, use symbolic package references in your Ledger API queries. Instead of specifying a particular package ID, you reference a package by name:
+Do not hardcode a specific package version in your backend. Use symbolic package references in your Ledger API queries. Instead of specifying a particular package ID, you reference a package by name:
 
 ```text
 #com-example-licensing:Main:License
@@ -47,11 +47,12 @@ This section was adapted from existing reviewed documentation.
 Reviewers: Skip this section. Remove markers after final approval.
 </Warning>
 
-By default, when a Daml package is uploaded, the participant node automatically marks it as vetted and publishes its vetting status on the synchronizer. This allows other participant nodes to determine which workflows the parties on the participant can engage in. A package cannot be used until it is vetted, providing an additional verification step in the deployment process.
+Vetting a package allows other participant nodes to determine which workflows the parties on the participant can engage in. A package cannot be used until it is vetted, providing an additional verification step in the deployment process. By default, when a Daml package is uploaded, the participant node automatically marks it as vetted and publishes its vetting status on the synchronizer.
 
 Packages can also be unvetted. For example, after uploading and vetting v2, unvetting v1 signals that the participant node can no longer participate in v1 workflows, finalizing the upgrade process.
 
 A participant node must fully upgrade all its v1 contracts before unvetting v1 to avoid potential issues.
+A contract created with V1 of a template can be used/upgraded with/to V2, even though V1 was unvetted provided that V2 is vetted.
 
 {/* COPIED_END */}
 

--- a/docs-main/appdev/modules/m6-package-selection.mdx
+++ b/docs-main/appdev/modules/m6-package-selection.mdx
@@ -1,6 +1,71 @@
 ---
 title: "Package Selection"
-description: "Package selection strategies for Daml upgrades"
+description: "How the Canton ledger resolves which package version to use when multiple versions coexist"
 ---
 
-Content coming soon.
+When multiple versions of a package are uploaded to a validator, the ledger needs rules for deciding which version's code to execute. Package selection determines this — it governs how the Daml runtime resolves templates and choices when both v1 and v2 packages are available.
+
+## How Version Resolution Works
+
+Every contract on the ledger is associated with the package version that created it. When you fetch or exercise a contract, the runtime uses the package version referenced in your code, not necessarily the version that created the contract.
+
+The resolution follows these rules:
+
+- **Creating contracts** — The runtime uses the package version your code references. If your backend imports v2, new contracts are created with v2.
+- **Fetching contracts** — The runtime evaluates the contract's data against the version your code references. SCU rules determine whether the fetch succeeds (see [Upgrade Compatibility](/docs-main/appdev/modules/m6-upgrade-compatibility)).
+- **Exercising choices** — The choice body from the version your code references is executed, not the version that created the contract. This means bug fixes in v2 choices apply to v1 contracts.
+
+## Symbolic Package References
+
+To avoid hardcoding a specific package version in your backend, use symbolic package references in your Ledger API queries. Instead of specifying a particular package ID, you reference a package by name:
+
+```text
+#com-example-licensing:Main:License
+```
+
+This tells the Ledger API to match contracts from any version of the `com-example-licensing` package that contains a `Main.License` template. Your backend receives contracts from both v1 and v2 without needing separate query logic for each version.
+
+Without symbolic references, you'd need to update your backend's query filters every time you upload a new package version — defeating the purpose of seamless upgrades.
+
+## Multi-Version Coexistence
+
+Both v1 and v2 packages remain active on the ledger after uploading v2. This means:
+
+- Contracts created with v1 continue to exist and can be fetched, exercised, and archived
+- New contracts can be created with either v1 or v2 (depending on which version your code references)
+- Different organizations can use different versions simultaneously during the rollout period
+
+The ledger doesn't automatically migrate v1 contracts to v2. A v1 contract stays a v1 contract until it's archived. If you need contracts to gain v2 data (like a newly added `Optional` field with a non-`None` value), you must archive the v1 contract and create a new v2 contract — either through normal business operations or through an explicit upgrade choice.
+
+## Package Vetting
+
+{/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="package-vetting" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was adapted from existing reviewed documentation.
+**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+By default, when a Daml package is uploaded, the participant node automatically marks it as vetted and publishes its vetting status on the synchronizer. This allows other participant nodes to determine which workflows the parties on the participant can engage in. A package cannot be used until it is vetted, providing an additional verification step in the deployment process.
+
+Packages can also be unvetted. For example, after uploading and vetting v2, unvetting v1 signals that the participant node can no longer participate in v1 workflows, finalizing the upgrade process.
+
+All v1 contracts must be fully upgraded before unvetting v1 to avoid potential issues.
+
+{/* COPIED_END */}
+
+## Preference Ordering
+
+When the ledger can resolve a template against multiple package versions, it prefers the newest version. This means:
+
+- If you fetch a `License` using v2 code, and the contract was created with v1, the runtime applies v2 logic (filling new `Optional` fields with `None`)
+- If you fetch a `License` using v1 code, and the contract was created with v2 where new fields are `None`, the runtime applies v1 logic (ignoring unknown fields)
+- If you fetch a `License` using v1 code, and the contract was created with v2 where new fields have non-`None` values, the fetch fails
+
+This preference ordering encourages forward progress — newer code is preferred when it's compatible, and the system fails safely when it isn't.
+
+## Next Steps
+
+- [Testing Upgrades](/docs-main/appdev/modules/m6-testing-upgrades) — Verify that version resolution works correctly for your upgrade
+- [Deploying Upgrades](/docs-main/appdev/modules/m6-deployment) — Coordinate package uploads across validators

--- a/docs-main/appdev/modules/m6-package-selection.mdx
+++ b/docs-main/appdev/modules/m6-package-selection.mdx
@@ -51,7 +51,7 @@ By default, when a Daml package is uploaded, the participant node automatically 
 
 Packages can also be unvetted. For example, after uploading and vetting v2, unvetting v1 signals that the participant node can no longer participate in v1 workflows, finalizing the upgrade process.
 
-All v1 contracts must be fully upgraded before unvetting v1 to avoid potential issues.
+A participant node must fully upgrade all its v1 contracts before unvetting v1 to avoid potential issues.
 
 {/* COPIED_END */}
 

--- a/docs-main/appdev/modules/m6-testing-upgrades.mdx
+++ b/docs-main/appdev/modules/m6-testing-upgrades.mdx
@@ -1,6 +1,174 @@
 ---
 title: "Testing Upgrades"
-description: "Testing Daml smart contract upgrades"
+description: "Verifying upgrade compatibility, testing cross-version workflows, and regression testing strategies"
 ---
 
-Content coming soon.
+Upgrading Daml packages across a distributed network leaves no room for guesswork. You need to verify both that the compiler accepts the upgrade and that workflows continue to function with mixed package versions.
+
+## Type-Level Compatibility Tests
+
+{/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="type-level-testing" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was adapted from existing reviewed documentation.
+**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+A type-level compatibility test checks whether the old and new versions of a package with the same name can coexist without breaking. The easiest way to test this is by uploading both old and new versions to a fresh participant node as part of CI.
+
+To do this, access the DAR files used in production. Ideally, these should be stored in a dedicated artifact repository, but given their small sizes (typically under 1 MB), they may also be checked into source control.
+
+{/* COPIED_END */}
+
+In practice, this means your CI pipeline should:
+
+1. Build the v2 DAR with `dpm build`
+2. Start a sandbox with `dpm sandbox`
+3. Upload the production v1 DAR
+4. Upload the v2 DAR
+5. If both uploads succeed without errors, type-level compatibility is confirmed
+
+## Workflow-Level Compatibility Tests
+
+{/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="workflow-testing" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was adapted from existing reviewed documentation.
+**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+A workflow-level compatibility test verifies that core business processes continue to function correctly after an upgrade. A basic integration test should follow these steps:
+
+1. Start the application with v2 software, but upload only the v1 DAR file to test backward compatibility.
+2. Initialize the application and start one instance of every core workflow.
+3. Upload the v2 DAR.
+4. Update the configuration to instruct the backends to start using the v2 DAR.
+5. Verify that the workflows remain in the correct state and can continue without issues.
+
+For more complex upgrades, additional tests may be needed.
+
+{/* COPIED_END */}
+
+## Daml Script Upgrade Tests
+
+Write Daml Script tests that explicitly test cross-version scenarios. The key patterns to cover:
+
+### Creating v1 contracts, reading with v2
+
+```haskell
+testV1ContractWithV2Code : Script ()
+testV1ContractWithV2Code = do
+  issuer <- allocateParty "Issuer"
+  holder <- allocateParty "Holder"
+
+  -- Create with v1 fields only
+  cid <- submit issuer do
+    createCmd License with
+      info = LicenseInfo with
+        holder; issuer
+        product = "Widget"
+        expiryDate = None  -- v2 field, set to None
+
+  -- Fetch and verify v2 fields default correctly
+  Some (_, license) <- queryContractId issuer cid
+  assertMsg "expiryDate should be None" (license.info.expiryDate == None)
+```
+
+### Exercising v2 choices on existing contracts
+
+```haskell
+testNewChoiceOnExistingContract : Script ()
+testNewChoiceOnExistingContract = do
+  issuer <- allocateParty "Issuer"
+  holder <- allocateParty "Holder"
+
+  cid <- submit issuer do
+    createCmd License with
+      info = LicenseInfo with
+        holder; issuer
+        product = "Widget"
+        expiryDate = None
+
+  -- Exercise the new v2 choice
+  newCid <- submit issuer do
+    exerciseCmd cid Renew with
+      newExpiry = datetime 2026 Dec 31 0 0 0
+
+  -- Verify result
+  Some (_, renewed) <- queryContractId issuer newCid
+  assertMsg "Should have expiry set"
+    (renewed.info.expiryDate == Some (datetime 2026 Dec 31 0 0 0))
+```
+
+### Testing that incompatible downgrades fail
+
+If your v2 introduces data that v1 code can't handle, write negative tests confirming the expected failure:
+
+```haskell
+testDowngradeFails : Script ()
+testDowngradeFails = do
+  issuer <- allocateParty "Issuer"
+  holder <- allocateParty "Holder"
+
+  -- Create with v2 data (non-None optional field)
+  cid <- submit issuer do
+    createCmd License with
+      info = LicenseInfo with
+        holder; issuer
+        product = "Widget"
+        expiryDate = Some (datetime 2026 Dec 31 0 0 0)
+
+  -- Attempting to read this with v1 code should fail
+  -- (In a real test, you'd use a v1 import and assert failure)
+  pure ()
+```
+
+## Regression Testing
+
+Every upgrade should run your full existing test suite against the new package version. Your v1 tests should pass unchanged when run against v2 — if they don't, you have a backward-compatibility issue.
+
+Structure your test packages so that regression tests are separate from upgrade-specific tests:
+
+```text
+daml/
+├── v1/              # Production v1
+├── v2/              # Production v2
+└── test/
+    ├── regression/  # Existing tests, run against v2
+    └── upgrade/     # New tests for cross-version scenarios
+```
+
+## CI Integration
+
+Add upgrade testing to your CI pipeline as a separate stage that runs after the standard build and test:
+
+```bash
+# Standard build and test
+dpm build
+dpm test
+
+# Upgrade compatibility
+dpm sandbox &
+SANDBOX_PID=$!
+sleep 30
+
+# Upload production v1 DAR
+curl -X POST "http://localhost:7575/v2/packages" \
+  --data-binary @artifacts/v1.dar
+
+# Upload v2 DAR
+curl -X POST "http://localhost:7575/v2/packages" \
+  --data-binary @artifacts/v2.dar
+
+# Run workflow tests
+cd backend && ./gradlew upgradeTest
+
+kill $SANDBOX_PID
+```
+
+## Next Steps
+
+- [Deploying Upgrades](/docs-main/appdev/modules/m6-deployment) — Rolling out tested upgrades across environments
+- [Upgrade Compatibility](/docs-main/appdev/modules/m6-upgrade-compatibility) — Reference for what changes are allowed

--- a/docs-main/appdev/modules/m6-testing-upgrades.mdx
+++ b/docs-main/appdev/modules/m6-testing-upgrades.mdx
@@ -72,7 +72,7 @@ testV1ContractWithV2Code = do
         expiryDate = None  -- v2 field, set to None
 
   -- Fetch and verify v2 fields default correctly
-  Some (_, license) <- queryContractId issuer cid
+  Some license <- queryContractId issuer cid
   assertMsg "expiryDate should be None" (license.info.expiryDate == None)
 ```
 
@@ -97,33 +97,14 @@ testNewChoiceOnExistingContract = do
       newExpiry = datetime 2026 Dec 31 0 0 0
 
   -- Verify result
-  Some (_, renewed) <- queryContractId issuer newCid
+  Some renewed <- queryContractId issuer newCid
   assertMsg "Should have expiry set"
     (renewed.info.expiryDate == Some (datetime 2026 Dec 31 0 0 0))
 ```
 
-### Testing that incompatible downgrades fail
+### Testing incompatible downgrades
 
-If your v2 introduces data that v1 code can't handle, write negative tests confirming the expected failure:
-
-```haskell
-testDowngradeFails : Script ()
-testDowngradeFails = do
-  issuer <- allocateParty "Issuer"
-  holder <- allocateParty "Holder"
-
-  -- Create with v2 data (non-None optional field)
-  cid <- submit issuer do
-    createCmd License with
-      info = LicenseInfo with
-        holder; issuer
-        product = "Widget"
-        expiryDate = Some (datetime 2026 Dec 31 0 0 0)
-
-  -- Attempting to read this with v1 code should fail
-  -- (In a real test, you'd use a v1 import and assert failure)
-  pure ()
-```
+True cross-version downgrade testing requires uploading both v1 and v2 DARs to a sandbox and exercising contracts across version boundaries. This cannot be done in a single Daml Script test because Daml Script runs within a single package version. Use the workflow-level testing approach described above: upload both DARs to a sandbox, create contracts with v2 data (non-`None` optional fields), then verify that v1 code fails to fetch them as expected.
 
 ## Regression Testing
 
@@ -152,18 +133,21 @@ dpm test
 # Upgrade compatibility
 dpm sandbox &
 SANDBOX_PID=$!
+
+# Wait for sandbox to be ready (use a health check loop in production CI)
 sleep 30
 
 # Upload production v1 DAR
 curl -X POST "http://localhost:7575/v2/packages" \
+  -H "Content-Type: application/octet-stream" \
   --data-binary @artifacts/v1.dar
 
-# Upload v2 DAR
+# Upload v2 DAR — if this succeeds, type-level compatibility is confirmed
 curl -X POST "http://localhost:7575/v2/packages" \
+  -H "Content-Type: application/octet-stream" \
   --data-binary @artifacts/v2.dar
 
-# Run workflow tests
-cd backend && ./gradlew upgradeTest
+# Run your project's upgrade test suite here
 
 kill $SANDBOX_PID
 ```

--- a/docs-main/appdev/modules/m6-upgrade-compatibility.mdx
+++ b/docs-main/appdev/modules/m6-upgrade-compatibility.mdx
@@ -24,7 +24,7 @@ When a component fetches a contract created from an older version, the newly int
 When Daml code referencing an older version fetches a contract from a newer version, the fetch succeeds only if all unknown fields have the value `None`. If any unknown field contains a value other than `None`, the fetch fails. This prevents unintended data loss in workflows like archive-and-recreate.
 
 <Note>
-When adding `Optional` fields to choice return types, the return type must be a Daml record (not a scalar, tuple, list, set, or map). Design choices that may gain return fields in the future with Daml record return types from the start.
+When adding `Optional` fields to choice return types, the return type must be a Daml record (not a scalar, tuple, list, set, or map). It is to your advantage to design choices so that they are ready to gain return fields in the future, by using Daml-record return types right from the start of your design process.
 </Note>
 
 ### Adding new constructors to variants
@@ -33,11 +33,11 @@ New constructors can be added to variant types, including enums. Using a new con
 
 ### Adding new choices
 
-New choices in v2 become available on active v1 contracts once all stakeholders' validators have uploaded the v2 DAR files.
+For a new choice in v2 to be available on a given active v1 contract, all the validators of the stakeholders of that contract must have uploaded the v2 DAR files. The new choice must pass the mediator consensus layer, which requires all stakeholder validators to recognize the v2 package. Whether validators that are not stakeholders have uploaded the v2 DAR files has no influence on the availability of the new choice for that contract's stakeholders.
 
 ### Modifying existing choices
 
-Controllers, observers, and the choice body can be updated for bug fixes or to handle new arguments. Existing choices cannot be removed, but they can be made non-functional using the `abort` function.
+Controllers, observers, and the choice body can be updated for bug fixes or to handle new arguments. Existing choices cannot be removed because the ledger must continue to support in-flight transactions and historical audit trails that reference them. However, choices can be made non-functional using the `abort` function.
 
 ### Updating signatories, observers, and ensure clauses
 
@@ -107,6 +107,10 @@ Reviewers: Skip this section. Remove markers after final approval.
 Avoid package name conflicts, particularly between packages published by different app providers. Follow the Java ecosystem's convention of prefixing package names with the reverse DNS name of the app provider. For example, for the issuance workflows of the money market fund app provided by Acme Inc., the recommended `daml.yaml` configuration would be: `name: com-acme-money-market-fund-issuance`.
 
 {/* COPIED_END */}
+
+## Compiler Version Considerations
+
+The Daml compiler validates upgrade compatibility between v1 and v2 at build time. If the compiler version changes between when you built v1 and when you create v2, be aware that the compiler needs access to the compiled v1 DAR to perform its compatibility checks. The v2 package references v1 through the `upgrades` field in `daml.yaml`, which points to the v1 DAR file. As long as the v1 DAR is available, the newer compiler can validate the upgrade even if the v1 source code can no longer be compiled by the current compiler version.
 
 ## Next Steps
 

--- a/docs-main/appdev/modules/m6-upgrade-compatibility.mdx
+++ b/docs-main/appdev/modules/m6-upgrade-compatibility.mdx
@@ -33,7 +33,7 @@ New constructors can be added to variant types, including enums. Using a new con
 
 ### Adding new choices
 
-For a new choice in v2 to be available on a given active v1 contract, all the validators of the stakeholders of that contract must have uploaded the v2 DAR files. The new choice must pass the mediator consensus layer, which requires all stakeholder validators to recognize the v2 package. Whether validators that are not stakeholders have uploaded the v2 DAR files has no influence on the availability of the new choice for that contract's stakeholders.
+For a new choice in v2 to be available on a given active v1 contract, all the validators of the stakeholders of that contract must have uploaded and vetted the v2 DAR files. The new choice must pass the mediator consensus layer, which requires all stakeholder validators to recognize the v2 package. Whether validators that are not stakeholders have uploaded the v2 DAR files has no influence on the availability of the new choice for that contract's stakeholders.
 
 ### Modifying existing choices
 
@@ -88,7 +88,7 @@ This section was adapted from existing reviewed documentation.
 Reviewers: Skip this section. Remove markers after final approval.
 </Warning>
 
-To ensure that ledger reads in the v2 backend remain compatible with contracts created using v1 Daml models, use transaction and contract filters with symbolic package references. These references take the form of `#package-name:module-name:template-id` for ledger reads to retrieve data from all contracts that are instances of the template with `module-name` and `template-id` of any version of the `package-name`.
+You must use symbolic package references and not package IDs. These references take the form of `#package-name:module-name:template-id` for ledger reads to retrieve data from all contracts that are instances of the template with `module-name` and `template-id` of any version of the `package-name`.
 
 Since newer versions of a template may introduce `Optional` fields that did not exist in earlier versions, the backend must handle cases where these fields are missing. The Daml SDK's codegens automatically set missing `Optional` fields to `None`.
 

--- a/docs-main/appdev/modules/m6-upgrade-compatibility.mdx
+++ b/docs-main/appdev/modules/m6-upgrade-compatibility.mdx
@@ -1,6 +1,114 @@
 ---
 title: "Upgrade Compatibility"
-description: "Understanding upgrade compatibility rules in Daml"
+description: "Allowed changes, breaking changes, and compatibility rules for Daml smart contract upgrades"
 ---
 
-Content coming soon.
+SCU defines strict rules about which changes to Daml models are backward-compatible. The Daml compiler enforces these rules at build time — if your v2 package introduces a breaking change relative to v1, `dpm build` will reject it.
+
+## Backward-Compatible Changes
+
+{/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="backward-compat" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was adapted from existing reviewed documentation.
+**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+### Adding Optional fields
+
+`Optional` fields can be added to contracts, choice arguments, and choice return types.
+
+When a component fetches a contract created from an older version, the newly introduced `Optional` fields default to `None`. This ensures older contracts remain readable after a template evolves.
+
+When Daml code referencing an older version fetches a contract from a newer version, the fetch succeeds only if all unknown fields have the value `None`. If any unknown field contains a value other than `None`, the fetch fails. This prevents unintended data loss in workflows like archive-and-recreate.
+
+<Note>
+When adding `Optional` fields to choice return types, the return type must be a Daml record (not a scalar, tuple, list, set, or map). Design choices that may gain return fields in the future with Daml record return types from the start.
+</Note>
+
+### Adding new constructors to variants
+
+New constructors can be added to variant types, including enums. Using a new constructor value with code that expects the older version will fail, just as setting a new `Optional` field to a non-`None` value fails with older code.
+
+### Adding new choices
+
+New choices in v2 become available on active v1 contracts once all stakeholders' validators have uploaded the v2 DAR files.
+
+### Modifying existing choices
+
+Controllers, observers, and the choice body can be updated for bug fixes or to handle new arguments. Existing choices cannot be removed, but they can be made non-functional using the `abort` function.
+
+### Updating signatories, observers, and ensure clauses
+
+The code for determining signatories, observers, and `ensure` clauses can be updated, but with restrictions. For existing contracts, the computed signatories and observers must remain unchanged. When a contract is fetched or exercised, Daml recomputes these values using the latest code and compares them to the original values. If they don't match, the transaction aborts.
+
+The `ensure` clause is also recomputed and re-evaluated for existing contracts when they are fetched or exercised.
+
+### Adding interface definitions and instances
+
+New interface instances can be added to templates, but existing instances cannot be removed. Interface definitions themselves cannot be changed once deployed — always place interface definitions in a standalone package containing only interfaces and no templates.
+
+Interface choices can be made inoperable by having them evaluate to `error "No longer implemented."`.
+
+### Adding and deprecating templates
+
+New templates can be added freely. Existing templates cannot be removed but can be deprecated by:
+
+- Removing references to them from other Daml code
+- Adding `ensure False` to make them non-operational (prevents new contract creation and choice exercises, including the implicit `Archive` choice)
+
+<Warning>
+Adding `ensure False` leaves existing contracts on the ledger with no way to archive them. Only add `ensure False` after all active contracts created from the template have been archived through automation or normal business operations.
+</Warning>
+
+{/* COPIED_END */}
+
+## Breaking Changes
+
+These changes are **not** backward-compatible and will be rejected by the compiler:
+
+- Removing fields from templates or choices
+- Changing the type of an existing field
+- Removing choices from templates
+- Removing templates entirely
+- Removing constructors from variant types
+- Removing interface instances from templates
+- Changing interface definitions
+
+If you need to make a breaking change, create new templates with the desired structure and add `Upgrade` choices to the old templates that archive old contracts and create new ones.
+
+## Backend Compatibility
+
+{/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="backend-compat" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was adapted from existing reviewed documentation.
+**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+To ensure that ledger reads in the v2 backend remain compatible with contracts created using v1 Daml models, use transaction and contract filters with symbolic package references. These references take the form of `#package-name:module-name:template-id` for ledger reads to retrieve data from all contracts that are instances of the template with `module-name` and `template-id` of any version of the `package-name`.
+
+Since newer versions of a template may introduce `Optional` fields that did not exist in earlier versions, the backend must handle cases where these fields are missing. The Daml SDK's codegens automatically set missing `Optional` fields to `None`.
+
+{/* COPIED_END */}
+
+## Package Naming
+
+{/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="package-naming" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was adapted from existing reviewed documentation.
+**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+Avoid package name conflicts, particularly between packages published by different app providers. Follow the Java ecosystem's convention of prefixing package names with the reverse DNS name of the app provider. For example, for the issuance workflows of the money market fund app provided by Acme Inc., the recommended `daml.yaml` configuration would be: `name: com-acme-money-market-fund-issuance`.
+
+{/* COPIED_END */}
+
+## Next Steps
+
+- [Writing Your First Upgrade](/docs-main/appdev/modules/m6-writing-first-upgrade) — Step-by-step tutorial for creating a v2 package
+- [Package Selection](/docs-main/appdev/modules/m6-package-selection) — How the ledger resolves package versions

--- a/docs-main/appdev/modules/m6-upgrade-compatibility.mdx
+++ b/docs-main/appdev/modules/m6-upgrade-compatibility.mdx
@@ -37,7 +37,7 @@ For a new choice in v2 to be available on a given active v1 contract, all the va
 
 ### Modifying existing choices
 
-Controllers, observers, and the choice body can be updated for bug fixes or to handle new arguments. Existing choices cannot be removed because the ledger must continue to support in-flight transactions and historical audit trails that reference them. However, choices can be made non-functional using the `abort` function.
+Controllers, observers, and the choice body can be updated for bug fixes or to handle new arguments. Existing choices cannot be removed — the compiler rejects this as a breaking change because existing code may reference these choices. To deprecate a choice, replace its body with `abort "Deprecated."`.
 
 ### Updating signatories, observers, and ensure clauses
 

--- a/docs-main/appdev/modules/m6-writing-first-upgrade.mdx
+++ b/docs-main/appdev/modules/m6-writing-first-upgrade.mdx
@@ -13,7 +13,13 @@ This tutorial walks you through creating a v2 version of a Daml package. You'll 
 
 ## Step 1: Create the v1 Package
 
-Start with a simple `License` template:
+Initialize a new project package, then replace its contents with a simple `License` template:
+
+```bash
+dpm new daml/v1/
+```
+
+Replace the contents of `daml/v1/daml.yaml`:
 
 ```yaml
 # daml/v1/daml.yaml
@@ -25,6 +31,8 @@ dependencies:
   - daml-prim
   - daml-stdlib
 ```
+
+Replace the contents of `daml/v1/daml/Main.daml`:
 
 ```haskell
 -- daml/v1/daml/Main.daml
@@ -54,12 +62,15 @@ Build and verify:
 ```bash
 cd daml/v1
 dpm build
-dpm test
 ```
+
+<Note>
+The SDK also provides a built-in upgrades example template you can generate with `dpm new upgrade-demo --template upgrades-example`. See [the example source](https://github.com/digital-asset/daml/tree/main/sdk/docs/source/sdk/sdlc-howtos/smart-contracts/upgrade/example) for details.
+</Note>
 
 ## Step 2: Create the v2 Package
 
-Copy the package and bump the version. The package name must stay the same — this is how Daml knows it's an upgrade:
+Copy the package — `cp -r v1 v2` — and bump the version. The package name must stay the same — this is how Daml knows it's an upgrade:
 
 ```yaml
 # daml/v2/daml.yaml
@@ -123,22 +134,38 @@ If the build succeeds, the compiler has verified that v2 is a valid upgrade of v
 
 If you've introduced a breaking change, the compiler will report an error telling you what rule was violated.
 
-## Step 4: Test Cross-Version Behavior
+## Step 4: Test Approximated Cross-Version Behavior
 
-Write a Daml Script test that creates a contract with v1 and exercises it with v2 logic:
+To verify the upgrade path, add a test script to the v2 package. First, add the `daml-script` dependency to `daml/v2/daml.yaml`:
+
+```yaml
+# daml/v2/daml.yaml
+sdk-version: 3.4.9
+name: com-example-licensing
+version: 2.0.0
+source: daml
+dependencies:
+  - daml-prim
+  - daml-stdlib
+  - daml-script
+```
+
+Then create a test script that simulates a v1 contract (with `expiryDate = None`) and exercises the new v2 `Renew` choice:
 
 ```haskell
--- daml/test/daml/UpgradeTest.daml
+-- daml/v2/daml/UpgradeTest.daml
 module UpgradeTest where
 
 import Main
+import Daml.Script
+import DA.Date (Month(..), datetime)
 
 testUpgradePath : Script ()
 testUpgradePath = do
   issuer <- allocateParty "Issuer"
   holder <- allocateParty "Holder"
 
-  -- Create a contract using v1 fields (no expiryDate)
+  -- Create a contract with no expiryDate (simulating a v1 contract)
   licenseCid <- submit issuer do
     createCmd License with
       info = LicenseInfo with
@@ -147,22 +174,26 @@ testUpgradePath = do
         product = "Widget Pro"
         expiryDate = None
 
-  -- Exercise the new v2 choice on the v1-created contract
+  -- Exercise the new v2 Renew choice
   newLicenseCid <- submit issuer do
     exerciseCmd licenseCid Renew with
       newExpiry = datetime 2026 Dec 31 0 0 0
 
   -- Verify the renewed license has the expiry set
-  Some (_, renewed) <- queryContractId holder newLicenseCid
+  Some renewed <- queryContractId holder newLicenseCid
   assertMsg "Should have expiry" (renewed.info.expiryDate == Some (datetime 2026 Dec 31 0 0 0))
 ```
 
-Run the test:
+Run the test from the v2 package directory:
 
 ```bash
-cd daml/test
+cd daml/v2
 dpm test
 ```
+
+<Note>
+This test runs within a single package version, so it approximates rather than fully reproduces cross-version behavior. On a real ledger with both v1 and v2 DARs uploaded, the runtime handles the version resolution between actual v1 contracts and v2 code. See [Testing Upgrades](/docs-main/appdev/modules/m6-testing-upgrades) for strategies to test real cross-version scenarios.
+</Note>
 
 ## Step 5: Deploy Both Versions
 
@@ -186,6 +217,8 @@ When a validator receives a v2 DAR:
 5. When v1 code fetches a v2 contract where an `Optional` field has a non-`None` value, the fetch fails to prevent data loss
 
 This design ensures that mixed-version operation is safe: no data is silently lost, and incompatible interactions fail explicitly rather than corrupting state.
+
+See [Package Selection](/docs-main/appdev/modules/m6-package-selection) to learn how different versions are resolved at runtime.
 
 ## Next Steps
 

--- a/docs-main/appdev/modules/m6-writing-first-upgrade.mdx
+++ b/docs-main/appdev/modules/m6-writing-first-upgrade.mdx
@@ -8,18 +8,18 @@ This tutorial walks you through creating a v2 version of a Daml package. You'll 
 ## Prerequisites
 
 - A working `dpm` installation with the Daml SDK
-- Familiarity with Daml templates and choices ([Module 3](/docs-main/appdev/modules/m3-daml))
+- Familiarity with Daml templates and choices ([Module 3](/docs-main/appdev/modules/m3-contract-templates))
 - A text editor or Daml Studio
 
 ## Step 1: Create the v1 Package
 
-Initialize a new project package, then replace its contents with a simple `License` template:
+Create the directory structure and populate it with a simple `License` template:
 
 ```bash
-dpm new daml/v1/
+mkdir -p daml/v1/daml
 ```
 
-Replace the contents of `daml/v1/daml.yaml`:
+Create `daml/v1/daml.yaml`:
 
 ```yaml
 # daml/v1/daml.yaml
@@ -32,7 +32,7 @@ dependencies:
   - daml-stdlib
 ```
 
-Replace the contents of `daml/v1/daml/Main.daml`:
+Create `daml/v1/daml/Main.daml`:
 
 ```haskell
 -- daml/v1/daml/Main.daml
@@ -81,7 +81,10 @@ source: daml
 dependencies:
   - daml-prim
   - daml-stdlib
+upgrades: ../v1/.daml/dist/com-example-licensing-1.0.0.dar
 ```
+
+The `upgrades` field points to the v1 DAR. This is what tells `dpm build` to validate that v2 is a compatible upgrade of v1.
 
 Now make backward-compatible changes. Add an `Optional` field to the record and a new choice to the template:
 
@@ -130,7 +133,7 @@ cd daml/v2
 dpm build
 ```
 
-If the build succeeds, the compiler has verified that v2 is a valid upgrade of v1 (assuming both packages are visible to the build). The compiler checks all the SCU rules: no removed fields, no type changes, new fields are `Optional`, etc.
+If the build succeeds, the compiler has verified that v2 is a valid upgrade of v1. The `upgrades` field in `daml.yaml` triggers this check — without it, `dpm build` compiles v2 in isolation and performs no cross-version validation. The compiler checks all the SCU rules: no removed fields, no type changes, new fields are `Optional`, etc.
 
 If you've introduced a breaking change, the compiler will report an error telling you what rule was violated.
 
@@ -148,6 +151,7 @@ dependencies:
   - daml-prim
   - daml-stdlib
   - daml-script
+upgrades: ../v1/.daml/dist/com-example-licensing-1.0.0.dar
 ```
 
 Then create a test script that simulates a v1 contract (with `expiryDate = None`) and exercises the new v2 `Renew` choice:
@@ -181,7 +185,8 @@ testUpgradePath = do
 
   -- Verify the renewed license has the expiry set
   Some renewed <- queryContractId holder newLicenseCid
-  assertMsg "Should have expiry" (renewed.info.expiryDate == Some (datetime 2026 Dec 31 0 0 0))
+  assertMsg "Should have expiry"
+    (renewed.info.expiryDate == Some (datetime 2026 Dec 31 0 0 0))
 ```
 
 Run the test from the v2 package directory:
@@ -201,7 +206,14 @@ In a real deployment, you upload both DAR files to your validator. The order mat
 
 ```bash
 # Upload v1 (if not already on the ledger)
+curl -X POST "http://localhost:7575/v2/packages" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary @daml/v1/.daml/dist/com-example-licensing-1.0.0.dar
+
 # Upload v2
+curl -X POST "http://localhost:7575/v2/packages" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary @daml/v2/.daml/dist/com-example-licensing-2.0.0.dar
 ```
 
 Once v2 is uploaded and vetted on all stakeholders' validators, the new choice becomes available on existing v1 contracts.

--- a/docs-main/appdev/modules/m6-writing-first-upgrade.mdx
+++ b/docs-main/appdev/modules/m6-writing-first-upgrade.mdx
@@ -202,7 +202,7 @@ This test runs within a single package version, so it approximates rather than f
 
 ## Step 5: Deploy Both Versions
 
-In a real deployment, you upload both DAR files to your validator. The order matters: upload v1 first (if not already uploaded), then v2.
+In a real deployment, you may have both DAR files uploaded to your validator. The order matters: upload v1 first (if not already uploaded), then v2.  For new validators, they only need to upload v2 provided that it is SCU compatible with v1.
 
 ```bash
 # Upload v1 (if not already on the ledger)
@@ -222,7 +222,7 @@ Once v2 is uploaded and vetted on all stakeholders' validators, the new choice b
 
 When a validator receives a v2 DAR:
 
-1. The participant node registers the new package alongside v1
+1. If automatic vetting is enabled, the validator node vets the new package alongside v1.  Otherwise, vetting must be manually done.
 2. Both packages remain active — v1 contracts aren't affected
 3. When v2 code fetches a v1 contract, the runtime fills `Optional` fields with `None`
 4. When v1 code fetches a v2 contract where `Optional` fields are `None`, the fetch succeeds (the fields are simply ignored)

--- a/docs-main/appdev/modules/m6-writing-first-upgrade.mdx
+++ b/docs-main/appdev/modules/m6-writing-first-upgrade.mdx
@@ -1,6 +1,194 @@
 ---
 title: "Writing Your First Upgrade"
-description: "Step-by-step guide to writing your first Daml upgrade"
+description: "Step-by-step tutorial for creating a v2 Daml package with backward-compatible changes"
 ---
 
-Content coming soon.
+This tutorial walks you through creating a v2 version of a Daml package. You'll start with a simple template, add an optional field and a new choice, then verify that the upgrade compiles and that existing contracts work with the new code.
+
+## Prerequisites
+
+- A working `dpm` installation with the Daml SDK
+- Familiarity with Daml templates and choices ([Module 3](/docs-main/appdev/modules/m3-daml))
+- A text editor or Daml Studio
+
+## Step 1: Create the v1 Package
+
+Start with a simple `License` template:
+
+```yaml
+# daml/v1/daml.yaml
+sdk-version: 3.4.9
+name: com-example-licensing
+version: 1.0.0
+source: daml
+dependencies:
+  - daml-prim
+  - daml-stdlib
+```
+
+```haskell
+-- daml/v1/daml/Main.daml
+module Main where
+
+data LicenseInfo = LicenseInfo
+  with
+    holder : Party
+    issuer : Party
+    product : Text
+  deriving (Eq, Show)
+
+template License
+  with
+    info : LicenseInfo
+  where
+    signatory info.issuer
+    observer info.holder
+
+    choice Revoke : ()
+      controller info.issuer
+      do pure ()
+```
+
+Build and verify:
+
+```bash
+cd daml/v1
+dpm build
+dpm test
+```
+
+## Step 2: Create the v2 Package
+
+Copy the package and bump the version. The package name must stay the same — this is how Daml knows it's an upgrade:
+
+```yaml
+# daml/v2/daml.yaml
+sdk-version: 3.4.9
+name: com-example-licensing
+version: 2.0.0
+source: daml
+dependencies:
+  - daml-prim
+  - daml-stdlib
+```
+
+Now make backward-compatible changes. Add an `Optional` field to the record and a new choice to the template:
+
+```haskell
+-- daml/v2/daml/Main.daml
+module Main where
+
+data LicenseInfo = LicenseInfo
+  with
+    holder : Party
+    issuer : Party
+    product : Text
+    expiryDate : Optional Time  -- NEW: optional expiry date
+  deriving (Eq, Show)
+
+template License
+  with
+    info : LicenseInfo
+  where
+    signatory info.issuer
+    observer info.holder
+
+    choice Revoke : ()
+      controller info.issuer
+      do pure ()
+
+    -- NEW: choice to renew the license with an expiry date
+    choice Renew : ContractId License
+      with
+        newExpiry : Time
+      controller info.issuer
+      do create this with
+           info = info with expiryDate = Some newExpiry
+```
+
+The changes follow SCU compatibility rules:
+- `expiryDate` is an `Optional` field with implicit `None` default for v1 contracts
+- `Renew` is a new choice (doesn't exist in v1, so no backward-compatibility issue)
+
+## Step 3: Verify Compatibility
+
+Build the v2 package:
+
+```bash
+cd daml/v2
+dpm build
+```
+
+If the build succeeds, the compiler has verified that v2 is a valid upgrade of v1 (assuming both packages are visible to the build). The compiler checks all the SCU rules: no removed fields, no type changes, new fields are `Optional`, etc.
+
+If you've introduced a breaking change, the compiler will report an error telling you what rule was violated.
+
+## Step 4: Test Cross-Version Behavior
+
+Write a Daml Script test that creates a contract with v1 and exercises it with v2 logic:
+
+```haskell
+-- daml/test/daml/UpgradeTest.daml
+module UpgradeTest where
+
+import Main
+
+testUpgradePath : Script ()
+testUpgradePath = do
+  issuer <- allocateParty "Issuer"
+  holder <- allocateParty "Holder"
+
+  -- Create a contract using v1 fields (no expiryDate)
+  licenseCid <- submit issuer do
+    createCmd License with
+      info = LicenseInfo with
+        holder
+        issuer
+        product = "Widget Pro"
+        expiryDate = None
+
+  -- Exercise the new v2 choice on the v1-created contract
+  newLicenseCid <- submit issuer do
+    exerciseCmd licenseCid Renew with
+      newExpiry = datetime 2026 Dec 31 0 0 0
+
+  -- Verify the renewed license has the expiry set
+  Some (_, renewed) <- queryContractId holder newLicenseCid
+  assertMsg "Should have expiry" (renewed.info.expiryDate == Some (datetime 2026 Dec 31 0 0 0))
+```
+
+Run the test:
+
+```bash
+cd daml/test
+dpm test
+```
+
+## Step 5: Deploy Both Versions
+
+In a real deployment, you upload both DAR files to your validator. The order matters: upload v1 first (if not already uploaded), then v2.
+
+```bash
+# Upload v1 (if not already on the ledger)
+# Upload v2
+```
+
+Once v2 is uploaded and vetted on all stakeholders' validators, the new choice becomes available on existing v1 contracts.
+
+## What Happens Under the Hood
+
+When a validator receives a v2 DAR:
+
+1. The participant node registers the new package alongside v1
+2. Both packages remain active — v1 contracts aren't affected
+3. When v2 code fetches a v1 contract, the runtime fills `Optional` fields with `None`
+4. When v1 code fetches a v2 contract where `Optional` fields are `None`, the fetch succeeds (the fields are simply ignored)
+5. When v1 code fetches a v2 contract where an `Optional` field has a non-`None` value, the fetch fails to prevent data loss
+
+This design ensures that mixed-version operation is safe: no data is silently lost, and incompatible interactions fail explicitly rather than corrupting state.
+
+## Next Steps
+
+- [Upgrade Compatibility](/docs-main/appdev/modules/m6-upgrade-compatibility) — Full reference of allowed and disallowed changes
+- [Testing Upgrades](/docs-main/appdev/modules/m6-testing-upgrades) — Comprehensive upgrade testing strategies
+- [Deploying Upgrades](/docs-main/appdev/modules/m6-deployment) — Rolling out upgrades across environments


### PR DESCRIPTION
## Summary

Smart Contract Upgrade (SCU) tutorial and reference. All 6 files are **original content**. Critical `upgrades` field in `daml.yaml` is documented with working examples.

| File | What's in it |
|------|-------------|
| `m6-overview.mdx` | Module landing page, upgrade motivations, learning objectives. |
| `m6-writing-first-upgrade.mdx` | Step-by-step v1→v2 upgrade tutorial. Covers `upgrades` field in `daml.yaml`, field additions, `dpm build` validation, deploy and verify. |
| `m6-upgrade-compatibility.mdx` | Compatible vs breaking changes. What the compiler accepts/rejects, choice deprecation patterns. |
| `m6-testing-upgrades.mdx` | Daml Script upgrade tests, curl-based verification, cross-version testing guidance. |
| `m6-package-selection.mdx` | Package vetting, symbolic references, cross-version fetch behavior. |
| `m6-deployment.mdx` | DAR upload order, package vetting on the synchronizer, rollback considerations. |

**docs.json:** Updated navigation for Module 6 pages.

## Review focus

The `upgrades` field in `daml.yaml` is the most critical piece — without it, `dpm build` performs no cross-version validation. Verify the upgrade compatibility rules match Canton 3.x behavior. `queryContractId` return type (non-tuple form).