### PR TITLE
Week 11 - AppDev: Reference Pages

### DIFF
--- a/docs-main/appdev/reference/configuration-reference.mdx
+++ b/docs-main/appdev/reference/configuration-reference.mdx
@@ -1,6 +1,312 @@
 ---
 title: "Configuration Reference"
-description: "Configuration reference for Canton applications"
+description: "Reference for Canton configuration files, DPM project settings, storage, command line arguments, and environment variables"
 ---
 
-Content coming soon.
+Canton uses [HOCON](https://github.com/lightbend/config/blob/master/HOCON.md) (Human-Optimized Config Object Notation) for its static configuration files. Static configuration covers settings that must be known at process startup, such as storage backends, API ports, and node identities. Dynamic settings like party registration and synchronizer connections are managed at runtime through the [console](/docs-main/global-synchronizer/reference/canton-console-reference) or administration APIs.
+
+## HOCON Format Basics
+
+{/* COPIED_START - source: conf_file.rst */}
+Canton configuration files are written in HOCON format with some extensions:
+
+- Durations use a `<length><unit>` format. Valid units are `ms`, `s`, `m`, `h`, `d` (milliseconds, seconds, minutes, hours, days). Durations must be non-negative.
+{/* COPIED_END */}
+
+HOCON supports JSON-like object syntax with relaxed quoting, nested key paths (`a.b.c = value`), and `//` or `#` comments. Repeated keys are merged, with the last definition winning.
+
+### File Includes
+
+{/* COPIED_START - source: conf_file.rst */}
+Configuration files can be nested and combined together using the `include required` directive:
+
+```hocon
+canton {
+    synchronizers {
+        include required(file("synchronizer1.conf"))
+    }
+}
+```
+
+The `required` keyword triggers an error if the included file does not exist; without it, missing files are silently ignored. The `file` keyword instructs the parser to interpret its argument as a file name rather than a URL or classpath resource.
+{/* COPIED_END */}
+
+### Environment Variable Substitution
+
+HOCON substitutes environment variables using `${VAR_NAME}` syntax. Two forms are available:
+
+- `${VAR_NAME}` -- required. The process fails to start if the variable is not set.
+- `${?VAR_NAME}` -- optional. The key is only set when the variable exists.
+
+```hocon
+properties = {
+    serverName = "localhost"
+    serverName = ${?POSTGRES_HOST}  # overrides only if POSTGRES_HOST is set
+    user = ${POSTGRES_USER}          # required, fails if unset
+    password = ${POSTGRES_PASSWORD}  # required, fails if unset
+}
+```
+
+<Warning>
+Never hardcode credentials in configuration files. Use environment variable substitution for passwords and other secrets.
+</Warning>
+
+## Canton Configuration Structure
+
+{/* COPIED_START - source: conf_file.rst */}
+Canton can run any number of nodes in the same process. The root configuration defines instances of sequencers, mediators, and participant nodes together with general process parameters.
+
+```hocon
+canton {
+  sequencers {
+    sequencer1 {
+      storage.type = memory
+      public-api.port = 5001
+      admin-api.port = 5002
+      sequencer.type = BFT
+    }
+  }
+
+  mediators {
+    mediator1 {
+      storage.type = memory
+      admin-api.port = 5202
+    }
+  }
+
+  participants {
+    participant1 {
+      storage.type = memory
+      admin-api.port = 5012
+      ledger-api.port = 5011
+      http-ledger-api.port = 5013
+    }
+    participant2 {
+      storage.type = memory
+      admin-api.port = 5022
+      ledger-api.port = 5021
+      http-ledger-api.port = 5023
+    }
+  }
+}
+```
+{/* COPIED_END */}
+
+CamelCase Scala names map to lowercase-with-dashes in config files (e.g., `synchronizerParameters` becomes `synchronizer-parameters`).
+
+### Init Configuration
+
+Some values apply only during the first initialization of a node and cannot be changed afterward. These live under the `init` section:
+
+```hocon
+participant1 {
+  init {
+    ledger-api.max-deduplication-duration = 1 minute
+    identity.node-identifier.type = random
+  }
+}
+```
+
+## Command Line Arguments
+
+{/* COPIED_START - source: command_line.rst */}
+Canton requires at least one configuration file. Provide configuration files with `-c` or `--config`:
+
+```bash
+bin/canton --config conf_filename -c conf_filename2
+```
+
+This merges `conf_filename2` into `conf_filename`. If several files assign values to the same key, the last value wins.
+
+You can also override individual parameters on the command line using `-C`:
+
+```bash
+bin/canton --config conf_filename -C canton.participants.participant1.storage.type=memory
+```
+{/* COPIED_END */}
+
+### Run Modes
+
+{/* COPIED_START - source: command_line.rst */}
+- **Interactive console** (default) -- starts a REPL for operating and inspecting the Canton process. Useful for development and expert use.
+- **Daemon** -- `bin/canton daemon --config ...` starts Canton without a console. For server deployments. Administer with a remote console.
+- **Sandbox** -- `bin/canton sandbox --dar Main.dar` runs a lightweight ledger for local development.
+- **Headless script** -- `bin/canton run <script-path> --config ...` executes a script then exits. Useful for testing and CI.
+{/* COPIED_END */}
+
+### JVM Arguments
+
+{/* COPIED_START - source: command_line.rst */}
+The `bin/canton` wrapper supports additional JVM options through the `JAVA_OPTS` environment variable or the `-D` flag:
+
+```bash
+JAVA_OPTS="-Xmx2G" ./bin/canton --config ...
+```
+{/* COPIED_END */}
+
+## Storage Configuration
+
+Canton supports three storage backends:
+
+- **Memory** -- for quick tests; data is lost on restart
+- **H2** -- embedded database, suitable for local development
+- **PostgreSQL** -- the only supported option for production
+
+### PostgreSQL Example
+
+{/* COPIED_START - source: postgres.rst */}
+```hocon
+canton {
+  participants.participant1.storage {
+    type = postgres
+    config {
+      dataSourceClassName = "org.postgresql.ds.PGSimpleDataSource"
+      properties = {
+        serverName = "localhost"
+        databaseName = "participant1_db"
+        portNumber = "5432"
+        user = "participant1"
+        password = "pgpass"
+      }
+    }
+  }
+}
+```
+{/* COPIED_END */}
+
+Each Canton node requires its own database. Create databases with UTF-8 encoding:
+
+```sql
+CREATE DATABASE participant1_db ENCODING = 'UTF8';
+CREATE USER participant1_user WITH PASSWORD 'change-me';
+GRANT ALL PRIVILEGES ON DATABASE participant1_db TO participant1_user;
+```
+
+Canton uses [HikariCP](https://github.com/brettwooldridge/HikariCP) for connection pooling. You can tune pool properties (`maximumPoolSize`, `connectionTimeout`, `idleTimeout`, etc.) under `storage.config`.
+
+### Configuration Mixin Pattern
+
+When running multiple nodes against the same database server, define shared storage settings in a mixin and reference them per node:
+
+{/* COPIED_START - source: conf_file.rst */}
+```hocon
+_shared {
+    storage {
+        type = postgres
+        config {
+            dataSourceClass = "org.postgresql.ds.PGSimpleDataSource"
+            properties = {
+                serverName = "localhost"
+                serverName = ${?POSTGRES_HOST}
+                portNumber = "5432"
+                portNumber = ${?POSTGRES_PORT}
+                user = ${POSTGRES_USER}
+                password = ${POSTGRES_PASSWORD}
+            }
+        }
+        parameters {
+            max-connections = ${?POSTGRES_NUM_CONNECTIONS}
+            migrate-and-start = false
+            fail-fast-on-startup = true
+        }
+    }
+}
+
+canton {
+    participants {
+        participant1 {
+            storage = ${_shared.storage}
+            storage.config.properties.databaseName = "participant1_db"
+        }
+    }
+}
+```
+{/* COPIED_END */}
+
+## Key Parameters
+
+### Fail-Fast Mode
+
+{/* COPIED_START - source: conf_file.rst */}
+By default, Canton fails to start if it cannot access an external dependency such as the database. This is preferable during development, but can cause problems in production when services start in parallel. To disable the fail-fast behavior for a node:
+
+```hocon
+canton.participants.participant1.storage.parameters.fail-fast-on-startup = "no"
+```
+{/* COPIED_END */}
+
+<Note>
+Use this with care -- disabling fail-fast can cause indefinite, noisy waits if the database is unreachable.
+</Note>
+
+### Protocol Version
+
+{/* COPIED_START - source: parameters.rst */}
+Set a minimum protocol version to prevent a participant from connecting to a synchronizer running a version lower than expected:
+
+```hocon
+canton.participants.participant1.parameters.minimum-protocol-version = 33
+```
+{/* COPIED_END */}
+
+### Early Access Protocol Versions
+
+Alpha and beta protocol versions are for non-production environments only. Enabling them requires setting `non-standard-config = yes` at the `canton.parameters` level and the corresponding version support flag on the participant:
+
+```hocon
+canton.parameters {
+  non-standard-config = yes
+  alpha-version-support = yes
+}
+
+canton.participants.participant1.parameters = {
+  alpha-version-support = yes
+}
+```
+
+## DPM Project Configuration
+
+DPM uses YAML files for project configuration, separate from Canton's HOCON node configuration.
+
+### daml.yaml (Single Package)
+
+Each Daml package has a `daml.yaml` specifying the SDK version, package name, source directory, and dependencies.
+
+### multi-package.yaml (Multi-Package Projects)
+
+{/* COPIED_START - source: configuration.rst */}
+The `multi-package.yaml` file informs Daml Build and the IDE of projects containing multiple connected Daml packages:
+
+```yaml
+packages:
+  - ./path/to/package/a
+  - ./path/to/package/b
+```
+{/* COPIED_END */}
+
+### DPM Environment Variables
+
+{/* COPIED_START - source: configuration.rst */}
+Both `daml.yaml` and `multi-package.yaml` support environment variable interpolation on all string fields using `${MY_ENVIRONMENT_VARIABLE}` syntax. Escape with a backslash: `\${NOT_INTERPOLATED}`.
+
+```yaml
+sdk-version: ${SDK_VERSION}
+name: ${PROJECT_NAME}_test
+source: daml
+version: ${PROJECT_VERSION}
+dependencies:
+  ${DEPENDENCY_DIRECTORY}/my-dependency-1.0.0.dar
+  ${DAML_FINANCE_DAR}
+```
+{/* COPIED_END */}
+
+### DPM Global Configuration
+
+DPM reads global settings from `${DPM_HOME}/dpm-config.yaml`. Environment variables take precedence over file values:
+
+- `DPM_REGISTRY` -- override the Docker registry for SDKs and components
+- `DPM_REGISTRY_AUTH` -- override the registry auth file
+- `DPM_INSECURE_REGISTRY` -- allow pulling from HTTP registries
+- `DPM_LOG_LEVEL` -- set log level (`debug`, `info`, `warn`, `error`)
+- `DPM_SDK_VERSION` -- override the SDK version globally across all projects
+- `DAML_PACKAGE` -- run `dpm` commands in a package context without changing directories

--- a/docs-main/appdev/reference/configuration-reference.mdx
+++ b/docs-main/appdev/reference/configuration-reference.mdx
@@ -7,29 +7,9 @@ Canton uses [HOCON](https://github.com/lightbend/config/blob/master/HOCON.md) (H
 
 ## HOCON Format Basics
 
-{/* COPIED_START - source: conf_file.rst */}
-Canton configuration files are written in HOCON format with some extensions:
-
-- Durations use a `<length><unit>` format. Valid units are `ms`, `s`, `m`, `h`, `d` (milliseconds, seconds, minutes, hours, days). Durations must be non-negative.
-{/* COPIED_END */}
-
 HOCON supports JSON-like object syntax with relaxed quoting, nested key paths (`a.b.c = value`), and `//` or `#` comments. Repeated keys are merged, with the last definition winning.
 
 ### File Includes
-
-{/* COPIED_START - source: conf_file.rst */}
-Configuration files can be nested and combined together using the `include required` directive:
-
-```hocon
-canton {
-    synchronizers {
-        include required(file("synchronizer1.conf"))
-    }
-}
-```
-
-The `required` keyword triggers an error if the included file does not exist; without it, missing files are silently ignored. The `file` keyword instructs the parser to interpret its argument as a file name rather than a URL or classpath resource.
-{/* COPIED_END */}
 
 ### Environment Variable Substitution
 
@@ -53,45 +33,6 @@ Never hardcode credentials in configuration files. Use environment variable subs
 
 ## Canton Configuration Structure
 
-{/* COPIED_START - source: conf_file.rst */}
-Canton can run any number of nodes in the same process. The root configuration defines instances of sequencers, mediators, and participant nodes together with general process parameters.
-
-```hocon
-canton {
-  sequencers {
-    sequencer1 {
-      storage.type = memory
-      public-api.port = 5001
-      admin-api.port = 5002
-      sequencer.type = BFT
-    }
-  }
-
-  mediators {
-    mediator1 {
-      storage.type = memory
-      admin-api.port = 5202
-    }
-  }
-
-  participants {
-    participant1 {
-      storage.type = memory
-      admin-api.port = 5012
-      ledger-api.port = 5011
-      http-ledger-api.port = 5013
-    }
-    participant2 {
-      storage.type = memory
-      admin-api.port = 5022
-      ledger-api.port = 5021
-      http-ledger-api.port = 5023
-    }
-  }
-}
-```
-{/* COPIED_END */}
-
 CamelCase Scala names map to lowercase-with-dashes in config files (e.g., `synchronizerParameters` becomes `synchronizer-parameters`).
 
 ### Init Configuration
@@ -109,40 +50,9 @@ participant1 {
 
 ## Command Line Arguments
 
-{/* COPIED_START - source: command_line.rst */}
-Canton requires at least one configuration file. Provide configuration files with `-c` or `--config`:
-
-```bash
-bin/canton --config conf_filename -c conf_filename2
-```
-
-This merges `conf_filename2` into `conf_filename`. If several files assign values to the same key, the last value wins.
-
-You can also override individual parameters on the command line using `-C`:
-
-```bash
-bin/canton --config conf_filename -C canton.participants.participant1.storage.type=memory
-```
-{/* COPIED_END */}
-
 ### Run Modes
 
-{/* COPIED_START - source: command_line.rst */}
-- **Interactive console** (default) -- starts a REPL for operating and inspecting the Canton process. Useful for development and expert use.
-- **Daemon** -- `bin/canton daemon --config ...` starts Canton without a console. For server deployments. Administer with a remote console.
-- **Sandbox** -- `bin/canton sandbox --dar Main.dar` runs a lightweight ledger for local development.
-- **Headless script** -- `bin/canton run <script-path> --config ...` executes a script then exits. Useful for testing and CI.
-{/* COPIED_END */}
-
 ### JVM Arguments
-
-{/* COPIED_START - source: command_line.rst */}
-The `bin/canton` wrapper supports additional JVM options through the `JAVA_OPTS` environment variable or the `-D` flag:
-
-```bash
-JAVA_OPTS="-Xmx2G" ./bin/canton --config ...
-```
-{/* COPIED_END */}
 
 ## Storage Configuration
 
@@ -153,26 +63,6 @@ Canton supports three storage backends:
 - **PostgreSQL** -- the only supported option for production
 
 ### PostgreSQL Example
-
-{/* COPIED_START - source: postgres.rst */}
-```hocon
-canton {
-  participants.participant1.storage {
-    type = postgres
-    config {
-      dataSourceClassName = "org.postgresql.ds.PGSimpleDataSource"
-      properties = {
-        serverName = "localhost"
-        databaseName = "participant1_db"
-        portNumber = "5432"
-        user = "participant1"
-        password = "pgpass"
-      }
-    }
-  }
-}
-```
-{/* COPIED_END */}
 
 Each Canton node requires its own database. Create databases with UTF-8 encoding:
 
@@ -188,66 +78,15 @@ Canton uses [HikariCP](https://github.com/brettwooldridge/HikariCP) for connecti
 
 When running multiple nodes against the same database server, define shared storage settings in a mixin and reference them per node:
 
-{/* COPIED_START - source: conf_file.rst */}
-```hocon
-_shared {
-    storage {
-        type = postgres
-        config {
-            dataSourceClass = "org.postgresql.ds.PGSimpleDataSource"
-            properties = {
-                serverName = "localhost"
-                serverName = ${?POSTGRES_HOST}
-                portNumber = "5432"
-                portNumber = ${?POSTGRES_PORT}
-                user = ${POSTGRES_USER}
-                password = ${POSTGRES_PASSWORD}
-            }
-        }
-        parameters {
-            max-connections = ${?POSTGRES_NUM_CONNECTIONS}
-            migrate-and-start = false
-            fail-fast-on-startup = true
-        }
-    }
-}
-
-canton {
-    participants {
-        participant1 {
-            storage = ${_shared.storage}
-            storage.config.properties.databaseName = "participant1_db"
-        }
-    }
-}
-```
-{/* COPIED_END */}
-
 ## Key Parameters
 
 ### Fail-Fast Mode
-
-{/* COPIED_START - source: conf_file.rst */}
-By default, Canton fails to start if it cannot access an external dependency such as the database. This is preferable during development, but can cause problems in production when services start in parallel. To disable the fail-fast behavior for a node:
-
-```hocon
-canton.participants.participant1.storage.parameters.fail-fast-on-startup = "no"
-```
-{/* COPIED_END */}
 
 <Note>
 Use this with care -- disabling fail-fast can cause indefinite, noisy waits if the database is unreachable.
 </Note>
 
 ### Protocol Version
-
-{/* COPIED_START - source: parameters.rst */}
-Set a minimum protocol version to prevent a participant from connecting to a synchronizer running a version lower than expected:
-
-```hocon
-canton.participants.participant1.parameters.minimum-protocol-version = 33
-```
-{/* COPIED_END */}
 
 ### Early Access Protocol Versions
 
@@ -274,31 +113,7 @@ Each Daml package has a `daml.yaml` specifying the SDK version, package name, so
 
 ### multi-package.yaml (Multi-Package Projects)
 
-{/* COPIED_START - source: configuration.rst */}
-The `multi-package.yaml` file informs Daml Build and the IDE of projects containing multiple connected Daml packages:
-
-```yaml
-packages:
-  - ./path/to/package/a
-  - ./path/to/package/b
-```
-{/* COPIED_END */}
-
 ### DPM Environment Variables
-
-{/* COPIED_START - source: configuration.rst */}
-Both `daml.yaml` and `multi-package.yaml` support environment variable interpolation on all string fields using `${MY_ENVIRONMENT_VARIABLE}` syntax. Escape with a backslash: `\${NOT_INTERPOLATED}`.
-
-```yaml
-sdk-version: ${SDK_VERSION}
-name: ${PROJECT_NAME}_test
-source: daml
-version: ${PROJECT_VERSION}
-dependencies:
-  ${DEPENDENCY_DIRECTORY}/my-dependency-1.0.0.dar
-  ${DAML_FINANCE_DAR}
-```
-{/* COPIED_END */}
 
 ### DPM Global Configuration
 

--- a/docs-main/appdev/reference/daml-language-reference.mdx
+++ b/docs-main/appdev/reference/daml-language-reference.mdx
@@ -11,7 +11,7 @@ For a printable overview, see the [Daml language cheat sheet](https://docs.digit
 
 ### Templates
 
-A template defines a contract type. Every template has a `signatory`, and may declare `observer`, `ensure`, `key`, and `choice` blocks.
+A template defines a contract type. Every template has a `signatory`, and may declare `observer`, `ensure`, `key`, and `choice` blocks. Contract key uniqueness semantics are being reworked in Canton 3.x -- keys exist syntactically but their uniqueness guarantees differ from 2.x. Contract key support is under active development for Canton 3.5.
 
 ```daml
 template Iou

--- a/docs-main/appdev/reference/daml-language-reference.mdx
+++ b/docs-main/appdev/reference/daml-language-reference.mdx
@@ -50,105 +50,208 @@ newtype Token = Token Int
 
 ## Built-in Functions
 
-{/* COPIED_START - source: working-with.rst */}
+{/* COPIED_START source="docs-website:replicated/daml/3.5/sdk/reference/daml/working-with.rst" hash="56b3d265" */}
 
-### Time
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `replicated/daml/3.5/sdk/reference/daml/working-with.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
 
-- `datetime` -- creates a `Time` given year, month, day, hours, minutes, and seconds as argument.
-- `subTime` -- subtracts one time from another. Returns the `RelTime` difference between `time1` and `time2`.
-- `addRelTime` -- add times. Takes a `Time` and `RelTime` and adds the `RelTime` to the `Time`.
-- `days`, `hours`, `minutes`, `seconds` -- constructs a `RelTime` of the specified length.
-- `pass` -- (in Daml Script tests only) use `pass : RelTime -> Script Time` to advance the ledger time by the argument amount. Returns the new time.
+# Reference: Built-in Functions
 
-### Numbers
+This page gives reference information on built-in functions for working with a variety of common concepts.
 
-- `round` -- rounds a `Decimal` number to `Int`. `round d` is the nearest `Int` to `d`. Tie-breaks are resolved by rounding away from zero (`round 2.5 == 3`, `round (-2.5) == -3`).
-- `truncate` -- converts a `Decimal` number to `Int`, truncating the value towards zero (`truncate 2.2 == 2`, `truncate (-2.2) == -2`).
-- `intToDecimal` -- converts an `Int` to `Decimal`.
+## Work with Time
 
-The set of numbers expressed by `Decimal` is not closed under division, as the result may require more than 10 decimal places to represent. For example, `1.0 / 3.0 == 0.3333...` is a rational number but not a `Decimal`.
+Daml has these built-in functions for working with time:
 
-### Text
+- `datetime`: creates a `Time` given year, month, day, hours, minutes, and seconds as argument.
+- `subTime`: subtracts one time from another. Returns the `RelTime` difference between `time1` and `time2`.
+- `addRelTime`: add times. Takes a `Time` and `RelTime` and adds the `RelTime` to the `Time`.
+- `days`, `hours`, `minutes`, `seconds`: constructs a `RelTime` of the specified length.
+- `pass`: (in `Daml Script tests <test-using-scripts>` only) use `pass : RelTime -> Script Time` to advance the ledger time by the argument amount. Returns the new time.
 
-- `<>` operator -- concatenates two `Text` values.
-- `show` -- converts a value of primitive types (`Bool`, `Int`, `Decimal`, `Party`, `Time`, `RelTime`) to `Text`.
+## Work with Numbers
 
-Escape sequences in Daml strings: `\\` (backslash), `\"` (double quote), `\'` (single quote), `\n` (newline), `\t` (tab), `\r` (carriage return). Unicode escapes are also supported: decimal (`\33`), octal (`\o41`), hexadecimal (`\x21`).
+Daml has these built-in functions for working with numbers:
 
-### Lists and Fold
+- `round`: rounds a `Decimal` number to `Int`.
 
-- `foldl` -- processes list elements left-to-right. Takes a binary operator, an initial accumulator, and a list. The operator is applied to the accumulator and each successive element, producing a new accumulator each time.
-- `foldr` -- same as `foldl` but processes right-to-left.
+  `round d` is the *nearest* `Int` to `d`. Tie-breaks are resolved by rounding away from zero, for example:
+
+  ``` none
+  round 2.5 == 3    round (-2.5) == -3
+  round 3.4 == 3    round (-3.7) == -4
+  ```
+
+- `truncate`: converts a `Decimal` number to `Int`, truncating the value towards zero, for example:
+
+  ``` none
+  truncate 2.2 == 2    truncate (-2.2) == -2
+  truncate 4.9 == 4    v (-4.9) == -4
+  ```
+
+- `intToDecimal`: converts an `Int` to `Decimal`.
+
+The set of numbers expressed by `Decimal` is not closed under division as the result may require more than 10 decimal places to represent. For example, `1.0 / 3.0 == 0.3333...` is a rational number, but not a `Decimal`.
+
+## Work with Text
+
+Daml has these built-in functions for working with text:
+
+- `<>` operator: concatenates two `Text` values.
+- `show` converts a value of the primitive types (`Bool`, `Int`, `Decimal`, `Party`, `Time`, `RelTime`) to a `Text`.
+
+To escape text in Daml strings, use `\`:
+
+<table style="width:69%;">
+<colgroup>
+<col style="width: 27%" />
+<col style="width: 41%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><blockquote>
+<p>Character</p>
+</blockquote></th>
+<th>How to escape it</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><code>\</code></td>
+<td><code>\\</code></td>
+</tr>
+<tr class="even">
+<td><code>"</code></td>
+<td><code>\"</code></td>
+</tr>
+<tr class="odd">
+<td><code>'</code></td>
+<td><code>\'</code></td>
+</tr>
+<tr class="even">
+<td>Newline</td>
+<td><code>\n</code></td>
+</tr>
+<tr class="odd">
+<td>Tab</td>
+<td><code>\t</code></td>
+</tr>
+<tr class="even">
+<td>Carriage return</td>
+<td><code>\r</code></td>
+</tr>
+<tr class="odd">
+<td>Unicode (using <code>!</code> as an example)</td>
+<td><ul>
+<li>Decimal code: <code>\33</code></li>
+<li>Octal code: <code>\o41</code></li>
+<li>Hexadecimal code: <code>\x21</code></li>
+</ul></td>
+</tr>
+</tbody>
+</table>
+
+## Work with Lists
+
+Daml has these built-in functions for working with lists:
+
+- `foldl` and `foldr`: see `daml-ref-folding` below.
+
+### Fold
+
+A *fold* takes:
+
+- a binary operator
+- a first *accumulator* value
+- a list of values
+
+The elements of the list are processed one-by-one (from the left in a `foldl`, or from the right in a `foldr`).
 
 <Note>
-Prefer `foldl` over `foldr` in most cases, since `foldr` must traverse the entire list before it can begin reducing.
+We'd usually recommend using `foldl`, as `foldr` is usually slower. This is because it needs to traverse the whole list before starting to discharge its elements.
 </Note>
 
-Example -- summing a list:
+Processing goes like this:
+
+1.  The binary operator is applied to the first accumulator value and the first element in the list. This produces a second accumulator value.
+2.  The binary operator is applied to the *second* accumulator value and the second element in the list. This produces a third accumulator value.
+3.  This continues until there are no more elements in the list. Then, the last accumulator value is returned.
+
+As an example, to sum up a list of integers in Daml:
 
 ```daml
-sumList : [Int] -> Int
-sumList xs = foldl (+) 0 xs
+-- Code from: code-snippets/Snippets.daml
+-- [Include actual code example here]
 ```
 
 {/* COPIED_END */}
 
 ## Operator Fixity and Precedence
 
-{/* COPIED_START - source: fixity.rst */}
-
-Infix operators in Daml have a declared *associativity* (left, right, or non-associative) and an integer *precedence* from 0 (lowest) to 9 (highest). Left-associative means `x - y - z` parses as `(x - y) - z`. Right-associative means `a -> b -> c` parses as `a -> (b -> (c))`. Non-associative operators (such as `==` and `>`) produce a parse error when chained ambiguously.
-
-You declare fixity with `infixl`, `infix`, or `infixr` followed by a precedence level and the operator name. For example, `infixl 6 +`.
-
-| Precedence | Left-associative | Non-associative | Right-associative |
-|:---:|---|---|---|
-| 9 | `` `!!` `` | | `.` |
-| 8 | | | `<#&&>`, `^`, `**` |
-| 7 | `*`, `/`, `%` | | |
-| 6 | `+`, `-` | | `<>` |
-| 5 | | | `` `++` ``, `::` |
-| 4 | `<$`, `<$>`, `$>`, `<*`, `<*>`, `*>` | `==`, `/=`, `<`, `<=`, `>==`, `>`, `===`, `=/=` | |
-| 3 | | | `&&`, `&&&` |
-| 2 | | | `\|\|`, `\|\|\|` |
-| 1 | `>>`, `>>=`, `<&>` | | `=<<`, `<=<`, `>=>` |
-| 0 | | | `$` |
-
-{/* COPIED_END */}
-
 ## Standard Library
 
-{/* COPIED_START - source: stdlib/index.rst */}
+{/* COPIED_START source="docs-website:replicated/daml/3.5/sdk/reference/daml/stdlib/index.rst" hash="33e68583" */}
 
-The Daml standard library ships with the SDK. The `Prelude` module is imported automatically in every Daml module. Other modules require an explicit import:
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `replicated/daml/3.5/sdk/reference/daml/stdlib/index.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+# The Standard Library
+
+The Daml standard library is a collection of Daml modules that are bundled with the SDK, and can be used to implement Daml applications.
+
+The `Prelude <module-prelude-72703>` module is imported automatically in every Daml module. Other modules must be imported manually, just like your own project's modules. For example:
 
 ```daml
 import DA.Optional
 import DA.Time
 ```
 
-Key modules:
+Here is a complete list of modules in the standard library:
 
-- **Prelude** -- automatically imported; core types, type classes, and functions
-- **DA.List** / **DA.List.Total** -- list operations and total (non-partial) variants
-- **DA.Optional** -- `Optional` type utilities (`fromOptional`, `isSome`, `isNone`)
-- **DA.Map** / **DA.TextMap** -- map data structures keyed by ordered types or `Text`
-- **DA.Set** -- set data structure
-- **DA.Time** / **DA.Date** -- time and date utilities
-- **DA.Text** -- text manipulation functions
-- **DA.Math** / **DA.Numeric** -- math operations and numeric type conversions
-- **DA.Action** / **DA.Action.State** -- monadic utilities and stateful computations
-- **DA.Assert** -- assertion helpers for scripts and tests
-- **DA.Either** -- `Either` type utilities
-- **DA.Foldable** / **DA.Traversable** -- type class abstractions for folding and traversal
-- **DA.Exception** -- exception types
-- **DA.Logic** -- propositional logic combinators
-- **DA.Validation** -- applicative validation
-- **DA.NonEmpty** -- non-empty list type
-- **DA.Crypto.Text** -- cryptographic text utilities
-- **DA.Bifunctor** / **DA.Functor** -- functor abstractions
-- **DA.Monoid** / **DA.Semigroup** -- algebraic type classes
-- **DA.Record** / **DA.Tuple** -- record and tuple utilities
+- `Prelude <Prelude>`
+- `DA.Action <DA-Action>`
+- `DA.Action.State <DA-Action-State>`
+- `DA.Action.State.Class <DA-Action-State-Class>`
+- `DA.Assert <DA-Assert>`
+- `DA.Bifunctor <DA-Bifunctor>`
+- `DA.Crypto.Text <DA-Crypto-Text>`
+- `DA.Date <DA-Date>`
+- `DA.Either <DA-Either>`
+- `DA.Exception <DA-Exception>`
+- `DA.Fail <DA-Fail>`
+- `DA.Foldable <DA-Foldable>`
+- `DA.Functor <DA-Functor>`
+- `DA.Internal.Interface.AnyView <DA-Internal-Interface-AnyView>`
+- `DA.Internal.Interface.AnyView.Types <DA-Internal-Interface-AnyView-Types>`
+- `DA.List <DA-List>`
+- `DA.List.BuiltinOrder <DA-List-BuiltinOrder>`
+- `DA.List.Total <DA-List-Total>`
+- `DA.Logic <DA-Logic>`
+- `DA.Map <DA-Map>`
+- `DA.Math <DA-Math>`
+- `DA.Monoid <DA-Monoid>`
+- `DA.NonEmpty <DA-NonEmpty>`
+- `DA.NonEmpty.Types <DA-NonEmpty-Types>`
+- `DA.Numeric <DA-Numeric>`
+- `DA.Optional <DA-Optional>`
+- `DA.Record <DA-Record>`
+- `DA.Semigroup <DA-Semigroup>`
+- `DA.Set <DA-Set>`
+- `DA.Stack <DA-Stack>`
+- `DA.Text <DA-Text>`
+- `DA.TextMap <DA-TextMap>`
+- `DA.Time <DA-Time>`
+- `DA.Traversable <DA-Traversable>`
+- `DA.Tuple <DA-Tuple>`
+- `DA.Validation <DA-Validation>`
+- `GHC.Show.Text <GHC-Show-Text>`
+- `GHC.Tuple.Check <GHC-Tuple-Check>`
 
 {/* COPIED_END */}
 

--- a/docs-main/appdev/reference/daml-language-reference.mdx
+++ b/docs-main/appdev/reference/daml-language-reference.mdx
@@ -1,6 +1,155 @@
 ---
 title: "Daml Language Reference"
-description: "Reference documentation for the Daml programming language"
+description: "Quick reference for Daml syntax, built-in functions, operator precedence, and the standard library"
 ---
 
-Content coming soon.
+This page collects the most commonly needed Daml reference material in one place: core syntax patterns, built-in functions, operator precedence, and the standard library module list.
+
+For a printable overview, see the [Daml language cheat sheet](https://docs.digitalasset.com/build/3.4/reference/cheat-sheet.html). Full language documentation is available at [docs.digitalasset.com](https://docs.digitalasset.com/build/3.4).
+
+## Syntax Fundamentals
+
+### Templates
+
+A template defines a contract type. Every template has a `signatory`, and may declare `observer`, `ensure`, `key`, and `choice` blocks.
+
+```daml
+template Iou
+  with
+    issuer : Party
+    owner  : Party
+    amount : Decimal
+  where
+    signatory issuer
+    observer owner
+
+    choice Transfer : ContractId Iou
+      with newOwner : Party
+      controller owner
+      do create this with owner = newOwner
+```
+
+### Data Types
+
+Daml supports records, variants (sum types), and newtypes.
+
+```daml
+data Address = Address
+  { street : Text
+  , city   : Text
+  }
+
+data Color = Red | Green | Blue
+
+newtype Token = Token Int
+```
+
+### Parties and Authorization
+
+`Party` is a built-in type representing a ledger identity. Authorization is enforced through `signatory` and `controller` declarations on templates and choices. A contract can only be created when all its signatories authorize the transaction.
+
+## Built-in Functions
+
+{/* COPIED_START - source: working-with.rst */}
+
+### Time
+
+- `datetime` -- creates a `Time` given year, month, day, hours, minutes, and seconds as argument.
+- `subTime` -- subtracts one time from another. Returns the `RelTime` difference between `time1` and `time2`.
+- `addRelTime` -- add times. Takes a `Time` and `RelTime` and adds the `RelTime` to the `Time`.
+- `days`, `hours`, `minutes`, `seconds` -- constructs a `RelTime` of the specified length.
+- `pass` -- (in Daml Script tests only) use `pass : RelTime -> Script Time` to advance the ledger time by the argument amount. Returns the new time.
+
+### Numbers
+
+- `round` -- rounds a `Decimal` number to `Int`. `round d` is the nearest `Int` to `d`. Tie-breaks are resolved by rounding away from zero (`round 2.5 == 3`, `round (-2.5) == -3`).
+- `truncate` -- converts a `Decimal` number to `Int`, truncating the value towards zero (`truncate 2.2 == 2`, `truncate (-2.2) == -2`).
+- `intToDecimal` -- converts an `Int` to `Decimal`.
+
+The set of numbers expressed by `Decimal` is not closed under division, as the result may require more than 10 decimal places to represent. For example, `1.0 / 3.0 == 0.3333...` is a rational number but not a `Decimal`.
+
+### Text
+
+- `<>` operator -- concatenates two `Text` values.
+- `show` -- converts a value of primitive types (`Bool`, `Int`, `Decimal`, `Party`, `Time`, `RelTime`) to `Text`.
+
+Escape sequences in Daml strings: `\\` (backslash), `\"` (double quote), `\'` (single quote), `\n` (newline), `\t` (tab), `\r` (carriage return). Unicode escapes are also supported: decimal (`\33`), octal (`\o41`), hexadecimal (`\x21`).
+
+### Lists and Fold
+
+- `foldl` -- processes list elements left-to-right. Takes a binary operator, an initial accumulator, and a list. The operator is applied to the accumulator and each successive element, producing a new accumulator each time.
+- `foldr` -- same as `foldl` but processes right-to-left.
+
+<Note>
+Prefer `foldl` over `foldr` in most cases, since `foldr` must traverse the entire list before it can begin reducing.
+</Note>
+
+Example -- summing a list:
+
+```daml
+sumList : [Int] -> Int
+sumList xs = foldl (+) 0 xs
+```
+
+{/* COPIED_END */}
+
+## Operator Fixity and Precedence
+
+{/* COPIED_START - source: fixity.rst */}
+
+Infix operators in Daml have a declared *associativity* (left, right, or non-associative) and an integer *precedence* from 0 (lowest) to 9 (highest). Left-associative means `x - y - z` parses as `(x - y) - z`. Right-associative means `a -> b -> c` parses as `a -> (b -> (c))`. Non-associative operators (such as `==` and `>`) produce a parse error when chained ambiguously.
+
+You declare fixity with `infixl`, `infix`, or `infixr` followed by a precedence level and the operator name. For example, `infixl 6 +`.
+
+| Precedence | Left-associative | Non-associative | Right-associative |
+|:---:|---|---|---|
+| 9 | `` `!!` `` | | `.` |
+| 8 | | | `<#&&>`, `^`, `**` |
+| 7 | `*`, `/`, `%` | | |
+| 6 | `+`, `-` | | `<>` |
+| 5 | | | `` `++` ``, `::` |
+| 4 | `<$`, `<$>`, `$>`, `<*`, `<*>`, `*>` | `==`, `/=`, `<`, `<=`, `>==`, `>`, `===`, `=/=` | |
+| 3 | | | `&&`, `&&&` |
+| 2 | | | `\|\|`, `\|\|\|` |
+| 1 | `>>`, `>>=`, `<&>` | | `=<<`, `<=<`, `>=>` |
+| 0 | | | `$` |
+
+{/* COPIED_END */}
+
+## Standard Library
+
+{/* COPIED_START - source: stdlib/index.rst */}
+
+The Daml standard library ships with the SDK. The `Prelude` module is imported automatically in every Daml module. Other modules require an explicit import:
+
+```daml
+import DA.Optional
+import DA.Time
+```
+
+Key modules:
+
+- **Prelude** -- automatically imported; core types, type classes, and functions
+- **DA.List** / **DA.List.Total** -- list operations and total (non-partial) variants
+- **DA.Optional** -- `Optional` type utilities (`fromOptional`, `isSome`, `isNone`)
+- **DA.Map** / **DA.TextMap** -- map data structures keyed by ordered types or `Text`
+- **DA.Set** -- set data structure
+- **DA.Time** / **DA.Date** -- time and date utilities
+- **DA.Text** -- text manipulation functions
+- **DA.Math** / **DA.Numeric** -- math operations and numeric type conversions
+- **DA.Action** / **DA.Action.State** -- monadic utilities and stateful computations
+- **DA.Assert** -- assertion helpers for scripts and tests
+- **DA.Either** -- `Either` type utilities
+- **DA.Foldable** / **DA.Traversable** -- type class abstractions for folding and traversal
+- **DA.Exception** -- exception types
+- **DA.Logic** -- propositional logic combinators
+- **DA.Validation** -- applicative validation
+- **DA.NonEmpty** -- non-empty list type
+- **DA.Crypto.Text** -- cryptographic text utilities
+- **DA.Bifunctor** / **DA.Functor** -- functor abstractions
+- **DA.Monoid** / **DA.Semigroup** -- algebraic type classes
+- **DA.Record** / **DA.Tuple** -- record and tuple utilities
+
+{/* COPIED_END */}
+
+For full API documentation of each module, see the [standard library reference](https://docs.digitalasset.com/build/3.4/reference/stdlib/index.html).

--- a/docs-main/appdev/reference/daml-language-reference.mdx
+++ b/docs-main/appdev/reference/daml-language-reference.mdx
@@ -5,7 +5,7 @@ description: "Quick reference for Daml syntax, built-in functions, operator prec
 
 This page collects the most commonly needed Daml reference material in one place: core syntax patterns, built-in functions, operator precedence, and the standard library module list.
 
-For a printable overview, see the [Daml language cheat sheet](https://docs.digitalasset.com/build/3.4/reference/cheat-sheet.html). Full language documentation is available at [docs.digitalasset.com](https://docs.digitalasset.com/build/3.4).
+For a printable overview, see the [Daml language cheat sheet](https://docs.daml.com/cheat-sheet/). Full language documentation is available at [docs.digitalasset.com](https://docs.digitalasset.com/build/3.5).
 
 ## Syntax Fundamentals
 
@@ -152,4 +152,4 @@ Key modules:
 
 {/* COPIED_END */}
 
-For full API documentation of each module, see the [standard library reference](https://docs.digitalasset.com/build/3.4/reference/stdlib/index.html).
+For full API documentation of each module, see the [standard library reference](https://docs.digitalasset.com/build/3.5/reference/daml/stdlib/index.html).

--- a/docs-main/appdev/reference/error-codes.mdx
+++ b/docs-main/appdev/reference/error-codes.mdx
@@ -1,6 +1,180 @@
 ---
 title: "Error Codes"
-description: "Complete list of Canton development error codes"
+description: "Reference for Canton error codes, categories, gRPC status mappings, and retry strategies"
 ---
 
-Content coming soon.
+Canton returns structured error information through gRPC responses. Every error carries a machine-readable code, a category that determines the gRPC status code, and a human-readable description. You can use these components to build automated error handling in your application.
+
+## Error message format
+
+{/* COPIED_START - source: error_codes.rst */}
+
+Error descriptions follow this format:
+
+```
+ERROR_CODE_ID(CATEGORY_ID,CORRELATION_ID_PREFIX):HUMAN_READABLE_MESSAGE
+```
+
+- `ERROR_CODE_ID` -- a unique string of upper-case letters, underscores, or digits (max 63 characters). Identifies the error code.
+- `CATEGORY_ID` -- a small integer identifying the error category.
+- `CORRELATION_ID_PREFIX` -- the first 8 characters of the request's submission ID, or `0` if no correlation ID is available.
+- `:` -- separates the machine-readable prefix from the human-readable message.
+- `HUMAN_READABLE_MESSAGE` -- a description for human readers. Do not parse this in application code; the text may change between releases.
+
+For example:
+
+```
+TRANSACTION_NOT_FOUND(11,12345): Transaction not found, or not visible.
+```
+
+{/* COPIED_END */}
+
+## Machine-readable error details
+
+Each gRPC error response includes structured details following the [rich gRPC error model](https://cloud.google.com/apis/design/errors#error_details):
+
+- `ErrorInfo` (mandatory) -- contains the error code ID in `reason` and the category ID in `metadata["category"]`
+- `RequestInfo` (mandatory) -- contains the full correlation ID (not truncated) in `requestId`
+- `RetryInfo` (optional) -- contains the recommended retry interval when the error is retryable
+- `ResourceInfo` (optional) -- identifies the resource involved in the failure (contract, contract key, package, party, synchronizer, etc.)
+
+<Warning>
+Some errors are redacted for security. The API response omits sensitive details, but the full error message appears in server-side logs. Work with your operator if you need the complete error context.
+</Warning>
+
+## Error categories
+
+{/* COPIED_START - source: canton-error-categories-inventory.rst.inc */}
+
+Error categories group error codes by their expected handling strategy. Each category maps to exactly one [gRPC status code](https://grpc.github.io/grpc/core/md_doc_statuscodes.html). Handle errors at the category level when possible, and fall back to specific error code IDs only when category-level handling is too broad.
+
+| Category ID | Category name | gRPC status | Retry strategy |
+|---|---|---|---|
+| 1 | TransientServerFailure | UNAVAILABLE | Retry quickly, including in load balancer |
+| 2 | ContentionOnSharedResources | ABORTED | Retry with backoff; do not retry in load balancer |
+| 3 | DeadlineExceededRequestStateUnknown | DEADLINE_EXCEEDED | Limited retries with deduplication |
+| 4 | SystemInternalAssumptionViolated | INTERNAL | Contact operator; do not retry automatically |
+| 5 | SecurityAlert | INVALID_ARGUMENT | Non-retryable; contact operator |
+| 6 | AuthInterceptorInvalidAuthenticationCredentials | UNAUTHENTICATED | Fix credentials, then retry |
+| 7 | InsufficientPermission | PERMISSION_DENIED | Fix permissions, then retry |
+| 8 | InvalidIndependentOfSystemState | INVALID_ARGUMENT | Fix application code or configuration |
+| 9 | InvalidGivenCurrentSystemStateOther | FAILED_PRECONDITION | Application-specific; may resolve with state changes |
+| 10 | InvalidGivenCurrentSystemStateResourceExists | ALREADY_EXISTS | Inspect resource, resolve conflict |
+| 11 | InvalidGivenCurrentSystemStateResourceMissing | NOT_FOUND | Inspect resource, resolve absence |
+| 12 | InvalidGivenCurrentSystemStateSeekAfterEnd | OUT_OF_RANGE | Wait and retry; state may advance naturally |
+| 13 | BackgroundProcessDegradationWarning | N/A | Not an API error; operator-facing only |
+| 14 | InternalUnsupportedOperation | UNIMPLEMENTED | Non-retryable; requires operator intervention |
+
+{/* COPIED_END */}
+
+## Retry strategy by category
+
+**Automatic retry (categories 1-3):**
+Categories 1, 2, and 3 represent transient conditions. Your application should retry these automatically. For category 1 (UNAVAILABLE), retry quickly -- a load balancer can handle this. For category 2 (ABORTED), use exponential backoff since the issue is resource contention. For category 3 (DEADLINE_EXCEEDED), retry a limited number of times and use command deduplication to avoid duplicate submissions.
+
+**Fix and retry (categories 6-8):**
+These errors indicate a problem with the request itself. Category 6 (UNAUTHENTICATED) means your JWT token is missing or invalid. Category 7 (PERMISSION_DENIED) means the token lacks the required rights. Category 8 (INVALID_ARGUMENT) means the request is malformed regardless of system state. Fix the issue in your application or configuration before retrying.
+
+**State-dependent (categories 9-12):**
+These errors depend on the current state of the ledger. A `CONTRACT_NOT_FOUND` (category 11) might be expected in a multi-party workflow where another party archived the contract, or it might indicate an application bug. Your handling strategy depends on your application's logic.
+
+**Do not retry (categories 4, 5, 14):**
+These indicate internal errors, security issues, or unimplemented operations. Escalate to your operator or check server-side logs for details.
+
+## Common error codes for app developers
+
+### Authentication and authorization
+
+| Error code | Category | Description |
+|---|---|---|
+| `UNAUTHENTICATED` | 6 | No JWT token provided on a participant that requires authentication |
+| `PERMISSION_DENIED` | 7 | JWT token lacks sufficient rights for the operation |
+| `ACCESS_TOKEN_EXPIRED` | 2 | JWT token has expired; obtain a fresh token |
+| `INVALID_TOKEN` | 8 | JWT token is malformed or otherwise invalid |
+| `STALE_STREAM_AUTHORIZATION` | 2 | User rights changed during an active stream; reconnect |
+
+### Contracts and transactions
+
+| Error code | Category | Description |
+|---|---|---|
+| `CONTRACT_NOT_FOUND` | 11 | Contract does not exist or is not visible to the requesting party |
+| `TRANSACTION_NOT_FOUND` | 11 | Transaction does not exist or is not visible |
+| `CONTRACT_KEY_NOT_FOUND` | 11 | No active contract found for the given key |
+| `DUPLICATE_CONTRACT_KEY` | 10 | A contract with this key already exists |
+| `INCONSISTENT_CONTRACTS` | 9 | Contracts referenced in the command have changed |
+
+### Submission and processing
+
+| Error code | Category | Description |
+|---|---|---|
+| `ABORTED_DUE_TO_SHUTDOWN` | 1 | Node is shutting down; retry against an available node |
+| `SERVER_OVERLOADED` | 2 | Node is at capacity; retry with exponential backoff |
+| `SEQUENCER_REQUEST_FAILED` | 2 | Request to the sequencer failed (e.g., batch size exceeded) |
+| `PACKAGE_SELECTION_FAILED` | 9 | Required package not found or not vetted |
+
+## Extracting error details from gRPC responses
+
+The following Scala example shows how to extract error components from a `StatusRuntimeException`:
+
+{/* COPIED_START - source: error_codes.rst */}
+
+```scala
+import com.google.rpc.{ErrorInfo, RequestInfo, RetryInfo, ResourceInfo}
+import io.grpc.StatusRuntimeException
+import scala.jdk.CollectionConverters._
+
+try {
+  // your gRPC call here
+} catch {
+  case e: StatusRuntimeException =>
+    val status = io.grpc.protobuf.StatusProto.fromThrowable(e)
+
+    // gRPC status code
+    val code = status.getCode
+
+    // Full error description: "ERROR_CODE_ID(CATEGORY,CORRELATION): message"
+    val message = status.getMessage
+
+    // Extract structured details
+    val details = status.getDetailsList.asScala.toSeq
+
+    // Error code ID and category
+    details.collectFirst {
+      case any if any.is(classOf[ErrorInfo]) =>
+        val info = any.unpack(classOf[ErrorInfo])
+        val errorId = info.getReason           // e.g. "CONTRACT_NOT_FOUND"
+        val category = info.getMetadataMap.get("category") // e.g. "11"
+    }
+
+    // Full correlation ID for log lookup
+    details.collectFirst {
+      case any if any.is(classOf[RequestInfo]) =>
+        val requestId = any.unpack(classOf[RequestInfo]).getRequestId
+    }
+
+    // Retry interval (if error is retryable)
+    details.collectFirst {
+      case any if any.is(classOf[RetryInfo]) =>
+        val delay = any.unpack(classOf[RetryInfo]).getRetryDelay
+        val retryMs = delay.getSeconds * 1000 + delay.getNanos / 1_000_000
+    }
+
+    // Resource that caused the failure (if applicable)
+    details.collectFirst {
+      case any if any.is(classOf[ResourceInfo]) =>
+        val resource = any.unpack(classOf[ResourceInfo])
+        val resType = resource.getResourceType  // e.g. "CONTRACT_ID"
+        val resName = resource.getResourceName  // e.g. the contract ID
+    }
+}
+```
+
+{/* COPIED_END */}
+
+For other languages, use the equivalent gRPC status and protobuf utilities to unpack `com.google.rpc.Status` details from the trailing metadata.
+
+## Further reading
+
+- [Troubleshooting cheat sheet](/docs-main/appdev/troubleshooting) -- quick-reference solutions for common issues including specific error codes
+- [gRPC status codes](https://grpc.github.io/grpc/core/md_doc_statuscodes.html) -- official gRPC status code definitions
+- [gRPC rich error model](https://cloud.google.com/apis/design/errors#error_details) -- the error detail types used in Canton responses

--- a/docs-main/appdev/reference/error-codes.mdx
+++ b/docs-main/appdev/reference/error-codes.mdx
@@ -7,28 +7,6 @@ Canton returns structured error information through gRPC responses. Every error 
 
 ## Error message format
 
-{/* COPIED_START - source: error_codes.rst */}
-
-Error descriptions follow this format:
-
-```
-ERROR_CODE_ID(CATEGORY_ID,CORRELATION_ID_PREFIX):HUMAN_READABLE_MESSAGE
-```
-
-- `ERROR_CODE_ID` -- a unique string of upper-case letters, underscores, or digits (max 63 characters). Identifies the error code.
-- `CATEGORY_ID` -- a small integer identifying the error category.
-- `CORRELATION_ID_PREFIX` -- the first 8 characters of the request's submission ID, or `0` if no correlation ID is available.
-- `:` -- separates the machine-readable prefix from the human-readable message.
-- `HUMAN_READABLE_MESSAGE` -- a description for human readers. Do not parse this in application code; the text may change between releases.
-
-For example:
-
-```
-TRANSACTION_NOT_FOUND(11,12345): Transaction not found, or not visible.
-```
-
-{/* COPIED_END */}
-
 ## Machine-readable error details
 
 Each gRPC error response includes structured details following the [rich gRPC error model](https://cloud.google.com/apis/design/errors#error_details):
@@ -43,29 +21,6 @@ Some errors are redacted for security. The API response omits sensitive details,
 </Warning>
 
 ## Error categories
-
-{/* COPIED_START - source: canton-error-categories-inventory.rst.inc */}
-
-Error categories group error codes by their expected handling strategy. Each category maps to exactly one [gRPC status code](https://grpc.github.io/grpc/core/md_doc_statuscodes.html). Handle errors at the category level when possible, and fall back to specific error code IDs only when category-level handling is too broad.
-
-| Category ID | Category name | gRPC status | Retry strategy |
-|---|---|---|---|
-| 1 | TransientServerFailure | UNAVAILABLE | Retry quickly, including in load balancer |
-| 2 | ContentionOnSharedResources | ABORTED | Retry with backoff; do not retry in load balancer |
-| 3 | DeadlineExceededRequestStateUnknown | DEADLINE_EXCEEDED | Limited retries with deduplication |
-| 4 | SystemInternalAssumptionViolated | INTERNAL | Contact operator; do not retry automatically |
-| 5 | SecurityAlert | INVALID_ARGUMENT | Non-retryable; contact operator |
-| 6 | AuthInterceptorInvalidAuthenticationCredentials | UNAUTHENTICATED | Fix credentials, then retry |
-| 7 | InsufficientPermission | PERMISSION_DENIED | Fix permissions, then retry |
-| 8 | InvalidIndependentOfSystemState | INVALID_ARGUMENT | Fix application code or configuration |
-| 9 | InvalidGivenCurrentSystemStateOther | FAILED_PRECONDITION | Application-specific; may resolve with state changes |
-| 10 | InvalidGivenCurrentSystemStateResourceExists | ALREADY_EXISTS | Inspect resource, resolve conflict |
-| 11 | InvalidGivenCurrentSystemStateResourceMissing | NOT_FOUND | Inspect resource, resolve absence |
-| 12 | InvalidGivenCurrentSystemStateSeekAfterEnd | OUT_OF_RANGE | Wait and retry; state may advance naturally |
-| 13 | BackgroundProcessDegradationWarning | N/A | Not an API error; operator-facing only |
-| 14 | InternalUnsupportedOperation | UNIMPLEMENTED | Non-retryable; requires operator intervention |
-
-{/* COPIED_END */}
 
 ## Retry strategy by category
 
@@ -115,61 +70,6 @@ These indicate internal errors, security issues, or unimplemented operations. Es
 ## Extracting error details from gRPC responses
 
 The following Scala example shows how to extract error components from a `StatusRuntimeException`:
-
-{/* COPIED_START - source: error_codes.rst */}
-
-```scala
-import com.google.rpc.{ErrorInfo, RequestInfo, RetryInfo, ResourceInfo}
-import io.grpc.StatusRuntimeException
-import scala.jdk.CollectionConverters._
-
-try {
-  // your gRPC call here
-} catch {
-  case e: StatusRuntimeException =>
-    val status = io.grpc.protobuf.StatusProto.fromThrowable(e)
-
-    // gRPC status code
-    val code = status.getCode
-
-    // Full error description: "ERROR_CODE_ID(CATEGORY,CORRELATION): message"
-    val message = status.getMessage
-
-    // Extract structured details
-    val details = status.getDetailsList.asScala.toSeq
-
-    // Error code ID and category
-    details.collectFirst {
-      case any if any.is(classOf[ErrorInfo]) =>
-        val info = any.unpack(classOf[ErrorInfo])
-        val errorId = info.getReason           // e.g. "CONTRACT_NOT_FOUND"
-        val category = info.getMetadataMap.get("category") // e.g. "11"
-    }
-
-    // Full correlation ID for log lookup
-    details.collectFirst {
-      case any if any.is(classOf[RequestInfo]) =>
-        val requestId = any.unpack(classOf[RequestInfo]).getRequestId
-    }
-
-    // Retry interval (if error is retryable)
-    details.collectFirst {
-      case any if any.is(classOf[RetryInfo]) =>
-        val delay = any.unpack(classOf[RetryInfo]).getRetryDelay
-        val retryMs = delay.getSeconds * 1000 + delay.getNanos / 1_000_000
-    }
-
-    // Resource that caused the failure (if applicable)
-    details.collectFirst {
-      case any if any.is(classOf[ResourceInfo]) =>
-        val resource = any.unpack(classOf[ResourceInfo])
-        val resType = resource.getResourceType  // e.g. "CONTRACT_ID"
-        val resName = resource.getResourceName  // e.g. the contract ID
-    }
-}
-```
-
-{/* COPIED_END */}
 
 The following Java example shows the equivalent extraction. Java has first-class codegen support in Canton, so this is the most common non-Scala pattern:
 

--- a/docs-main/appdev/reference/error-codes.mdx
+++ b/docs-main/appdev/reference/error-codes.mdx
@@ -100,7 +100,7 @@ These indicate internal errors, security issues, or unimplemented operations. Es
 | `CONTRACT_NOT_FOUND` | 11 | Contract does not exist or is not visible to the requesting party |
 | `TRANSACTION_NOT_FOUND` | 11 | Transaction does not exist or is not visible |
 | `CONTRACT_KEY_NOT_FOUND` | 11 | No active contract found for the given key |
-| `DUPLICATE_CONTRACT_KEY` | 10 | A contract with this key already exists |
+| `DUPLICATE_CONTRACT_KEY` | 10 | A contract with this key already exists (contract key semantics are changing in Canton 3.x; see note below) |
 | `INCONSISTENT_CONTRACTS` | 9 | Contracts referenced in the command have changed |
 
 ### Submission and processing
@@ -171,7 +171,46 @@ try {
 
 {/* COPIED_END */}
 
-For other languages, use the equivalent gRPC status and protobuf utilities to unpack `com.google.rpc.Status` details from the trailing metadata.
+The following Java example shows the equivalent extraction. Java has first-class codegen support in Canton, so this is the most common non-Scala pattern:
+
+```java
+import com.google.rpc.ErrorInfo;
+import com.google.rpc.RequestInfo;
+import com.google.rpc.RetryInfo;
+import io.grpc.StatusRuntimeException;
+import io.grpc.protobuf.StatusProto;
+
+try {
+    // your gRPC call here
+} catch (StatusRuntimeException e) {
+    com.google.rpc.Status status = StatusProto.fromThrowable(e);
+
+    // gRPC status code
+    int code = status.getCode();
+
+    // Full error description
+    String message = status.getMessage();
+
+    // Extract structured details
+    for (com.google.protobuf.Any detail : status.getDetailsList()) {
+        if (detail.is(ErrorInfo.class)) {
+            ErrorInfo info = detail.unpack(ErrorInfo.class);
+            String errorId = info.getReason();
+            String category = info.getMetadataMap().get("category");
+        }
+        if (detail.is(RequestInfo.class)) {
+            String requestId = detail.unpack(RequestInfo.class).getRequestId();
+        }
+        if (detail.is(RetryInfo.class)) {
+            RetryInfo retry = detail.unpack(RetryInfo.class);
+            long retryMs = retry.getRetryDelay().getSeconds() * 1000
+                + retry.getRetryDelay().getNanos() / 1_000_000;
+        }
+    }
+}
+```
+
+These error codes are also surfaced through the JSON API (HTTP Ledger API) with equivalent error detail structures. For other languages, use the equivalent gRPC status and protobuf utilities to unpack `com.google.rpc.Status` details from the trailing metadata.
 
 ## Further reading
 

--- a/docs-main/appdev/reference/pqs-sql-reference.mdx
+++ b/docs-main/appdev/reference/pqs-sql-reference.mdx
@@ -3,15 +3,17 @@ title: "PQS SQL Reference"
 description: "Complete SQL API reference for the Participant Query Store (PQS), including table functions, offset management, maintenance operations, and JSONB indexing."
 ---
 
-The PQS SQL API is provisioned directly in the PostgreSQL database. Data consumers interact with it through SQL -- not through the PQS process itself. The API provides a stable interface of functions and views that should be the only database artifacts readers interact with.
+The PQS SQL API is provisioned directly in the PostgreSQL database. Data consumers interact with it through SQL -- not through the PQS process itself.
+
+PQS data can be joined across contract tables to build projections (for example, joining holdings with account templates). The temporal offset model and historical event functions (`creates`, `archives`, `exercises`) make PQS well-suited for audit trails and compliance queries.
 
 ## Offset model
 
-A Participant Node models time using an **offset**, a unique integer index into its local ledger. Offsets are ordered and represent the causal order of transactions. Due to privacy filtering, the sequence of offsets on a given Participant Node usually contains gaps.
+A validator models time using an **offset**, a unique integer index into its local ledger. Offsets are ordered and represent the causal order of transactions. Due to privacy filtering, the sequence of offsets on a given validator usually contains gaps.
 
-Offsets are specific to a single Participant Node and are not consistent across peers, even for common transactions. Each node allocates its own offsets based on its permissioned view.
+Offsets are specific to a single validator and are not consistent across peers, even for common transactions. Each node allocates its own offsets based on its permissioned view.
 
-In addition to offsets, PQS exposes **ledger time** (approximate wall-clock time preserving causal ordering) and **transaction IDs** (opaque identifiers common across all Participant Nodes). Use offsets for causal analysis, transaction IDs for cross-node correlation, and ledger time for temporal queries.
+In addition to offsets, PQS exposes **ledger time** (approximate wall-clock time preserving causal ordering) and **transaction IDs** (opaque identifiers common across all validators). Use offsets for causal analysis, transaction IDs for cross-node correlation, and ledger time for temporal queries.
 
 ## Offset management
 
@@ -268,5 +270,5 @@ select * from reset_to_offset('<offset>');
 ```
 
 <Warning>
-Resetting is destructive and permanent. Stop PQS and all consuming applications before resetting. Coordinate with your Participant Node operator, especially in disaster-recovery scenarios.
+Resetting is destructive and permanent. Stop PQS and all consuming applications before resetting. Coordinate with your validator operator, especially in disaster-recovery scenarios.
 </Warning>

--- a/docs-main/appdev/reference/pqs-sql-reference.mdx
+++ b/docs-main/appdev/reference/pqs-sql-reference.mdx
@@ -1,6 +1,272 @@
 ---
 title: "PQS SQL Reference"
-description: "SQL reference for the Participant Query Store"
+description: "Complete SQL API reference for the Participant Query Store (PQS), including table functions, offset management, maintenance operations, and JSONB indexing."
 ---
 
-Content coming soon.
+The PQS SQL API is provisioned directly in the PostgreSQL database. Data consumers interact with it through SQL -- not through the PQS process itself. The API provides a stable interface of functions and views that should be the only database artifacts readers interact with.
+
+## Offset model
+
+A Participant Node models time using an **offset**, a unique integer index into its local ledger. Offsets are ordered and represent the causal order of transactions. Due to privacy filtering, the sequence of offsets on a given Participant Node usually contains gaps.
+
+Offsets are specific to a single Participant Node and are not consistent across peers, even for common transactions. Each node allocates its own offsets based on its permissioned view.
+
+In addition to offsets, PQS exposes **ledger time** (approximate wall-clock time preserving causal ordering) and **transaction IDs** (opaque identifiers common across all Participant Nodes). Use offsets for causal analysis, transaction IDs for cross-node correlation, and ledger time for temporal queries.
+
+## Offset management
+
+{/* COPIED_START - source: sql-api.rst */}
+
+These functions control the temporal perspective of the ledger:
+
+- `set_latest(offset)` -- nominates the offset of the latest data to include in observing the ledger. If `NULL` it uses the latest available. The actual offset to be used is returned. If the supplied offset is beyond what is available, an error occurs.
+- `validate_offset_exists(offset)` -- validates that the datastore has a complete history up to and including the offset provided. Returns an error if the nominated offset is not available (too old, or too new).
+- `set_oldest(offset)` -- nominates the offset of the oldest events to include in query scope. If `NULL` then it uses the oldest available. Function returns the actual offset used. If the supplied offset is beyond what is available, an error occurs.
+- `nearest_offset(time)` -- a helper function to determine the offset of a given time (or interval prior to now).
+
+{/* COPIED_END */}
+
+Call `set_oldest` and `set_latest` before running queries in a session to pin the temporal window, or pass offset arguments directly to table functions (see below).
+
+## Table functions for contracts and exercises
+
+{/* COPIED_START - source: sql-api.rst */}
+
+The following table functions allow access to the ledger and are used directly in queries. They are designed to be used in a similar manner to tables or views:
+
+- `active(name, [at_offset])` -- active instances of the target template/interface views that existed at the time of the latest offset
+- `creates(name, [from_offset], [to_offset])` -- create events of the target template/interface views that occurred between the oldest and latest offset
+- `archives(name, [from_offset], [to_offset])` -- archive events of the target template/interface views that occurred between the oldest and latest offset
+- `exercises(name, [from_offset], [to_offset])` -- exercise events of the target choice that occurred between the oldest and latest offset
+
+The `name` identifier can be used with or without the package specified:
+
+- Fully qualified: `<package>:<module>:<template|interface|choice>`
+- Partially qualified: `<module>:<template|interface|choice>` or `<template|interface|choice>` (if unambiguous)
+
+{/* COPIED_END */}
+
+<Warning>
+Partially qualified identifiers fail if the result is ambiguous.
+</Warning>
+
+These functions accept optional offset parameters as an alternative to calling `set_oldest`/`set_latest` beforehand. The following two approaches are equivalent:
+
+```sql
+-- Implicit: set scope first, then query
+select set_oldest('from_offset');
+select set_latest('to_offset');
+select * from creates('package:My.Module:Template');
+```
+
+```sql
+-- Explicit: inline the entire context in a single statement
+select *
+from creates('package:My.Module:Template', 'from_offset', 'to_offset');
+```
+
+## Lookup functions
+
+{/* COPIED_START - source: sql-api.rst */}
+
+- `lookup_contract(contract_id)` is a mechanism to retrieve contract data without needing to know its Daml qualified name. The function returns both contract and all associated interface view projections, distinguishable by the `payload_type` column.
+- `lookup_exercises(contract_id)` is a mechanism to retrieve choice exercise data without needing to know the Daml qualified name; knowing the contract ID is sufficient.
+
+{/* COPIED_END */}
+
+## Transactions view
+
+The `transactions` view provides transaction metadata not directly exposed by the table functions above.
+
+| Column | Type | Description |
+|---|---|---|
+| `ix` | `bigint` | Internal primary key of the ledger transaction |
+| `offset` | `bigint` | Ledger offset |
+| `transaction_id` | `text` | Transaction ID assigned by the ledger |
+| `effective_at` | `timestamp with time zone` | Ledger effective time |
+| `workflow_id` | `text` | Workflow ID used in command submission |
+| `trace_context` | `trace_context` | Ledger API trace context (user-defined type containing `trace_parent` and `trace_state`) |
+| `external_transaction_hash` | `bytea` | Hash of the transaction submitted by the external party |
+
+Join through the `*_at_ix` column to enrich contract or exercise data with transaction metadata:
+
+```sql
+select c.contract_id, t.transaction_id, (t.trace_context).trace_parent
+from creates('package:My.Module:Template') c
+inner join transactions t on c.created_at_ix = t.ix
+where c.create_event_id = (42::bigint, 0);
+```
+
+## Summary functions
+
+{/* COPIED_START - source: sql-api.rst */}
+
+Summary functions provide an overview of the ledger data available within the nominated offset range:
+
+- `summary_transients(from_offset, to_offset)` -- the number of transients per Daml fully qualified name within the offset range
+- `summary_updates(from_offset, to_offset)` -- summary of create and archive counts per Daml fully qualified name within the offset range
+
+The following functions retrieve event counts per `template_fqn`:
+
+- `summary_active(at_offset)`
+- `summary_creates(from_offset, to_offset)`
+- `summary_archives(from_offset, to_offset)`
+- `summary_exercises(from_offset, to_offset)`
+
+{/* COPIED_END */}
+
+## Contract columns
+
+{/* COPIED_START - source: sql-api.rst */}
+
+All functions returning contract data return the following columns:
+
+| Column | Type | Description |
+|---|---|---|
+| `template_fqn` | `text` | Fully-qualified name of the template or interface |
+| `payload_type` | `'template'` or `'interface'` | Type of contract payload |
+| `create_event_pk` | `bigint` | Reference to contract creation event primary key |
+| `create_event_id` | `(bigint, integer)` | Orderable addressing type `(offset, node ID)` of the creation event |
+| `created_at_ix` | `bigint` | Ordinal index of the transaction containing the creation event |
+| `created_at_offset` | `bigint` | Ledger offset of the transaction containing the creation event |
+| `created_effective_at` | `timestamp with time zone` | Ledger effective time of the transaction containing the creation event |
+| `archive_event_pk` | `bigint` | Reference to contract archival event primary key |
+| `archive_event_id` | `(bigint, integer)` | Orderable addressing type `(offset, node ID)` of the archival event |
+| `archived_at_ix` | `bigint` | Ordinal index of the transaction containing the archival event |
+| `archived_at_offset` | `bigint` | Ledger offset of the transaction containing the archival event |
+| `archived_effective_at` | `timestamp with time zone` | Ledger effective time of the transaction containing the archival event |
+| `life_ix` | `int8range` | Contract's lifespan expressed in ordinal indexes |
+| `contract_id` | `text` | Ledger-assigned contract ID |
+| `payload` | `jsonb` | JSONB representation of contract data |
+| `metadata` | `bytea` | Explicit contract disclosure metadata |
+| `package_name` | `text` | Daml package name |
+| `package_version` | `text` | Daml package version |
+| `package_id` | `text` | Daml package ID |
+| `redaction_id` | `text` | Redaction process reference |
+| `signatories` | `text[]` | Parties consenting to the creation of the contract |
+| `observers` | `text[]` | Additional stakeholders whom the contract is visible to |
+| `witnesses` | `text[]` | Parties that are notified of this event |
+| `divulged_only` | `boolean` | Whether the contract was only divulged (`true`) or properly disclosed (`false`) |
+
+{/* COPIED_END */}
+
+## Exercise columns
+
+{/* COPIED_START - source: sql-api.rst */}
+
+All functions returning exercise data return the following columns:
+
+| Column | Type | Description |
+|---|---|---|
+| `template_fqn` | `text` | Fully-qualified name of the template where choice is defined |
+| `choice_fqn` | `text` | Fully-qualified name of the choice |
+| `choice` | `text` | Choice name |
+| `consuming` | `boolean` | Whether the choice is consuming |
+| `exercise_event_pk` | `bigint` | Reference to choice exercise event primary key |
+| `exercise_event_id` | `(bigint, integer)` | Orderable addressing type `(offset, node ID)` of the exercise event |
+| `exercised_at_ix` | `bigint` | Ordinal index of the transaction containing the exercise event |
+| `exercised_at_offset` | `bigint` | Ledger offset of the transaction containing the exercise event |
+| `exercised_effective_at` | `timestamp with time zone` | Ledger effective time of the transaction containing the exercise event |
+| `contract_id` | `text` | Ledger-assigned contract ID |
+| `argument` | `jsonb` | JSONB representation of the choice argument type |
+| `result` | `jsonb` | JSONB representation of the choice return type |
+| `package_name` | `text` | Daml package name |
+| `package_version` | `text` | Daml package version |
+| `package_id` | `text` | Daml package ID |
+| `redaction_id` | `text` | Redaction process reference |
+| `signatories` | `text[]` | Parties that consented to the creation of the contract that choice was exercised on |
+| `observers` | `text[]` | Additional stakeholders made aware of the creation of the contract that choice was exercised on |
+| `controllers` | `text[]` | Parties that collectively exercised this choice |
+| `witnesses` | `text[]` | Parties that are notified of this event |
+| `last_descendant_node_id` | `integer` | Upper boundary of node IDs for events in the same transaction resulting from this exercise |
+
+{/* COPIED_END */}
+
+## JSONB indexing
+
+PQS metadata columns are indexed by default, but queries on `payload` contents (the JSONB column) need custom indexes for acceptable performance. Use the `create_index_for_contract` helper to create expression indexes on the internal contract tables:
+
+```sql
+call create_index_for_contract(
+  'token_quantity',         -- index name suffix
+  'Token',                  -- template name
+  '((payload->>''quantity'')::decimal)',  -- expression
+  'btree'                   -- index type (btree, hash, gin, gist)
+);
+```
+
+After creating the index, run `VACUUM ANALYZE` on the underlying table so PostgreSQL collects statistics:
+
+```sql
+-- Determine the internal table number for your template
+select __contract_tpe4name('Token');  -- returns e.g. 14
+
+-- Then analyze
+vacuum analyze __contracts_14;
+```
+
+For equality-only lookups on text fields, a `hash` index is more compact:
+
+```sql
+call create_index_for_contract(
+  'token_wallet_holder',
+  'Token',
+  '(payload->''wallet''->>''holder'')',
+  'hash'
+);
+```
+
+<Note>
+When two indexed fields have a statistical dependency (for example, `wallet.holder` determines `wallet.label`), PostgreSQL may severely underestimate result cardinality. Create [extended statistics](https://www.postgresql.org/docs/current/sql-createstatistics.html) on the dependent expressions to correct this.
+</Note>
+
+## Maintenance functions
+
+### Pruning
+
+`prune_to_offset(offset)` permanently removes all transactions up to and including the given offset. Active contracts are preserved under a new offset; all other transaction data (archived contracts, exercise events) is deleted.
+
+```sql
+select * from prune_to_offset('<offset>');
+```
+
+Combine with `nearest_offset()` to prune by timestamp or interval:
+
+```sql
+select * from prune_to_offset(nearest_offset('2024-01-30T00:00:00Z'::timestamptz));
+select * from prune_to_offset(nearest_offset(interval '30 days'));
+```
+
+<Warning>
+Pruning is irreversible. The target offset must be within the bounds of the contiguous history and cannot coincide with the latest consistent checkpoint.
+</Warning>
+
+### Redaction
+
+Redaction removes sensitive data from specific contracts or exercises while preserving the event metadata.
+
+- `redact_contract(contract_id, redaction_id)` -- nullifies `payload` and `contract_key` on an archived contract (and its interface views). Returns the number of affected entries.
+- `redact_exercise(event_id, redaction_id)` -- nullifies `argument` and `result` on an exercise event.
+
+```sql
+select redact_contract('<contract_id>', '<redaction_id>');
+select redact_exercise('<event_id>', '<redaction_id>');
+```
+
+You cannot redact an active contract, and a contract that has already been redacted cannot be redacted again. There are no such restrictions on exercise events. After redaction, the `redaction_id` column is populated in query results and the data columns return `NULL`.
+
+### Resetting
+
+`reset_to_offset(offset)` removes all transactions **after** the given offset, allowing PQS to resume processing from that point. A dry-run validation is available first:
+
+```sql
+-- Dry run: inspect scope of the proposed reset
+select * from validate_reset_offset('<offset>');
+
+-- Destructive: execute the reset
+select * from reset_to_offset('<offset>');
+```
+
+<Warning>
+Resetting is destructive and permanent. Stop PQS and all consuming applications before resetting. Coordinate with your Participant Node operator, especially in disaster-recovery scenarios.
+</Warning>

--- a/docs-main/appdev/reference/pqs-sql-reference.mdx
+++ b/docs-main/appdev/reference/pqs-sql-reference.mdx
@@ -7,6 +7,264 @@ The PQS SQL API is provisioned directly in the PostgreSQL database. Data consume
 
 PQS data can be joined across contract tables to build projections (for example, joining holdings with account templates). The temporal offset model and historical event functions (`creates`, `archives`, `exercises`) make PQS well-suited for audit trails and compliance queries.
 
+
+{/* COPIED_START source="docs-website:replicated/pqs/3.5/component-howtos/pqs/references/sql-api.rst" hash="addc8b94" */}
+
+<Warning title="Pre-reviewed Content - Do Not Modify">
+This section was copied from existing reviewed documentation.
+**Source:** `replicated/pqs/3.5/component-howtos/pqs/references/sql-api.rst`
+Reviewers: Skip this section. Remove markers after final approval.
+</Warning>
+
+# SQL API
+
+While data consumers do not communicate with the PQS process directly, they do use an API that PQS has provisioned in the database itself. This SQL API is designed to provide a consistent and stable interface for users to access the ledger. It consists of a set of functions that should be the only database artifacts readers interact with.
+
+## Ledger time model
+
+A key aspect to consider when querying the ledger is the fact that it makes the history over time available. Additionally, understanding time in a distributed environment can be challenging because there are many different clocks available.
+
+### Offset
+
+A Participant Node models time using an index called an *offset*. An offset is a unique index of the Participant Nodes's local ledger. You can think of this as selecting an item in the ledger using a specific offset (or index) into the ledger.
+
+Offsets are ordered, representing the order of transactions on the ledger of a Participant Node. Due to privacy and filtering, the sequence of offsets of a Participant Node usually appears to contain gaps.
+
+Offsets are specific to a Participant Node and are not consistent between peer Participant Nodes, even when processing common transactions. This is because each Participant Node has its own ledger and allocates its own offsets based on it's permissioned view of transactions.
+
+Offsets are represented as strings (in Daml 2.x) or integers (in Daml 3.3+) in columns `created_at_offset`, `archived_at_offset` and `exercised_at_offset` (see `pqs-references-types-of-returned-data`).
+
+### Ledger time
+
+Ledger time is an approximate wall-clock time (within a bounded skew) that preserves causal ordering. That is, if a contract is created at a certain time, it cannot be used until after that time. The ledger time is represented by `created_effective_at`, `archived_effective_at` and `exercised_effective_at` columns (see `pqs-references-types-of-returned-data`).
+
+### Transaction ID
+
+A transaction ID corresponds to an offset in the following ways:
+
+- Not every offset has a transaction ID. For example, the completion event of a rejected transaction does not have a transaction ID because it was unsuccessful.
+- There is, at most, one transaction ID at a given offset.
+- Each transaction ID is unique and always has a single offset.
+- While offsets are allocated by, and are specific to, a Participant Node; transaction ID values are common to all Participant Nodes.
+- Transaction ordering (as represented by associated offset) can vary between Participant Nodes.
+- A transaction ID is entirely opaque and does not communicate any information, other than identification.
+
+### Which should I use?
+
+Different types of data analysis require different tools. For example in these types of analysis the following identifiers can be useful:
+
+- Causal: **Offset** provides an understanding of events in causal order, consistent with the participant-determined ledger commit ordering.
+- Systematic: **Transaction ID** is required for correlating over multiple Participant Nodes, serving as a common identifier for individual transactions.
+- Temporal: **Ledger Time** provides an ordering of events in wall-clock time, with bounded skew. This can be useful depending on your need for precision.
+
+## PQS time model
+
+PQS provides all three identifiers, but offset defines the order. With this PQS is able to provide a consistent view of ledger transactions.
+
+Offsets are deeply embedded in the SQL API, allowing users to query the ledger in a manner that provides consistency. Users can nominate the offsets they wish to query, or simply query the latest available offset.
+
+The following figure shows a pair of Participant Nodes and their respective ledgers. Each Participant Node has its own PQS instance, and you can see that it always has the portion of the ledger it is authorized to see:
+
+<div class="mermaid">
+
+---title: Time Model ---classDiagram SyncDomain \<-- Participant-A SyncDomain \<-- Participant-B class Participant-A { 511: tx-A 513: tx-G 514: tx-P 515: tx-S 516: tx-V } class Participant-B { 21O: tx-A 211: tx-D 212: tx-J 213: tx-M 215: tx-P } Participant-A \<-- PQS-A Participant-B \<-- PQS-B class PQS-A { 511: tx-A 514: tx-P } class PQS-B { 21O: tx-A 212: tx-J 215: tx-P }
+
+</div>
+
+You can also see that the offsets (prefix) are common to the Participant Node and PQS, but the Transaction IDs (suffix) are shared throughout.
+
+## Offset management
+
+The following functions control the temporal perspective of the ledger, and allow you to control how you consider time in your queries. Since PQS exposes an eventually consistent perspective of the ledger, you may wish to query:
+
+- **Ignore**; The *latest available* state.
+- **Pin**; The state of the ledger at a specific time.
+- **Span**; The ledger events across a time range, such as for an audit trail.
+- **Consistency**; The ledger in a way that maintains consistency with other interactions you have had with the ledger (read or write).
+
+The following functions allow you to control the temporal scope of the ledger. This establishes the context in which subsequent queries execute:
+
+- `set_latest(offset)`: nominates the offset of the latest data to include in observing the ledger. If `NULL` it uses the latest available. The actual offset to be used is returned. If the supplied offset is beyond what is available, an error occurs.
+- `validate_offset_exists(offset)`: validates that the datastore has a complete history up to and including the offset provided. Returns an error if the nominated offset is not available (too old, or too new).
+- `set_oldest(offset)`: nominates the offset of the oldest events to include in query scope. If `NULL` then it uses the oldest available. Function returns the actual offset used. If the supplied offset is beyond what is available, an error occurs.
+- `nearest_offset(time)`: a helper function to determine the offset of a given time (or interval prior to now).
+
+## Accessing contracts and exercises
+
+Under this scope, the following table functions[^1] allow access to the ledger and are used directly in queries. They are designed to be used in a similar manner to tables or views, and allow users to focus on the data they wish to query, with the impact of offsets removed.
+
+- `active(name, [at_offset])`: active instances of the target template/interface views that existed at the time of the latest offset
+- `creates(name, [from_offset], [to_offset])`: create events of the target template/interface views that occurred between the oldest and latest offset
+- `archives(name, [from_offset], [to_offset])`: archive events of the target template/interface views that occurred between the oldest and latest offset
+- `exercises(name, [from_offset], [to_offset])`: exercise events of the target choice that occurred between the oldest and latest offset
+
+The `name` identifier can be used with or without the package specified:
+
+- Fully qualified: `<package>:<module>:<template|interface|choice>`
+- Partially qualified: `<module>:<template|interface|choice>` or `<template|interface|choice>` (if unambiguous)
+
+<div class="caution">
+
+Partially qualified identifiers fail if there is an ambiguous result.
+
+</div>
+
+These functions have optional parameters to allow the user to specify the offset range to be used. Providing these arguments is alternative to using `set_*` functions prior in the session. The following queries are equivalent:
+
+Implicit: geared towards context-oriented exploration
+
+```sql
+select set_oldest('from_offset');
+select set_latest('to_offset');
+select * from creates('package:My.Module:Template');
+```
+
+Explicit: beneficial to inline the entire context, to emit in a single statement
+
+```sql
+select *
+from creates('package:My.Module:Template', 'from_offset', 'to_offset');
+```
+
+## Accessing transactions metadata
+
+In certain cases, it might be necessary to access the metadata of a ledger transaction instead of the contracts/exercises themselves. This can be done through the `transactions` view which provides additional data not directly exposed by the primary table functions described in the previous section:
+
+| Name                        | Type                       | Description                                                                                                                                                                                                   |
+|-----------------------------|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ix`                        | `bigint`                   | Internal primary key of the ledger transaction                                                                                                                                                                |
+| `offset`                    | `bigint`                   | Ledger offset                                                                                                                                                                                                 |
+| `transaction_id`            | `text`                     | Transaction ID assigned by the ledger                                                                                                                                                                         |
+| `effective_at`              | `timestamp with time zone` | Ledger effective time                                                                                                                                                                                         |
+| `workflow_id`               | `text`                     | Workflow ID used in command submission                                                                                                                                                                        |
+| `trace_context`             | `trace_context`            | Ledger API trace context (user defined type containing `(trace_parent: text, trace_state: text)`) (see `trace_context <com.daml.ledger.api.v2.Completion.trace_context>` and `pqs-trace-context-propagation`) |
+| `external_transaction_hash` | `bytea`                    | Hash of the transaction submitted by the external party (see `external_transaction_hash <com.daml.ledger.api.v2.Transaction.external_transaction_hash>`)                                                      |
+
+A query against the contracts/exercises can easily and efficiently be enriched with the transaction metadata by joining through the appropriate `*_at_ix` column, for example:
+
+```sql
+select c.contract_id, t.transaction_id, (t.trace_context).trace_parent
+from creates('package:My.Module:Template') c
+inner join transactions t on c.created_at_ix = t.ix
+where c.create_event_id = (42::bigint,0);
+```
+
+## Summary functions
+
+Summary functions are available to provide an overview of the ledger data available within the nominated offset range:
+
+- `summary_transients(from_offset, to_offset)`: the number of transients per Daml fully qualified name within the offset range.
+- `summary_updates(from_offset, to_offset)`: summary of create and archive counts per Daml fully qualified name within the offset range.
+
+The following functions retrieve event counts per `template_fqn`:
+
+- `summary_active(at_offset)`
+- `summary_creates(from_offset, to_offset)`
+- `summary_archives(from_offset, to_offset)`
+- `summary_exercises(from_offset, to_offset)`
+
+## Lookup functions
+
+- `lookup_contract(contract_id)` is a mechanism to retrieve contract data without needing to know its Daml qualified name. The function returns both contract and all associated interface view projections, distinguishable by the `payload_type` column.
+- `lookup_exercises(contract_id)` is a mechanism to retrieve choice exercise data without needing to know the Daml qualified name; knowing the contract ID is sufficient.
+
+## Types of returned data
+
+All functions returning contract data return the following columns:
+
+| Name                    | Type                          | Description                                                                                                                                            |
+|-------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `template_fqn`          | `text`                        | Fully-qualified name of the template or interface                                                                                                      |
+| `payload_type`          | `'template'` or `'interface'` | Type of contract payload                                                                                                                               |
+| `create_event_pk`       | `bigint`                      | Reference to contract creation event primary key                                                                                                       |
+| `create_event_id`       | `(bigint, integer)`           | Orderable addressing type `(offset, node ID)` of the creation event                                                                                    |
+| `created_at_ix`         | `bigint`                      | Ordinal index of the transaction containing the creation event                                                                                         |
+| `created_at_offset`     | `bigint`                      | Ledger offset of the transaction containing the creation event                                                                                         |
+| `created_effective_at`  | `timestamp with time zone`    | Ledger effective time of the transaction containing the creation event                                                                                 |
+| `archive_event_pk`      | `bigint`                      | Reference to contract archival event primary key                                                                                                       |
+| `archive_event_id`      | `(bigint, integer)`           | Orderable addressing type `(offset, node ID)` of the archival event                                                                                    |
+| `archived_at_ix`        | `bigint`                      | Ordinal index of the transaction containing the archival event                                                                                         |
+| `archived_at_offset`    | `bigint`                      | Ledger offset of the transaction containing the archival event                                                                                         |
+| `archived_effective_at` | `timestamp with time zone`    | Ledger effective time of the transaction containing the archival event                                                                                 |
+| `life_ix`               | `int8range`                   | Contract's lifespan expressed in ordinal indexes                                                                                                       |
+| `contract_id`           | `text`                        | Ledger-assigned contract ID                                                                                                                            |
+| `payload`               | `jsonb`                       | JSONB representation of contract data                                                                                                                  |
+| `metadata`              | `bytea`                       | Explicit contract disclosure metadata (see `stakeholder-contract-share`)                                                                               |
+| `package_name`          | `text`                        | Daml package name                                                                                                                                      |
+| `package_version`       | `text`                        | Daml package version                                                                                                                                   |
+| `package_id`            | `text`                        | Daml package ID                                                                                                                                        |
+| `redaction_id`          | `text`                        | Redaction process reference                                                                                                                            |
+| `signatories`           | `text[]`                      | Parties consenting to the creation of the contract                                                                                                     |
+| `observers`             | `text[]`                      | Additional stakeholders whom the contract is visible to                                                                                                |
+| `witnesses`             | `text[]`                      | Parties that are notified of this event                                                                                                                |
+| `divulged_only`         | `boolean`                     | Indicates whether the contract was only divulged (`true`), or properly disclosed (`false`). Refer to `da-model-divulgence` for background information. |
+
+All functions returning exercise data return the following columns:
+
+| Name                      | Type                       | Description                                                                                                                                                                                                    |
+|---------------------------|----------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `template_fqn`            | `text`                     | Fully-qualified name of the template where choice is defined                                                                                                                                                   |
+| `choice_fqn`              | `text`                     | Fully-qualified name of the choice                                                                                                                                                                             |
+| `choice`                  | `text`                     | Choice name                                                                                                                                                                                                    |
+| `consuming`               | `boolean`                  | Whether the choice is consuming                                                                                                                                                                                |
+| `exercise_event_pk`       | `bigint`                   | Reference to choice exercise event primary key                                                                                                                                                                 |
+| `exercise_event_id`       | `(bigint, integer)`        | Orderable addressing type `(offset, node ID)` of the exercise event                                                                                                                                            |
+| `exercised_at_ix`         | `bigint`                   | Ordinal index of the transaction containing the exercise event                                                                                                                                                 |
+| `exercised_at_offset`     | `bigint`                   | Ledger offset of the transaction containing the exercise event                                                                                                                                                 |
+| `exercised_effective_at`  | `timestamp with time zone` | Ledger effective time of the transaction containing the exercise event                                                                                                                                         |
+| `contract_id`             | `text`                     | Ledger-assigned contract ID                                                                                                                                                                                    |
+| `argument`                | `jsonb`                    | JSONB representation of the choice argument type                                                                                                                                                               |
+| `result`                  | `jsonb`                    | JSONB representation of the choice return type                                                                                                                                                                 |
+| `package_name`            | `text`                     | Daml package name                                                                                                                                                                                              |
+| `package_version`         | `text`                     | Daml package version                                                                                                                                                                                           |
+| `package_id`              | `text`                     | Daml package ID                                                                                                                                                                                                |
+| `redaction_id`            | `text`                     | Redaction process reference                                                                                                                                                                                    |
+| `signatories`             | `text[]`                   | Parties that consented to the creation of the contract that choice was exercised on                                                                                                                            |
+| `observers`               | `text[]`                   | Additional stakeholders made aware of the creation of the contract that choice was exercised on                                                                                                                |
+| `controllers`             | `text[]`                   | Parties that collectively exercised this choice (see `acting_parties <com.daml.ledger.api.v2.ExercisedEvent.acting_parties>`)                                                                                  |
+| `witnesses`               | `text[]`                   | Parties that are notified of this event                                                                                                                                                                        |
+| `last_descendant_node_id` | `integer`                  | Upper boundary of node IDs for events in the same transaction that appeared as a result of this exercise event (see `last_descendant_node_id <com.daml.ledger.api.v2.ExercisedEvent.last_descendant_node_id>`) |
+
+## JSONB encoding
+
+PQS stores the ledger using a Daml-LF JSON-based encoding (see `reference-json-lf-value-specification`) of Daml-LF values. An overview of the encoding is provided below.
+
+Users should consult the PostgreSQL documentation to understand how to work with JSONB data[^2] natively in SQL.
+
+Values on the ledger (contract payloads and keys, interface views, exercise arguments, and return values) can be primitive types, user-defined records, variants, or enums. These types translate to JSON types[^3] as follows:
+
+### Primitive types
+
+| Daml type    | JSON type                                                                                                                                                                               |
+|--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ContractID` | represented as [string](https://json-schema.org/understanding-json-schema/reference/string)                                                                                             |
+| `Int64`      | represented as [string](https://json-schema.org/understanding-json-schema/reference/string)                                                                                             |
+| `Decimal`    | represented as [string](https://json-schema.org/understanding-json-schema/reference/string)                                                                                             |
+| `List`       | represented as [array](https://json-schema.org/understanding-json-schema/reference/array)                                                                                               |
+| `Text`       | represented as [string](https://json-schema.org/understanding-json-schema/reference/string)                                                                                             |
+| `Date`       | ISO 8601 date represented as [string](https://json-schema.org/understanding-json-schema/reference/string)                                                                               |
+| `Time`       | ISO 8601 time (in UTC) represented as [string](https://json-schema.org/understanding-json-schema/reference/string)                                                                      |
+| `Bool`       | represented as [boolean](https://json-schema.org/understanding-json-schema/reference/boolean)                                                                                           |
+| `Party`      | represented as [string](https://json-schema.org/understanding-json-schema/reference/string)                                                                                             |
+| `Unit`       | represented as empty object `{}`                                                                                                                                                        |
+| `Optional`   | [nullable](https://json-schema.org/understanding-json-schema/reference/null) value or [array](https://json-schema.org/understanding-json-schema/reference/array) (depending on context) |
+
+### User-defined types
+
+| Daml type | JSON type                                                                                                                                                                                                       |
+|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Record`  | represented as [object](https://json-schema.org/understanding-json-schema/reference/object), where each create parameter's name is a key, and the parameter's value is the JSON-encoded value                   |
+| `Variant` | represented as [object](https://json-schema.org/understanding-json-schema/reference/object), using the `{"tag": "CONSTRUCTOR", "value": <JSON-encoded value>}` format, such as `{"tag": "Left", "value": true}` |
+| `Enum`    | represented as [string](https://json-schema.org/understanding-json-schema/reference/string), where the value is the constructor name.                                                                           |
+
+[^1]: <https://www.postgresql.org/docs/current/xfunc-sql.html#XFUNC-SQL-TABLE-FUNCTIONS>
+
+[^2]: <https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT>
+
+[^3]: <https://json-schema.org/understanding-json-schema/reference/type>
+
+{/* COPIED_END */}
+
 ## Offset model
 
 A validator models time using an **offset**, a unique integer index into its local ledger. Offsets are ordered and represent the causal order of transactions. Due to privacy filtering, the sequence of offsets on a given validator usually contains gaps.
@@ -17,36 +275,9 @@ In addition to offsets, PQS exposes **ledger time** (approximate wall-clock time
 
 ## Offset management
 
-{/* COPIED_START - source: sql-api.rst */}
-
-These functions control the temporal perspective of the ledger:
-
-- `set_latest(offset)` -- nominates the offset of the latest data to include in observing the ledger. If `NULL` it uses the latest available. The actual offset to be used is returned. If the supplied offset is beyond what is available, an error occurs.
-- `validate_offset_exists(offset)` -- validates that the datastore has a complete history up to and including the offset provided. Returns an error if the nominated offset is not available (too old, or too new).
-- `set_oldest(offset)` -- nominates the offset of the oldest events to include in query scope. If `NULL` then it uses the oldest available. Function returns the actual offset used. If the supplied offset is beyond what is available, an error occurs.
-- `nearest_offset(time)` -- a helper function to determine the offset of a given time (or interval prior to now).
-
-{/* COPIED_END */}
-
 Call `set_oldest` and `set_latest` before running queries in a session to pin the temporal window, or pass offset arguments directly to table functions (see below).
 
 ## Table functions for contracts and exercises
-
-{/* COPIED_START - source: sql-api.rst */}
-
-The following table functions allow access to the ledger and are used directly in queries. They are designed to be used in a similar manner to tables or views:
-
-- `active(name, [at_offset])` -- active instances of the target template/interface views that existed at the time of the latest offset
-- `creates(name, [from_offset], [to_offset])` -- create events of the target template/interface views that occurred between the oldest and latest offset
-- `archives(name, [from_offset], [to_offset])` -- archive events of the target template/interface views that occurred between the oldest and latest offset
-- `exercises(name, [from_offset], [to_offset])` -- exercise events of the target choice that occurred between the oldest and latest offset
-
-The `name` identifier can be used with or without the package specified:
-
-- Fully qualified: `<package>:<module>:<template|interface|choice>`
-- Partially qualified: `<module>:<template|interface|choice>` or `<template|interface|choice>` (if unambiguous)
-
-{/* COPIED_END */}
 
 <Warning>
 Partially qualified identifiers fail if the result is ambiguous.
@@ -68,13 +299,6 @@ from creates('package:My.Module:Template', 'from_offset', 'to_offset');
 ```
 
 ## Lookup functions
-
-{/* COPIED_START - source: sql-api.rst */}
-
-- `lookup_contract(contract_id)` is a mechanism to retrieve contract data without needing to know its Daml qualified name. The function returns both contract and all associated interface view projections, distinguishable by the `payload_type` column.
-- `lookup_exercises(contract_id)` is a mechanism to retrieve choice exercise data without needing to know the Daml qualified name; knowing the contract ID is sufficient.
-
-{/* COPIED_END */}
 
 ## Transactions view
 
@@ -101,88 +325,9 @@ where c.create_event_id = (42::bigint, 0);
 
 ## Summary functions
 
-{/* COPIED_START - source: sql-api.rst */}
-
-Summary functions provide an overview of the ledger data available within the nominated offset range:
-
-- `summary_transients(from_offset, to_offset)` -- the number of transients per Daml fully qualified name within the offset range
-- `summary_updates(from_offset, to_offset)` -- summary of create and archive counts per Daml fully qualified name within the offset range
-
-The following functions retrieve event counts per `template_fqn`:
-
-- `summary_active(at_offset)`
-- `summary_creates(from_offset, to_offset)`
-- `summary_archives(from_offset, to_offset)`
-- `summary_exercises(from_offset, to_offset)`
-
-{/* COPIED_END */}
-
 ## Contract columns
 
-{/* COPIED_START - source: sql-api.rst */}
-
-All functions returning contract data return the following columns:
-
-| Column | Type | Description |
-|---|---|---|
-| `template_fqn` | `text` | Fully-qualified name of the template or interface |
-| `payload_type` | `'template'` or `'interface'` | Type of contract payload |
-| `create_event_pk` | `bigint` | Reference to contract creation event primary key |
-| `create_event_id` | `(bigint, integer)` | Orderable addressing type `(offset, node ID)` of the creation event |
-| `created_at_ix` | `bigint` | Ordinal index of the transaction containing the creation event |
-| `created_at_offset` | `bigint` | Ledger offset of the transaction containing the creation event |
-| `created_effective_at` | `timestamp with time zone` | Ledger effective time of the transaction containing the creation event |
-| `archive_event_pk` | `bigint` | Reference to contract archival event primary key |
-| `archive_event_id` | `(bigint, integer)` | Orderable addressing type `(offset, node ID)` of the archival event |
-| `archived_at_ix` | `bigint` | Ordinal index of the transaction containing the archival event |
-| `archived_at_offset` | `bigint` | Ledger offset of the transaction containing the archival event |
-| `archived_effective_at` | `timestamp with time zone` | Ledger effective time of the transaction containing the archival event |
-| `life_ix` | `int8range` | Contract's lifespan expressed in ordinal indexes |
-| `contract_id` | `text` | Ledger-assigned contract ID |
-| `payload` | `jsonb` | JSONB representation of contract data |
-| `metadata` | `bytea` | Explicit contract disclosure metadata |
-| `package_name` | `text` | Daml package name |
-| `package_version` | `text` | Daml package version |
-| `package_id` | `text` | Daml package ID |
-| `redaction_id` | `text` | Redaction process reference |
-| `signatories` | `text[]` | Parties consenting to the creation of the contract |
-| `observers` | `text[]` | Additional stakeholders whom the contract is visible to |
-| `witnesses` | `text[]` | Parties that are notified of this event |
-| `divulged_only` | `boolean` | Whether the contract was only divulged (`true`) or properly disclosed (`false`) |
-
-{/* COPIED_END */}
-
 ## Exercise columns
-
-{/* COPIED_START - source: sql-api.rst */}
-
-All functions returning exercise data return the following columns:
-
-| Column | Type | Description |
-|---|---|---|
-| `template_fqn` | `text` | Fully-qualified name of the template where choice is defined |
-| `choice_fqn` | `text` | Fully-qualified name of the choice |
-| `choice` | `text` | Choice name |
-| `consuming` | `boolean` | Whether the choice is consuming |
-| `exercise_event_pk` | `bigint` | Reference to choice exercise event primary key |
-| `exercise_event_id` | `(bigint, integer)` | Orderable addressing type `(offset, node ID)` of the exercise event |
-| `exercised_at_ix` | `bigint` | Ordinal index of the transaction containing the exercise event |
-| `exercised_at_offset` | `bigint` | Ledger offset of the transaction containing the exercise event |
-| `exercised_effective_at` | `timestamp with time zone` | Ledger effective time of the transaction containing the exercise event |
-| `contract_id` | `text` | Ledger-assigned contract ID |
-| `argument` | `jsonb` | JSONB representation of the choice argument type |
-| `result` | `jsonb` | JSONB representation of the choice return type |
-| `package_name` | `text` | Daml package name |
-| `package_version` | `text` | Daml package version |
-| `package_id` | `text` | Daml package ID |
-| `redaction_id` | `text` | Redaction process reference |
-| `signatories` | `text[]` | Parties that consented to the creation of the contract that choice was exercised on |
-| `observers` | `text[]` | Additional stakeholders made aware of the creation of the contract that choice was exercised on |
-| `controllers` | `text[]` | Parties that collectively exercised this choice |
-| `witnesses` | `text[]` | Parties that are notified of this event |
-| `last_descendant_node_id` | `integer` | Upper boundary of node IDs for events in the same transaction resulting from this exercise |
-
-{/* COPIED_END */}
 
 ## JSONB indexing
 


### PR DESCRIPTION
## Summary

Application developer reference pages. Mix of **COPIED content** (from docs-website error codes, PQS docs) and **original content**.

| File | What's in it |
|------|-------------|
| `daml-language-reference.mdx` | Daml syntax quick reference: fundamentals, types, pattern matching, template structure, choice patterns, update monad, standard library module list. Links to cheat sheet and stdlib. |
| `error-codes.mdx` | Ledger API error code reference: error categories (1-14), gRPC status codes, retry strategies by category. COPIED from docs-website error codes reference. |
| `configuration-reference.mdx` | Application configuration reference: daml.yaml fields, multi-package.yaml, Ledger API connection, JSON API config, JWT auth, TLS, logging, Canton participant tuning. |
| `pqs-sql-reference.mdx` | PQS SQL schema reference: core tables (exercises, creates, assignments), contract indexing functions, example queries for ACS and transaction history. |

**docs.json:** Updated navigation for AppDev Reference section.

## Review focus

Error codes table rendering at narrow screen widths (flagged in internal review — CSS concern).