### PR TITLE
Make Osano only active on the production site

### DIFF
--- a/osano.js
+++ b/osano.js
@@ -1,3 +1,5 @@
-var script = document.createElement("script");
-script.src = "https://cmp.osano.com/16A4BWTQ2aBjp3tNZ/54d97448-ff70-4b63-aaff-7dcf04da4e6c/osano.js";
-document.head.appendChild(script);
+if (window.location.hostname === "docs.canton.network") {
+  var script = document.createElement("script");
+  script.src = "https://cmp.osano.com/16A4BWTQ2aBjp3tNZ/54d97448-ff70-4b63-aaff-7dcf04da4e6c/osano.js";
+  document.head.appendChild(script);
+}


### PR DESCRIPTION
Running Osano on all deployments (including pull-request builds, and `localhost`-based builds) causes a lot of noise on the Osano dashboard, and these aren't intended to be shared with external users.

Make Osano only active on the production site, and not pull-request builds or when running locally.