### PR TITLE
Add generated JSON API reference page

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ By default this writes:
 - `docs-main/appdev/reference/json-api-reference.mdx`
 - `docs-main/docs.json`
 
-The generated page is placed under the top-level `Reference` dropdown in `docs-main/docs.json`.
+The generated page is placed directly under the top-level `Reference` dropdown in `docs-main/docs.json`, outside the `MainNet`/`TestNet`/`DevNet` versioned navigation branches.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,23 @@ Then run:
 direnv allow
 mintlify dev
 ```
+
+### Generate the JSON API reference
+
+This repo includes the checked-in Ledger API OpenAPI manifest and snapshots under `config/x2mdx/ledger-api/`.
+The Nix shell pins `x2mdx` from `github.com/danielporterda/x2mdx`, so once `direnv` has loaded you can regenerate the page and `docs.json` update with:
+
+```bash
+python3 scripts/generate_json_api_reference.py
+```
+
+or:
+
+```bash
+npm run generate:json-api-reference
+```
+
+By default this writes:
+
+- `docs-main/appdev/reference/json-api-reference.mdx`
+- `docs-main/docs.json`

--- a/README.md
+++ b/README.md
@@ -82,3 +82,5 @@ By default this writes:
 
 - `docs-main/appdev/reference/json-api-reference.mdx`
 - `docs-main/docs.json`
+
+The generated page is placed under the top-level `Reference` dropdown in `docs-main/docs.json`.

--- a/config/x2mdx/ledger-api/3.4/openapi.yaml
+++ b/config/x2mdx/ledger-api/3.4/openapi.yaml
@@ -1,0 +1,7976 @@
+  openapi: 3.0.3
+  info:
+    title: JSON Ledger API HTTP endpoints
+    version: 3.4.12-SNAPSHOT
+    description: |-
+      This specification version fixes the API inconsistencies where certain fields marked as required in the spec are in fact optional.
+      If you use code generation tool based on this file, you might need to adjust the existing application code to handle those fields as optional.
+      If you do not want to change your client code, continue using the OpenAPI specification from the previous Canton 3.4 patch release.
+      MINIMUM_CANTON_VERSION=3.4.12
+  paths:
+    /v2/commands/submit-and-wait:
+      post:
+        description: Submit a batch of commands and wait for the completion details
+        operationId: postV2CommandsSubmit-and-wait
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsCommands'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SubmitAndWaitResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/submit-and-wait-for-transaction:
+      post:
+        description: Submit a batch of commands and wait for the transaction response
+        operationId: postV2CommandsSubmit-and-wait-for-transaction
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsSubmitAndWaitForTransactionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsSubmitAndWaitForTransactionResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/submit-and-wait-for-reassignment:
+      post:
+        description: Submit a batch of reassignment commands and wait for the reassignment
+          response
+        operationId: postV2CommandsSubmit-and-wait-for-reassignment
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmitAndWaitForReassignmentRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsSubmitAndWaitForReassignmentResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/submit-and-wait-for-transaction-tree:
+      post:
+        description: Submit a batch of commands and wait for the transaction trees response.
+          Provided for backwards compatibility, it will be removed in the Canton version
+          3.5.0, use submit-and-wait-for-transaction instead.
+        operationId: postV2CommandsSubmit-and-wait-for-transaction-tree
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsCommands'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsSubmitAndWaitForTransactionTreeResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/async/submit:
+      post:
+        description: Submit a command asynchronously
+        operationId: postV2CommandsAsyncSubmit
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsCommands'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SubmitResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/async/submit-reassignment:
+      post:
+        description: Submit reassignment command asynchronously
+        operationId: postV2CommandsAsyncSubmit-reassignment
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmitReassignmentRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SubmitReassignmentResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/completions:
+      post:
+        description: |-
+          Query completions list (blocking call)
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2CommandsCompletions
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompletionStreamRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/CompletionStreamResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: query parameter
+              limit, Invalid value for: query parameter stream_idle_timeout_ms, Invalid
+              value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/events/events-by-contract-id:
+      post:
+        description: Get events by contract Id
+        operationId: postV2EventsEvents-by-contract-id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetEventsByContractIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetEventsByContractIdResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/version:
+      get:
+        description: Get the version details of the participant node
+        operationId: getV2Version
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetLedgerApiVersionResponse'
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/dars/validate:
+      post:
+        description: Validates a DAR for upgrade-compatibility against the current vetting
+          state on the target synchronizer
+        operationId: postV2DarsValidate
+        parameters:
+        - name: synchronizerId
+          in: query
+          required: false
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          required: true
+        responses:
+          '200':
+            description: ''
+          '400':
+            description: 'Invalid value for: body, Invalid value for: query parameter
+              synchronizerId, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/dars:
+      post:
+        description: Upload a DAR to the participant node
+        operationId: postV2Dars
+        parameters:
+        - name: vetAllPackages
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: synchronizerId
+          in: query
+          required: false
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UploadDarFileResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: query parameter
+              vetAllPackages, Invalid value for: query parameter synchronizerId, Invalid
+              value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/packages:
+      get:
+        description: List all packages uploaded on the participant node
+        operationId: getV2Packages
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListPackagesResponse'
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: Upload a DAR to the participant node. Behaves the same as /dars.
+          This endpoint will be deprecated and removed in a future release.
+        operationId: postV2Packages
+        parameters:
+        - name: vetAllPackages
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: synchronizerId
+          in: query
+          required: false
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UploadDarFileResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: query parameter
+              vetAllPackages, Invalid value for: query parameter synchronizerId, Invalid
+              value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/packages/{package-id}:
+      get:
+        description: Download the package for the requested package-id
+        operationId: getV2PackagesPackage-id
+        parameters:
+        - name: package-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            headers:
+              Canton-Package-Hash:
+                required: true
+                schema:
+                  type: string
+            content:
+              application/octet-stream:
+                schema:
+                  type: string
+                  format: binary
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/packages/{package-id}/status:
+      get:
+        description: Get package status
+        operationId: getV2PackagesPackage-idStatus
+        parameters:
+        - name: package-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPackageStatusResponse'
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/package-vetting:
+      get:
+        description: List vetted packages
+        operationId: getV2Package-vetting
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListVettedPackagesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListVettedPackagesResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: Update vetted packages
+        operationId: postV2Package-vetting
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateVettedPackagesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateVettedPackagesResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties:
+      get:
+        description: List all known parties.
+        operationId: getV2Parties
+        parameters:
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: filter-party
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description: maximum number of elements in a returned page
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: pageToken
+          in: query
+          description: token - to continue results from a given page, leave empty to
+            start from the beginning of the list, obtain token from the result of previous
+            page
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListKnownPartiesResponse'
+          '400':
+            description: 'Invalid value for: query parameter identity-provider-id, Invalid
+              value for: query parameter filter-party, Invalid value for: query parameter
+              pageSize, Invalid value for: query parameter pageToken, Invalid value
+              for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: Allocate a new party to the participant node
+        operationId: postV2Parties
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocatePartyRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/AllocatePartyResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/external/allocate:
+      post:
+        description: Allocate a new external party
+        operationId: postV2PartiesExternalAllocate
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocateExternalPartyRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/AllocateExternalPartyResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/participant-id:
+      get:
+        description: Get participant id
+        operationId: getV2PartiesParticipant-id
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetParticipantIdResponse'
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/{party}:
+      get:
+        description: Get party details
+        operationId: getV2PartiesParty
+        parameters:
+        - name: party
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPartiesResponse'
+          '400':
+            description: 'Invalid value for: query parameter identity-provider-id, Invalid
+              value for: query parameter parties, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: Allocate a new party to the participant node
+        operationId: patchV2PartiesParty
+        parameters:
+        - name: party
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdatePartyDetailsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdatePartyDetailsResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/external/generate-topology:
+      post:
+        description: Generate a topology for an external party
+        operationId: postV2PartiesExternalGenerate-topology
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateExternalPartyTopologyRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenerateExternalPartyTopologyResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/active-contracts:
+      post:
+        description: |-
+          Query active contracts list (blocking call).
+          Querying active contracts is an expensive operation and if possible should not be repeated often.
+          Consider querying active contracts initially (for a given offset)
+          and then repeatedly call one of `/v2/updates/...`endpoints  to get subsequent modifications.
+          You can also use websockets to get updates with better performance.
+
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2StateActive-contracts
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetActiveContractsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetActiveContractsResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: query parameter
+              limit, Invalid value for: query parameter stream_idle_timeout_ms, Invalid
+              value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/connected-synchronizers:
+      get:
+        description: Get connected synchronizers
+        operationId: getV2StateConnected-synchronizers
+        parameters:
+        - name: party
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: participantId
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: identityProviderId
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetConnectedSynchronizersResponse'
+          '400':
+            description: 'Invalid value for: query parameter party, Invalid value for:
+              query parameter participantId, Invalid value for: query parameter identityProviderId,
+              Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/ledger-end:
+      get:
+        description: Get ledger end
+        operationId: getV2StateLedger-end
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetLedgerEndResponse'
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/latest-pruned-offsets:
+      get:
+        description: Get latest pruned offsets
+        operationId: getV2StateLatest-pruned-offsets
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetLatestPrunedOffsetsResponse'
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates:
+      post:
+        description: |-
+          Query updates list (blocking call)
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2Updates
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdatesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetUpdatesResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: query parameter
+              limit, Invalid value for: query parameter stream_idle_timeout_ms, Invalid
+              value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/flats:
+      post:
+        description: |-
+          Query flat transactions update list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2UpdatesFlats
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdatesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetUpdatesResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: query parameter
+              limit, Invalid value for: query parameter stream_idle_timeout_ms, Invalid
+              value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/trees:
+      post:
+        description: |-
+          Query update transactions tree list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2UpdatesTrees
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdatesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetUpdateTreesResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: query parameter
+              limit, Invalid value for: query parameter stream_idle_timeout_ms, Invalid
+              value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-tree-by-offset/{offset}:
+      get:
+        description: Get transaction tree by offset. Provided for backwards compatibility,
+          it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset
+          instead.
+        operationId: getV2UpdatesTransaction-tree-by-offsetOffset
+        parameters:
+        - name: offset
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionTreeResponse'
+          '400':
+            description: 'Invalid value for: path parameter offset, Invalid value for:
+              query parameter parties, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-by-offset:
+      post:
+        description: Get transaction by offset. Provided for backwards compatibility,
+          it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset
+          instead.
+        operationId: postV2UpdatesTransaction-by-offset
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTransactionByOffsetRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/update-by-offset:
+      post:
+        description: Get update by offset
+        operationId: postV2UpdatesUpdate-by-offset
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdateByOffsetRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetUpdateResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-by-id:
+      post:
+        description: Get transaction by id. Provided for backwards compatibility, it
+          will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.
+        operationId: postV2UpdatesTransaction-by-id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTransactionByIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/update-by-id:
+      post:
+        description: Get update by id
+        operationId: postV2UpdatesUpdate-by-id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdateByIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetUpdateResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-tree-by-id/{update-id}:
+      get:
+        description: Get transaction tree by id. Provided for backwards compatibility,
+          it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id
+          instead.
+        operationId: getV2UpdatesTransaction-tree-by-idUpdate-id
+        parameters:
+        - name: update-id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionTreeResponse'
+          '400':
+            description: 'Invalid value for: query parameter parties, Invalid value
+              for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users:
+      get:
+        description: List all users.
+        operationId: getV2Users
+        parameters:
+        - name: pageSize
+          in: query
+          description: maximum number of elements in a returned page
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: pageToken
+          in: query
+          description: token - to continue results from a given page, leave empty to
+            start from the beginning of the list, obtain token from the result of previous
+            page
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListUsersResponse'
+          '400':
+            description: 'Invalid value for: query parameter pageSize, Invalid value
+              for: query parameter pageToken, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: Create user.
+        operationId: postV2Users
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateUserRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/CreateUserResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users/{user-id}:
+      get:
+        description: Get user details.
+        operationId: getV2UsersUser-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetUserResponse'
+          '400':
+            description: 'Invalid value for: query parameter identity-provider-id, Invalid
+              value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      delete:
+        description: Delete user.
+        operationId: deleteV2UsersUser-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: object
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: Update  user.
+        operationId: patchV2UsersUser-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateUserRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateUserResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/authenticated-user:
+      get:
+        description: Get current user details (uses user for JWT).
+        operationId: getV2Authenticated-user
+        parameters:
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetUserResponse'
+          '400':
+            description: 'Invalid value for: query parameter identity-provider-id, Invalid
+              value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users/{user-id}/rights:
+      get:
+        description: List user rights.
+        operationId: getV2UsersUser-idRights
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListUserRightsResponse'
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: Grant user rights.
+        operationId: postV2UsersUser-idRights
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GrantUserRightsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GrantUserRightsResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: Revoke user rights.
+        operationId: patchV2UsersUser-idRights
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevokeUserRightsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/RevokeUserRightsResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users/{user-id}/identity-provider-id:
+      patch:
+        description: Update user identity provider.
+        operationId: patchV2UsersUser-idIdentity-provider-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateUserIdentityProviderIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateUserIdentityProviderIdResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/idps:
+      get:
+        description: List all identity provider configs
+        operationId: getV2Idps
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListIdentityProviderConfigsResponse'
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: Create identity provider configs
+        operationId: postV2Idps
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateIdentityProviderConfigRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/CreateIdentityProviderConfigResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/idps/{idp-id}:
+      get:
+        description: Get identity provider config
+        operationId: getV2IdpsIdp-id
+        parameters:
+        - name: idp-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetIdentityProviderConfigResponse'
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      delete:
+        description: Delete identity provider config
+        operationId: deleteV2IdpsIdp-id
+        parameters:
+        - name: idp-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/DeleteIdentityProviderConfigResponse'
+          '400':
+            description: 'Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: Update identity provider config
+        operationId: patchV2IdpsIdp-id
+        parameters:
+        - name: idp-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateIdentityProviderConfigRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateIdentityProviderConfigResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/prepare:
+      post:
+        description: Prepare commands for signing
+        operationId: postV2Interactive-submissionPrepare
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsPrepareSubmissionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsPrepareSubmissionResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/execute:
+      post:
+        description: Execute a signed transaction
+        operationId: postV2Interactive-submissionExecute
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsExecuteSubmissionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ExecuteSubmissionResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/executeAndWait:
+      post:
+        description: Execute a signed transaction and wait for its completion
+        operationId: postV2Interactive-submissionExecuteandwait
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsExecuteSubmissionAndWaitRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ExecuteSubmissionAndWaitResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/executeAndWaitForTransaction:
+      post:
+        description: Execute a signed transaction and wait for the transaction response
+        operationId: postV2Interactive-submissionExecuteandwaitfortransaction
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsExecuteSubmissionAndWaitForTransactionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsExecuteSubmissionAndWaitForTransactionResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/preferred-package-version:
+      get:
+        description: Get the preferred package version for constructing a command submission
+        operationId: getV2Interactive-submissionPreferred-package-version
+        parameters:
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: package-name
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: vetting_valid_at
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: synchronizer-id
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPreferredPackageVersionResponse'
+          '400':
+            description: 'Invalid value for: query parameter parties, Invalid value
+              for: query parameter package-name, Invalid value for: query parameter
+              vetting_valid_at, Invalid value for: query parameter synchronizer-id,
+              Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/preferred-packages:
+      post:
+        description: Get the version of preferred packages for constructing a command
+          submission
+        operationId: postV2Interactive-submissionPreferred-packages
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPreferredPackagesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPreferredPackagesResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/contracts/contract-by-id:
+      post:
+        description: |
+          Looking up contract data by contract ID.
+          This endpoint is experimental / alpha, therefore no backwards compatibility is guaranteed.
+          This endpoint must not be used to look up contracts which entered the participant via party replication
+          or repair service.
+        operationId: postV2ContractsContract-by-id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetContractRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetContractResponse'
+          '400':
+            description: 'Invalid value for: body, Invalid value for: headers'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+  components:
+    schemas:
+      AllocateExternalPartyRequest:
+        title: AllocateExternalPartyRequest
+        description: 'Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id)``'
+        type: object
+        required:
+        - synchronizer
+        - onboardingTransactions
+        properties:
+          synchronizer:
+            description: |-
+              TODO(#27670) support synchronizer aliases
+              Synchronizer ID on which to onboard the party
+
+              Required
+            type: string
+          onboardingTransactions:
+            description: |-
+              TopologyTransactions to onboard the external party
+              Can contain:
+              - A namespace for the party.
+              This can be either a single NamespaceDelegation,
+              or DecentralizedNamespaceDefinition along with its authorized namespace owners in the form of NamespaceDelegations.
+              May be provided, if so it must be fully authorized by the signatures in this request combined with the existing topology state.
+              - A PartyToKeyMapping to register the party's signing keys.
+              May be provided, if so it must be fully authorized by the signatures in this request combined with the existing topology state.
+              - A PartyToParticipant to register the hosting relationship of the party.
+              Must be provided.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/SignedTransaction'
+          multiHashSignatures:
+            description: |-
+              Optional signatures of the combined hash of all onboarding_transactions
+              This may be used instead of providing signatures on each individual transaction
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Signature'
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the party is managed by the default identity provider.
+
+              Optional
+            type: string
+      AllocateExternalPartyResponse:
+        title: AllocateExternalPartyResponse
+        type: object
+        required:
+        - partyId
+        properties:
+          partyId:
+            description: |-
+              The allocated party id
+
+              Required
+            type: string
+      AllocatePartyRequest:
+        title: AllocatePartyRequest
+        description: 'Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id)``'
+        type: object
+        properties:
+          partyIdHint:
+            description: |-
+              A hint to the participant which party ID to allocate. It can be
+              ignored.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          localMetadata:
+            $ref: '#/components/schemas/ObjectMeta'
+            description: |-
+              Formerly "display_name"
+              Participant-local metadata to be stored in the ``PartyDetails`` of this newly allocated party.
+
+              Optional
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the party is managed by the default identity provider or party is not hosted by the participant.
+
+              Optional
+            type: string
+          synchronizerId:
+            description: |-
+              The synchronizer, on which the party should be allocated.
+              For backwards compatibility, this field may be omitted, if the participant is connected to only one synchronizer.
+              Otherwise a synchronizer must be specified.
+
+              Optional
+            type: string
+          userId:
+            description: |-
+              The user who will get the act_as rights to the newly allocated party.
+              If set to an empty string (the default), no user will get rights to the party.
+
+              Optional
+            type: string
+      AllocatePartyResponse:
+        title: AllocatePartyResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
+            $ref: '#/components/schemas/PartyDetails'
+            description: |-
+              The allocated party details
+
+              Required
+      ArchivedEvent:
+        title: ArchivedEvent
+        description: Records that a contract has been archived, and choices may no longer
+          be exercised on it.
+        type: object
+        required:
+        - offset
+        - nodeId
+        - contractId
+        - templateId
+        - packageName
+        - witnessParties
+        properties:
+          offset:
+            description: |-
+              The offset of origin.
+              Offsets are managed by the participant nodes.
+              Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
+              It is a valid absolute offset (positive integer)
+
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating transaction or reassignment.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of transactions.
+              Must be valid node ID (non-negative integer)
+
+              Required
+            type: integer
+            format: int32
+          contractId:
+            description: |-
+              The ID of the archived contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Required
+            type: string
+          templateId:
+            description: |-
+              Identifies the template that defines the choice that archived the contract.
+              This template's package-id may differ from the target contract's package-id
+              if the target contract has been upgraded or downgraded.
+
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          witnessParties:
+            description: |-
+              The parties that are notified of this event. For an ``ArchivedEvent``,
+              these are the intersection of the stakeholders of the contract in
+              question and the parties specified in the ``TransactionFilter``. The
+              stakeholders are the union of the signatories and the observers of
+              the contract.
+              Each one of its elements must be a valid PartyIdString (as described
+              in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          packageName:
+            description: |-
+              The package name of the contract.
+
+              Required
+            type: string
+          implementedInterfaces:
+            description: |-
+              The interfaces implemented by the target template that have been
+              matched from the interface filter query.
+              Populated only in case interface filters with include_interface_view set.
+
+              If defined, the identifier uses the package-id reference format.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      AssignCommand:
+        title: AssignCommand
+        description: Assign a contract
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/AssignCommand1'
+      AssignCommand1:
+        title: AssignCommand
+        description: Assign a contract
+        type: object
+        required:
+        - reassignmentId
+        - source
+        - target
+        properties:
+          reassignmentId:
+            description: |-
+              The ID from the unassigned event to be completed by this assignment.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          source:
+            description: |-
+              The ID of the source synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+          target:
+            description: |-
+              The ID of the target synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+      CanActAs:
+        title: CanActAs
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanActAs1'
+      CanActAs1:
+        title: CanActAs
+        type: object
+        required:
+        - party
+        properties:
+          party:
+            type: string
+      CanExecuteAs:
+        title: CanExecuteAs
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanExecuteAs1'
+      CanExecuteAs1:
+        title: CanExecuteAs
+        type: object
+        required:
+        - party
+        properties:
+          party:
+            type: string
+      CanExecuteAsAnyParty:
+        title: CanExecuteAsAnyParty
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanExecuteAsAnyParty1'
+      CanExecuteAsAnyParty1:
+        title: CanExecuteAsAnyParty
+        type: object
+      CanReadAs:
+        title: CanReadAs
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanReadAs1'
+      CanReadAs1:
+        title: CanReadAs
+        type: object
+        required:
+        - party
+        properties:
+          party:
+            type: string
+      CanReadAsAnyParty:
+        title: CanReadAsAnyParty
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanReadAsAnyParty1'
+      CanReadAsAnyParty1:
+        title: CanReadAsAnyParty
+        type: object
+      Command:
+        title: Command
+        description: A command can either create a new contract or exercise a choice
+          on an existing contract.
+        oneOf:
+        - type: object
+          required:
+          - CreateAndExerciseCommand
+          properties:
+            CreateAndExerciseCommand:
+              $ref: '#/components/schemas/CreateAndExerciseCommand'
+        - type: object
+          required:
+          - CreateCommand
+          properties:
+            CreateCommand:
+              $ref: '#/components/schemas/CreateCommand'
+        - type: object
+          required:
+          - ExerciseByKeyCommand
+          properties:
+            ExerciseByKeyCommand:
+              $ref: '#/components/schemas/ExerciseByKeyCommand'
+        - type: object
+          required:
+          - ExerciseCommand
+          properties:
+            ExerciseCommand:
+              $ref: '#/components/schemas/ExerciseCommand'
+      Command1:
+        title: Command
+        description: A command can either create a new contract or exercise a choice
+          on an existing contract.
+        oneOf:
+        - type: object
+          required:
+          - AssignCommand
+          properties:
+            AssignCommand:
+              $ref: '#/components/schemas/AssignCommand'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty2'
+        - type: object
+          required:
+          - UnassignCommand
+          properties:
+            UnassignCommand:
+              $ref: '#/components/schemas/UnassignCommand'
+      Completion:
+        title: Completion
+        description: 'A completion represents the status of a submitted command on the
+          ledger: it can be successful or failed.'
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Completion1'
+      Completion1:
+        title: Completion
+        description: 'A completion represents the status of a submitted command on the
+          ledger: it can be successful or failed.'
+        type: object
+        required:
+        - commandId
+        - userId
+        - offset
+        - actAs
+        - synchronizerTime
+        properties:
+          commandId:
+            description: |-
+              The ID of the succeeded or failed command.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          status:
+            $ref: '#/components/schemas/JsStatus'
+            description: |-
+              Identifies the exact type of the error.
+              It uses the same format of conveying error details as it is used for the RPC responses of the APIs.
+
+              Optional
+          updateId:
+            description: |-
+              The update_id of the transaction or reassignment that resulted from the command with command_id.
+
+              Only set for successfully executed commands.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Optional
+            type: string
+          userId:
+            description: |-
+              The user-id that was used for the submission, as described in ``commands.proto``.
+              Must be a valid UserIdString (as described in ``value.proto``).
+
+              Required
+            type: string
+          actAs:
+            description: |-
+              The set of parties on whose behalf the commands were executed.
+              Contains the ``act_as`` parties from ``commands.proto``
+              filtered to the requesting parties in CompletionStreamRequest.
+              The order of the parties need not be the same as in the submission.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          submissionId:
+            description: |-
+              The submission ID this completion refers to, as described in ``commands.proto``.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod1'
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              The Ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+
+              Optional
+          offset:
+            description: |-
+              May be used in a subsequent CompletionStreamRequest to resume the consumption of this stream at a later time.
+              Must be a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          synchronizerTime:
+            $ref: '#/components/schemas/SynchronizerTime'
+            description: |-
+              The synchronizer along with its record time.
+              The synchronizer id provided, in case of
+
+              - successful/failed transactions: identifies the synchronizer of the transaction
+              - for successful/failed unassign commands: identifies the source synchronizer
+              - for successful/failed assign commands: identifies the target synchronizer
+
+              Required
+          paidTrafficCost:
+            description: |-
+              The traffic cost paid by this participant node for the confirmation request
+              for the submitted command.
+
+              Commands whose execution is rejected before their corresponding
+              confirmation request is ordered by the synchronizer will report a paid
+              traffic cost of zero.
+              If a confirmation request is ordered for a command, but the request fails
+              (e.g., due to contention with a concurrent contract archival), the traffic
+              cost is paid and reported on the failed completion for the request.
+
+              If you want to correlate the traffic cost of a successful completion
+              with the transaction that resulted from the command, you can use the
+              ``offset`` field to retrieve the transaction using
+              ``UpdateService.GetUpdateByOffset`` on the same participant node; or alternatively use the ``update_id``
+              field to retrieve the transaction using ``UpdateService.GetUpdateById`` on any participant node
+              that sees the transaction.
+
+              Note: for completions processed before the participant started serving
+              traffic cost on the Ledger API, this field will be set to zero.
+              Additionally, the total cost incurred by the submitting node for the submission of the transaction may be greater
+              than the reported cost, for example if retries were issued due to failed submissions to the synchronizer.
+              The cost reported here is the one paid for ordering the confirmation request.
+
+              Optional
+            type: integer
+            format: int64
+      CompletionResponse:
+        title: CompletionResponse
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - Completion
+          properties:
+            Completion:
+              $ref: '#/components/schemas/Completion'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty4'
+        - type: object
+          required:
+          - OffsetCheckpoint
+          properties:
+            OffsetCheckpoint:
+              $ref: '#/components/schemas/OffsetCheckpoint'
+      CompletionStreamRequest:
+        title: CompletionStreamRequest
+        type: object
+        required:
+        - parties
+        properties:
+          userId:
+            description: |-
+              Only completions of commands submitted with the same user_id will be visible in the stream.
+              Must be a valid UserIdString (as described in ``value.proto``).
+
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
+
+              Optional
+            type: string
+          parties:
+            description: |-
+              Non-empty list of parties whose data should be included.
+              The stream shows only completions of commands for which at least one of the ``act_as`` parties is in the given set of parties.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          beginExclusive:
+            description: |-
+              This optional field indicates the minimum offset for completions. This can be used to resume an earlier completion stream.
+              If not set the ledger uses the ledger begin offset instead.
+              If specified, it must be a valid absolute offset (positive integer) or zero (ledger begin offset).
+              If the ledger has been pruned, this parameter must be specified and greater than the pruning offset.
+
+              Optional
+            type: integer
+            format: int64
+      CompletionStreamResponse:
+        title: CompletionStreamResponse
+        type: object
+        properties:
+          completionResponse:
+            $ref: '#/components/schemas/CompletionResponse'
+      ConnectedSynchronizer:
+        title: ConnectedSynchronizer
+        type: object
+        required:
+        - synchronizerAlias
+        - synchronizerId
+        - permission
+        properties:
+          synchronizerAlias:
+            type: string
+          synchronizerId:
+            type: string
+          permission:
+            type: string
+            enum:
+            - PARTICIPANT_PERMISSION_UNSPECIFIED
+            - PARTICIPANT_PERMISSION_SUBMISSION
+            - PARTICIPANT_PERMISSION_CONFIRMATION
+            - PARTICIPANT_PERMISSION_OBSERVATION
+      CostEstimation:
+        title: CostEstimation
+        description: |-
+          Estimation of the cost of submitting the prepared transaction
+          The estimation is done against the synchronizer chosen during preparation of the transaction
+          (or the one explicitly requested).
+          The cost of re-assigning contracts to another synchronizer when necessary is not included in the estimation.
+        type: object
+        required:
+        - confirmationRequestTrafficCostEstimation
+        - confirmationResponseTrafficCostEstimation
+        - totalTrafficCostEstimation
+        - estimationTimestamp
+        properties:
+          estimationTimestamp:
+            description: |-
+              Timestamp at which the estimation was made
+
+              Required
+            type: string
+          confirmationRequestTrafficCostEstimation:
+            description: |-
+              Estimated traffic cost of the confirmation request associated with the transaction
+
+              Required
+            type: integer
+            format: int64
+          confirmationResponseTrafficCostEstimation:
+            description: |-
+              Estimated traffic cost of the confirmation response associated with the transaction
+              This field can also be used as an indication of the cost that other potential confirming nodes
+              of the party will incur to approve or reject the transaction
+
+              Required
+            type: integer
+            format: int64
+          totalTrafficCostEstimation:
+            description: |-
+              Sum of the fields above
+
+              Required
+            type: integer
+            format: int64
+      CostEstimationHints:
+        title: CostEstimationHints
+        description: Hints to improve cost estimation precision of a prepared transaction
+        type: object
+        properties:
+          disabled:
+            description: |-
+              Disable cost estimation
+              Default (not set) is false
+
+              Optional
+            type: boolean
+          expectedSignatures:
+            description: |-
+              Details on the keys that will be used to sign the transaction (how many and of which type).
+              Signature size impacts the cost of the transaction.
+              If empty, the signature sizes will be approximated with threshold-many signatures (where threshold is defined
+              in the PartyToKeyMapping of the external party), using keys in the order they are registered.
+              Empty list is equivalent to not providing this field
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+              enum:
+              - SIGNING_ALGORITHM_SPEC_UNSPECIFIED
+              - SIGNING_ALGORITHM_SPEC_ED25519
+              - SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256
+              - SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384
+      CreateAndExerciseCommand:
+        title: CreateAndExerciseCommand
+        description: Create a contract and exercise a choice on it in the same transaction.
+        type: object
+        required:
+        - templateId
+        - createArguments
+        - choice
+        - choiceArgument
+        properties:
+          templateId:
+            description: |-
+              The template of the contract the client wants to create.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          createArguments:
+            description: |-
+              The arguments required for creating a contract from this template.
+
+              Required
+          choice:
+            description: |-
+              The name of the choice the client wants to exercise.
+              Must be a valid NameString (as described in ``value.proto``).
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument for this choice.
+
+              Required
+      CreateCommand:
+        title: CreateCommand
+        description: Create a new contract instance based on a template.
+        type: object
+        required:
+        - templateId
+        - createArguments
+        properties:
+          templateId:
+            description: |-
+              The template of contract the client wants to create.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          createArguments:
+            description: |-
+              The arguments required for creating a contract from this template.
+
+              Required
+      CreateIdentityProviderConfigRequest:
+        title: CreateIdentityProviderConfigRequest
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: Required
+      CreateIdentityProviderConfigResponse:
+        title: CreateIdentityProviderConfigResponse
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: Required
+      CreateUserRequest:
+        title: CreateUserRequest
+        description: |2-
+           RPC requests and responses
+          ///////////////////////////
+           Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(user.identity_provider_id)``
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              The user to create.
+
+              Required
+          rights:
+            description: |-
+              The rights to be assigned to the user upon creation,
+              which SHOULD include appropriate rights for the ``user.primary_party``.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      CreateUserResponse:
+        title: CreateUserResponse
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              Created user.
+
+              Required
+      CreatedEvent:
+        title: CreatedEvent
+        description: Records that a contract has been created, and choices may now be
+          exercised on it.
+        type: object
+        required:
+        - offset
+        - nodeId
+        - contractId
+        - templateId
+        - createdAt
+        - packageName
+        - representativePackageId
+        - acsDelta
+        - createArgument
+        - witnessParties
+        - signatories
+        properties:
+          offset:
+            description: |-
+              The offset of origin, which has contextual meaning, please see description at messages that include a CreatedEvent.
+              Offsets are managed by the participant nodes.
+              Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
+              It is a valid absolute offset (positive integer)
+
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating transaction or reassignment.
+              The origin has contextual meaning, please see description at messages that include a CreatedEvent.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of transactions.
+              Must be valid node ID (non-negative integer)
+
+              Required
+            type: integer
+            format: int32
+          contractId:
+            description: |-
+              The ID of the created contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          templateId:
+            description: |-
+              The template of the created contract.
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          contractKey:
+            description: |-
+              The key of the created contract.
+              This will be set if and only if ``template_id`` defines a contract key.
+
+              Optional
+          createArgument:
+            description: |-
+              The arguments that have been used to create the contract.
+
+              Required
+          createdEventBlob:
+            description: |-
+              Opaque representation of contract create event payload intended for forwarding
+              to an API server as a contract disclosed as part of a command
+              submission.
+
+              Optional: can be empty
+            type: string
+          interfaceViews:
+            description: |-
+              Interface views specified in the transaction filter.
+              Includes an ``InterfaceView`` for each interface for which there is a ``InterfaceFilter`` with
+
+              - its party in the ``witness_parties`` of this event,
+              - and which is implemented by the template of this event,
+              - and which has ``include_interface_view`` set.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/JsInterfaceView'
+          witnessParties:
+            description: |-
+              The parties that are notified of this event. When a ``CreatedEvent``
+              is returned as part of a transaction tree or ledger-effects transaction, this will include all
+              the parties specified in the ``TransactionFilter`` that are witnesses  of the event
+              (the stakeholders of the contract and all informees of all the ancestors
+              of this create action that this participant knows about).
+              If served as part of a ACS delta transaction those will
+              be limited to all parties specified in the ``TransactionFilter`` that
+              are stakeholders of the contract (i.e. either signatories or observers).
+              If the ``CreatedEvent`` is returned as part of an AssignedEvent,
+              ActiveContract or IncompleteUnassigned (so the event is related to
+              an assignment or unassignment): this will include all parties of the
+              ``TransactionFilter`` that are stakeholders of the contract.
+
+              The behavior of reading create events visible to parties not hosted
+              on the participant node serving the Ledger API is undefined. Concretely,
+              there is neither a guarantee that the participant node will serve all their
+              create events on the ACS stream, nor is there a guarantee that matching archive
+              events are delivered for such create events.
+
+              For most clients this is not a problem, as they only read events for parties
+              that are hosted on the participant node. If you need to read events
+              for parties that may not be hosted at all times on the participant node,
+              subscribe to the ``TopologyEvent``s for that party by setting a corresponding
+              ``UpdateFormat``.  Using these events, query the ACS as-of an offset where the
+              party is hosted on the participant node, and ignore create events at offsets
+              where the party is not hosted on the participant node.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          signatories:
+            description: |-
+              The signatories for this contract as specified by the template.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          observers:
+            description: |-
+              The observers for this contract as specified explicitly by the template or implicitly as choice controllers.
+              This field never contains parties that are signatories.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          createdAt:
+            description: |-
+              Ledger effective time of the transaction that created the contract.
+
+              Required
+            type: string
+          packageName:
+            description: |-
+              The package name of the created contract.
+
+              Required
+            type: string
+          representativePackageId:
+            description: |-
+              A package-id present in the participant package store that typechecks the contract's argument.
+              This may differ from the package-id of the template used to create the contract.
+              For contracts created before Canton 3.4, this field matches the contract's creation package-id.
+
+              NOTE: Experimental, server internal concept, not for client consumption. Subject to change without notice.
+
+              Required
+            type: string
+          acsDelta:
+            description: |-
+              Whether this event would be part of respective ACS_DELTA shaped stream,
+              and should therefore considered when tracking contract activeness on the client-side.
+
+              Required
+            type: boolean
+      CreatedTreeEvent:
+        title: CreatedTreeEvent
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CreatedEvent'
+      CumulativeFilter:
+        title: CumulativeFilter
+        description: |-
+          A filter that matches all contracts that are either an instance of one of
+          the ``template_filters`` or that match one of the ``interface_filters``.
+        type: object
+        properties:
+          identifierFilter:
+            $ref: '#/components/schemas/IdentifierFilter'
+      DeduplicationDuration:
+        title: DeduplicationDuration
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      DeduplicationDuration1:
+        title: DeduplicationDuration
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      DeduplicationDuration2:
+        title: DeduplicationDuration
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      DeduplicationOffset:
+        title: DeduplicationOffset
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int64
+      DeduplicationOffset1:
+        title: DeduplicationOffset
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int64
+      DeduplicationOffset2:
+        title: DeduplicationOffset
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int64
+      DeduplicationPeriod:
+        title: DeduplicationPeriod
+        description: |-
+          Specifies the deduplication period for the change ID.
+          If omitted, the participant will assume the configured maximum deduplication time.
+
+          Optional
+        oneOf:
+        - type: object
+          required:
+          - DeduplicationDuration
+          properties:
+            DeduplicationDuration:
+              $ref: '#/components/schemas/DeduplicationDuration'
+        - type: object
+          required:
+          - DeduplicationOffset
+          properties:
+            DeduplicationOffset:
+              $ref: '#/components/schemas/DeduplicationOffset'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty'
+      DeduplicationPeriod1:
+        title: DeduplicationPeriod
+        description: |-
+          The actual deduplication window used for the submission, which is derived from
+          ``Commands.deduplication_period``. The ledger may convert the deduplication period into other
+          descriptions and extend the period in implementation-specified ways.
+
+          Used to audit the deduplication guarantee described in ``commands.proto``.
+
+          The deduplication guarantee applies even if the completion omits this field.
+
+          Optional
+        oneOf:
+        - type: object
+          required:
+          - DeduplicationDuration
+          properties:
+            DeduplicationDuration:
+              $ref: '#/components/schemas/DeduplicationDuration1'
+        - type: object
+          required:
+          - DeduplicationOffset
+          properties:
+            DeduplicationOffset:
+              $ref: '#/components/schemas/DeduplicationOffset1'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty3'
+      DeduplicationPeriod2:
+        title: DeduplicationPeriod
+        oneOf:
+        - type: object
+          required:
+          - DeduplicationDuration
+          properties:
+            DeduplicationDuration:
+              $ref: '#/components/schemas/DeduplicationDuration2'
+        - type: object
+          required:
+          - DeduplicationOffset
+          properties:
+            DeduplicationOffset:
+              $ref: '#/components/schemas/DeduplicationOffset2'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty10'
+      DeleteIdentityProviderConfigResponse:
+        title: DeleteIdentityProviderConfigResponse
+        description: Does not (yet) contain any data.
+        type: object
+      DisclosedContract:
+        title: DisclosedContract
+        description: |-
+          An additional contract that is used to resolve
+          contract & contract key lookups.
+        type: object
+        required:
+        - createdEventBlob
+        properties:
+          templateId:
+            description: |-
+              The template id of the contract.
+              The identifier uses the package-id reference format.
+
+              If provided, used to validate the template id of the contract serialized in the created_event_blob.
+
+              Optional
+            type: string
+          contractId:
+            description: |-
+              The contract id
+
+              If provided, used to validate the contract id of the contract serialized in the created_event_blob.
+
+              Optional
+            type: string
+          createdEventBlob:
+            description: |-
+              Opaque byte string containing the complete payload required by the Daml engine
+              to reconstruct a contract not known to the receiving participant.
+
+              Required: must be non-empty
+            type: string
+          synchronizerId:
+            description: |-
+              The ID of the synchronizer where the contract is currently assigned
+
+              Optional
+            type: string
+      Duration:
+        title: Duration
+        type: object
+        required:
+        - seconds
+        - nanos
+        properties:
+          seconds:
+            type: integer
+            format: int64
+          nanos:
+            type: integer
+            format: int32
+          unknownFields:
+            $ref: '#/components/schemas/UnknownFieldSet'
+            description: This field is automatically added as part of protobuf to json
+              mapping
+      Empty:
+        title: Empty
+        type: object
+      Empty1:
+        title: Empty
+        type: object
+      Empty10:
+        title: Empty
+        type: object
+      Empty2:
+        title: Empty
+        type: object
+      Empty3:
+        title: Empty
+        type: object
+      Empty4:
+        title: Empty
+        type: object
+      Empty5:
+        title: Empty
+        type: object
+      Empty6:
+        title: Empty
+        type: object
+      Empty7:
+        title: Empty
+        type: object
+      Empty8:
+        title: Empty
+        type: object
+      Empty9:
+        title: Empty
+        type: object
+      Event:
+        title: Event
+        description: |-
+          Events in transactions can have two primary shapes:
+
+          - ACS delta: events can be CreatedEvent or ArchivedEvent
+          - ledger effects: events can be CreatedEvent or ExercisedEvent
+
+          In the update service the events are restricted to the events
+          visible for the parties specified in the transaction filter. Each
+          event message type below contains a ``witness_parties`` field which
+          indicates the subset of the requested parties that can see the event
+          in question.
+        oneOf:
+        - type: object
+          required:
+          - ArchivedEvent
+          properties:
+            ArchivedEvent:
+              $ref: '#/components/schemas/ArchivedEvent'
+        - type: object
+          required:
+          - CreatedEvent
+          properties:
+            CreatedEvent:
+              $ref: '#/components/schemas/CreatedEvent'
+        - type: object
+          required:
+          - ExercisedEvent
+          properties:
+            ExercisedEvent:
+              $ref: '#/components/schemas/ExercisedEvent'
+      EventFormat:
+        title: EventFormat
+        description: |-
+          A format for events which defines both which events should be included
+          and what data should be computed and included for them.
+
+          Note that some of the filtering behavior depends on the `TransactionShape`,
+          which is expected to be specified alongside usages of `EventFormat`.
+        type: object
+        properties:
+          filtersByParty:
+            $ref: '#/components/schemas/Map_Filters'
+            description: |-
+              Each key must be a valid PartyIdString (as described in ``value.proto``).
+              The interpretation of the filter depends on the transaction-shape being filtered:
+
+              1. For **ledger-effects** create and exercise events are returned, for which the witnesses include at least one of
+                 the listed parties and match the per-party filter.
+              2. For **transaction and active-contract-set streams** create and archive events are returned for all contracts whose
+                 stakeholders include at least one of the listed parties and match the per-party filter.
+
+              Optional: can be empty
+          filtersForAnyParty:
+            $ref: '#/components/schemas/Filters'
+            description: |-
+              Wildcard filters that apply to all the parties existing on the participant. The interpretation of the filters is the same
+              with the per-party filter as described above.
+
+              Optional
+          verbose:
+            description: |-
+              If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
+              In particular, setting the verbose flag to true triggers the ledger to include labels for record fields.
+
+              Optional
+            type: boolean
+      ExecuteSubmissionAndWaitResponse:
+        title: ExecuteSubmissionAndWaitResponse
+        type: object
+        required:
+        - updateId
+        - completionOffset
+        properties:
+          updateId:
+            description: |-
+              The id of the transaction that resulted from the submitted command.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          completionOffset:
+            description: |-
+              The details of the offset field are described in ``community/ledger-api/README.md``.
+
+              Required
+            type: integer
+            format: int64
+      ExecuteSubmissionResponse:
+        title: ExecuteSubmissionResponse
+        type: object
+      ExerciseByKeyCommand:
+        title: ExerciseByKeyCommand
+        description: Exercise a choice on an existing contract specified by its key.
+        type: object
+        required:
+        - templateId
+        - contractKey
+        - choice
+        - choiceArgument
+        properties:
+          templateId:
+            description: |-
+              The template of contract the client wants to exercise.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          contractKey:
+            description: |-
+              The key of the contract the client wants to exercise upon.
+
+              Required
+          choice:
+            description: |-
+              The name of the choice the client wants to exercise.
+              Must be a valid NameString (as described in ``value.proto``)
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument for this choice.
+
+              Required
+      ExerciseCommand:
+        title: ExerciseCommand
+        description: Exercise a choice on an existing contract.
+        type: object
+        required:
+        - templateId
+        - contractId
+        - choice
+        - choiceArgument
+        properties:
+          templateId:
+            description: |-
+              The template or interface of the contract the client wants to exercise.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+              To exercise a choice on an interface, specify the interface identifier in the template_id field.
+
+              Required
+            type: string
+          contractId:
+            description: |-
+              The ID of the contract the client wants to exercise upon.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          choice:
+            description: |-
+              The name of the choice the client wants to exercise.
+              Must be a valid NameString (as described in ``value.proto``)
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument for this choice.
+
+              Required
+      ExercisedEvent:
+        title: ExercisedEvent
+        description: Records that a choice has been exercised on a target contract.
+        type: object
+        required:
+        - offset
+        - nodeId
+        - contractId
+        - templateId
+        - choice
+        - choiceArgument
+        - consuming
+        - lastDescendantNodeId
+        - packageName
+        - acsDelta
+        - actingParties
+        - witnessParties
+        properties:
+          offset:
+            description: |-
+              The offset of origin.
+              Offsets are managed by the participant nodes.
+              Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
+              It is a valid absolute offset (positive integer)
+
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating transaction or reassignment.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of transactions.
+              Must be valid node ID (non-negative integer)
+
+              Required
+            type: integer
+            format: int32
+          contractId:
+            description: |-
+              The ID of the target contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Required
+            type: string
+          templateId:
+            description: |-
+              Identifies the template that defines the executed choice.
+              This template's package-id may differ from the target contract's package-id
+              if the target contract has been upgraded or downgraded.
+
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          interfaceId:
+            description: |-
+              The interface where the choice is defined, if inherited.
+              If defined, the identifier uses the package-id reference format.
+
+              Optional
+            type: string
+          choice:
+            description: |-
+              The choice that was exercised on the target contract.
+              Must be a valid NameString (as described in ``value.proto``).
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument of the exercised choice.
+
+              Required
+          actingParties:
+            description: |-
+              The parties that exercised the choice.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          consuming:
+            description: |-
+              If true, the target contract may no longer be exercised.
+
+              Required
+            type: boolean
+          witnessParties:
+            description: |-
+              The parties that are notified of this event. The witnesses of an exercise
+              node will depend on whether the exercise was consuming or not.
+              If consuming, the witnesses are the union of the stakeholders,
+              the actors and all informees of all the ancestors of this event this
+              participant knows about.
+              If not consuming, the witnesses are the union of the signatories,
+              the actors and all informees of all the ancestors of this event this
+              participant knows about.
+              In both cases the witnesses are limited to the querying parties, or not
+              limited in case anyParty filters are used.
+              Note that the actors might not necessarily be observers
+              and thus stakeholders. This is the case when the controllers of a
+              choice are specified using "flexible controllers", using the
+              ``choice ... controller`` syntax, and said controllers are not
+              explicitly marked as observers.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          lastDescendantNodeId:
+            description: |-
+              Specifies the upper boundary of the node ids of the events in the same transaction that appeared as a result of
+              this ``ExercisedEvent``. This allows unambiguous identification of all the members of the subtree rooted at this
+              node. A full subtree can be constructed when all descendant nodes are present in the stream. If nodes are heavily
+              filtered, it is only possible to determine if a node is in a consequent subtree or not.
+
+              Required
+            type: integer
+            format: int32
+          exerciseResult:
+            description: |-
+              The result of exercising the choice.
+
+              Optional
+          packageName:
+            description: |-
+              The package name of the contract.
+
+              Required
+            type: string
+          implementedInterfaces:
+            description: |-
+              If the event is consuming, the interfaces implemented by the target template that have been
+              matched from the interface filter query.
+              Populated only in case interface filters with include_interface_view set.
+
+              The identifier uses the package-id reference format.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          acsDelta:
+            description: |-
+              Whether this event would be part of respective ACS_DELTA shaped stream,
+              and should therefore considered when tracking contract activeness on the client-side.
+
+              Required
+            type: boolean
+      ExercisedTreeEvent:
+        title: ExercisedTreeEvent
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ExercisedEvent'
+      ExperimentalCommandInspectionService:
+        title: ExperimentalCommandInspectionService
+        description: Whether the Ledger API supports command inspection service
+        type: object
+        required:
+        - supported
+        properties:
+          supported:
+            description: Required
+            type: boolean
+      ExperimentalFeatures:
+        title: ExperimentalFeatures
+        description: See the feature message definitions for descriptions.
+        type: object
+        properties:
+          staticTime:
+            $ref: '#/components/schemas/ExperimentalStaticTime'
+            description: Optional
+          commandInspectionService:
+            $ref: '#/components/schemas/ExperimentalCommandInspectionService'
+            description: Optional
+      ExperimentalStaticTime:
+        title: ExperimentalStaticTime
+        description: Ledger is in the static time mode and exposes a time service.
+        type: object
+        required:
+        - supported
+        properties:
+          supported:
+            description: Required
+            type: boolean
+      FeaturesDescriptor:
+        title: FeaturesDescriptor
+        type: object
+        required:
+        - experimental
+        - userManagement
+        - partyManagement
+        - offsetCheckpoint
+        - packageFeature
+        properties:
+          experimental:
+            $ref: '#/components/schemas/ExperimentalFeatures'
+            description: |-
+              Features under development or features that are used
+              for ledger implementation testing purposes only.
+
+              Daml applications SHOULD not depend on these in production.
+
+              Required
+          userManagement:
+            $ref: '#/components/schemas/UserManagementFeature'
+            description: |-
+              If set, then the Ledger API server supports user management.
+              It is recommended that clients query this field to gracefully adjust their behavior for
+              ledgers that do not support user management.
+
+              Required
+          partyManagement:
+            $ref: '#/components/schemas/PartyManagementFeature'
+            description: |-
+              If set, then the Ledger API server supports party management configurability.
+              It is recommended that clients query this field to gracefully adjust their behavior to
+              maximum party page size.
+
+              Required
+          offsetCheckpoint:
+            $ref: '#/components/schemas/OffsetCheckpointFeature'
+            description: |-
+              It contains the timeouts related to the periodic offset checkpoint emission
+
+              Required
+          packageFeature:
+            $ref: '#/components/schemas/PackageFeature'
+            description: |-
+              If set, then the Ledger API server supports package listing
+              configurability. It is recommended that clients query this field to
+              gracefully adjust their behavior to maximum package listing page size.
+
+              Required
+      Field:
+        title: Field
+        type: object
+        properties:
+          varint:
+            type: array
+            items:
+              type: integer
+              format: int64
+          fixed64:
+            type: array
+            items:
+              type: integer
+              format: int64
+          fixed32:
+            type: array
+            items:
+              type: integer
+              format: int32
+          lengthDelimited:
+            type: array
+            items:
+              type: string
+      FieldMask:
+        title: FieldMask
+        type: object
+        required:
+        - unknownFields
+        properties:
+          paths:
+            type: array
+            items:
+              type: string
+          unknownFields:
+            $ref: '#/components/schemas/UnknownFieldSet'
+      Filters:
+        title: Filters
+        description: The union of a set of template filters, interface filters, or a
+          wildcard.
+        type: object
+        properties:
+          cumulative:
+            description: |-
+              Every filter in the cumulative list expands the scope of the resulting stream. Each interface,
+              template or wildcard filter means additional events that will match the query.
+              The impact of include_interface_view and include_created_event_blob fields in the filters will
+              also be accumulated.
+              A template or an interface SHOULD NOT appear twice in the accumulative field.
+              A wildcard filter SHOULD NOT be defined more than once in the accumulative field.
+              If no ``CumulativeFilter`` defined, the default of a single ``WildcardFilter`` with
+              include_created_event_blob unset is used.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/CumulativeFilter'
+      GenerateExternalPartyTopologyRequest:
+        title: GenerateExternalPartyTopologyRequest
+        type: object
+        required:
+        - synchronizer
+        - partyHint
+        - publicKey
+        properties:
+          synchronizer:
+            description: |-
+              Synchronizer-id for which we are building this request.
+              TODO(#27670) support synchronizer aliases
+
+              Required
+            type: string
+          partyHint:
+            description: |-
+              The actual party id will be constructed from this hint and a fingerprint of the public key
+
+              Required
+            type: string
+          publicKey:
+            $ref: '#/components/schemas/SigningPublicKey'
+            description: |-
+              Public key
+
+              Required
+          localParticipantObservationOnly:
+            description: |-
+              If true, then the local participant will only be observing, not confirming. Default false.
+
+              Optional
+            type: boolean
+          otherConfirmingParticipantUids:
+            description: |-
+              Other participant ids which should be confirming for this party
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          confirmationThreshold:
+            description: |-
+              Confirmation threshold >= 1 for the party. Defaults to all available confirmers (or if set to 0).
+
+              Optional
+            type: integer
+            format: int32
+          observingParticipantUids:
+            description: |-
+              Other observing participant ids for this party
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      GenerateExternalPartyTopologyResponse:
+        title: GenerateExternalPartyTopologyResponse
+        description: Response message with topology transactions and the multi-hash
+          to be signed.
+        type: object
+        required:
+        - partyId
+        - publicKeyFingerprint
+        - multiHash
+        - topologyTransactions
+        properties:
+          partyId:
+            description: |-
+              The generated party id
+
+              Required
+            type: string
+          publicKeyFingerprint:
+            description: |-
+              The fingerprint of the supplied public key
+
+              Required
+            type: string
+          topologyTransactions:
+            description: |-
+              The serialized topology transactions which need to be signed and submitted as part of the allocate party process
+              Note that the serialization includes the versioning information. Therefore, the transaction here is serialized
+              as an `UntypedVersionedMessage` which in turn contains the serialized `TopologyTransaction` in the version
+              supported by the synchronizer.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          multiHash:
+            description: |-
+              the multi-hash which may be signed instead of each individual transaction
+
+              Required: must be non-empty
+            type: string
+      GetActiveContractsRequest:
+        title: GetActiveContractsRequest
+        description: |-
+          If the given offset is different than the ledger end, and there are (un)assignments in-flight at the given offset,
+          the snapshot may fail with "FAILED_PRECONDITION/PARTICIPANT_PRUNED_DATA_ACCESSED".
+          Note that it is ok to request acs snapshots for party migration with offsets other than ledger end, because party
+          migration is not concerned with incomplete (un)assignments.
+        type: object
+        required:
+        - activeAtOffset
+        - eventFormat
+        properties:
+          filter:
+            $ref: '#/components/schemas/TransactionFilter'
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              Templates to include in the served snapshot, per party.
+              Optional, if specified event_format must be unset, if not specified event_format must be set.
+          verbose:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
+              In particular, setting the verbose flag to true triggers the ledger to include labels for record fields.
+              Optional, if specified event_format must be unset.
+            type: boolean
+          activeAtOffset:
+            description: |-
+              The offset at which the snapshot of the active contracts will be computed.
+              Must be no greater than the current ledger end offset.
+              Must be greater than or equal to the last pruning offset.
+              Must be a valid absolute offset (positive integer) or ledger begin offset (zero).
+              If zero, the empty set will be returned.
+
+              Required
+            type: integer
+            format: int64
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              Format of the contract_entries in the result. In case of CreatedEvent the presentation will be of
+              TRANSACTION_SHAPE_ACS_DELTA.
+
+              Required
+      GetConnectedSynchronizersResponse:
+        title: GetConnectedSynchronizersResponse
+        type: object
+        properties:
+          connectedSynchronizers:
+            description: 'Optional: can be empty'
+            type: array
+            items:
+              $ref: '#/components/schemas/ConnectedSynchronizer'
+      GetContractRequest:
+        title: GetContractRequest
+        type: object
+        required:
+        - contractId
+        properties:
+          contractId:
+            description: |-
+              The ID of the contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          queryingParties:
+            description: |-
+              The list of querying parties
+              The stakeholders of the referenced contract must have an intersection with any of these parties
+              to return the result.
+              If no querying_parties specified, all possible contracts could be returned.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      GetContractResponse:
+        title: GetContractResponse
+        type: object
+        required:
+        - createdEvent
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The representative_package_id will be always set to the contract package ID, therefore this endpoint should
+              not be used to lookup contract which entered the participant via party replication or repair service.
+              The witnesses field will contain only the querying_parties which are also stakeholders of the contract as well.
+              The following fields of the created event cannot be populated, so those should not be used / parsed:
+
+              - offset
+              - node_id
+              - created_event_blob
+              - interface_views
+              - acs_delta
+
+              Required
+      GetEventsByContractIdRequest:
+        title: GetEventsByContractIdRequest
+        type: object
+        required:
+        - contractId
+        - eventFormat
+        properties:
+          contractId:
+            description: |-
+              The contract id being queried.
+
+              Required
+            type: string
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              Format of the events in the result, the presentation will be of TRANSACTION_SHAPE_ACS_DELTA.
+
+              Required
+      GetIdentityProviderConfigResponse:
+        title: GetIdentityProviderConfigResponse
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: Required
+      GetLatestPrunedOffsetsResponse:
+        title: GetLatestPrunedOffsetsResponse
+        type: object
+        properties:
+          participantPrunedUpToInclusive:
+            description: |-
+              It will always be a non-negative integer.
+              If positive, the absolute offset up to which the ledger has been pruned,
+              disregarding the state of all divulged contracts pruning.
+              If zero, the ledger has not been pruned yet.
+
+              Optional
+            type: integer
+            format: int64
+          allDivulgedContractsPrunedUpToInclusive:
+            description: |-
+              It will always be a non-negative integer.
+              If positive, the absolute offset up to which all divulged events have been pruned on the ledger.
+              It can be at or before the ``participant_pruned_up_to_inclusive`` offset.
+              For more details about all divulged events pruning,
+              see ``PruneRequest.prune_all_divulged_contracts`` in ``participant_pruning_service.proto``.
+              If zero, the divulged events have not been pruned yet.
+
+              Optional
+            type: integer
+            format: int64
+      GetLedgerApiVersionResponse:
+        title: GetLedgerApiVersionResponse
+        type: object
+        required:
+        - version
+        - features
+        properties:
+          version:
+            description: |-
+              The version of the ledger API.
+
+              Required
+            type: string
+          features:
+            $ref: '#/components/schemas/FeaturesDescriptor'
+            description: |-
+              The features supported by this Ledger API endpoint.
+
+              Daml applications CAN use the feature descriptor on top of
+              version constraints on the Ledger API version to determine
+              whether a given Ledger API endpoint supports the features
+              required to run the application.
+
+              See the feature descriptions themselves for the relation between
+              Ledger API versions and feature presence.
+
+              Required
+      GetLedgerEndResponse:
+        title: GetLedgerEndResponse
+        type: object
+        properties:
+          offset:
+            description: |-
+              It will always be a non-negative integer.
+              If zero, the participant view of the ledger is empty.
+              If positive, the absolute offset of the ledger as viewed by the participant.
+
+              Optional
+            type: integer
+            format: int64
+      GetPackageStatusResponse:
+        title: GetPackageStatusResponse
+        type: object
+        required:
+        - packageStatus
+        properties:
+          packageStatus:
+            description: |-
+              The status of the package.
+
+              Required
+            type: string
+            enum:
+            - PACKAGE_STATUS_UNSPECIFIED
+            - PACKAGE_STATUS_REGISTERED
+      GetParticipantIdResponse:
+        title: GetParticipantIdResponse
+        type: object
+        required:
+        - participantId
+        properties:
+          participantId:
+            description: |-
+              Identifier of the participant, which SHOULD be globally unique.
+              Must be a valid LedgerString (as describe in ``value.proto``).
+
+              Required
+            type: string
+      GetPartiesResponse:
+        title: GetPartiesResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
+            description: |-
+              The details of the requested Daml parties by the participant, if known.
+              The party details may not be in the same order as requested.
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PartyDetails'
+      GetPreferredPackageVersionResponse:
+        title: GetPreferredPackageVersionResponse
+        type: object
+        properties:
+          packagePreference:
+            $ref: '#/components/schemas/PackagePreference'
+            description: |-
+              Not populated when no preferred package is found
+
+              Optional
+      GetPreferredPackagesRequest:
+        title: GetPreferredPackagesRequest
+        type: object
+        required:
+        - packageVettingRequirements
+        properties:
+          packageVettingRequirements:
+            description: |-
+              The package-name vetting requirements for which the preferred packages should be resolved.
+
+              Generally it is enough to provide the requirements for the intended command's root package-names.
+              Additional package-name requirements can be provided when additional Daml transaction informees need to use
+              package dependencies of the command's root packages.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PackageVettingRequirement'
+          synchronizerId:
+            description: |-
+              The synchronizer whose vetting state should be used for resolving this query.
+              If not specified, the vetting states of all synchronizers to which the participant is connected are used.
+              Optional
+            type: string
+          vettingValidAt:
+            description: |-
+              The timestamp at which the package vetting validity should be computed
+              on the latest topology snapshot as seen by the participant.
+              If not provided, the participant's current clock time is used.
+
+              Optional
+            type: string
+      GetPreferredPackagesResponse:
+        title: GetPreferredPackagesResponse
+        type: object
+        required:
+        - synchronizerId
+        - packageReferences
+        properties:
+          packageReferences:
+            description: |-
+              The package references of the preferred packages.
+              Must contain one package reference for each requested package-name.
+
+              If you build command submissions whose content depends on the returned
+              preferred packages, then we recommend submitting the preferred package-ids
+              in the ``package_id_selection_preference`` of the command submission to
+              avoid race conditions with concurrent changes of the on-ledger package vetting state.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PackageReference'
+          synchronizerId:
+            description: |-
+              The synchronizer for which the package preferences are computed.
+              If the synchronizer_id was specified in the request, then it matches the request synchronizer_id.
+
+              Required
+            type: string
+      GetTransactionByIdRequest:
+        title: GetTransactionByIdRequest
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - updateId
+        properties:
+          updateId:
+            description: |-
+              The ID of a particular transaction.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Required
+            type: string
+          requestingParties:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              The parties whose events the client expects to see.
+              Events that are not visible for the parties in this collection will not be present in the response.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+              Optional for backwards compatibility for GetTransactionById request: if defined transaction_format must be
+              unset (falling back to defaults).
+            type: array
+            items:
+              type: string
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              Optional for GetTransactionById request for backwards compatibility: defaults to a transaction_format, where:
+
+              - event_format.filters_by_party will have template-wildcard filters for all the requesting_parties
+              - event_format.filters_for_any_party is unset
+              - event_format.verbose = true
+              - transaction_shape = TRANSACTION_SHAPE_ACS_DELTA
+      GetTransactionByOffsetRequest:
+        title: GetTransactionByOffsetRequest
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - offset
+        properties:
+          offset:
+            description: |-
+              The offset of the transaction being looked up.
+              Must be a valid absolute offset (positive integer).
+              Required
+            type: integer
+            format: int64
+          requestingParties:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              The parties whose events the client expects to see.
+              Events that are not visible for the parties in this collection will not be present in the response.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+              Optional for backwards compatibility for GetTransactionByOffset request: if defined transaction_format must be
+              unset (falling back to defaults).
+            type: array
+            items:
+              type: string
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              Optional for GetTransactionByOffset request for backwards compatibility: defaults to a TransactionFormat, where:
+
+              - event_format.filters_by_party will have template-wildcard filters for all the requesting_parties
+              - event_format.filters_for_any_party is unset
+              - event_format.verbose = true
+              - transaction_shape = TRANSACTION_SHAPE_ACS_DELTA
+      GetUpdateByIdRequest:
+        title: GetUpdateByIdRequest
+        type: object
+        required:
+        - updateId
+        - updateFormat
+        properties:
+          updateId:
+            description: |-
+              The ID of a particular update.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          updateFormat:
+            $ref: '#/components/schemas/UpdateFormat'
+            description: |-
+              The format for the update.
+
+              Required
+      GetUpdateByOffsetRequest:
+        title: GetUpdateByOffsetRequest
+        type: object
+        required:
+        - offset
+        - updateFormat
+        properties:
+          offset:
+            description: |-
+              The offset of the update being looked up.
+              Must be a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          updateFormat:
+            $ref: '#/components/schemas/UpdateFormat'
+            description: |-
+              The format for the update.
+
+              Required
+      GetUpdatesRequest:
+        title: GetUpdatesRequest
+        type: object
+        required:
+        - updateFormat
+        properties:
+          beginExclusive:
+            description: |-
+              Beginning of the requested ledger section (non-negative integer).
+              The response will only contain transactions whose offset is strictly greater than this.
+              If not populated or set to zero, the stream will start from the beginning of the ledger.
+              If positive, the streaming will start after this absolute offset.
+              If the ledger has been pruned, this parameter must be specified and be greater than the pruning offset.
+
+              Optional
+            type: integer
+            format: int64
+          endInclusive:
+            description: |-
+              End of the requested ledger section.
+              The response will only contain transactions whose offset is less than or equal to this.
+              If empty, the stream will not terminate.
+              If specified, the stream will terminate after this absolute offset (positive integer) is reached.
+
+              Optional
+            type: integer
+            format: int64
+          filter:
+            $ref: '#/components/schemas/TransactionFilter'
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              Requesting parties with template filters.
+              Template filters must be empty for GetUpdateTrees requests.
+              Optional for backwards compatibility, if defined update_format must be unset
+          verbose:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
+              In particular, setting the verbose flag to true triggers the ledger to include labels, record and variant type ids
+              for record fields.
+              Optional for backwards compatibility, if defined update_format must be unset
+            type: boolean
+          updateFormat:
+            $ref: '#/components/schemas/UpdateFormat'
+            description: |-
+              The update format for this request
+
+              Required
+      GetUserResponse:
+        title: GetUserResponse
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              Retrieved user.
+
+              Required
+      GrantUserRightsRequest:
+        title: GrantUserRightsRequest
+        description: |-
+          Add the rights to the set of rights granted to the user.
+
+          Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id)``
+        type: object
+        required:
+        - userId
+        properties:
+          userId:
+            description: |-
+              The user to whom to grant rights.
+
+              Required
+            type: string
+          rights:
+            description: |-
+              The rights to grant.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the user is managed by the default identity provider.
+
+              Optional
+            type: string
+      GrantUserRightsResponse:
+        title: GrantUserRightsResponse
+        type: object
+        properties:
+          newlyGrantedRights:
+            description: |-
+              The rights that were newly granted by the request.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      Identifier:
+        title: Identifier
+        type: object
+        required:
+        - packageId
+        - moduleName
+        - entityName
+        properties:
+          packageId:
+            type: string
+          moduleName:
+            type: string
+          entityName:
+            type: string
+      IdentifierFilter:
+        title: IdentifierFilter
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty1'
+        - type: object
+          required:
+          - InterfaceFilter
+          properties:
+            InterfaceFilter:
+              $ref: '#/components/schemas/InterfaceFilter'
+        - type: object
+          required:
+          - TemplateFilter
+          properties:
+            TemplateFilter:
+              $ref: '#/components/schemas/TemplateFilter'
+        - type: object
+          required:
+          - WildcardFilter
+          properties:
+            WildcardFilter:
+              $ref: '#/components/schemas/WildcardFilter'
+      IdentityProviderAdmin:
+        title: IdentityProviderAdmin
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/IdentityProviderAdmin1'
+      IdentityProviderAdmin1:
+        title: IdentityProviderAdmin
+        type: object
+      IdentityProviderConfig:
+        title: IdentityProviderConfig
+        type: object
+        required:
+        - identityProviderId
+        - issuer
+        - jwksUrl
+        properties:
+          identityProviderId:
+            description: |-
+              The identity provider identifier
+              Must be a valid LedgerString (as describe in ``value.proto``).
+
+              Required
+            type: string
+          isDeactivated:
+            description: |-
+              When set, the callers using JWT tokens issued by this identity provider are denied all access
+              to the Ledger API.
+              Modifiable
+
+              Optional
+            type: boolean
+          issuer:
+            description: |-
+              Specifies the issuer of the JWT token.
+              The issuer value is a case sensitive URL using the https scheme that contains scheme, host,
+              and optionally, port number and path components and no query or fragment components.
+              Modifiable
+
+              Can be left empty when used in `UpdateIdentityProviderConfigRequest` if the issuer is not being updated.
+
+              Required
+            type: string
+          jwksUrl:
+            description: |-
+              The JWKS (JSON Web Key Set) URL.
+              The Ledger API uses JWKs (JSON Web Keys) from the provided URL to verify that the JWT has been
+              signed with the loaded JWK. Only RS256 (RSA Signature with SHA-256) signing algorithm is supported.
+              Modifiable
+
+              Required
+            type: string
+          audience:
+            description: |-
+              Specifies the audience of the JWT token.
+              When set, the callers using JWT tokens issued by this identity provider are allowed to get an access
+              only if the "aud" claim includes the string specified here
+              Modifiable
+
+              Optional
+            type: string
+      InterfaceFilter:
+        title: InterfaceFilter
+        description: This filter matches contracts that implement a specific interface.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/InterfaceFilter1'
+      InterfaceFilter1:
+        title: InterfaceFilter
+        description: This filter matches contracts that implement a specific interface.
+        type: object
+        required:
+        - interfaceId
+        properties:
+          interfaceId:
+            description: |-
+              The interface that a matching contract must implement.
+              The ``interface_id`` needs to be valid: corresponding interface should be defined in
+              one of the available packages at the time of the query.
+              Both package-name and package-id reference formats for the identifier are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          includeInterfaceView:
+            description: |-
+              Whether to include the interface view on the contract in the returned ``CreatedEvent``.
+              Use this to access contract data in a uniform manner in your API client.
+
+              Optional
+            type: boolean
+          includeCreatedEventBlob:
+            description: |-
+              Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
+              Use this to access the contract create event payload in your API client
+              for submitting it as a disclosed contract with future commands.
+
+              Optional
+            type: boolean
+      JsActiveContract:
+        title: JsActiveContract
+        type: object
+        required:
+        - createdEvent
+        - synchronizerId
+        - reassignmentCounter
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The event as it appeared in the context of its last update (i.e. daml transaction or
+              reassignment). In particular, the last offset, node_id pair is preserved.
+              The last update is the most recent update created or assigned this contract on synchronizer_id synchronizer.
+              The offset of the CreatedEvent might point to an already pruned update, therefore it cannot necessarily be used
+              for lookups.
+
+              Required
+          synchronizerId:
+            description: |-
+              A valid synchronizer id
+
+              Required
+            type: string
+          reassignmentCounter:
+            description: |-
+              Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
+              with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
+              equals zero.
+              This field will be the reassignment_counter of the latest observable activation event on this synchronizer, which is
+              before the active_at_offset.
+
+              Required
+            type: integer
+            format: int64
+      JsArchived:
+        title: JsArchived
+        type: object
+        required:
+        - archivedEvent
+        - synchronizerId
+        properties:
+          archivedEvent:
+            $ref: '#/components/schemas/ArchivedEvent'
+            description: Required
+          synchronizerId:
+            description: |-
+              The synchronizer which sequenced the archival of the contract
+
+              Required
+            type: string
+      JsAssignedEvent:
+        title: JsAssignedEvent
+        description: Records that a contract has been assigned, and it can be used on
+          the target synchronizer.
+        type: object
+        required:
+        - source
+        - target
+        - reassignmentId
+        - reassignmentCounter
+        - createdEvent
+        properties:
+          source:
+            description: |-
+              The ID of the source synchronizer.
+              Must be a valid synchronizer id.
+
+              Required
+            type: string
+          target:
+            description: |-
+              The ID of the target synchronizer.
+              Must be a valid synchronizer id.
+
+              Required
+            type: string
+          reassignmentId:
+            description: |-
+              The ID from the unassigned event.
+              For correlation capabilities.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          submitter:
+            description: |-
+              Party on whose behalf the assign command was executed.
+              Empty if the assignment happened offline via the repair service.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          reassignmentCounter:
+            description: |-
+              Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
+              with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
+              equals zero.
+
+              Required
+            type: integer
+            format: int64
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The offset of this event refers to the offset of the assignment,
+              while the node_id is the index of within the batch.
+
+              Required
+      JsAssignmentEvent:
+        title: JsAssignmentEvent
+        type: object
+        required:
+        - source
+        - target
+        - reassignmentId
+        - submitter
+        - reassignmentCounter
+        - createdEvent
+        properties:
+          source:
+            type: string
+          target:
+            type: string
+          reassignmentId:
+            type: string
+          submitter:
+            type: string
+          reassignmentCounter:
+            type: integer
+            format: int64
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+      JsCantonError:
+        title: JsCantonError
+        type: object
+        required:
+        - code
+        - cause
+        - context
+        - errorCategory
+        properties:
+          code:
+            type: string
+          cause:
+            type: string
+          correlationId:
+            type: string
+          traceId:
+            type: string
+          context:
+            $ref: '#/components/schemas/Map_String'
+          resources:
+            type: array
+            items:
+              $ref: '#/components/schemas/Tuple2_String_String'
+          errorCategory:
+            type: integer
+            format: int32
+          grpcCodeValue:
+            type: integer
+            format: int32
+          retryInfo:
+            type: string
+          definiteAnswer:
+            type: boolean
+      JsCommands:
+        title: JsCommands
+        description: A composite command that groups multiple commands together.
+        type: object
+        required:
+        - commandId
+        - commands
+        - actAs
+        properties:
+          commands:
+            description: |-
+              Individual elements of this atomic command. Must be non-empty.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Command'
+          commandId:
+            description: |-
+              Uniquely identifies the command.
+              The triple (user_id, act_as, command_id) constitutes the change ID for the intended ledger change,
+              where act_as is interpreted as a set of party names.
+              The change ID can be used for matching the intended ledger changes with all their completions.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          actAs:
+            description: |-
+              Set of parties on whose behalf the command should be executed.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to act on behalf of each of the given parties.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          userId:
+            description: |-
+              Uniquely identifies the participant user that issued the command.
+              Must be a valid UserIdString (as described in ``value.proto``).
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
+
+              Optional
+            type: string
+          readAs:
+            description: |-
+              Set of parties on whose behalf (in addition to all parties listed in ``act_as``) contracts can be retrieved.
+              This affects Daml operations such as ``fetch``, ``fetchByKey``, ``lookupByKey``, ``exercise``, and ``exerciseByKey``.
+              Note: A participant node of a Daml network can host multiple parties. Each contract present on the participant
+              node is only visible to a subset of these parties. A command can only use contracts that are visible to at least
+              one of the parties in ``act_as`` or ``read_as``. This visibility check is independent from the Daml authorization
+              rules for fetch operations.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to read contract data on behalf of each of the given parties.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          workflowId:
+            description: |-
+              Identifier of the on-ledger workflow that this command is a part of.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod'
+          minLedgerTimeAbs:
+            description: |-
+              Lower bound for the ledger time assigned to the resulting transaction.
+              Note: The ledger time of a transaction is assigned as part of command interpretation.
+              Use this property if you expect that command interpretation will take a considerate amount of time, such that by
+              the time the resulting transaction is sequenced, its assigned ledger time is not valid anymore.
+              Must not be set at the same time as min_ledger_time_rel.
+
+              Optional
+            type: string
+          minLedgerTimeRel:
+            $ref: '#/components/schemas/Duration'
+            description: |-
+              Same as min_ledger_time_abs, but specified as a duration, starting from the time the command is received by the server.
+              Must not be set at the same time as min_ledger_time_abs.
+
+              Optional
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              If omitted, the participant or the committer may set a value of their choice.
+
+              Optional
+            type: string
+          disclosedContracts:
+            description: |-
+              Additional contracts used to resolve contract & contract key lookups.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/DisclosedContract'
+          synchronizerId:
+            description: |-
+              Must be a valid synchronizer id
+
+              Optional
+            type: string
+          packageIdSelectionPreference:
+            description: |-
+              The package-id selection preference of the client for resolving
+              package names and interface instances in command submission and interpretation
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          prefetchContractKeys:
+            description: |-
+              Fetches the contract keys into the caches to speed up the command processing.
+              Should only contain contract keys that are expected to be resolved during interpretation of the commands.
+              Keys of disclosed contracts do not need prefetching.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PrefetchContractKey'
+          tapsMaxPasses:
+            description: |-
+              The maximum number of passes for the Topology-Aware Package Selection (TAPS).
+              Higher values can increase the chance of successful package selection for routing of interpreted transactions.
+              If unset, this defaults to the value defined in the participant configuration.
+              The provided value must not exceed the limit specified in the participant configuration.
+
+              Optional
+            type: integer
+            format: int32
+      JsContractEntry:
+        title: JsContractEntry
+        description: |-
+          For a contract there could be multiple contract_entry-s in the entire snapshot. These together define
+          the state of one contract in the snapshot.
+          A contract_entry is included in the result, if and only if there is at least one stakeholder party of the contract
+          that is hosted on the synchronizer at the time of the event and the party satisfies the
+          ``TransactionFilter`` in the query.
+
+          Required
+        oneOf:
+        - type: object
+          required:
+          - JsActiveContract
+          properties:
+            JsActiveContract:
+              $ref: '#/components/schemas/JsActiveContract'
+        - type: object
+          required:
+          - JsEmpty
+          properties:
+            JsEmpty:
+              $ref: '#/components/schemas/JsEmpty'
+        - type: object
+          required:
+          - JsIncompleteAssigned
+          properties:
+            JsIncompleteAssigned:
+              $ref: '#/components/schemas/JsIncompleteAssigned'
+        - type: object
+          required:
+          - JsIncompleteUnassigned
+          properties:
+            JsIncompleteUnassigned:
+              $ref: '#/components/schemas/JsIncompleteUnassigned'
+      JsCreated:
+        title: JsCreated
+        type: object
+        required:
+        - createdEvent
+        - synchronizerId
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The event as it appeared in the context of its original update (i.e. daml transaction or
+              reassignment) on this participant node. You can use its offset and node_id to find the
+              corresponding update and the node within it.
+
+              Required
+          synchronizerId:
+            description: |-
+              The synchronizer which sequenced the creation of the contract
+
+              Required
+            type: string
+      JsEmpty:
+        title: JsEmpty
+        type: object
+      JsExecuteSubmissionAndWaitForTransactionRequest:
+        title: JsExecuteSubmissionAndWaitForTransactionRequest
+        type: object
+        required:
+        - preparedTransaction
+        - partySignatures
+        - submissionId
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              the prepared transaction
+              Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
+              obtained from calling `prepareSubmission`.
+
+              Required
+            type: string
+          partySignatures:
+            $ref: '#/components/schemas/PartySignatures'
+            description: |-
+              The party(ies) signatures that authorize the prepared submission to be executed by this node.
+              Each party can provide one or more signatures..
+              and one or more parties can sign.
+              Note that currently, only single party submissions are supported.
+
+              Required
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod2'
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          userId:
+            description: |-
+              See [PrepareSubmissionRequest.user_id]
+
+              Optional
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: |-
+              If set will influence the chosen ledger effective time but will not result in a submission delay so any override
+              should be scheduled to executed within the window allowed by synchronizer.
+
+              Optional
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              If no ``transaction_format`` is provided, a default will be used where ``transaction_shape`` is set to
+              TRANSACTION_SHAPE_ACS_DELTA, ``event_format`` is defined with ``filters_by_party`` containing wildcard-template
+              filter for all original ``act_as`` and ``read_as`` parties and the ``verbose`` flag is set.
+              When the ``transaction_shape`` TRANSACTION_SHAPE_ACS_DELTA shape is used (explicitly or is defaulted to as explained above),
+              events will only be returned if the submitting party is hosted on this node.
+
+              Optional
+      JsExecuteSubmissionAndWaitForTransactionResponse:
+        title: JsExecuteSubmissionAndWaitForTransactionResponse
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransaction'
+            description: |-
+              The transaction that resulted from the submitted command.
+              The transaction might contain no events (request conditions result in filtering out all of them).
+
+              Required
+      JsExecuteSubmissionAndWaitRequest:
+        title: JsExecuteSubmissionAndWaitRequest
+        type: object
+        required:
+        - preparedTransaction
+        - partySignatures
+        - submissionId
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              the prepared transaction
+              Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
+              obtained from calling `prepareSubmission`.
+
+              Required
+            type: string
+          partySignatures:
+            $ref: '#/components/schemas/PartySignatures'
+            description: |-
+              The party(ies) signatures that authorize the prepared submission to be executed by this node.
+              Each party can provide one or more signatures..
+              and one or more parties can sign.
+              Note that currently, only single party submissions are supported.
+
+              Required
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod2'
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          userId:
+            description: |-
+              See [PrepareSubmissionRequest.user_id]
+
+              Optional
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: |-
+              If set will influence the chosen ledger effective time but will not result in a submission delay so any override
+              should be scheduled to executed within the window allowed by synchronizer.
+
+              Optional
+      JsExecuteSubmissionRequest:
+        title: JsExecuteSubmissionRequest
+        type: object
+        required:
+        - preparedTransaction
+        - partySignatures
+        - submissionId
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              the prepared transaction
+              Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
+              obtained from calling `prepareSubmission`.
+
+              Required
+            type: string
+          partySignatures:
+            $ref: '#/components/schemas/PartySignatures'
+            description: |-
+              The party(ies) signatures that authorize the prepared submission to be executed by this node.
+              Each party can provide one or more signatures..
+              and one or more parties can sign.
+              Note that currently, only single party submissions are supported.
+
+              Required
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod2'
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          userId:
+            description: |-
+              See [PrepareSubmissionRequest.user_id]
+
+              Optional
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: |-
+              If set will influence the chosen ledger effective time but will not result in a submission delay so any override
+              should be scheduled to executed within the window allowed by synchronizer.
+
+              Optional
+      JsGetActiveContractsResponse:
+        title: JsGetActiveContractsResponse
+        type: object
+        properties:
+          workflowId:
+            description: |-
+              The workflow ID used in command submission which corresponds to the contract_entry. Only set if
+              the ``workflow_id`` for the command was set.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          contractEntry:
+            $ref: '#/components/schemas/JsContractEntry'
+      JsGetEventsByContractIdResponse:
+        title: JsGetEventsByContractIdResponse
+        type: object
+        properties:
+          created:
+            $ref: '#/components/schemas/JsCreated'
+            description: |-
+              The create event for the contract with the ``contract_id`` given in the request
+              provided it exists and has not yet been pruned.
+
+              Optional
+          archived:
+            $ref: '#/components/schemas/JsArchived'
+            description: |-
+              The archive event for the contract with the ``contract_id`` given in the request
+              provided such an archive event exists and it has not yet been pruned.
+
+              Optional
+      JsGetTransactionResponse:
+        title: JsGetTransactionResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransaction'
+            description: Required
+      JsGetTransactionTreeResponse:
+        title: JsGetTransactionTreeResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransactionTree'
+            description: Required
+      JsGetUpdateResponse:
+        title: JsGetUpdateResponse
+        type: object
+        properties:
+          update:
+            $ref: '#/components/schemas/Update'
+      JsGetUpdateTreesResponse:
+        title: JsGetUpdateTreesResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        properties:
+          update:
+            $ref: '#/components/schemas/Update1'
+      JsGetUpdatesResponse:
+        title: JsGetUpdatesResponse
+        type: object
+        properties:
+          update:
+            $ref: '#/components/schemas/Update'
+      JsIncompleteAssigned:
+        title: JsIncompleteAssigned
+        type: object
+        required:
+        - assignedEvent
+        properties:
+          assignedEvent:
+            $ref: '#/components/schemas/JsAssignedEvent'
+            description: Required
+      JsIncompleteUnassigned:
+        title: JsIncompleteUnassigned
+        type: object
+        required:
+        - createdEvent
+        - unassignedEvent
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The event as it appeared in the context of its last activation update (i.e. daml transaction or
+              reassignment). In particular, the last activation offset, node_id pair is preserved.
+              The last activation update is the most recent update created or assigned this contract on synchronizer_id synchronizer before
+              the unassigned_event.
+              The offset of the CreatedEvent might point to an already pruned update, therefore it cannot necessarily be used
+              for lookups.
+
+              Required
+          unassignedEvent:
+            $ref: '#/components/schemas/UnassignedEvent'
+            description: Required
+      JsInterfaceView:
+        title: JsInterfaceView
+        description: View of a create event matched by an interface filter.
+        type: object
+        required:
+        - interfaceId
+        - viewStatus
+        properties:
+          interfaceId:
+            description: |-
+              The interface implemented by the matched event.
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          viewStatus:
+            $ref: '#/components/schemas/JsStatus'
+            description: |-
+              Whether the view was successfully computed, and if not,
+              the reason for the error. The error is reported using the same rules
+              for error codes and messages as the errors returned for API requests.
+
+              Required
+          viewValue:
+            description: |-
+              The value of the interface's view method on this event.
+              Set if it was requested in the ``InterfaceFilter`` and it could be
+              successfully computed.
+
+              Optional
+      JsPrepareSubmissionRequest:
+        title: JsPrepareSubmissionRequest
+        type: object
+        required:
+        - commandId
+        - commands
+        - actAs
+        properties:
+          userId:
+            description: |-
+              Uniquely identifies the participant user that prepares the transaction.
+              Must be a valid UserIdString (as described in ``value.proto``).
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
+
+              Optional
+            type: string
+          commandId:
+            description: |-
+              Uniquely identifies the command.
+              The triple (user_id, act_as, command_id) constitutes the change ID for the intended ledger change,
+              where act_as is interpreted as a set of party names.
+              The change ID can be used for matching the intended ledger changes with all their completions.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          commands:
+            description: |-
+              Individual elements of this atomic command. Must be non-empty.
+              Limitation: Only single command transaction are currently supported by the API.
+              The field is marked as repeated in preparation for future support of multiple commands.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Command'
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: Optional
+          actAs:
+            description: |-
+              Set of parties on whose behalf the command should be executed, if submitted.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to **read** (not act) on behalf of each of the given parties. This is because this RPC merely prepares a transaction
+              and does not execute it. Therefore read authorization is sufficient even for actAs parties.
+              Note: This may change, and more specific authorization scope may be introduced in the future.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          readAs:
+            description: |-
+              Set of parties on whose behalf (in addition to all parties listed in ``act_as``) contracts can be retrieved.
+              This affects Daml operations such as ``fetch``, ``fetchByKey``, ``lookupByKey``, ``exercise``, and ``exerciseByKey``.
+              Note: A command can only use contracts that are visible to at least
+              one of the parties in ``act_as`` or ``read_as``. This visibility check is independent from the Daml authorization
+              rules for fetch operations.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to read contract data on behalf of each of the given parties.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          disclosedContracts:
+            description: |-
+              Additional contracts used to resolve contract & contract key lookups.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/DisclosedContract'
+          synchronizerId:
+            description: |-
+              Must be a valid synchronizer id
+              If not set, a suitable synchronizer that this node is connected to will be chosen
+
+              Optional
+            type: string
+          packageIdSelectionPreference:
+            description: |-
+              The package-id selection preference of the client for resolving
+              package names and interface instances in command submission and interpretation
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          verboseHashing:
+            description: |-
+              When true, the response will contain additional details on how the transaction was encoded and hashed
+              This can be useful for troubleshooting of hash mismatches. Should only be used for debugging.
+              Defaults to false
+
+              Optional
+            type: boolean
+          prefetchContractKeys:
+            description: |-
+              Fetches the contract keys into the caches to speed up the command processing.
+              Should only contain contract keys that are expected to be resolved during interpretation of the commands.
+              Keys of disclosed contracts do not need prefetching.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PrefetchContractKey'
+          maxRecordTime:
+            description: |-
+              Maximum timestamp at which the transaction can be recorded onto the ledger via the synchronizer specified in the `PrepareSubmissionResponse`.
+              If submitted after it will be rejected even if otherwise valid, in which case it needs to be prepared and signed again
+              with a new valid max_record_time.
+              Use this to limit the time-to-life of a prepared transaction,
+              which is useful to know when it can definitely not be accepted
+              anymore and resorting to preparing another transaction for the same
+              intent is safe again.
+
+              Optional
+            type: string
+          estimateTrafficCost:
+            $ref: '#/components/schemas/CostEstimationHints'
+            description: |-
+              Hints to improve the accuracy of traffic cost estimation.
+              The estimation logic assumes that this node will be used for the execution of the transaction
+              If another node is used instead, the estimation may be less precise.
+              Request amplification is not accounted for in the estimation: each amplified request will
+              result in the cost of the confirmation request to be charged additionally.
+
+              Traffic cost estimation is enabled by default if this field is not set
+              To turn off cost estimation, set the CostEstimationHints#disabled field to true
+
+              Optional
+          tapsMaxPasses:
+            description: |-
+              The maximum number of passes for the Topology-Aware Package Selection (TAPS).
+              Higher values can increase the chance of successful package selection for routing of interpreted transactions.
+              If unset, this defaults to the value defined in the participant configuration.
+              The provided value must not exceed the limit specified in the participant configuration.
+
+              Optional
+            type: integer
+            format: int32
+      JsPrepareSubmissionResponse:
+        title: JsPrepareSubmissionResponse
+        description: '[docs-entry-end: HashingSchemeVersion]'
+        type: object
+        required:
+        - preparedTransaction
+        - preparedTransactionHash
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              The interpreted transaction, it represents the ledger changes necessary to execute the commands specified in the request.
+              Clients MUST display the content of the transaction to the user for them to validate before signing the hash if the preparing participant is not trusted.
+
+              Required
+            type: string
+          preparedTransactionHash:
+            description: |-
+              Hash of the transaction, this is what needs to be signed by the party to authorize the transaction.
+              Only provided for convenience, clients MUST recompute the hash from the raw transaction if the preparing participant is not trusted.
+              May be removed in future versions
+
+              Required: must be non-empty
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+          hashingDetails:
+            description: |-
+              Optional additional details on how the transaction was encoded and hashed. Only set if verbose_hashing = true in the request
+              Note that there are no guarantees on the stability of the format or content of this field.
+              Its content should NOT be parsed and should only be used for troubleshooting purposes.
+
+              Optional
+            type: string
+          costEstimation:
+            $ref: '#/components/schemas/CostEstimation'
+            description: |-
+              Traffic cost estimation of the prepared transaction
+
+              Optional
+      JsReassignment:
+        title: JsReassignment
+        description: Complete view of an on-ledger reassignment.
+        type: object
+        required:
+        - updateId
+        - offset
+        - recordTime
+        - synchronizerId
+        - events
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          commandId:
+            description: |-
+              The ID of the command which resulted in this reassignment. Missing for everyone except the submitting party on the submitting participant.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          workflowId:
+            description: |-
+              The workflow ID used in reassignment command submission. Only set if the ``workflow_id`` for the command was set.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          offset:
+            description: |-
+              The participant's offset. The details of this field are described in ``community/ledger-api/README.md``.
+              Must be a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          events:
+            description: |-
+              The collection of reassignment events.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/JsReassignmentEvent'
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+
+              Optional
+          recordTime:
+            description: |-
+              The time at which the reassignment was recorded. The record time refers to the source/target
+              synchronizer for an unassign/assign event respectively.
+
+              Required
+            type: string
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized this Reassignment.
+
+              Required
+            type: string
+          paidTrafficCost:
+            description: |-
+              The traffic cost that this participant node paid for the corresponding (un)assignment request.
+
+              Not set for transactions that were
+              - initiated by another participant
+              - initiated offline via the repair service
+              - processed before the participant started serving traffic cost on the Ledger API
+              - returned as part of a query filtering for a non submitting party
+
+              Optional: can be empty
+            type: integer
+            format: int64
+      JsReassignmentEvent:
+        title: JsReassignmentEvent
+        oneOf:
+        - type: object
+          required:
+          - JsAssignmentEvent
+          properties:
+            JsAssignmentEvent:
+              $ref: '#/components/schemas/JsAssignmentEvent'
+        - type: object
+          required:
+          - JsUnassignedEvent
+          properties:
+            JsUnassignedEvent:
+              $ref: '#/components/schemas/JsUnassignedEvent'
+      JsStatus:
+        title: JsStatus
+        type: object
+        required:
+        - code
+        - message
+        properties:
+          code:
+            type: integer
+            format: int32
+          message:
+            type: string
+          details:
+            type: array
+            items:
+              $ref: '#/components/schemas/ProtoAny'
+      JsSubmitAndWaitForReassignmentResponse:
+        title: JsSubmitAndWaitForReassignmentResponse
+        type: object
+        required:
+        - reassignment
+        properties:
+          reassignment:
+            $ref: '#/components/schemas/JsReassignment'
+            description: |-
+              The reassignment that resulted from the submitted reassignment command.
+              The reassignment might contain no events (request conditions result in filtering out all of them).
+
+              Required
+      JsSubmitAndWaitForTransactionRequest:
+        title: JsSubmitAndWaitForTransactionRequest
+        description: These commands are executed as a single atomic transaction.
+        type: object
+        required:
+        - commands
+        properties:
+          commands:
+            $ref: '#/components/schemas/JsCommands'
+            description: |-
+              The commands to be submitted.
+
+              Required
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              If no ``transaction_format`` is provided, a default will be used where ``transaction_shape`` is set to
+              TRANSACTION_SHAPE_ACS_DELTA, ``event_format`` is defined with ``filters_by_party`` containing wildcard-template
+              filter for all original ``act_as`` and ``read_as`` parties and the ``verbose`` flag is set.
+
+              Optional
+      JsSubmitAndWaitForTransactionResponse:
+        title: JsSubmitAndWaitForTransactionResponse
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransaction'
+            description: |-
+              The transaction that resulted from the submitted command.
+              The transaction might contain no events (request conditions result in filtering out all of them).
+
+              Required
+      JsSubmitAndWaitForTransactionTreeResponse:
+        title: JsSubmitAndWaitForTransactionTreeResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        properties:
+          transactionTree:
+            $ref: '#/components/schemas/JsTransactionTree'
+      JsTopologyTransaction:
+        title: JsTopologyTransaction
+        type: object
+        required:
+        - updateId
+        - offset
+        - synchronizerId
+        - recordTime
+        - events
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          offset:
+            description: |-
+              The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
+              It is a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized the topology transaction.
+
+              Required
+            type: string
+          recordTime:
+            description: |-
+              The time at which the changes in the topology transaction become effective. There is a small delay between a
+              topology transaction being sequenced and the changes it contains becoming effective. Topology transactions appear
+              in order relative to a synchronizer based on their effective time rather than their sequencing time.
+
+              Required
+            type: string
+          events:
+            description: |-
+              A non-empty list of topology events.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/TopologyEvent'
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+
+              Optional
+      JsTransaction:
+        title: JsTransaction
+        description: Filtered view of an on-ledger transaction's create and archive
+          events.
+        type: object
+        required:
+        - updateId
+        - effectiveAt
+        - offset
+        - synchronizerId
+        - recordTime
+        - events
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          commandId:
+            description: |-
+              The ID of the command which resulted in this transaction. Missing for everyone except the submitting party.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          workflowId:
+            description: |-
+              The workflow ID used in command submission.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          effectiveAt:
+            description: |-
+              Ledger effective time.
+
+              Required
+            type: string
+          events:
+            description: |-
+              The collection of events.
+              Contains:
+
+              - ``CreatedEvent`` or ``ArchivedEvent`` in case of ACS_DELTA transaction shape
+              - ``CreatedEvent`` or ``ExercisedEvent`` in case of LEDGER_EFFECTS transaction shape
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Event'
+          offset:
+            description: |-
+              The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
+              It is a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized the transaction.
+
+              Required
+            type: string
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+
+              Optional
+          recordTime:
+            description: |-
+              The time at which the transaction was recorded. The record time refers to the synchronizer
+              which synchronized the transaction.
+
+              Required
+            type: string
+          externalTransactionHash:
+            description: |-
+              For transaction externally signed, contains the external transaction hash
+              signed by the external party. Can be used to correlate an external submission with a committed transaction.
+
+              Optional: can be empty
+            type: string
+          paidTrafficCost:
+            description: |-
+              The traffic cost that this participant node paid for the confirmation
+              request for this transaction.
+
+              Not set for transactions that were
+              - initiated by another participant
+              - initiated offline via the repair service
+              - processed before the participant started serving traffic cost on the Ledger API
+              - returned as part of a query filtering for a non submitting party
+
+              Optional: can be empty
+            type: integer
+            format: int64
+      JsTransactionTree:
+        title: JsTransactionTree
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Complete view of an on-ledger transaction.
+        type: object
+        required:
+        - updateId
+        - effectiveAt
+        - offset
+        - eventsById
+        - synchronizerId
+        - recordTime
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Required
+            type: string
+          commandId:
+            description: |-
+              The ID of the command which resulted in this transaction. Missing for everyone except the submitting party.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Optional
+            type: string
+          workflowId:
+            description: |-
+              The workflow ID used in command submission. Only set if the ``workflow_id`` for the command was set.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Optional
+            type: string
+          effectiveAt:
+            description: |-
+              Ledger effective time.
+              Required
+            type: string
+          offset:
+            description: |-
+              The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
+              Required, it is a valid absolute offset (positive integer).
+            type: integer
+            format: int64
+          eventsById:
+            $ref: '#/components/schemas/Map_Int_TreeEvent'
+            description: |-
+              Changes to the ledger that were caused by this transaction. Nodes of the transaction tree.
+              Each key must be a valid node ID (non-negative integer).
+              Required
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized the transaction.
+              Required
+            type: string
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Optional; ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+          recordTime:
+            description: |-
+              The time at which the transaction was recorded. The record time refers to the synchronizer
+              which synchronized the transaction.
+              Required
+            type: string
+      JsUnassignedEvent:
+        title: JsUnassignedEvent
+        description: Records that a contract has been unassigned, and it becomes unusable
+          on the source synchronizer
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/UnassignedEvent'
+      Kind:
+        title: Kind
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - CanActAs
+          properties:
+            CanActAs:
+              $ref: '#/components/schemas/CanActAs'
+        - type: object
+          required:
+          - CanExecuteAs
+          properties:
+            CanExecuteAs:
+              $ref: '#/components/schemas/CanExecuteAs'
+        - type: object
+          required:
+          - CanExecuteAsAnyParty
+          properties:
+            CanExecuteAsAnyParty:
+              $ref: '#/components/schemas/CanExecuteAsAnyParty'
+        - type: object
+          required:
+          - CanReadAs
+          properties:
+            CanReadAs:
+              $ref: '#/components/schemas/CanReadAs'
+        - type: object
+          required:
+          - CanReadAsAnyParty
+          properties:
+            CanReadAsAnyParty:
+              $ref: '#/components/schemas/CanReadAsAnyParty'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty8'
+        - type: object
+          required:
+          - IdentityProviderAdmin
+          properties:
+            IdentityProviderAdmin:
+              $ref: '#/components/schemas/IdentityProviderAdmin'
+        - type: object
+          required:
+          - ParticipantAdmin
+          properties:
+            ParticipantAdmin:
+              $ref: '#/components/schemas/ParticipantAdmin'
+      ListIdentityProviderConfigsResponse:
+        title: ListIdentityProviderConfigsResponse
+        type: object
+        required:
+        - identityProviderConfigs
+        properties:
+          identityProviderConfigs:
+            description: |-
+              The list of identity provider configs
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/IdentityProviderConfig'
+      ListKnownPartiesResponse:
+        title: ListKnownPartiesResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
+            description: |-
+              The details of all Daml parties known by the participant.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PartyDetails'
+          nextPageToken:
+            description: |-
+              Pagination token to retrieve the next page.
+              Empty, if there are no further results.
+
+              Optional
+            type: string
+      ListPackagesResponse:
+        title: ListPackagesResponse
+        type: object
+        required:
+        - packageIds
+        properties:
+          packageIds:
+            description: |-
+              The IDs of all Daml-LF packages supported by the server.
+              Each element must be a valid PackageIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+      ListUserRightsResponse:
+        title: ListUserRightsResponse
+        type: object
+        properties:
+          rights:
+            description: |-
+              All rights of the user.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      ListUsersResponse:
+        title: ListUsersResponse
+        type: object
+        properties:
+          users:
+            description: |-
+              A subset of users of the participant node that fit into this page.
+              Can be empty if no more users
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+          nextPageToken:
+            description: |-
+              Pagination token to retrieve the next page.
+              Empty, if there are no further results.
+
+              Optional
+            type: string
+      ListVettedPackagesRequest:
+        title: ListVettedPackagesRequest
+        type: object
+        properties:
+          packageMetadataFilter:
+            $ref: '#/components/schemas/PackageMetadataFilter'
+            description: |-
+              The package metadata filter the returned vetted packages set must satisfy.
+
+              Optional
+          topologyStateFilter:
+            $ref: '#/components/schemas/TopologyStateFilter'
+            description: |-
+              The topology filter the returned vetted packages set must satisfy.
+
+              Optional
+          pageToken:
+            description: |-
+              Pagination token to determine the specific page to fetch. Using the token
+              guarantees that ``VettedPackages`` on a subsequent page are all greater
+              (``VettedPackages`` are sorted by synchronizer ID then participant ID) than
+              the last ``VettedPackages`` on a previous page.
+
+              The server does not store intermediate results between calls chained by a
+              series of page tokens. As a consequence, if new vetted packages are being
+              added and a page is requested twice using the same token, more packages can
+              be returned on the second call.
+
+              Leave unspecified (i.e. as empty string) to fetch the first page.
+
+              Optional
+            type: string
+          pageSize:
+            description: |-
+              Maximum number of ``VettedPackages`` results to return in a single page.
+
+              If the page_size is unspecified (i.e. left as 0), the server will decide
+              the number of results to be returned.
+
+              If the page_size exceeds the maximum supported by the server, an
+              error will be returned.
+
+              To obtain the server's maximum consult the PackageService descriptor
+              available in the VersionService.
+
+              Optional
+            type: integer
+            format: int32
+      ListVettedPackagesResponse:
+        title: ListVettedPackagesResponse
+        type: object
+        properties:
+          vettedPackages:
+            description: |-
+              All ``VettedPackages`` that contain at least one ``VettedPackage`` matching
+              both a ``PackageMetadataFilter`` and a ``TopologyStateFilter``.
+              Sorted by synchronizer_id then participant_id.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackages'
+          nextPageToken:
+            description: |-
+              Pagination token to retrieve the next page.
+              Empty string if there are no further results.
+
+              Optional
+            type: string
+      Map_Filters:
+        title: Map_Filters
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/Filters'
+      Map_Int_Field:
+        title: Map_Int_Field
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/Field'
+      Map_Int_TreeEvent:
+        title: Map_Int_TreeEvent
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/TreeEvent'
+      Map_String:
+        title: Map_String
+        type: object
+        additionalProperties:
+          type: string
+      MinLedgerTime:
+        title: MinLedgerTime
+        type: object
+        properties:
+          time:
+            $ref: '#/components/schemas/Time'
+      MinLedgerTimeAbs:
+        title: MinLedgerTimeAbs
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: string
+      MinLedgerTimeRel:
+        title: MinLedgerTimeRel
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      NoPrior:
+        title: NoPrior
+        type: object
+      ObjectMeta:
+        title: ObjectMeta
+        description: |-
+          Represents metadata corresponding to a participant resource (e.g. a participant user or participant local information about a party).
+
+          Based on ``ObjectMeta`` meta used in Kubernetes API.
+          See https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/generated.proto#L640
+        type: object
+        properties:
+          resourceVersion:
+            description: |-
+              An opaque, non-empty value, populated by a participant server which represents the internal version of the resource
+              this ``ObjectMeta`` message is attached to. The participant server will change it to a unique value each time the corresponding resource is updated.
+              You must not rely on the format of resource version. The participant server might change it without notice.
+              You can obtain the newest resource version value by issuing a read request.
+              You may use it for concurrent change detection by passing it back unmodified in an update request.
+              The participant server will then compare the passed value with the value maintained by the system to determine
+              if any other updates took place since you had read the resource version.
+              Upon a successful update you are guaranteed that no other update took place during your read-modify-write sequence.
+              However, if another update took place during your read-modify-write sequence then your update will fail with an appropriate error.
+              Concurrent change control is optional. It will be applied only if you include a resource version in an update request.
+              When creating a new instance of a resource you must leave the resource version empty.
+              Its value will be populated by the participant server upon successful resource creation.
+
+              Optional
+            type: string
+          annotations:
+            $ref: '#/components/schemas/Map_String'
+            description: |-
+              A set of modifiable key-value pairs that can be used to represent arbitrary, client-specific metadata.
+              Constraints:
+
+              1. The total size over all keys and values cannot exceed 256kb in UTF-8 encoding.
+              2. Keys are composed of an optional prefix segment and a required name segment such that:
+
+                 - key prefix, when present, must be a valid DNS subdomain with at most 253 characters, followed by a '/' (forward slash) character,
+                 - name segment must have at most 63 characters that are either alphanumeric ([a-z0-9A-Z]), or a '.' (dot), '-' (dash) or '_' (underscore);
+                   and it must start and end with an alphanumeric character.
+
+              3. Values can be any non-empty strings.
+
+              Keys with empty prefix are reserved for end-users.
+              Properties set by external tools or internally by the participant server must use non-empty key prefixes.
+              Duplicate keys are disallowed by the semantics of the protobuf3 maps.
+              See: https://developers.google.com/protocol-buffers/docs/proto3#maps
+              Annotations may be a part of a modifiable resource.
+              Use the resource's update RPC to update its annotations.
+              In order to add a new annotation or update an existing one using an update RPC, provide the desired annotation in the update request.
+              In order to remove an annotation using an update RPC, provide the target annotation's key but set its value to the empty string in the update request.
+              Modifiable
+
+              Optional: can be empty
+      OffsetCheckpoint:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/OffsetCheckpoint1'
+      OffsetCheckpoint1:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - offset
+        properties:
+          offset:
+            description: |-
+              The participant's offset, the details of the offset field are described in ``community/ledger-api/README.md``.
+              Must be a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          synchronizerTimes:
+            description: |-
+              The times associated with each synchronizer at this offset.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/SynchronizerTime'
+      OffsetCheckpoint2:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/OffsetCheckpoint1'
+      OffsetCheckpoint3:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/OffsetCheckpoint1'
+      OffsetCheckpointFeature:
+        title: OffsetCheckpointFeature
+        type: object
+        required:
+        - maxOffsetCheckpointEmissionDelay
+        properties:
+          maxOffsetCheckpointEmissionDelay:
+            $ref: '#/components/schemas/Duration'
+            description: |-
+              The maximum delay to emmit a new OffsetCheckpoint if it exists
+
+              Required
+      Operation:
+        title: Operation
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty5'
+        - type: object
+          required:
+          - Unvet
+          properties:
+            Unvet:
+              $ref: '#/components/schemas/Unvet'
+        - type: object
+          required:
+          - Vet
+          properties:
+            Vet:
+              $ref: '#/components/schemas/Vet'
+      PackageFeature:
+        title: PackageFeature
+        type: object
+        required:
+        - maxVettedPackagesPageSize
+        properties:
+          maxVettedPackagesPageSize:
+            description: |-
+              The maximum number of vetted packages the server can return in a single
+              response (page) when listing them.
+
+              Required
+            type: integer
+            format: int32
+      PackageMetadataFilter:
+        title: PackageMetadataFilter
+        description: |-
+          Filter the VettedPackages by package metadata.
+
+          A PackageMetadataFilter without package_ids and without package_name_prefixes
+          matches any vetted package.
+
+          Non-empty fields specify candidate values of which at least one must match.
+          If both fields are set, then a candidate is returned if it matches one of the fields.
+        type: object
+        properties:
+          packageIds:
+            description: |-
+              If this list is non-empty, any vetted package with a package ID in this
+              list will match the filter.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          packageNamePrefixes:
+            description: |-
+              If this list is non-empty, any vetted package with a name matching at least
+              one prefix in this list will match the filter.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      PackagePreference:
+        title: PackagePreference
+        type: object
+        required:
+        - synchronizerId
+        - packageReference
+        properties:
+          packageReference:
+            $ref: '#/components/schemas/PackageReference'
+            description: |-
+              The package reference of the preferred package.
+
+              Required
+          synchronizerId:
+            description: |-
+              The synchronizer for which the preferred package was computed.
+              If the synchronizer_id was specified in the request, then it matches the request synchronizer_id.
+
+              Required
+            type: string
+      PackageReference:
+        title: PackageReference
+        type: object
+        required:
+        - packageId
+        - packageName
+        - packageVersion
+        properties:
+          packageId:
+            description: Required
+            type: string
+          packageName:
+            description: Required
+            type: string
+          packageVersion:
+            description: Required
+            type: string
+      PackageVettingRequirement:
+        title: PackageVettingRequirement
+        description: Defines a package-name for which the commonly vetted package with
+          the highest version must be found.
+        type: object
+        required:
+        - packageName
+        - parties
+        properties:
+          parties:
+            description: |-
+              The parties whose participants' vetting state should be considered when resolving the preferred package.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          packageName:
+            description: |-
+              The package-name for which the preferred package should be resolved.
+
+              Required
+            type: string
+      ParticipantAdmin:
+        title: ParticipantAdmin
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAdmin1'
+      ParticipantAdmin1:
+        title: ParticipantAdmin
+        type: object
+      ParticipantAuthorizationAdded:
+        title: ParticipantAuthorizationAdded
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAuthorizationAdded1'
+      ParticipantAuthorizationAdded1:
+        title: ParticipantAuthorizationAdded
+        type: object
+        required:
+        - partyId
+        - participantId
+        - participantPermission
+        properties:
+          partyId:
+            description: Required
+            type: string
+          participantId:
+            description: Required
+            type: string
+          participantPermission:
+            description: Required
+            type: string
+            enum:
+            - PARTICIPANT_PERMISSION_UNSPECIFIED
+            - PARTICIPANT_PERMISSION_SUBMISSION
+            - PARTICIPANT_PERMISSION_CONFIRMATION
+            - PARTICIPANT_PERMISSION_OBSERVATION
+      ParticipantAuthorizationChanged:
+        title: ParticipantAuthorizationChanged
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAuthorizationChanged1'
+      ParticipantAuthorizationChanged1:
+        title: ParticipantAuthorizationChanged
+        type: object
+        required:
+        - partyId
+        - participantId
+        - participantPermission
+        properties:
+          partyId:
+            description: Required
+            type: string
+          participantId:
+            description: Required
+            type: string
+          participantPermission:
+            description: Required
+            type: string
+            enum:
+            - PARTICIPANT_PERMISSION_UNSPECIFIED
+            - PARTICIPANT_PERMISSION_SUBMISSION
+            - PARTICIPANT_PERMISSION_CONFIRMATION
+            - PARTICIPANT_PERMISSION_OBSERVATION
+      ParticipantAuthorizationRevoked:
+        title: ParticipantAuthorizationRevoked
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAuthorizationRevoked1'
+      ParticipantAuthorizationRevoked1:
+        title: ParticipantAuthorizationRevoked
+        type: object
+        required:
+        - partyId
+        - participantId
+        properties:
+          partyId:
+            description: Required
+            type: string
+          participantId:
+            description: Required
+            type: string
+      ParticipantAuthorizationTopologyFormat:
+        title: ParticipantAuthorizationTopologyFormat
+        description: A format specifying which participant authorization topology transactions
+          to include and how to render them.
+        type: object
+        properties:
+          parties:
+            description: |-
+              List of parties for which the topology transactions should be sent.
+              Empty means: for all parties.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      PartyDetails:
+        title: PartyDetails
+        type: object
+        required:
+        - party
+        properties:
+          party:
+            description: |-
+              The stable unique identifier of a Daml party.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required
+            type: string
+          isLocal:
+            description: |-
+              true if party is hosted by the participant and the party shares the same identity provider as the user issuing the request.
+
+              Optional
+            type: boolean
+          localMetadata:
+            $ref: '#/components/schemas/ObjectMeta'
+            description: |-
+              Participant-local metadata of this party.
+              Modifiable
+
+              Optional
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              Optional, if not set, there could be 3 options:
+
+              1. the party is managed by the default identity provider.
+              2. party is not hosted by the participant.
+              3. party is hosted by the participant, but is outside of the user's identity provider.
+
+              Optional
+            type: string
+      PartyManagementFeature:
+        title: PartyManagementFeature
+        type: object
+        required:
+        - maxPartiesPageSize
+        properties:
+          maxPartiesPageSize:
+            description: |-
+              The maximum number of parties the server can return in a single response (page).
+
+              Required
+            type: integer
+            format: int32
+      PartySignatures:
+        title: PartySignatures
+        description: Additional signatures provided by the submitting parties
+        type: object
+        required:
+        - signatures
+        properties:
+          signatures:
+            description: |-
+              Additional signatures provided by all individual parties
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/SinglePartySignatures'
+      PrefetchContractKey:
+        title: PrefetchContractKey
+        description: Preload contracts
+        type: object
+        required:
+        - contractKey
+        - templateId
+        properties:
+          templateId:
+            description: |-
+              The template of contract the client wants to prefetch.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          contractKey:
+            description: |-
+              The key of the contract the client wants to prefetch.
+
+              Required
+      Prior:
+        title: Prior
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int32
+      PriorTopologySerial:
+        title: PriorTopologySerial
+        description: |-
+          The serial of last ``VettedPackages`` topology transaction on a given
+          participant and synchronizer.
+        type: object
+        properties:
+          serial:
+            $ref: '#/components/schemas/Serial'
+      ProtoAny:
+        title: ProtoAny
+        type: object
+        required:
+        - typeUrl
+        - value
+        - unknownFields
+        properties:
+          typeUrl:
+            type: string
+          value:
+            type: string
+          unknownFields:
+            $ref: '#/components/schemas/UnknownFieldSet'
+          valueDecoded:
+            type: string
+      Reassignment:
+        title: Reassignment
+        description: Complete view of an on-ledger reassignment.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsReassignment'
+      Reassignment1:
+        title: Reassignment
+        description: Complete view of an on-ledger reassignment.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsReassignment'
+      ReassignmentCommand:
+        title: ReassignmentCommand
+        type: object
+        properties:
+          command:
+            $ref: '#/components/schemas/Command1'
+      ReassignmentCommands:
+        title: ReassignmentCommands
+        type: object
+        required:
+        - commandId
+        - submitter
+        - commands
+        properties:
+          workflowId:
+            description: |-
+              Identifier of the on-ledger workflow that this command is a part of.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Optional
+            type: string
+          userId:
+            description: |-
+              Uniquely identifies the participant user that issued the command.
+              Must be a valid UserIdString (as described in ``value.proto``).
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
+
+              Optional
+            type: string
+          commandId:
+            description: |-
+              Uniquely identifies the command.
+              The triple (user_id, submitter, command_id) constitutes the change ID for the intended ledger change.
+              The change ID can be used for matching the intended ledger changes with all their completions.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          submitter:
+            description: |-
+              Party on whose behalf the command should be executed.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to act on behalf of the given party.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required
+            type: string
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              If omitted, the participant or the committer may set a value of their choice.
+              Optional
+            type: string
+          commands:
+            description: |-
+              Individual elements of this reassignment. Must be non-empty.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/ReassignmentCommand'
+      RevokeUserRightsRequest:
+        title: RevokeUserRightsRequest
+        description: |-
+          Remove the rights from the set of rights granted to the user.
+
+          Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id)``
+        type: object
+        required:
+        - userId
+        properties:
+          userId:
+            description: |-
+              The user from whom to revoke rights.
+
+              Required
+            type: string
+          rights:
+            description: |-
+              The rights to revoke.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the user is managed by the default identity provider.
+
+              Optional
+            type: string
+      RevokeUserRightsResponse:
+        title: RevokeUserRightsResponse
+        type: object
+        properties:
+          newlyRevokedRights:
+            description: |-
+              The rights that were actually revoked by the request.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      Right:
+        title: Right
+        description: A right granted to a user.
+        type: object
+        properties:
+          kind:
+            $ref: '#/components/schemas/Kind'
+      Serial:
+        title: Serial
+        description: Optional
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty6'
+        - type: object
+          required:
+          - NoPrior
+          properties:
+            NoPrior:
+              $ref: '#/components/schemas/NoPrior'
+        - type: object
+          required:
+          - Prior
+          properties:
+            Prior:
+              $ref: '#/components/schemas/Prior'
+      Signature:
+        title: Signature
+        type: object
+        required:
+        - format
+        - signature
+        - signedBy
+        - signingAlgorithmSpec
+        properties:
+          format:
+            description: Required
+            type: string
+          signature:
+            description: 'Required: must be non-empty'
+            type: string
+          signedBy:
+            description: |-
+              The fingerprint/id of the keypair used to create this signature and needed to verify.
+
+              Required
+            type: string
+          signingAlgorithmSpec:
+            description: |-
+              The signing algorithm specification used to produce this signature
+
+              Required
+            type: string
+      SignedTransaction:
+        title: SignedTransaction
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            type: string
+          signatures:
+            type: array
+            items:
+              $ref: '#/components/schemas/Signature'
+      SigningPublicKey:
+        title: SigningPublicKey
+        type: object
+        required:
+        - format
+        - keyData
+        - keySpec
+        properties:
+          format:
+            description: |-
+              The serialization format of the public key
+
+              Required
+            example: CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO
+            type: string
+          keyData:
+            description: |-
+              Serialized public key in the format specified above
+
+              Required: must be non-empty
+            type: string
+          keySpec:
+            description: |-
+              The key specification
+
+              Required
+            example: SIGNING_KEY_SPEC_EC_CURVE25519
+            type: string
+      SinglePartySignatures:
+        title: SinglePartySignatures
+        description: Signatures provided by a single party
+        type: object
+        required:
+        - party
+        - signatures
+        properties:
+          party:
+            description: |-
+              Submitting party
+
+              Required
+            type: string
+          signatures:
+            description: |-
+              Signatures
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Signature'
+      SubmitAndWaitForReassignmentRequest:
+        title: SubmitAndWaitForReassignmentRequest
+        description: This reassignment is executed as a single atomic update.
+        type: object
+        required:
+        - reassignmentCommands
+        properties:
+          reassignmentCommands:
+            $ref: '#/components/schemas/ReassignmentCommands'
+            description: |-
+              The reassignment commands to be submitted.
+
+              Required
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              If no event_format provided, the result will contain no events.
+              The events in the result, will take shape TRANSACTION_SHAPE_ACS_DELTA.
+
+              Optional
+      SubmitAndWaitResponse:
+        title: SubmitAndWaitResponse
+        type: object
+        required:
+        - updateId
+        - completionOffset
+        properties:
+          updateId:
+            description: |-
+              The id of the transaction that resulted from the submitted command.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          completionOffset:
+            description: |-
+              The details of the offset field are described in ``community/ledger-api/README.md``.
+
+              Required
+            type: integer
+            format: int64
+      SubmitReassignmentRequest:
+        title: SubmitReassignmentRequest
+        type: object
+        required:
+        - reassignmentCommands
+        properties:
+          reassignmentCommands:
+            $ref: '#/components/schemas/ReassignmentCommands'
+            description: |-
+              The reassignment command to be submitted.
+
+              Required
+      SubmitReassignmentResponse:
+        title: SubmitReassignmentResponse
+        type: object
+      SubmitResponse:
+        title: SubmitResponse
+        type: object
+      SynchronizerTime:
+        title: SynchronizerTime
+        type: object
+        required:
+        - synchronizerId
+        - recordTime
+        properties:
+          synchronizerId:
+            description: |-
+              The id of the synchronizer.
+
+              Required
+            type: string
+          recordTime:
+            description: |-
+              All commands with a maximum record time below this value MUST be considered lost if their completion has not arrived before this checkpoint.
+
+              Required
+            type: string
+      TemplateFilter:
+        title: TemplateFilter
+        description: This filter matches contracts of a specific template.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/TemplateFilter1'
+      TemplateFilter1:
+        title: TemplateFilter
+        description: This filter matches contracts of a specific template.
+        type: object
+        required:
+        - templateId
+        properties:
+          templateId:
+            description: |-
+              A template for which the payload should be included in the response.
+              The ``template_id`` needs to be valid: corresponding template should be defined in
+              one of the available packages at the time of the query.
+              Both package-name and package-id reference formats for the identifier are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          includeCreatedEventBlob:
+            description: |-
+              Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
+              Use this to access the contract event payload in your API client
+              for submitting it as a disclosed contract with future commands.
+
+              Optional
+            type: boolean
+      Time:
+        title: Time
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty9'
+        - type: object
+          required:
+          - MinLedgerTimeAbs
+          properties:
+            MinLedgerTimeAbs:
+              $ref: '#/components/schemas/MinLedgerTimeAbs'
+        - type: object
+          required:
+          - MinLedgerTimeRel
+          properties:
+            MinLedgerTimeRel:
+              $ref: '#/components/schemas/MinLedgerTimeRel'
+      TopologyEvent:
+        title: TopologyEvent
+        type: object
+        properties:
+          event:
+            $ref: '#/components/schemas/TopologyEventEvent'
+      TopologyEventEvent:
+        title: TopologyEventEvent
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty7'
+        - type: object
+          required:
+          - ParticipantAuthorizationAdded
+          properties:
+            ParticipantAuthorizationAdded:
+              $ref: '#/components/schemas/ParticipantAuthorizationAdded'
+        - type: object
+          required:
+          - ParticipantAuthorizationChanged
+          properties:
+            ParticipantAuthorizationChanged:
+              $ref: '#/components/schemas/ParticipantAuthorizationChanged'
+        - type: object
+          required:
+          - ParticipantAuthorizationRevoked
+          properties:
+            ParticipantAuthorizationRevoked:
+              $ref: '#/components/schemas/ParticipantAuthorizationRevoked'
+      TopologyFormat:
+        title: TopologyFormat
+        description: A format specifying which topology transactions to include and
+          how to render them.
+        type: object
+        properties:
+          includeParticipantAuthorizationEvents:
+            $ref: '#/components/schemas/ParticipantAuthorizationTopologyFormat'
+            description: |-
+              Include participant authorization topology events in streams.
+              If unset, no participant authorization topology events are emitted in the stream.
+
+              Optional
+      TopologyStateFilter:
+        title: TopologyStateFilter
+        description: |-
+          Filter the vetted packages by the participant and synchronizer that they are
+          hosted on.
+
+          Empty fields are ignored, such that a ``TopologyStateFilter`` without
+          participant_ids and without synchronizer_ids matches a vetted package hosted
+          on any participant and synchronizer.
+
+          Non-empty fields specify candidate values of which at least one must match.
+          If both fields are set then at least one candidate value must match from each
+          field.
+        type: object
+        properties:
+          participantIds:
+            description: |-
+              If this list is non-empty, only vetted packages hosted on participants
+              listed in this field match the filter.
+              Query the current Ledger API's participant's ID via the public
+              ``GetParticipantId`` command in ``PartyManagementService``.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          synchronizerIds:
+            description: |-
+              If this list is non-empty, only vetted packages from the topology state of
+              the synchronizers in this list match the filter.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      TopologyTransaction:
+        title: TopologyTransaction
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsTopologyTransaction'
+      TraceContext:
+        title: TraceContext
+        type: object
+        properties:
+          traceparent:
+            description: |-
+              https://www.w3.org/TR/trace-context/
+              Optional
+            type: string
+          tracestate:
+            description: Optional
+            type: string
+      Transaction:
+        title: Transaction
+        description: Filtered view of an on-ledger transaction's create and archive
+          events.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsTransaction'
+      TransactionFilter:
+        title: TransactionFilter
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Used both for filtering create and archive events as well as for filtering transaction trees.
+        type: object
+        properties:
+          filtersByParty:
+            $ref: '#/components/schemas/Map_Filters'
+            description: |-
+              Each key must be a valid PartyIdString (as described in ``value.proto``).
+              The interpretation of the filter depends on the transaction-shape being filtered:
+
+              1. For **transaction trees** (used in GetUpdateTreesResponse for backwards compatibility) all party keys used as
+                 wildcard filters, and all subtrees whose root has one of the listed parties as an informee are returned.
+                 If there are ``CumulativeFilter``s, those will control returned ``CreatedEvent`` fields where applicable, but will
+                 not be used for template/interface filtering.
+              2. For **ledger-effects** create and exercise events are returned, for which the witnesses include at least one of
+                 the listed parties and match the per-party filter.
+              3. For **transaction and active-contract-set streams** create and archive events are returned for all contracts whose
+                 stakeholders include at least one of the listed parties and match the per-party filter.
+          filtersForAnyParty:
+            $ref: '#/components/schemas/Filters'
+            description: |-
+              Wildcard filters that apply to all the parties existing on the participant. The interpretation of the filters is the same
+              with the per-party filter as described above.
+      TransactionFormat:
+        title: TransactionFormat
+        description: |-
+          A format that specifies what events to include in Daml transactions
+          and what data to compute and include for them.
+        type: object
+        required:
+        - transactionShape
+        - eventFormat
+        properties:
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: Required
+          transactionShape:
+            description: |-
+              What transaction shape to use for interpreting the filters of the event format.
+
+              Required
+            type: string
+            enum:
+            - TRANSACTION_SHAPE_UNSPECIFIED
+            - TRANSACTION_SHAPE_ACS_DELTA
+            - TRANSACTION_SHAPE_LEDGER_EFFECTS
+      TransactionTree:
+        title: TransactionTree
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Complete view of an on-ledger transaction.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsTransactionTree'
+      TreeEvent:
+        title: TreeEvent
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Each tree event message type below contains a ``witness_parties`` field which
+          indicates the subset of the requested parties that can see the event
+          in question.
+
+          Note that transaction trees might contain events with
+          _no_ witness parties, which were included simply because they were
+          children of events which have witnesses.
+        oneOf:
+        - type: object
+          required:
+          - CreatedTreeEvent
+          properties:
+            CreatedTreeEvent:
+              $ref: '#/components/schemas/CreatedTreeEvent'
+        - type: object
+          required:
+          - ExercisedTreeEvent
+          properties:
+            ExercisedTreeEvent:
+              $ref: '#/components/schemas/ExercisedTreeEvent'
+      Tuple2_String_String:
+        title: Tuple2_String_String
+        type: array
+        maxItems: 2
+        minItems: 2
+        items:
+          type: string
+      UnassignCommand:
+        title: UnassignCommand
+        description: Unassign a contract
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/UnassignCommand1'
+      UnassignCommand1:
+        title: UnassignCommand
+        description: Unassign a contract
+        type: object
+        required:
+        - contractId
+        - source
+        - target
+        properties:
+          contractId:
+            description: |-
+              The ID of the contract the client wants to unassign.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          source:
+            description: |-
+              The ID of the source synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+          target:
+            description: |-
+              The ID of the target synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+      UnassignedEvent:
+        title: UnassignedEvent
+        description: Records that a contract has been unassigned, and it becomes unusable
+          on the source synchronizer
+        type: object
+        required:
+        - reassignmentId
+        - contractId
+        - source
+        - target
+        - reassignmentCounter
+        - packageName
+        - offset
+        - nodeId
+        - templateId
+        - witnessParties
+        properties:
+          reassignmentId:
+            description: |-
+              The ID of the unassignment. This needs to be used as an input for a assign ReassignmentCommand.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          contractId:
+            description: |-
+              The ID of the reassigned contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          templateId:
+            description: |-
+              The template of the reassigned contract.
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          source:
+            description: |-
+              The ID of the source synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+          target:
+            description: |-
+              The ID of the target synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+          submitter:
+            description: |-
+              Party on whose behalf the unassign command was executed.
+              Empty if the unassignment happened offline via the repair service.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          reassignmentCounter:
+            description: |-
+              Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
+              with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
+              equals zero.
+
+              Required
+            type: integer
+            format: int64
+          assignmentExclusivity:
+            description: |-
+              Assignment exclusivity
+              Before this time (measured on the target synchronizer), only the submitter of the unassignment can initiate the assignment
+              Defined for reassigning participants.
+
+              Optional
+            type: string
+          witnessParties:
+            description: |-
+              The parties that are notified of this event.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          packageName:
+            description: |-
+              The package name of the contract.
+
+              Required
+            type: string
+          offset:
+            description: |-
+              The offset of origin.
+              Offsets are managed by the participant nodes.
+              Reassignments can thus NOT be assumed to have the same offsets on different participant nodes.
+              Must be a valid absolute offset (positive integer)
+
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating reassignment.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of reassignments.
+              Must be valid node ID (non-negative integer)
+
+              Required
+            type: integer
+            format: int32
+      UnknownFieldSet:
+        title: UnknownFieldSet
+        type: object
+        required:
+        - fields
+        properties:
+          fields:
+            $ref: '#/components/schemas/Map_Int_Field'
+      Unvet:
+        title: Unvet
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Unvet1'
+      Unvet1:
+        title: Unvet
+        type: object
+        properties:
+          packages:
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackagesRef'
+      Update:
+        title: Update
+        oneOf:
+        - type: object
+          required:
+          - OffsetCheckpoint
+          properties:
+            OffsetCheckpoint:
+              $ref: '#/components/schemas/OffsetCheckpoint2'
+        - type: object
+          required:
+          - Reassignment
+          properties:
+            Reassignment:
+              $ref: '#/components/schemas/Reassignment'
+        - type: object
+          required:
+          - TopologyTransaction
+          properties:
+            TopologyTransaction:
+              $ref: '#/components/schemas/TopologyTransaction'
+        - type: object
+          required:
+          - Transaction
+          properties:
+            Transaction:
+              $ref: '#/components/schemas/Transaction'
+      Update1:
+        title: Update
+        oneOf:
+        - type: object
+          required:
+          - OffsetCheckpoint
+          properties:
+            OffsetCheckpoint:
+              $ref: '#/components/schemas/OffsetCheckpoint3'
+        - type: object
+          required:
+          - Reassignment
+          properties:
+            Reassignment:
+              $ref: '#/components/schemas/Reassignment1'
+        - type: object
+          required:
+          - TransactionTree
+          properties:
+            TransactionTree:
+              $ref: '#/components/schemas/TransactionTree'
+      UpdateFormat:
+        title: UpdateFormat
+        description: A format specifying what updates to include and how to render them.
+        type: object
+        properties:
+          includeTransactions:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              Include Daml transactions in streams.
+              If unset, no transactions are emitted in the stream.
+
+              Optional
+          includeReassignments:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              Include (un)assignments in the stream.
+              The events in the result take the shape TRANSACTION_SHAPE_ACS_DELTA.
+              If unset, no (un)assignments are emitted in the stream.
+
+              Optional
+          includeTopologyEvents:
+            $ref: '#/components/schemas/TopologyFormat'
+            description: |-
+              Include topology events in streams.
+              If unset no topology events are emitted in the stream.
+
+              Optional
+      UpdateIdentityProviderConfigRequest:
+        title: UpdateIdentityProviderConfigRequest
+        type: object
+        required:
+        - identityProviderConfig
+        - updateMask
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: |-
+              The identity provider config to update.
+              Modifiable
+
+              Required
+          updateMask:
+            $ref: '#/components/schemas/FieldMask'
+            description: |-
+              An update mask specifies how and which properties of the ``IdentityProviderConfig`` message are to be updated.
+              An update mask consists of a set of update paths.
+              A valid update path points to a field or a subfield relative to the ``IdentityProviderConfig`` message.
+              A valid update mask must:
+
+              1. contain at least one update path,
+              2. contain only valid update paths.
+
+              Fields that can be updated are marked as ``Modifiable``.
+              For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
+
+              Required
+      UpdateIdentityProviderConfigResponse:
+        title: UpdateIdentityProviderConfigResponse
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: |-
+              Updated identity provider config
+
+              Required
+      UpdatePartyDetailsRequest:
+        title: UpdatePartyDetailsRequest
+        description: 'Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(party_details.identity_provider_id)``'
+        type: object
+        required:
+        - partyDetails
+        - updateMask
+        properties:
+          partyDetails:
+            $ref: '#/components/schemas/PartyDetails'
+            description: |-
+              Party to be updated
+              Modifiable
+
+              Required
+          updateMask:
+            $ref: '#/components/schemas/FieldMask'
+            description: |-
+              An update mask specifies how and which properties of the ``PartyDetails`` message are to be updated.
+              An update mask consists of a set of update paths.
+              A valid update path points to a field or a subfield relative to the ``PartyDetails`` message.
+              A valid update mask must:
+
+              1. contain at least one update path,
+              2. contain only valid update paths.
+
+              Fields that can be updated are marked as ``Modifiable``.
+              An update path can also point to non-``Modifiable`` fields such as 'party' and 'local_metadata.resource_version'
+              because they are used:
+
+              1. to identify the party details resource subject to the update,
+              2. for concurrent change control.
+
+              An update path can also point to non-``Modifiable`` fields such as 'is_local'
+              as long as the values provided in the update request match the server values.
+              Examples of update paths: 'local_metadata.annotations', 'local_metadata'.
+              For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
+              For similar Ledger API see ``com.daml.ledger.api.v2.admin.UpdateUserRequest``.
+
+              Required
+      UpdatePartyDetailsResponse:
+        title: UpdatePartyDetailsResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
+            $ref: '#/components/schemas/PartyDetails'
+            description: |-
+              Updated party details
+
+              Required
+      UpdateUserIdentityProviderIdRequest:
+        title: UpdateUserIdentityProviderIdRequest
+        description: 'Required authorization: ``HasRight(ParticipantAdmin)``'
+        type: object
+        required:
+        - userId
+        properties:
+          userId:
+            description: |-
+              User to update
+
+              Required
+            type: string
+          sourceIdentityProviderId:
+            description: |-
+              Current identity provider ID of the user
+              If omitted, the default IDP is assumed
+
+              Optional
+            type: string
+          targetIdentityProviderId:
+            description: |-
+              Target identity provider ID of the user
+              If omitted, the default IDP is assumed
+
+              Optional
+            type: string
+      UpdateUserIdentityProviderIdResponse:
+        title: UpdateUserIdentityProviderIdResponse
+        type: object
+      UpdateUserRequest:
+        title: UpdateUserRequest
+        description: 'Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(user.identity_provider_id)``'
+        type: object
+        required:
+        - user
+        - updateMask
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              The user to update.
+              Modifiable
+
+              Required
+          updateMask:
+            $ref: '#/components/schemas/FieldMask'
+            description: |-
+              An update mask specifies how and which properties of the ``User`` message are to be updated.
+              An update mask consists of a set of update paths.
+              A valid update path points to a field or a subfield relative to the ``User`` message.
+              A valid update mask must:
+
+              1. contain at least one update path,
+              2. contain only valid update paths.
+
+              Fields that can be updated are marked as ``Modifiable``.
+              An update path can also point to a non-``Modifiable`` fields such as 'id' and 'metadata.resource_version'
+              because they are used:
+
+              1. to identify the user resource subject to the update,
+              2. for concurrent change control.
+
+              Examples of valid update paths: 'primary_party', 'metadata', 'metadata.annotations'.
+              For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
+              For similar Ledger API see ``com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest``.
+
+              Required
+      UpdateUserResponse:
+        title: UpdateUserResponse
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              Updated user
+
+              Required
+      UpdateVettedPackagesRequest:
+        title: UpdateVettedPackagesRequest
+        type: object
+        required:
+        - changes
+        properties:
+          changes:
+            description: |-
+              Changes to apply to the current vetting state of the participant on the
+              specified synchronizer. The changes are applied in order.
+              Any package not changed will keep their previous vetting state.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackagesChange'
+          dryRun:
+            description: |-
+              If dry_run is true, then the changes are only prepared, but not applied. If
+              a request would trigger an error when run (e.g. TOPOLOGY_DEPENDENCIES_NOT_VETTED),
+              it will also trigger an error when dry_run.
+
+              Use this flag to preview a change before applying it.
+              Defaults to false.
+
+              Optional
+            type: boolean
+          synchronizerId:
+            description: |-
+              If set, the requested changes will take place on the specified
+              synchronizer. If synchronizer_id is unset and the participant is only
+              connected to a single synchronizer, that synchronizer will be used by
+              default. If synchronizer_id is unset and the participant is connected to
+              multiple synchronizers, the request will error out with
+              PACKAGE_SERVICE_CANNOT_AUTODETECT_SYNCHRONIZER.
+
+              Optional
+            type: string
+          expectedTopologySerial:
+            $ref: '#/components/schemas/PriorTopologySerial'
+            description: |-
+              The serial of the last ``VettedPackages`` topology transaction of this
+              participant and on this synchronizer.
+
+              Execution of the request fails if this is not correct. Use this to guard
+              against concurrent changes.
+
+              If left unspecified, no validation is done against the last transaction's
+              serial.
+
+              Optional
+          updateVettedPackagesForceFlags:
+            description: |-
+              Controls whether potentially unsafe vetting updates are allowed.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+              enum:
+              - UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED
+              - UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES
+              - UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES
+      UpdateVettedPackagesResponse:
+        title: UpdateVettedPackagesResponse
+        type: object
+        required:
+        - newVettedPackages
+        properties:
+          pastVettedPackages:
+            $ref: '#/components/schemas/VettedPackages'
+            description: |-
+              All vetted packages on this participant and synchronizer, before the
+              specified changes. Empty if no vetting state existed beforehand.
+
+              Not populated if no vetted topology state exists prior to the update.
+
+              Optional
+          newVettedPackages:
+            $ref: '#/components/schemas/VettedPackages'
+            description: |-
+              All vetted packages on this participant and synchronizer, after the specified changes.
+
+              Required
+      UploadDarFileResponse:
+        title: UploadDarFileResponse
+        description: A message that is received when the upload operation succeeded.
+        type: object
+      User:
+        title: User
+        description: |2-
+           Users and rights
+          /////////////////
+           Users are used to dynamically manage the rights given to Daml applications.
+           They are stored and managed per participant node.
+        type: object
+        required:
+        - id
+        properties:
+          id:
+            description: |-
+              The user identifier, which must be a non-empty string of at most 128
+              characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:()".
+
+              Required
+            type: string
+          primaryParty:
+            description: |-
+              The primary party as which this user reads and acts by default on the ledger
+              *provided* it has the corresponding ``CanReadAs(primary_party)`` or
+              ``CanActAs(primary_party)`` rights.
+              Ledger API clients SHOULD set this field to a non-empty value for all users to
+              enable the users to act on the ledger using their own Daml party.
+              Users for participant administrators MAY have an associated primary party.
+              Modifiable
+
+              Optional
+            type: string
+          isDeactivated:
+            description: |-
+              When set, then the user is denied all access to the Ledger API.
+              Otherwise, the user has access to the Ledger API as per the user's rights.
+              Modifiable
+
+              Optional
+            type: boolean
+          metadata:
+            $ref: '#/components/schemas/ObjectMeta'
+            description: |-
+              The metadata of this user.
+              Note that the ``metadata.resource_version`` tracks changes to the properties described by the ``User`` message and not the user's rights.
+              Modifiable
+
+              Optional
+          identityProviderId:
+            description: |-
+              The ID of the identity provider configured by ``Identity Provider Config``
+              If not set, assume the user is managed by the default identity provider.
+
+              Optional
+            type: string
+      UserManagementFeature:
+        title: UserManagementFeature
+        type: object
+        required:
+        - supported
+        - maxRightsPerUser
+        - maxUsersPageSize
+        properties:
+          supported:
+            description: |-
+              Whether the Ledger API server provides the user management service.
+
+              Required
+            type: boolean
+          maxRightsPerUser:
+            description: |-
+              The maximum number of rights that can be assigned to a single user.
+              Servers MUST support at least 100 rights per user.
+              A value of 0 means that the server enforces no rights per user limit.
+
+              Required
+            type: integer
+            format: int32
+          maxUsersPageSize:
+            description: |-
+              The maximum number of users the server can return in a single response (page).
+              Servers MUST support at least a 100 users per page.
+              A value of 0 means that the server enforces no page size limit.
+
+              Required
+            type: integer
+            format: int32
+      Vet:
+        title: Vet
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Vet1'
+      Vet1:
+        title: Vet
+        type: object
+        properties:
+          packages:
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackagesRef'
+          newValidFromInclusive:
+            type: string
+          newValidUntilExclusive:
+            type: string
+      VettedPackage:
+        title: VettedPackage
+        description: |-
+          A package that is vetting on a given participant and synchronizer,
+          modelled after ``VettedPackage`` in `topology.proto <https://github.com/digital-asset/canton/blob/main/community/base/src/main/protobuf/com/digitalasset/canton/protocol/v30/topology.proto#L206>`_,
+          enriched with the package name and version.
+        type: object
+        required:
+        - packageId
+        properties:
+          packageId:
+            description: |-
+              Package ID of this package
+
+              Required
+            type: string
+          validFromInclusive:
+            description: |-
+              The time from which this package is vetted. Empty if vetting time has no
+              lower bound.
+
+              Optional
+            type: string
+          validUntilExclusive:
+            description: |-
+              The time until which this package is vetted. Empty if vetting time has no
+              upper bound.
+
+              Optional
+            type: string
+          packageName:
+            description: |-
+              Name of this package.
+              Only available if the package has been uploaded to the current participant.
+
+              Optional
+            type: string
+          packageVersion:
+            description: |-
+              Version of this package.
+              Only available if the package has been uploaded to the current participant.
+
+              Optional
+            type: string
+      VettedPackages:
+        title: VettedPackages
+        description: |-
+          The list of packages vetted on a given participant and synchronizer, modelled
+          after ``VettedPackages`` in `topology.proto <https://github.com/digital-asset/canton/blob/main/community/base/src/main/protobuf/com/digitalasset/canton/protocol/v30/topology.proto#L206>`_.
+          The list only contains packages that matched a filter in the query that
+          originated it.
+        type: object
+        required:
+        - participantId
+        - synchronizerId
+        - topologySerial
+        - packages
+        properties:
+          packages:
+            description: |-
+              Sorted by package_name and package_version where known, and package_id as a
+              last resort.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackage'
+          participantId:
+            description: |-
+              Participant on which these packages are vetted.
+
+              Required
+            type: string
+          synchronizerId:
+            description: |-
+              Synchronizer on which these packages are vetted.
+
+              Required
+            type: string
+          topologySerial:
+            description: |-
+              Serial of last ``VettedPackages`` topology transaction of this participant
+              and on this synchronizer.
+
+              Required
+            type: integer
+            format: int32
+      VettedPackagesChange:
+        title: VettedPackagesChange
+        description: A change to the set of vetted packages.
+        type: object
+        properties:
+          operation:
+            $ref: '#/components/schemas/Operation'
+      VettedPackagesRef:
+        title: VettedPackagesRef
+        description: |-
+          A reference to identify one or more packages.
+
+          A reference matches a package if its ``package_id`` matches the package's ID,
+          its ``package_name`` matches the package's name, and its ``package_version``
+          matches the package's version. If an attribute in the reference is left
+          unspecified (i.e. as an empty string), that attribute is treated as a
+          wildcard. At a minimum, ``package_id`` or the ``package_name`` must be
+          specified.
+
+          If a reference does not match any package, the reference is considered
+          unresolved and the entire update request is rejected.
+        type: object
+        properties:
+          packageId:
+            description: |-
+              Package's package id must be the same as this field.
+
+              Optional
+            type: string
+          packageName:
+            description: |-
+              Package's name must be the same as this field.
+
+              Optional
+            type: string
+          packageVersion:
+            description: |-
+              Package's version must be the same as this field.
+
+              Optional
+            type: string
+      WildcardFilter:
+        title: WildcardFilter
+        description: This filter matches all templates.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/WildcardFilter1'
+      WildcardFilter1:
+        title: WildcardFilter
+        description: This filter matches all templates.
+        type: object
+        properties:
+          includeCreatedEventBlob:
+            description: |-
+              Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
+              Use this to access the contract create event payload in your API client
+              for submitting it as a disclosed contract with future commands.
+
+              Optional
+            type: boolean
+    securitySchemes:
+      apiKeyAuth:
+        type: apiKey
+        description: Ledger API standard JWT token (websocket)
+        name: Sec-WebSocket-Protocol
+        in: header
+      httpAuth:
+        type: http
+        description: Ledger API standard JWT token
+        scheme: bearer
+

--- a/config/x2mdx/ledger-api/3.5/openapi.yaml
+++ b/config/x2mdx/ledger-api/3.5/openapi.yaml
@@ -1,0 +1,8307 @@
+  openapi: 3.0.3
+  info:
+    title: JSON Ledger API HTTP endpoints
+    version: 3.5.0-SNAPSHOT
+    description: |-
+      This specification version fixes the API inconsistencies where certain fields marked as required in the spec are in fact optional.
+      If you use code generation tool based on this file, you might need to adjust the existing application code to handle those fields as optional.
+      If you do not want to change your client code, continue using the OpenAPI specification for the latest Canton 3.4 patch release.
+      MINIMUM_CANTON_VERSION=3.5.0
+  paths:
+    /v2/commands/submit-and-wait:
+      post:
+        description: |-
+          Submits a single composite command and waits for its result.
+          Propagates the gRPC error of failed submissions including Daml interpretation errors.
+        operationId: postV2CommandsSubmit-and-wait
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsCommands'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SubmitAndWaitResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/submit-and-wait-for-transaction:
+      post:
+        description: |-
+          Submits a single composite command, waits for its result, and returns the transaction.
+          Propagates the gRPC error of failed submissions including Daml interpretation errors.
+        operationId: postV2CommandsSubmit-and-wait-for-transaction
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsSubmitAndWaitForTransactionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsSubmitAndWaitForTransactionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/submit-and-wait-for-reassignment:
+      post:
+        description: |-
+          Submits a single composite reassignment command, waits for its result, and returns the reassignment.
+          Propagates the gRPC error of failed submission.
+        operationId: postV2CommandsSubmit-and-wait-for-reassignment
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmitAndWaitForReassignmentRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsSubmitAndWaitForReassignmentResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/submit-and-wait-for-transaction-tree:
+      post:
+        description: Submit a batch of commands and wait for the transaction trees response.
+          Provided for backwards compatibility, it will be removed in the Canton version
+          3.5.0, use submit-and-wait-for-transaction instead.
+        operationId: postV2CommandsSubmit-and-wait-for-transaction-tree
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsCommands'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsSubmitAndWaitForTransactionTreeResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/async/submit:
+      post:
+        description: Submit a single composite command.
+        operationId: postV2CommandsAsyncSubmit
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsCommands'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SubmitResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/async/submit-reassignment:
+      post:
+        description: Submit a single reassignment.
+        operationId: postV2CommandsAsyncSubmit-reassignment
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmitReassignmentRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SubmitReassignmentResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/completions:
+      post:
+        description: |-
+          Query completions list (blocking call)
+
+          Subscribe to command completion events.
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2CommandsCompletions
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompletionStreamRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/CompletionStreamResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/events/events-by-contract-id:
+      post:
+        description: |-
+          Get the create and the consuming exercise event for the contract with the provided ID.
+          No events will be returned for contracts that have been pruned because they
+          have already been archived before the latest pruning offset.
+          If the contract cannot be found for the request, or all the contract-events are filtered, a CONTRACT_EVENTS_NOT_FOUND error will be raised.
+        operationId: postV2EventsEvents-by-contract-id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetEventsByContractIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetEventsByContractIdResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/version:
+      get:
+        description: Read the Ledger API version
+        operationId: getV2Version
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetLedgerApiVersionResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/dars/validate:
+      post:
+        description: |-
+          Validates the DAR and checks the upgrade compatibility of the DAR's packages
+          with the set of the already vetted packages on the target vetting synchronizer.
+          See ValidateDarFileRequest for details regarding the target vetting synchronizer.
+
+          The operation has no effect on the state of the participant or the Canton ledger:
+          the DAR payload and its packages are not persisted neither are the packages vetted.
+        operationId: postV2DarsValidate
+        parameters:
+        - name: synchronizerId
+          in: query
+          required: false
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          required: true
+        responses:
+          '200':
+            description: ''
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter synchronizerId'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/dars:
+      post:
+        description: Upload a DAR to the participant node
+        operationId: postV2Dars
+        parameters:
+        - name: vetAllPackages
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: synchronizerId
+          in: query
+          required: false
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UploadDarFileResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter vetAllPackages, Invalid value for: query parameter synchronizerId'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/packages:
+      get:
+        description: Returns the identifiers of all supported packages.
+        operationId: getV2Packages
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListPackagesResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: |-
+          Behaves the same as /dars. This endpoint will be deprecated and removed in a future release.
+          Upload a DAR file to the participant.
+
+          If vetting is enabled in the request, the DAR is checked for upgrade compatibility
+          with the set of the already vetted packages on the target vetting synchronizer
+          See UploadDarFileRequest for details regarding vetting and the target vetting synchronizer.
+        operationId: postV2Packages
+        parameters:
+        - name: vetAllPackages
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: synchronizerId
+          in: query
+          required: false
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UploadDarFileResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter vetAllPackages, Invalid value for: query parameter synchronizerId'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/packages/{package-id}:
+      get:
+        description: Returns the contents of a single package.
+        operationId: getV2PackagesPackage-id
+        parameters:
+        - name: package-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            headers:
+              Canton-Package-Hash:
+                required: true
+                schema:
+                  type: string
+            content:
+              application/octet-stream:
+                schema:
+                  type: string
+                  format: binary
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/packages/{package-id}/status:
+      get:
+        description: Returns the status of a single package.
+        operationId: getV2PackagesPackage-idStatus
+        parameters:
+        - name: package-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPackageStatusResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/package-vetting:
+      get:
+        description: |-
+          Lists which participant node vetted what packages on which synchronizer.
+          Can be called by any authenticated user.
+        operationId: getV2Package-vetting
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListVettedPackagesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListVettedPackagesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: Update the vetted packages of this participant
+        operationId: postV2Package-vetting
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateVettedPackagesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateVettedPackagesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties:
+      get:
+        description: |-
+          List the parties known by the participant.
+          The list returned contains parties whose ledger access is facilitated by
+          the participant and the ones maintained elsewhere.
+        operationId: getV2Parties
+        parameters:
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: filter-party
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: pageSize
+          in: query
+          description: maximum number of elements in a returned page
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: pageToken
+          in: query
+          description: token - to continue results from a given page, leave empty to
+            start from the beginning of the list, obtain token from the result of previous
+            page
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListKnownPartiesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter identity-provider-id,
+              Invalid value for: query parameter filter-party, Invalid value for: query
+              parameter pageSize, Invalid value for: query parameter pageToken'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: |-
+          Allocates a new party on a ledger and adds it to the set managed by the participant.
+          Caller specifies a party identifier suggestion, the actual identifier
+          allocated might be different and is implementation specific.
+          Caller can specify party metadata that is stored locally on the participant.
+          This call may:
+
+          - Succeed, in which case the actual allocated identifier is visible in
+            the response.
+          - Respond with a gRPC error
+
+          daml-on-kv-ledger: suggestion's uniqueness is checked by the validators in
+          the consensus layer and call rejected if the identifier is already present.
+          canton: completely different globally unique identifier is allocated.
+          Behind the scenes calls to an internal protocol are made. As that protocol
+          is richer than the surface protocol, the arguments take implicit values
+          The party identifier suggestion must be a valid party name. Party names are required to be non-empty US-ASCII strings built from letters, digits, space,
+          colon, minus and underscore limited to 255 chars
+        operationId: postV2Parties
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocatePartyRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/AllocatePartyResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/external/allocate:
+      post:
+        description: |-
+          Alpha 3.3: Endpoint to allocate a new external party on a synchronizer
+
+          Expected to be stable in 3.5
+
+          The external party must be hosted (at least) on this node with either confirmation or observation permissions
+          It can optionally be hosted on other nodes (then called a multi-hosted party).
+          If hosted on additional nodes, explicit authorization of the hosting relationship must be performed on those nodes
+          before the party can be used.
+          Decentralized namespaces are supported but must be provided fully authorized by their owners.
+          The individual owner namespace transactions can be submitted in the same call (fully authorized as well).
+          In the simple case of a non-multi hosted, non-decentralized party, the RPC will return once the party is
+          effectively allocated and ready to use, similarly to the AllocateParty behavior.
+          For more complex scenarios applications may need to query the party status explicitly (only through the admin API as of now).
+        operationId: postV2PartiesExternalAllocate
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocateExternalPartyRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/AllocateExternalPartyResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/participant-id:
+      get:
+        description: |-
+          Return the identifier of the participant.
+          All horizontally scaled replicas should return the same id.
+          daml-on-kv-ledger: returns an identifier supplied on command line at launch time
+          canton: returns globally unique identifier of the participant
+        operationId: getV2PartiesParticipant-id
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetParticipantIdResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/{party}:
+      get:
+        description: |-
+          Get the party details of the given parties. Only known parties will be
+          returned in the list.
+        operationId: getV2PartiesParty
+        parameters:
+        - name: party
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPartiesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter identity-provider-id,
+              Invalid value for: query parameter parties'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: |-
+          Update selected modifiable participant-local attributes of a party details resource.
+          Can update the participant's local information for local parties.
+        operationId: patchV2PartiesParty
+        parameters:
+        - name: party
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdatePartyDetailsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdatePartyDetailsResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/external/generate-topology:
+      post:
+        description: |-
+          Alpha 3.3: Convenience endpoint to generate topology transactions for external signing
+
+          Expected to be stable in 3.5
+
+          You may use this endpoint to generate the common external topology transactions
+          which can be signed externally and uploaded as part of the allocate party process
+
+          Note that this request will create a normal namespace using the same key for the
+          identity as for signing. More elaborate schemes such as multi-signature
+          or decentralized parties require you to construct the topology transactions yourself.
+        operationId: postV2PartiesExternalGenerate-topology
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateExternalPartyTopologyRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenerateExternalPartyTopologyResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/active-contracts:
+      post:
+        description: |-
+          Query active contracts list (blocking call).
+          Querying active contracts is an expensive operation and if possible should not be repeated often.
+          Consider querying active contracts initially (for a given offset)
+          and then repeatedly call one of `/v2/updates/...`endpoints  to get subsequent modifications.
+          You can also use websockets to get updates with better performance.
+
+          Returns a stream of the snapshot of the active contracts and incomplete (un)assignments at a ledger offset.
+          Once the stream of GetActiveContractsResponses completes,
+          the client SHOULD begin streaming updates from the update service,
+          starting at the GetActiveContractsRequest.active_at_offset specified in this request.
+          Clients SHOULD NOT assume that the set of active contracts they receive reflects the state at the ledger end.
+
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2StateActive-contracts
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetActiveContractsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetActiveContractsResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/connected-synchronizers:
+      get:
+        description: Get the list of connected synchronizers at the time of the query.
+        operationId: getV2StateConnected-synchronizers
+        parameters:
+        - name: party
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: participantId
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: identityProviderId
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetConnectedSynchronizersResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter party, Invalid
+              value for: query parameter participantId, Invalid value for: query parameter
+              identityProviderId'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/ledger-end:
+      get:
+        description: |-
+          Get the current ledger end.
+          Subscriptions started with the returned offset will serve events after this RPC was called.
+        operationId: getV2StateLedger-end
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetLedgerEndResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/latest-pruned-offsets:
+      get:
+        description: Get the latest successfully pruned ledger offsets
+        operationId: getV2StateLatest-pruned-offsets
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetLatestPrunedOffsetsResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates:
+      post:
+        description: |-
+          Read the ledger's filtered update stream for the specified contents and filters.
+          It returns the event types in accordance with the stream contents selected. Also the selection criteria
+          for individual events depends on the transaction shape chosen.
+
+          - ACS delta: a requesting party must be a stakeholder of an event for it to be included.
+          - ledger effects: a requesting party must be a witness of an event for it to be included.
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2Updates
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdatesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetUpdatesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/flats:
+      post:
+        description: |-
+          Query flat transactions update list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2UpdatesFlats
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdatesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetUpdatesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/trees:
+      post:
+        description: |-
+          Query update transactions tree list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2UpdatesTrees
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdatesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetUpdateTreesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-tree-by-offset/{offset}:
+      get:
+        description: Get transaction tree by offset. Provided for backwards compatibility,
+          it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset
+          instead.
+        operationId: getV2UpdatesTransaction-tree-by-offsetOffset
+        parameters:
+        - name: offset
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionTreeResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: path parameter offset, Invalid
+              value for: query parameter parties'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-by-offset:
+      post:
+        description: Get transaction by offset. Provided for backwards compatibility,
+          it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset
+          instead.
+        operationId: postV2UpdatesTransaction-by-offset
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTransactionByOffsetRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/update-by-offset:
+      post:
+        description: |-
+          Lookup an update by its offset.
+          If there is no update with this offset, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
+        operationId: postV2UpdatesUpdate-by-offset
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdateByOffsetRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetUpdateResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-by-id:
+      post:
+        description: Get transaction by id. Provided for backwards compatibility, it
+          will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.
+        operationId: postV2UpdatesTransaction-by-id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTransactionByIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/update-by-id:
+      post:
+        description: |-
+          Lookup an update by its ID.
+          If there is no update with this ID, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
+        operationId: postV2UpdatesUpdate-by-id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdateByIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetUpdateResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-tree-by-id/{update-id}:
+      get:
+        description: Get transaction tree by id. Provided for backwards compatibility,
+          it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id
+          instead.
+        operationId: getV2UpdatesTransaction-tree-by-idUpdate-id
+        parameters:
+        - name: update-id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionTreeResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter parties'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users:
+      get:
+        description: List all existing users.
+        operationId: getV2Users
+        parameters:
+        - name: pageSize
+          in: query
+          description: maximum number of elements in a returned page
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: pageToken
+          in: query
+          description: token - to continue results from a given page, leave empty to
+            start from the beginning of the list, obtain token from the result of previous
+            page
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListUsersResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter pageSize,
+              Invalid value for: query parameter pageToken'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: Create a new user.
+        operationId: postV2Users
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateUserRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/CreateUserResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users/{user-id}:
+      get:
+        description: Get the user data of a specific user or the authenticated user.
+        operationId: getV2UsersUser-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetUserResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter identity-provider-id'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      delete:
+        description: Delete an existing user and all its rights.
+        operationId: deleteV2UsersUser-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: object
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: Update selected modifiable attribute of a user resource described
+          by the ``User`` message.
+        operationId: patchV2UsersUser-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateUserRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateUserResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/authenticated-user:
+      get:
+        description: Get the user data of the current authenticated user.
+        operationId: getV2Authenticated-user
+        parameters:
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetUserResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter identity-provider-id'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users/{user-id}/rights:
+      get:
+        description: List the set of all rights granted to a user.
+        operationId: getV2UsersUser-idRights
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListUserRightsResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: |-
+          Grant rights to a user.
+          Granting rights does not affect the resource version of the corresponding user.
+        operationId: postV2UsersUser-idRights
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GrantUserRightsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GrantUserRightsResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: |-
+          Revoke rights from a user.
+          Revoking rights does not affect the resource version of the corresponding user.
+        operationId: patchV2UsersUser-idRights
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevokeUserRightsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/RevokeUserRightsResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users/{user-id}/identity-provider-id:
+      patch:
+        description: Update the assignment of a user from one IDP to another.
+        operationId: patchV2UsersUser-idIdentity-provider-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateUserIdentityProviderIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateUserIdentityProviderIdResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/idps:
+      get:
+        description: List all existing identity provider configurations.
+        operationId: getV2Idps
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListIdentityProviderConfigsResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: |-
+          Create a new identity provider configuration.
+          The request will fail if the maximum allowed number of separate configurations is reached.
+        operationId: postV2Idps
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateIdentityProviderConfigRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/CreateIdentityProviderConfigResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/idps/{idp-id}:
+      get:
+        description: Get the identity provider configuration data by id.
+        operationId: getV2IdpsIdp-id
+        parameters:
+        - name: idp-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetIdentityProviderConfigResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      delete:
+        description: Delete an existing identity provider configuration.
+        operationId: deleteV2IdpsIdp-id
+        parameters:
+        - name: idp-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/DeleteIdentityProviderConfigResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: |-
+          Update selected modifiable attribute of an identity provider config resource described
+          by the ``IdentityProviderConfig`` message.
+        operationId: patchV2IdpsIdp-id
+        parameters:
+        - name: idp-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateIdentityProviderConfigRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateIdentityProviderConfigResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/prepare:
+      post:
+        description: Requires `readAs` scope for the submitting party when LAPI User
+          authorization is enabled
+        operationId: postV2Interactive-submissionPrepare
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsPrepareSubmissionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsPrepareSubmissionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/execute:
+      post:
+        description: |-
+          Execute a prepared submission _asynchronously_ on the ledger.
+          Requires a signature of the transaction from the submitting external party.
+        operationId: postV2Interactive-submissionExecute
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsExecuteSubmissionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ExecuteSubmissionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/executeAndWait:
+      post:
+        description: |-
+          Similar to ExecuteSubmission but _synchronously_ wait for the completion of the transaction
+          IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest.
+          A malicious node could make a successfully committed request appeared failed and vice versa
+        operationId: postV2Interactive-submissionExecuteandwait
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsExecuteSubmissionAndWaitRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ExecuteSubmissionAndWaitResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/executeAndWaitForTransaction:
+      post:
+        description: |-
+          Similar to ExecuteSubmissionAndWait but additionally returns the transaction
+          IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest.
+          A malicious node could make a successfully committed request appear as failed and vice versa
+        operationId: postV2Interactive-submissionExecuteandwaitfortransaction
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsExecuteSubmissionAndWaitForTransactionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsExecuteSubmissionAndWaitForTransactionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/preferred-package-version:
+      get:
+        description: |-
+          A preferred package is the highest-versioned package for a provided package-name
+          that is vetted by all the participants hosting the provided parties.
+
+          Ledger API clients should use this endpoint for constructing command submissions
+          that are compatible with the provided preferred package, by making informed decisions on:
+          - which are the compatible packages that can be used to create contracts
+          - which contract or exercise choice argument version can be used in the command
+          - which choices can be executed on a template or interface of a contract
+
+          Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.
+
+          Provided for backwards compatibility, it will be removed in the Canton version 3.4.0
+        operationId: getV2Interactive-submissionPreferred-package-version
+        parameters:
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: package-name
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: vetting_valid_at
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: synchronizer-id
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPreferredPackageVersionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter parties,
+              Invalid value for: query parameter package-name, Invalid value for: query
+              parameter vetting_valid_at, Invalid value for: query parameter synchronizer-id'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/preferred-packages:
+      post:
+        description: |-
+          Compute the preferred packages for the vetting requirements in the request.
+          A preferred package is the highest-versioned package for a provided package-name
+          that is vetted by all the participants hosting the provided parties.
+
+          Ledger API clients should use this endpoint for constructing command submissions
+          that are compatible with the provided preferred packages, by making informed decisions on:
+          - which are the compatible packages that can be used to create contracts
+          - which contract or exercise choice argument version can be used in the command
+          - which choices can be executed on a template or interface of a contract
+
+          If the package preferences could not be computed due to no selection satisfying the requirements,
+          a `FAILED_PRECONDITION` error will be returned.
+
+          Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.
+
+          Experimental API: this endpoint is not guaranteed to provide backwards compatibility in future releases
+        operationId: postV2Interactive-submissionPreferred-packages
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPreferredPackagesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPreferredPackagesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /livez:
+      get:
+        description: Checks if the service is alive
+        operationId: getLivez
+        responses:
+          '200':
+            description: 'OK: service is alive'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /readyz:
+      get:
+        description: Checks if the service is ready to serve requests
+        operationId: getReadyz
+        responses:
+          '200':
+            description: 'OK: readiness message'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/contracts/contract-by-id:
+      post:
+        description: |-
+          Looking up contract data by contract ID.
+          This endpoint is experimental / alpha, therefore no backwards compatibility is guaranteed.
+          This endpoint must not be used to look up contracts which entered the participant via party replication
+          or repair service.
+        operationId: postV2ContractsContract-by-id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetContractRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetContractResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+  components:
+    schemas:
+      AllocateExternalPartyRequest:
+        title: AllocateExternalPartyRequest
+        description: |-
+          Required authorization:
+            ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id) OR IsAuthenticatedUser(user_id)``
+        type: object
+        required:
+        - synchronizer
+        - onboardingTransactions
+        properties:
+          synchronizer:
+            description: |-
+              TODO(#27670) support synchronizer aliases
+              Synchronizer ID on which to onboard the party
+
+              Required
+            type: string
+          onboardingTransactions:
+            description: |-
+              TopologyTransactions to onboard the external party
+              Can contain:
+              - A namespace for the party.
+              This can be either a single NamespaceDelegation,
+              or DecentralizedNamespaceDefinition along with its authorized namespace owners in the form of NamespaceDelegations.
+              May be provided, if so it must be fully authorized by the signatures in this request combined with the existing topology state.
+              - A PartyToKeyMapping to register the party's signing keys.
+              May be provided, if so it must be fully authorized by the signatures in this request combined with the existing topology state.
+              - A PartyToParticipant to register the hosting relationship of the party.
+              Must be provided.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/SignedTransaction'
+          multiHashSignatures:
+            description: |-
+              Optional signatures of the combined hash of all onboarding_transactions
+              This may be used instead of providing signatures on each individual transaction
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Signature'
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the party is managed by the default identity provider.
+
+              Optional
+            type: string
+          waitForAllocation:
+            description: |-
+              When true, this RPC will attempt to wait for the party to be allocated on the synchronizer before returning.
+              When false, the allocation will happen asynchronously.
+              This is a best effort only as this synchronization is only possible for non decentralized parties (single hosting node).
+              For decentralized parties, this flag is ignored.
+              Defaults to true.
+
+              Optional
+            type: boolean
+          userId:
+            description: |-
+              The user who will get the act_as rights to the newly allocated party.
+              If set to an empty string (the default), no user will get rights to the party.
+
+              Optional
+            type: string
+      AllocateExternalPartyResponse:
+        title: AllocateExternalPartyResponse
+        type: object
+        required:
+        - partyId
+        properties:
+          partyId:
+            description: |-
+              The allocated party id
+
+              Required
+            type: string
+      AllocatePartyRequest:
+        title: AllocatePartyRequest
+        description: |-
+          Required authorization:
+            ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id) OR IsAuthenticatedUser(user_id)``
+        type: object
+        properties:
+          partyIdHint:
+            description: |-
+              A hint to the participant which party ID to allocate. It can be
+              ignored.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          localMetadata:
+            $ref: '#/components/schemas/ObjectMeta'
+            description: |-
+              Formerly "display_name"
+              Participant-local metadata to be stored in the ``PartyDetails`` of this newly allocated party.
+
+              Optional
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the party is managed by the default identity provider or party is not hosted by the participant.
+
+              Optional
+            type: string
+          synchronizerId:
+            description: |-
+              The synchronizer, on which the party should be allocated.
+              For backwards compatibility, this field may be omitted, if the participant is connected to only one synchronizer.
+              Otherwise a synchronizer must be specified.
+
+              Optional
+            type: string
+          userId:
+            description: |-
+              The user who will get the act_as rights to the newly allocated party.
+              If set to an empty string (the default), no user will get rights to the party.
+
+              Optional
+            type: string
+      AllocatePartyResponse:
+        title: AllocatePartyResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
+            $ref: '#/components/schemas/PartyDetails'
+            description: |-
+              The allocated party details
+
+              Required
+      ArchivedEvent:
+        title: ArchivedEvent
+        description: Records that a contract has been archived, and choices may no longer
+          be exercised on it.
+        type: object
+        required:
+        - offset
+        - nodeId
+        - contractId
+        - templateId
+        - packageName
+        - witnessParties
+        properties:
+          offset:
+            description: |-
+              The offset of origin.
+              Offsets are managed by the participant nodes.
+              Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
+              It is a valid absolute offset (positive integer)
+
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating transaction or reassignment.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of transactions.
+              Must be valid node ID (non-negative integer)
+
+              Required
+            type: integer
+            format: int32
+          contractId:
+            description: |-
+              The ID of the archived contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          templateId:
+            description: |-
+              Identifies the template that defines the choice that archived the contract.
+              This template's package-id may differ from the target contract's package-id
+              if the target contract has been upgraded or downgraded.
+
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          witnessParties:
+            description: |-
+              The parties that are notified of this event. For an ``ArchivedEvent``,
+              these are the intersection of the stakeholders of the contract in
+              question and the parties specified in the ``TransactionFilter``. The
+              stakeholders are the union of the signatories and the observers of
+              the contract.
+              Each one of its elements must be a valid PartyIdString (as described
+              in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          packageName:
+            description: |-
+              The package name of the contract.
+
+              Required
+            type: string
+          implementedInterfaces:
+            description: |-
+              The interfaces implemented by the target template that have been
+              matched from the interface filter query.
+              Populated only in case interface filters with include_interface_view set.
+
+              If defined, the identifier uses the package-id reference format.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      AssignCommand:
+        title: AssignCommand
+        description: Assign a contract
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/AssignCommand1'
+      AssignCommand1:
+        title: AssignCommand
+        description: Assign a contract
+        type: object
+        required:
+        - reassignmentId
+        - source
+        - target
+        properties:
+          reassignmentId:
+            description: |-
+              The ID from the unassigned event to be completed by this assignment.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          source:
+            description: |-
+              The ID of the source synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+          target:
+            description: |-
+              The ID of the target synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+      CanActAs:
+        title: CanActAs
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanActAs1'
+      CanActAs1:
+        title: CanActAs
+        type: object
+        required:
+        - party
+        properties:
+          party:
+            description: |-
+              The right to authorize commands for this party.
+
+              Required
+            type: string
+      CanExecuteAs:
+        title: CanExecuteAs
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanExecuteAs1'
+      CanExecuteAs1:
+        title: CanExecuteAs
+        type: object
+        required:
+        - party
+        properties:
+          party:
+            description: |-
+              The right to prepare and execute submissions as this party.
+              This right does not entitle the user to perform any reads.
+              If reading is required, a separate ReadAs right must be added.
+              Right to execute as a party is also implicitly contained in the CanActAs right.
+
+              Required
+            type: string
+      CanExecuteAsAnyParty:
+        title: CanExecuteAsAnyParty
+        description: |-
+          The rights of a user to prepare and execute transactions as any party.
+          Its utility is predominantly for users that perform interactive submissions
+          on behalf of many parties.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanExecuteAsAnyParty1'
+      CanExecuteAsAnyParty1:
+        title: CanExecuteAsAnyParty
+        description: |-
+          The rights of a user to prepare and execute transactions as any party.
+          Its utility is predominantly for users that perform interactive submissions
+          on behalf of many parties.
+        type: object
+      CanReadAs:
+        title: CanReadAs
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanReadAs1'
+      CanReadAs1:
+        title: CanReadAs
+        type: object
+        required:
+        - party
+        properties:
+          party:
+            description: |-
+              The right to read ledger data visible to this party.
+
+              Required
+            type: string
+      CanReadAsAnyParty:
+        title: CanReadAsAnyParty
+        description: |-
+          The rights of a participant's super reader. Its utility is predominantly for
+          feeding external tools, such as PQS, continually without the need to change subscriptions
+          as new parties pop in and out of existence.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanReadAsAnyParty1'
+      CanReadAsAnyParty1:
+        title: CanReadAsAnyParty
+        description: |-
+          The rights of a participant's super reader. Its utility is predominantly for
+          feeding external tools, such as PQS, continually without the need to change subscriptions
+          as new parties pop in and out of existence.
+        type: object
+      Command:
+        title: Command
+        description: A command can either create a new contract or exercise a choice
+          on an existing contract.
+        oneOf:
+        - type: object
+          required:
+          - CreateAndExerciseCommand
+          properties:
+            CreateAndExerciseCommand:
+              $ref: '#/components/schemas/CreateAndExerciseCommand'
+        - type: object
+          required:
+          - CreateCommand
+          properties:
+            CreateCommand:
+              $ref: '#/components/schemas/CreateCommand'
+        - type: object
+          required:
+          - ExerciseByKeyCommand
+          properties:
+            ExerciseByKeyCommand:
+              $ref: '#/components/schemas/ExerciseByKeyCommand'
+        - type: object
+          required:
+          - ExerciseCommand
+          properties:
+            ExerciseCommand:
+              $ref: '#/components/schemas/ExerciseCommand'
+      Command1:
+        title: Command
+        description: A command can either create a new contract or exercise a choice
+          on an existing contract.
+        oneOf:
+        - type: object
+          required:
+          - AssignCommand
+          properties:
+            AssignCommand:
+              $ref: '#/components/schemas/AssignCommand'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty2'
+        - type: object
+          required:
+          - UnassignCommand
+          properties:
+            UnassignCommand:
+              $ref: '#/components/schemas/UnassignCommand'
+      Completion:
+        title: Completion
+        description: 'A completion represents the status of a submitted command on the
+          ledger: it can be successful or failed.'
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Completion1'
+      Completion1:
+        title: Completion
+        description: 'A completion represents the status of a submitted command on the
+          ledger: it can be successful or failed.'
+        type: object
+        required:
+        - commandId
+        - userId
+        - offset
+        - actAs
+        - synchronizerTime
+        properties:
+          commandId:
+            description: |-
+              The ID of the succeeded or failed command.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          status:
+            $ref: '#/components/schemas/JsStatus'
+            description: |-
+              Identifies the exact type of the error.
+              It uses the same format of conveying error details as it is used for the RPC responses of the APIs.
+
+              Optional
+          updateId:
+            description: |-
+              The update_id of the transaction or reassignment that resulted from the command with command_id.
+
+              Only set for successfully executed commands.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          userId:
+            description: |-
+              The user-id that was used for the submission, as described in ``commands.proto``.
+              Must be a valid UserIdString (as described in ``value.proto``).
+
+              Required
+            type: string
+          actAs:
+            description: |-
+              The set of parties on whose behalf the commands were executed.
+              Contains the ``act_as`` parties from ``commands.proto``
+              filtered to the requesting parties in CompletionStreamRequest.
+              The order of the parties need not be the same as in the submission.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          submissionId:
+            description: |-
+              The submission ID this completion refers to, as described in ``commands.proto``.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod1'
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              The Ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+
+              Optional
+          offset:
+            description: |-
+              May be used in a subsequent CompletionStreamRequest to resume the consumption of this stream at a later time.
+              Must be a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          synchronizerTime:
+            $ref: '#/components/schemas/SynchronizerTime'
+            description: |-
+              The synchronizer along with its record time.
+              The synchronizer id provided, in case of
+
+              - successful/failed transactions: identifies the synchronizer of the transaction
+              - for successful/failed unassign commands: identifies the source synchronizer
+              - for successful/failed assign commands: identifies the target synchronizer
+
+              Required
+      CompletionResponse:
+        title: CompletionResponse
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - Completion
+          properties:
+            Completion:
+              $ref: '#/components/schemas/Completion'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty4'
+        - type: object
+          required:
+          - OffsetCheckpoint
+          properties:
+            OffsetCheckpoint:
+              $ref: '#/components/schemas/OffsetCheckpoint'
+      CompletionStreamRequest:
+        title: CompletionStreamRequest
+        type: object
+        required:
+        - parties
+        properties:
+          userId:
+            description: |-
+              Only completions of commands submitted with the same user_id will be visible in the stream.
+              Must be a valid UserIdString (as described in ``value.proto``).
+
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
+
+              Optional
+            type: string
+          parties:
+            description: |-
+              Non-empty list of parties whose data should be included.
+              The stream shows only completions of commands for which at least one of the ``act_as`` parties is in the given set of parties.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          beginExclusive:
+            description: |-
+              This optional field indicates the minimum offset for completions. This can be used to resume an earlier completion stream.
+              If not set the ledger uses the ledger begin offset instead.
+              If specified, it must be a valid absolute offset (positive integer) or zero (ledger begin offset).
+              If the ledger has been pruned, this parameter must be specified and greater than the pruning offset.
+
+              Optional
+            type: integer
+            format: int64
+      CompletionStreamResponse:
+        title: CompletionStreamResponse
+        type: object
+        properties:
+          completionResponse:
+            $ref: '#/components/schemas/CompletionResponse'
+      ConnectedSynchronizer:
+        title: ConnectedSynchronizer
+        type: object
+        required:
+        - synchronizerAlias
+        - synchronizerId
+        properties:
+          synchronizerAlias:
+            description: |-
+              The alias of the synchronizer
+
+              Required
+            type: string
+          synchronizerId:
+            description: |-
+              The ID of the synchronizer
+
+              Required
+            type: string
+          permission:
+            description: |-
+              The permission on the synchronizer
+              Set if a party was used in the request, otherwise unspecified.
+
+              Optional
+            type: string
+            enum:
+            - PARTICIPANT_PERMISSION_UNSPECIFIED
+            - PARTICIPANT_PERMISSION_SUBMISSION
+            - PARTICIPANT_PERMISSION_CONFIRMATION
+            - PARTICIPANT_PERMISSION_OBSERVATION
+      CostEstimation:
+        title: CostEstimation
+        description: |-
+          Estimation of the cost of submitting the prepared transaction
+          The estimation is done against the synchronizer chosen during preparation of the transaction
+          (or the one explicitly requested).
+          The cost of re-assigning contracts to another synchronizer when necessary is not included in the estimation.
+        type: object
+        required:
+        - confirmationRequestTrafficCostEstimation
+        - confirmationResponseTrafficCostEstimation
+        - totalTrafficCostEstimation
+        - estimationTimestamp
+        properties:
+          estimationTimestamp:
+            description: |-
+              Timestamp at which the estimation was made
+
+              Required
+            type: string
+          confirmationRequestTrafficCostEstimation:
+            description: |-
+              Estimated traffic cost of the confirmation request associated with the transaction
+
+              Required
+            type: integer
+            format: int64
+          confirmationResponseTrafficCostEstimation:
+            description: |-
+              Estimated traffic cost of the confirmation response associated with the transaction
+              This field can also be used as an indication of the cost that other potential confirming nodes
+              of the party will incur to approve or reject the transaction
+
+              Required
+            type: integer
+            format: int64
+          totalTrafficCostEstimation:
+            description: |-
+              Sum of the fields above
+
+              Required
+            type: integer
+            format: int64
+      CostEstimationHints:
+        title: CostEstimationHints
+        description: Hints to improve cost estimation precision of a prepared transaction
+        type: object
+        properties:
+          disabled:
+            description: |-
+              Disable cost estimation
+              Default (not set) is false
+
+              Optional
+            type: boolean
+          expectedSignatures:
+            description: |-
+              Details on the keys that will be used to sign the transaction (how many and of which type).
+              Signature size impacts the cost of the transaction.
+              If empty, the signature sizes will be approximated with threshold-many signatures (where threshold is defined
+              in the PartyToKeyMapping of the external party), using keys in the order they are registered.
+              Empty list is equivalent to not providing this field
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+              enum:
+              - SIGNING_ALGORITHM_SPEC_UNSPECIFIED
+              - SIGNING_ALGORITHM_SPEC_ED25519
+              - SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256
+              - SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384
+      CreateAndExerciseCommand:
+        title: CreateAndExerciseCommand
+        description: Create a contract and exercise a choice on it in the same transaction.
+        type: object
+        required:
+        - templateId
+        - createArguments
+        - choice
+        - choiceArgument
+        properties:
+          templateId:
+            description: |-
+              The template of the contract the client wants to create.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          createArguments:
+            description: |-
+              The arguments required for creating a contract from this template.
+
+              Required
+          choice:
+            description: |-
+              The name of the choice the client wants to exercise.
+              Must be a valid NameString (as described in ``value.proto``).
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument for this choice.
+
+              Required
+      CreateCommand:
+        title: CreateCommand
+        description: Create a new contract instance based on a template.
+        type: object
+        required:
+        - templateId
+        - createArguments
+        properties:
+          templateId:
+            description: |-
+              The template of contract the client wants to create.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          createArguments:
+            description: |-
+              The arguments required for creating a contract from this template.
+
+              Required
+      CreateIdentityProviderConfigRequest:
+        title: CreateIdentityProviderConfigRequest
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: Required
+      CreateIdentityProviderConfigResponse:
+        title: CreateIdentityProviderConfigResponse
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: Required
+      CreateUserRequest:
+        title: CreateUserRequest
+        description: |2-
+           RPC requests and responses
+          ///////////////////////////
+           Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(user.identity_provider_id)``
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              The user to create.
+
+              Required
+          rights:
+            description: |-
+              The rights to be assigned to the user upon creation,
+              which SHOULD include appropriate rights for the ``user.primary_party``.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      CreateUserResponse:
+        title: CreateUserResponse
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              Created user.
+
+              Required
+      CreatedEvent:
+        title: CreatedEvent
+        description: Records that a contract has been created, and choices may now be
+          exercised on it.
+        type: object
+        required:
+        - offset
+        - nodeId
+        - contractId
+        - templateId
+        - createdAt
+        - packageName
+        - representativePackageId
+        - acsDelta
+        - createArgument
+        - witnessParties
+        - signatories
+        properties:
+          offset:
+            description: |-
+              The offset of origin, which has contextual meaning, please see description at messages that include a CreatedEvent.
+              Offsets are managed by the participant nodes.
+              Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
+              It is a valid absolute offset (positive integer)
+
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating transaction or reassignment.
+              The origin has contextual meaning, please see description at messages that include a CreatedEvent.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of transactions.
+              Must be valid node ID (non-negative integer)
+
+              Required
+            type: integer
+            format: int32
+          contractId:
+            description: |-
+              The ID of the created contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          templateId:
+            description: |-
+              The template of the created contract.
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          contractKey:
+            description: |-
+              The key of the created contract.
+              This will be set if and only if ``template_id`` defines a contract key.
+
+              Optional
+          contractKeyHash:
+            description: |-
+              The hash of contract_key.
+              This will be set if and only if ``template_id`` defines a contract key.
+
+              Optional: can be empty
+            type: string
+          createArgument:
+            description: |-
+              The arguments that have been used to create the contract.
+
+              Required
+          createdEventBlob:
+            description: |-
+              Opaque representation of contract create event payload intended for forwarding
+              to an API server as a contract disclosed as part of a command
+              submission.
+
+              Optional: can be empty
+            type: string
+          interfaceViews:
+            description: |-
+              Interface views specified in the transaction filter.
+              Includes an ``InterfaceView`` for each interface for which there is a ``InterfaceFilter`` with
+
+              - its party in the ``witness_parties`` of this event,
+              - and which is implemented by the template of this event,
+              - and which has ``include_interface_view`` set.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/JsInterfaceView'
+          witnessParties:
+            description: |-
+              The parties that are notified of this event. When a ``CreatedEvent``
+              is returned as part of a transaction tree or ledger-effects transaction, this will include all
+              the parties specified in the ``TransactionFilter`` that are witnesses  of the event
+              (the stakeholders of the contract and all informees of all the ancestors
+              of this create action that this participant knows about).
+              If served as part of a ACS delta transaction those will
+              be limited to all parties specified in the ``TransactionFilter`` that
+              are stakeholders of the contract (i.e. either signatories or observers).
+              If the ``CreatedEvent`` is returned as part of an AssignedEvent,
+              ActiveContract or IncompleteUnassigned (so the event is related to
+              an assignment or unassignment): this will include all parties of the
+              ``TransactionFilter`` that are stakeholders of the contract.
+
+              The behavior of reading create events visible to parties not hosted
+              on the participant node serving the Ledger API is undefined. Concretely,
+              there is neither a guarantee that the participant node will serve all their
+              create events on the ACS stream, nor is there a guarantee that matching archive
+              events are delivered for such create events.
+
+              For most clients this is not a problem, as they only read events for parties
+              that are hosted on the participant node. If you need to read events
+              for parties that may not be hosted at all times on the participant node,
+              subscribe to the ``TopologyEvent``s for that party by setting a corresponding
+              ``UpdateFormat``.  Using these events, query the ACS as-of an offset where the
+              party is hosted on the participant node, and ignore create events at offsets
+              where the party is not hosted on the participant node.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          signatories:
+            description: |-
+              The signatories for this contract as specified by the template.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          observers:
+            description: |-
+              The observers for this contract as specified explicitly by the template or implicitly as choice controllers.
+              This field never contains parties that are signatories.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          createdAt:
+            description: |-
+              Ledger effective time of the transaction that created the contract.
+
+              Required
+            type: string
+          packageName:
+            description: |-
+              The package name of the created contract.
+
+              Required
+            type: string
+          representativePackageId:
+            description: |-
+              A package-id present in the participant package store that typechecks the contract's argument.
+              This may differ from the package-id of the template used to create the contract.
+              For contracts created before Canton 3.4, this field matches the contract's creation package-id.
+
+              NOTE: Experimental, server internal concept, not for client consumption. Subject to change without notice.
+
+              Required
+            type: string
+          acsDelta:
+            description: |-
+              Whether this event would be part of respective ACS_DELTA shaped stream,
+              and should therefore considered when tracking contract activeness on the client-side.
+
+              Required
+            type: boolean
+      CreatedTreeEvent:
+        title: CreatedTreeEvent
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CreatedEvent'
+      CumulativeFilter:
+        title: CumulativeFilter
+        description: |-
+          A filter that matches all contracts that are either an instance of one of
+          the ``template_filters`` or that match one of the ``interface_filters``.
+        type: object
+        properties:
+          identifierFilter:
+            $ref: '#/components/schemas/IdentifierFilter'
+      DeduplicationDuration:
+        title: DeduplicationDuration
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      DeduplicationDuration1:
+        title: DeduplicationDuration
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      DeduplicationDuration2:
+        title: DeduplicationDuration
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      DeduplicationOffset:
+        title: DeduplicationOffset
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int64
+      DeduplicationOffset1:
+        title: DeduplicationOffset
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int64
+      DeduplicationOffset2:
+        title: DeduplicationOffset
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int64
+      DeduplicationPeriod:
+        title: DeduplicationPeriod
+        description: |-
+          Specifies the deduplication period for the change ID.
+          If omitted, the participant will assume the configured maximum deduplication time.
+
+          Optional
+        oneOf:
+        - type: object
+          required:
+          - DeduplicationDuration
+          properties:
+            DeduplicationDuration:
+              $ref: '#/components/schemas/DeduplicationDuration'
+        - type: object
+          required:
+          - DeduplicationOffset
+          properties:
+            DeduplicationOffset:
+              $ref: '#/components/schemas/DeduplicationOffset'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty'
+      DeduplicationPeriod1:
+        title: DeduplicationPeriod
+        description: |-
+          The actual deduplication window used for the submission, which is derived from
+          ``Commands.deduplication_period``. The ledger may convert the deduplication period into other
+          descriptions and extend the period in implementation-specified ways.
+
+          Used to audit the deduplication guarantee described in ``commands.proto``.
+
+          The deduplication guarantee applies even if the completion omits this field.
+
+          Optional
+        oneOf:
+        - type: object
+          required:
+          - DeduplicationDuration
+          properties:
+            DeduplicationDuration:
+              $ref: '#/components/schemas/DeduplicationDuration1'
+        - type: object
+          required:
+          - DeduplicationOffset
+          properties:
+            DeduplicationOffset:
+              $ref: '#/components/schemas/DeduplicationOffset1'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty3'
+      DeduplicationPeriod2:
+        title: DeduplicationPeriod
+        oneOf:
+        - type: object
+          required:
+          - DeduplicationDuration
+          properties:
+            DeduplicationDuration:
+              $ref: '#/components/schemas/DeduplicationDuration2'
+        - type: object
+          required:
+          - DeduplicationOffset
+          properties:
+            DeduplicationOffset:
+              $ref: '#/components/schemas/DeduplicationOffset2'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty10'
+      DeleteIdentityProviderConfigResponse:
+        title: DeleteIdentityProviderConfigResponse
+        description: Does not (yet) contain any data.
+        type: object
+      DisclosedContract:
+        title: DisclosedContract
+        description: |-
+          An additional contract that is used to resolve
+          contract & contract key lookups.
+        type: object
+        required:
+        - createdEventBlob
+        properties:
+          templateId:
+            description: |-
+              The template id of the contract.
+              The identifier uses the package-id reference format.
+
+              If provided, used to validate the template id of the contract serialized in the created_event_blob.
+
+              Optional
+            type: string
+          contractId:
+            description: |-
+              The contract id
+
+              If provided, used to validate the contract id of the contract serialized in the created_event_blob.
+
+              Optional
+            type: string
+          createdEventBlob:
+            description: |-
+              Opaque byte string containing the complete payload required by the Daml engine
+              to reconstruct a contract not known to the receiving participant.
+
+              Required: must be non-empty
+            type: string
+          synchronizerId:
+            description: |-
+              The ID of the synchronizer where the contract is currently assigned
+
+              Optional
+            type: string
+      Duration:
+        title: Duration
+        type: object
+        required:
+        - seconds
+        - nanos
+        properties:
+          seconds:
+            type: integer
+            format: int64
+          nanos:
+            type: integer
+            format: int32
+          unknownFields:
+            $ref: '#/components/schemas/UnknownFieldSet'
+            description: This field is automatically added as part of protobuf to json
+              mapping
+      Empty:
+        title: Empty
+        type: object
+      Empty1:
+        title: Empty
+        type: object
+      Empty10:
+        title: Empty
+        type: object
+      Empty2:
+        title: Empty
+        type: object
+      Empty3:
+        title: Empty
+        type: object
+      Empty4:
+        title: Empty
+        type: object
+      Empty5:
+        title: Empty
+        type: object
+      Empty6:
+        title: Empty
+        type: object
+      Empty7:
+        title: Empty
+        type: object
+      Empty8:
+        title: Empty
+        type: object
+      Empty9:
+        title: Empty
+        type: object
+      Event:
+        title: Event
+        description: |-
+          Events in transactions can have two primary shapes:
+
+          - ACS delta: events can be CreatedEvent or ArchivedEvent
+          - ledger effects: events can be CreatedEvent or ExercisedEvent
+
+          In the update service the events are restricted to the events
+          visible for the parties specified in the transaction filter. Each
+          event message type below contains a ``witness_parties`` field which
+          indicates the subset of the requested parties that can see the event
+          in question.
+        oneOf:
+        - type: object
+          required:
+          - ArchivedEvent
+          properties:
+            ArchivedEvent:
+              $ref: '#/components/schemas/ArchivedEvent'
+        - type: object
+          required:
+          - CreatedEvent
+          properties:
+            CreatedEvent:
+              $ref: '#/components/schemas/CreatedEvent'
+        - type: object
+          required:
+          - ExercisedEvent
+          properties:
+            ExercisedEvent:
+              $ref: '#/components/schemas/ExercisedEvent'
+      EventFormat:
+        title: EventFormat
+        description: |-
+          A format for events which defines both which events should be included
+          and what data should be computed and included for them.
+
+          Note that some of the filtering behavior depends on the `TransactionShape`,
+          which is expected to be specified alongside usages of `EventFormat`.
+        type: object
+        properties:
+          filtersByParty:
+            $ref: '#/components/schemas/Map_Filters'
+            description: |-
+              Each key must be a valid PartyIdString (as described in ``value.proto``).
+              The interpretation of the filter depends on the transaction-shape being filtered:
+
+              1. For **ledger-effects** create and exercise events are returned, for which the witnesses include at least one of
+                 the listed parties and match the per-party filter.
+              2. For **transaction and active-contract-set streams** create and archive events are returned for all contracts whose
+                 stakeholders include at least one of the listed parties and match the per-party filter.
+
+              Optional: can be empty
+          filtersForAnyParty:
+            $ref: '#/components/schemas/Filters'
+            description: |-
+              Wildcard filters that apply to all the parties existing on the participant. The interpretation of the filters is the same
+              with the per-party filter as described above.
+
+              Optional
+          verbose:
+            description: |-
+              If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
+              In particular, setting the verbose flag to true triggers the ledger to include labels for record fields.
+
+              Optional
+            type: boolean
+      ExecuteSubmissionAndWaitResponse:
+        title: ExecuteSubmissionAndWaitResponse
+        type: object
+        required:
+        - updateId
+        - completionOffset
+        properties:
+          updateId:
+            description: |-
+              The id of the transaction that resulted from the submitted command.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          completionOffset:
+            description: |-
+              The details of the offset field are described in ``community/ledger-api/README.md``.
+
+              Required
+            type: integer
+            format: int64
+      ExecuteSubmissionResponse:
+        title: ExecuteSubmissionResponse
+        type: object
+      ExerciseByKeyCommand:
+        title: ExerciseByKeyCommand
+        description: Exercise a choice on an existing contract specified by its key.
+        type: object
+        required:
+        - templateId
+        - contractKey
+        - choice
+        - choiceArgument
+        properties:
+          templateId:
+            description: |-
+              The template of contract the client wants to exercise.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          contractKey:
+            description: |-
+              The key of the contract the client wants to exercise upon.
+
+              Required
+          choice:
+            description: |-
+              The name of the choice the client wants to exercise.
+              Must be a valid NameString (as described in ``value.proto``)
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument for this choice.
+
+              Required
+      ExerciseCommand:
+        title: ExerciseCommand
+        description: Exercise a choice on an existing contract.
+        type: object
+        required:
+        - templateId
+        - contractId
+        - choice
+        - choiceArgument
+        properties:
+          templateId:
+            description: |-
+              The template or interface of the contract the client wants to exercise.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+              To exercise a choice on an interface, specify the interface identifier in the template_id field.
+
+              Required
+            type: string
+          contractId:
+            description: |-
+              The ID of the contract the client wants to exercise upon.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          choice:
+            description: |-
+              The name of the choice the client wants to exercise.
+              Must be a valid NameString (as described in ``value.proto``)
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument for this choice.
+
+              Required
+      ExercisedEvent:
+        title: ExercisedEvent
+        description: Records that a choice has been exercised on a target contract.
+        type: object
+        required:
+        - offset
+        - nodeId
+        - contractId
+        - templateId
+        - choice
+        - choiceArgument
+        - consuming
+        - lastDescendantNodeId
+        - packageName
+        - acsDelta
+        - actingParties
+        - witnessParties
+        properties:
+          offset:
+            description: |-
+              The offset of origin.
+              Offsets are managed by the participant nodes.
+              Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
+              It is a valid absolute offset (positive integer)
+
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating transaction or reassignment.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of transactions.
+              Must be valid node ID (non-negative integer)
+
+              Required
+            type: integer
+            format: int32
+          contractId:
+            description: |-
+              The ID of the target contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          templateId:
+            description: |-
+              Identifies the template that defines the executed choice.
+              This template's package-id may differ from the target contract's package-id
+              if the target contract has been upgraded or downgraded.
+
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          interfaceId:
+            description: |-
+              The interface where the choice is defined, if inherited.
+              If defined, the identifier uses the package-id reference format.
+
+              Optional
+            type: string
+          choice:
+            description: |-
+              The choice that was exercised on the target contract.
+              Must be a valid NameString (as described in ``value.proto``).
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument of the exercised choice.
+
+              Required
+          actingParties:
+            description: |-
+              The parties that exercised the choice.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          consuming:
+            description: |-
+              If true, the target contract may no longer be exercised.
+
+              Required
+            type: boolean
+          witnessParties:
+            description: |-
+              The parties that are notified of this event. The witnesses of an exercise
+              node will depend on whether the exercise was consuming or not.
+              If consuming, the witnesses are the union of the stakeholders,
+              the actors and all informees of all the ancestors of this event this
+              participant knows about.
+              If not consuming, the witnesses are the union of the signatories,
+              the actors and all informees of all the ancestors of this event this
+              participant knows about.
+              In both cases the witnesses are limited to the querying parties, or not
+              limited in case anyParty filters are used.
+              Note that the actors might not necessarily be observers
+              and thus stakeholders. This is the case when the controllers of a
+              choice are specified using "flexible controllers", using the
+              ``choice ... controller`` syntax, and said controllers are not
+              explicitly marked as observers.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          lastDescendantNodeId:
+            description: |-
+              Specifies the upper boundary of the node ids of the events in the same transaction that appeared as a result of
+              this ``ExercisedEvent``. This allows unambiguous identification of all the members of the subtree rooted at this
+              node. A full subtree can be constructed when all descendant nodes are present in the stream. If nodes are heavily
+              filtered, it is only possible to determine if a node is in a consequent subtree or not.
+
+              Required
+            type: integer
+            format: int32
+          exerciseResult:
+            description: |-
+              The result of exercising the choice.
+
+              Optional
+          packageName:
+            description: |-
+              The package name of the contract.
+
+              Required
+            type: string
+          implementedInterfaces:
+            description: |-
+              If the event is consuming, the interfaces implemented by the target template that have been
+              matched from the interface filter query.
+              Populated only in case interface filters with include_interface_view set.
+
+              The identifier uses the package-id reference format.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          acsDelta:
+            description: |-
+              Whether this event would be part of respective ACS_DELTA shaped stream,
+              and should therefore considered when tracking contract activeness on the client-side.
+
+              Required
+            type: boolean
+      ExercisedTreeEvent:
+        title: ExercisedTreeEvent
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ExercisedEvent'
+      ExperimentalCommandInspectionService:
+        title: ExperimentalCommandInspectionService
+        description: Whether the Ledger API supports command inspection service
+        type: object
+        required:
+        - supported
+        properties:
+          supported:
+            description: Required
+            type: boolean
+      ExperimentalFeatures:
+        title: ExperimentalFeatures
+        description: See the feature message definitions for descriptions.
+        type: object
+        properties:
+          staticTime:
+            $ref: '#/components/schemas/ExperimentalStaticTime'
+            description: Optional
+          commandInspectionService:
+            $ref: '#/components/schemas/ExperimentalCommandInspectionService'
+            description: Optional
+      ExperimentalStaticTime:
+        title: ExperimentalStaticTime
+        description: Ledger is in the static time mode and exposes a time service.
+        type: object
+        required:
+        - supported
+        properties:
+          supported:
+            description: Required
+            type: boolean
+      FeaturesDescriptor:
+        title: FeaturesDescriptor
+        type: object
+        required:
+        - experimental
+        - userManagement
+        - partyManagement
+        - offsetCheckpoint
+        - packageFeature
+        properties:
+          experimental:
+            $ref: '#/components/schemas/ExperimentalFeatures'
+            description: |-
+              Features under development or features that are used
+              for ledger implementation testing purposes only.
+
+              Daml applications SHOULD not depend on these in production.
+
+              Required
+          userManagement:
+            $ref: '#/components/schemas/UserManagementFeature'
+            description: |-
+              If set, then the Ledger API server supports user management.
+              It is recommended that clients query this field to gracefully adjust their behavior for
+              ledgers that do not support user management.
+
+              Required
+          partyManagement:
+            $ref: '#/components/schemas/PartyManagementFeature'
+            description: |-
+              If set, then the Ledger API server supports party management configurability.
+              It is recommended that clients query this field to gracefully adjust their behavior to
+              maximum party page size.
+
+              Required
+          offsetCheckpoint:
+            $ref: '#/components/schemas/OffsetCheckpointFeature'
+            description: |-
+              It contains the timeouts related to the periodic offset checkpoint emission
+
+              Required
+          packageFeature:
+            $ref: '#/components/schemas/PackageFeature'
+            description: |-
+              If set, then the Ledger API server supports package listing
+              configurability. It is recommended that clients query this field to
+              gracefully adjust their behavior to maximum package listing page size.
+
+              Required
+      Field:
+        title: Field
+        type: object
+        properties:
+          varint:
+            type: array
+            items:
+              type: integer
+              format: int64
+          fixed64:
+            type: array
+            items:
+              type: integer
+              format: int64
+          fixed32:
+            type: array
+            items:
+              type: integer
+              format: int32
+          lengthDelimited:
+            type: array
+            items:
+              type: string
+      FieldMask:
+        title: FieldMask
+        type: object
+        required:
+        - unknownFields
+        properties:
+          paths:
+            type: array
+            items:
+              type: string
+          unknownFields:
+            $ref: '#/components/schemas/UnknownFieldSet'
+      Filters:
+        title: Filters
+        description: The union of a set of template filters, interface filters, or a
+          wildcard.
+        type: object
+        properties:
+          cumulative:
+            description: |-
+              Every filter in the cumulative list expands the scope of the resulting stream. Each interface,
+              template or wildcard filter means additional events that will match the query.
+              The impact of include_interface_view and include_created_event_blob fields in the filters will
+              also be accumulated.
+              A template or an interface SHOULD NOT appear twice in the accumulative field.
+              A wildcard filter SHOULD NOT be defined more than once in the accumulative field.
+              If no ``CumulativeFilter`` defined, the default of a single ``WildcardFilter`` with
+              include_created_event_blob unset is used.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/CumulativeFilter'
+      GenerateExternalPartyTopologyRequest:
+        title: GenerateExternalPartyTopologyRequest
+        type: object
+        required:
+        - synchronizer
+        - partyHint
+        - publicKey
+        properties:
+          synchronizer:
+            description: |-
+              Synchronizer-id for which we are building this request.
+              TODO(#27670) support synchronizer aliases
+
+              Required
+            type: string
+          partyHint:
+            description: |-
+              The actual party id will be constructed from this hint and a fingerprint of the public key
+
+              Required
+            type: string
+          publicKey:
+            $ref: '#/components/schemas/SigningPublicKey'
+            description: |-
+              Public key
+
+              Required
+          localParticipantObservationOnly:
+            description: |-
+              If true, then the local participant will only be observing, not confirming. Default false.
+
+              Optional
+            type: boolean
+          otherConfirmingParticipantUids:
+            description: |-
+              Other participant ids which should be confirming for this party
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          confirmationThreshold:
+            description: |-
+              Confirmation threshold >= 1 for the party. Defaults to all available confirmers (or if set to 0).
+
+              Optional
+            type: integer
+            format: int32
+          observingParticipantUids:
+            description: |-
+              Other observing participant ids for this party
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      GenerateExternalPartyTopologyResponse:
+        title: GenerateExternalPartyTopologyResponse
+        description: Response message with topology transactions and the multi-hash
+          to be signed.
+        type: object
+        required:
+        - partyId
+        - publicKeyFingerprint
+        - multiHash
+        - topologyTransactions
+        properties:
+          partyId:
+            description: |-
+              The generated party id
+
+              Required
+            type: string
+          publicKeyFingerprint:
+            description: |-
+              The fingerprint of the supplied public key
+
+              Required
+            type: string
+          topologyTransactions:
+            description: |-
+              The serialized topology transactions which need to be signed and submitted as part of the allocate party process
+              Note that the serialization includes the versioning information. Therefore, the transaction here is serialized
+              as an `UntypedVersionedMessage` which in turn contains the serialized `TopologyTransaction` in the version
+              supported by the synchronizer.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          multiHash:
+            description: |-
+              the multi-hash which may be signed instead of each individual transaction
+
+              Required: must be non-empty
+            type: string
+      GetActiveContractsRequest:
+        title: GetActiveContractsRequest
+        description: |-
+          If the given offset is different than the ledger end, and there are (un)assignments in-flight at the given offset,
+          the snapshot may fail with "FAILED_PRECONDITION/PARTICIPANT_PRUNED_DATA_ACCESSED".
+          Note that it is ok to request acs snapshots for party migration with offsets other than ledger end, because party
+          migration is not concerned with incomplete (un)assignments.
+        type: object
+        required:
+        - activeAtOffset
+        properties:
+          filter:
+            $ref: '#/components/schemas/TransactionFilter'
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              Templates to include in the served snapshot, per party.
+              Optional, if specified event_format must be unset, if not specified event_format must be set.
+          verbose:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
+              In particular, setting the verbose flag to true triggers the ledger to include labels for record fields.
+              Optional, if specified event_format must be unset.
+            type: boolean
+          activeAtOffset:
+            description: |-
+              The offset at which the snapshot of the active contracts will be computed.
+              Must be no greater than the current ledger end offset.
+              Must be greater than or equal to the last pruning offset.
+              Must be a valid absolute offset (positive integer) or ledger begin offset (zero).
+              If zero, the empty set will be returned.
+
+              Required
+            type: integer
+            format: int64
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              Format of the contract_entries in the result. In case of CreatedEvent the presentation will be of
+              TRANSACTION_SHAPE_ACS_DELTA.
+              Optional for backwards compatibility, defaults to an EventFormat where:
+
+              - filters_by_party is the filter.filters_by_party from this request
+              - filters_for_any_party is the filter.filters_for_any_party from this request
+              - verbose is the verbose field from this request
+          streamContinuationToken:
+            description: |-
+              Opaque representation of a continuation token defining a position in the active contracts snapshot.
+              The prefix of the active contracts snapshot will be omitted up to and including the element from which
+              the continuation token was read.
+              To reuse the continuation token from a `GetActiveContractsPageResponse`:
+
+              - subsequent request must be executed on the same participant with the same version of canton,
+              - subsequent request must have the same active_at_offset,
+              - subsequent request must have the same event_format
+              - and the participant must not have been pruned after the active_at_offset.
+
+              If not specified, the whole active contracts snapshot will be returned.
+
+              Optional: can be empty
+            type: string
+      GetConnectedSynchronizersResponse:
+        title: GetConnectedSynchronizersResponse
+        type: object
+        properties:
+          connectedSynchronizers:
+            description: 'Optional: can be empty'
+            type: array
+            items:
+              $ref: '#/components/schemas/ConnectedSynchronizer'
+      GetContractRequest:
+        title: GetContractRequest
+        type: object
+        required:
+        - contractId
+        properties:
+          contractId:
+            description: |-
+              The ID of the contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          queryingParties:
+            description: |-
+              The list of querying parties
+              The stakeholders of the referenced contract must have an intersection with any of these parties
+              to return the result.
+              If no querying_parties specified, all possible contracts could be returned.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      GetContractResponse:
+        title: GetContractResponse
+        type: object
+        required:
+        - createdEvent
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The representative_package_id will be always set to the contract package ID, therefore this endpoint should
+              not be used to lookup contract which entered the participant via party replication or repair service.
+              The witnesses field will contain only the querying_parties which are also stakeholders of the contract as well.
+              The following fields of the created event cannot be populated, so those should not be used / parsed:
+
+              - offset
+              - node_id
+              - created_event_blob
+              - interface_views
+              - acs_delta
+
+              Required
+      GetEventsByContractIdRequest:
+        title: GetEventsByContractIdRequest
+        type: object
+        required:
+        - contractId
+        - eventFormat
+        properties:
+          contractId:
+            description: |-
+              The contract id being queried.
+
+              Required
+            type: string
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              Format of the events in the result, the presentation will be of TRANSACTION_SHAPE_ACS_DELTA.
+
+              Required
+      GetIdentityProviderConfigResponse:
+        title: GetIdentityProviderConfigResponse
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: Required
+      GetLatestPrunedOffsetsResponse:
+        title: GetLatestPrunedOffsetsResponse
+        type: object
+        properties:
+          participantPrunedUpToInclusive:
+            description: |-
+              It will always be a non-negative integer.
+              If positive, the absolute offset up to which the ledger has been pruned,
+              disregarding the state of all divulged contracts pruning.
+              If zero, the ledger has not been pruned yet.
+
+              Optional
+            type: integer
+            format: int64
+          allDivulgedContractsPrunedUpToInclusive:
+            description: |-
+              It will always be a non-negative integer.
+              If positive, the absolute offset up to which all divulged events have been pruned on the ledger.
+              It can be at or before the ``participant_pruned_up_to_inclusive`` offset.
+              For more details about all divulged events pruning,
+              see ``PruneRequest.prune_all_divulged_contracts`` in ``participant_pruning_service.proto``.
+              If zero, the divulged events have not been pruned yet.
+
+              Optional
+            type: integer
+            format: int64
+      GetLedgerApiVersionResponse:
+        title: GetLedgerApiVersionResponse
+        type: object
+        required:
+        - version
+        - features
+        properties:
+          version:
+            description: |-
+              The version of the ledger API.
+
+              Required
+            type: string
+          features:
+            $ref: '#/components/schemas/FeaturesDescriptor'
+            description: |-
+              The features supported by this Ledger API endpoint.
+
+              Daml applications CAN use the feature descriptor on top of
+              version constraints on the Ledger API version to determine
+              whether a given Ledger API endpoint supports the features
+              required to run the application.
+
+              See the feature descriptions themselves for the relation between
+              Ledger API versions and feature presence.
+
+              Required
+      GetLedgerEndResponse:
+        title: GetLedgerEndResponse
+        type: object
+        properties:
+          offset:
+            description: |-
+              It will always be a non-negative integer.
+              If zero, the participant view of the ledger is empty.
+              If positive, the absolute offset of the ledger as viewed by the participant.
+
+              Optional
+            type: integer
+            format: int64
+      GetPackageStatusResponse:
+        title: GetPackageStatusResponse
+        type: object
+        required:
+        - packageStatus
+        properties:
+          packageStatus:
+            description: |-
+              The status of the package.
+
+              Required
+            type: string
+            enum:
+            - PACKAGE_STATUS_UNSPECIFIED
+            - PACKAGE_STATUS_REGISTERED
+      GetParticipantIdResponse:
+        title: GetParticipantIdResponse
+        type: object
+        required:
+        - participantId
+        properties:
+          participantId:
+            description: |-
+              Identifier of the participant, which SHOULD be globally unique.
+              Must be a valid LedgerString (as describe in ``value.proto``).
+
+              Required
+            type: string
+      GetPartiesResponse:
+        title: GetPartiesResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
+            description: |-
+              The details of the requested Daml parties by the participant, if known.
+              The party details may not be in the same order as requested.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PartyDetails'
+      GetPreferredPackageVersionResponse:
+        title: GetPreferredPackageVersionResponse
+        type: object
+        properties:
+          packagePreference:
+            $ref: '#/components/schemas/PackagePreference'
+            description: |-
+              Not populated when no preferred package is found
+
+              Optional
+      GetPreferredPackagesRequest:
+        title: GetPreferredPackagesRequest
+        type: object
+        required:
+        - packageVettingRequirements
+        properties:
+          packageVettingRequirements:
+            description: |-
+              The package-name vetting requirements for which the preferred packages should be resolved.
+
+              Generally it is enough to provide the requirements for the intended command's root package-names.
+              Additional package-name requirements can be provided when additional Daml transaction informees need to use
+              package dependencies of the command's root packages.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PackageVettingRequirement'
+          synchronizerId:
+            description: |-
+              The synchronizer whose vetting state should be used for resolving this query.
+              If not specified, the vetting states of all synchronizers to which the participant is connected are used.
+
+              Optional
+            type: string
+          vettingValidAt:
+            description: |-
+              The timestamp at which the package vetting validity should be computed
+              on the latest topology snapshot as seen by the participant.
+              If not provided, the participant's current clock time is used.
+
+              Optional
+            type: string
+      GetPreferredPackagesResponse:
+        title: GetPreferredPackagesResponse
+        type: object
+        required:
+        - synchronizerId
+        - packageReferences
+        properties:
+          packageReferences:
+            description: |-
+              The package references of the preferred packages.
+              Must contain one package reference for each requested package-name.
+
+              If you build command submissions whose content depends on the returned
+              preferred packages, then we recommend submitting the preferred package-ids
+              in the ``package_id_selection_preference`` of the command submission to
+              avoid race conditions with concurrent changes of the on-ledger package vetting state.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PackageReference'
+          synchronizerId:
+            description: |-
+              The synchronizer for which the package preferences are computed.
+              If the synchronizer_id was specified in the request, then it matches the request synchronizer_id.
+
+              Required
+            type: string
+      GetTransactionByIdRequest:
+        title: GetTransactionByIdRequest
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - updateId
+        properties:
+          updateId:
+            description: |-
+              The ID of a particular transaction.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Required
+            type: string
+          requestingParties:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              The parties whose events the client expects to see.
+              Events that are not visible for the parties in this collection will not be present in the response.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+              Optional for backwards compatibility for GetTransactionById request: if defined transaction_format must be
+              unset (falling back to defaults).
+            type: array
+            items:
+              type: string
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              Optional for GetTransactionById request for backwards compatibility: defaults to a transaction_format, where:
+
+              - event_format.filters_by_party will have template-wildcard filters for all the requesting_parties
+              - event_format.filters_for_any_party is unset
+              - event_format.verbose = true
+              - transaction_shape = TRANSACTION_SHAPE_ACS_DELTA
+      GetTransactionByOffsetRequest:
+        title: GetTransactionByOffsetRequest
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - offset
+        properties:
+          offset:
+            description: |-
+              The offset of the transaction being looked up.
+              Must be a valid absolute offset (positive integer).
+              Required
+            type: integer
+            format: int64
+          requestingParties:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              The parties whose events the client expects to see.
+              Events that are not visible for the parties in this collection will not be present in the response.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+              Optional for backwards compatibility for GetTransactionByOffset request: if defined transaction_format must be
+              unset (falling back to defaults).
+            type: array
+            items:
+              type: string
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              Optional for GetTransactionByOffset request for backwards compatibility: defaults to a TransactionFormat, where:
+
+              - event_format.filters_by_party will have template-wildcard filters for all the requesting_parties
+              - event_format.filters_for_any_party is unset
+              - event_format.verbose = true
+              - transaction_shape = TRANSACTION_SHAPE_ACS_DELTA
+      GetUpdateByIdRequest:
+        title: GetUpdateByIdRequest
+        type: object
+        required:
+        - updateId
+        - updateFormat
+        properties:
+          updateId:
+            description: |-
+              The ID of a particular update.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          updateFormat:
+            $ref: '#/components/schemas/UpdateFormat'
+            description: |-
+              The format for the update.
+
+              Required
+      GetUpdateByOffsetRequest:
+        title: GetUpdateByOffsetRequest
+        type: object
+        required:
+        - offset
+        - updateFormat
+        properties:
+          offset:
+            description: |-
+              The offset of the update being looked up.
+              Must be a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          updateFormat:
+            $ref: '#/components/schemas/UpdateFormat'
+            description: |-
+              The format for the update.
+
+              Required
+      GetUpdatesRequest:
+        title: GetUpdatesRequest
+        type: object
+        properties:
+          beginExclusive:
+            description: |-
+              Beginning of the requested ledger section (non-negative integer).
+              The response will only contain transactions whose offset is strictly greater than this.
+              If not populated or set to zero, the stream will start from the beginning of the ledger.
+              If positive, the streaming will start after this absolute offset.
+              If the ledger has been pruned, this parameter must be specified and be greater than the pruning offset.
+
+              Optional
+            type: integer
+            format: int64
+          endInclusive:
+            description: |-
+              End of the requested ledger section.
+              The response will only contain transactions whose offset is less than or equal to this.
+              If empty, the stream will not terminate.
+              If specified, the stream will terminate after this absolute offset (positive integer) is reached.
+
+              Optional
+            type: integer
+            format: int64
+          filter:
+            $ref: '#/components/schemas/TransactionFilter'
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              Requesting parties with template filters.
+              Template filters must be empty for GetUpdateTrees requests.
+              Optional for backwards compatibility, if defined update_format must be unset
+          verbose:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
+              In particular, setting the verbose flag to true triggers the ledger to include labels, record and variant type ids
+              for record fields.
+              Optional for backwards compatibility, if defined update_format must be unset
+            type: boolean
+          updateFormat:
+            $ref: '#/components/schemas/UpdateFormat'
+            description: |-
+              Must be unset for GetUpdateTrees request.
+              Optional for backwards compatibility for GetUpdates request: defaults to an UpdateFormat where:
+
+              - include_transactions.event_format.filters_by_party = the filter.filters_by_party on this request
+              - include_transactions.event_format.filters_for_any_party = the filter.filters_for_any_party on this request
+              - include_transactions.event_format.verbose = the same flag specified on this request
+              - include_transactions.transaction_shape = TRANSACTION_SHAPE_ACS_DELTA
+              - include_reassignments.filter = the same filter specified on this request
+              - include_reassignments.verbose = the same flag specified on this request
+              - include_topology_events.include_participant_authorization_events.parties = all the parties specified in filter
+      GetUserResponse:
+        title: GetUserResponse
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              Retrieved user.
+
+              Required
+      GrantUserRightsRequest:
+        title: GrantUserRightsRequest
+        description: |-
+          Add the rights to the set of rights granted to the user.
+
+          Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id)``
+        type: object
+        required:
+        - userId
+        properties:
+          userId:
+            description: |-
+              The user to whom to grant rights.
+
+              Required
+            type: string
+          rights:
+            description: |-
+              The rights to grant.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the user is managed by the default identity provider.
+
+              Optional
+            type: string
+      GrantUserRightsResponse:
+        title: GrantUserRightsResponse
+        type: object
+        properties:
+          newlyGrantedRights:
+            description: |-
+              The rights that were newly granted by the request.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      IdentifierFilter:
+        title: IdentifierFilter
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty1'
+        - type: object
+          required:
+          - InterfaceFilter
+          properties:
+            InterfaceFilter:
+              $ref: '#/components/schemas/InterfaceFilter'
+        - type: object
+          required:
+          - TemplateFilter
+          properties:
+            TemplateFilter:
+              $ref: '#/components/schemas/TemplateFilter'
+        - type: object
+          required:
+          - WildcardFilter
+          properties:
+            WildcardFilter:
+              $ref: '#/components/schemas/WildcardFilter'
+      IdentityProviderAdmin:
+        title: IdentityProviderAdmin
+        description: |-
+          The right to administer the identity provider that the user is assigned to.
+          It means, being able to manage users and parties that are also assigned
+          to the same identity provider.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/IdentityProviderAdmin1'
+      IdentityProviderAdmin1:
+        title: IdentityProviderAdmin
+        description: |-
+          The right to administer the identity provider that the user is assigned to.
+          It means, being able to manage users and parties that are also assigned
+          to the same identity provider.
+        type: object
+      IdentityProviderConfig:
+        title: IdentityProviderConfig
+        type: object
+        required:
+        - identityProviderId
+        - issuer
+        - jwksUrl
+        properties:
+          identityProviderId:
+            description: |-
+              The identity provider identifier
+              Must be a valid LedgerString (as describe in ``value.proto``).
+
+              Required
+            type: string
+          isDeactivated:
+            description: |-
+              When set, the callers using JWT tokens issued by this identity provider are denied all access
+              to the Ledger API.
+              Modifiable
+
+              Optional
+            type: boolean
+          issuer:
+            description: |-
+              Specifies the issuer of the JWT token.
+              The issuer value is a case sensitive URL using the https scheme that contains scheme, host,
+              and optionally, port number and path components and no query or fragment components.
+              Modifiable
+
+              Can be left empty when used in `UpdateIdentityProviderConfigRequest` if the issuer is not being updated.
+
+              Required
+            type: string
+          jwksUrl:
+            description: |-
+              The JWKS (JSON Web Key Set) URL.
+              The Ledger API uses JWKs (JSON Web Keys) from the provided URL to verify that the JWT has been
+              signed with the loaded JWK. Only RS256 (RSA Signature with SHA-256) signing algorithm is supported.
+              Modifiable
+
+              Required
+            type: string
+          audience:
+            description: |-
+              Specifies the audience of the JWT token.
+              When set, the callers using JWT tokens issued by this identity provider are allowed to get an access
+              only if the "aud" claim includes the string specified here
+              Modifiable
+
+              Optional
+            type: string
+      InterfaceFilter:
+        title: InterfaceFilter
+        description: This filter matches contracts that implement a specific interface.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/InterfaceFilter1'
+      InterfaceFilter1:
+        title: InterfaceFilter
+        description: This filter matches contracts that implement a specific interface.
+        type: object
+        required:
+        - interfaceId
+        properties:
+          interfaceId:
+            description: |-
+              The interface that a matching contract must implement.
+              The ``interface_id`` needs to be valid: corresponding interface should be defined in
+              one of the available packages at the time of the query.
+              Both package-name and package-id reference formats for the identifier are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          includeInterfaceView:
+            description: |-
+              Whether to include the interface view on the contract in the returned ``CreatedEvent``.
+              Use this to access contract data in a uniform manner in your API client.
+
+              Optional
+            type: boolean
+          includeCreatedEventBlob:
+            description: |-
+              Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
+              Use this to access the contract create event payload in your API client
+              for submitting it as a disclosed contract with future commands.
+
+              Optional
+            type: boolean
+      JsActiveContract:
+        title: JsActiveContract
+        type: object
+        required:
+        - createdEvent
+        - synchronizerId
+        - reassignmentCounter
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The event as it appeared in the context of its last update (i.e. daml transaction or
+              reassignment). In particular, the last offset, node_id pair is preserved.
+              The last update is the most recent update created or assigned this contract on synchronizer_id synchronizer.
+              The offset of the CreatedEvent might point to an already pruned update, therefore it cannot necessarily be used
+              for lookups.
+
+              Required
+          synchronizerId:
+            description: |-
+              A valid synchronizer id
+
+              Required
+            type: string
+          reassignmentCounter:
+            description: |-
+              Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
+              with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
+              equals zero.
+              This field will be the reassignment_counter of the latest observable activation event on this synchronizer, which is
+              before the active_at_offset.
+
+              Required
+            type: integer
+            format: int64
+      JsArchived:
+        title: JsArchived
+        type: object
+        required:
+        - archivedEvent
+        - synchronizerId
+        properties:
+          archivedEvent:
+            $ref: '#/components/schemas/ArchivedEvent'
+            description: Required
+          synchronizerId:
+            description: |-
+              The synchronizer which sequenced the archival of the contract
+
+              Required
+            type: string
+      JsAssignedEvent:
+        title: JsAssignedEvent
+        description: Records that a contract has been assigned, and it can be used on
+          the target synchronizer.
+        type: object
+        required:
+        - source
+        - target
+        - reassignmentId
+        - reassignmentCounter
+        - createdEvent
+        properties:
+          source:
+            description: |-
+              The ID of the source synchronizer.
+              Must be a valid synchronizer id.
+
+              Required
+            type: string
+          target:
+            description: |-
+              The ID of the target synchronizer.
+              Must be a valid synchronizer id.
+
+              Required
+            type: string
+          reassignmentId:
+            description: |-
+              The ID from the unassigned event.
+              For correlation capabilities.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          submitter:
+            description: |-
+              Party on whose behalf the assign command was executed.
+              Empty if the assignment happened offline via the repair service.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          reassignmentCounter:
+            description: |-
+              Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
+              with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
+              equals zero.
+
+              Required
+            type: integer
+            format: int64
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The offset of this event refers to the offset of the assignment,
+              while the node_id is the index of within the batch.
+
+              Required
+      JsAssignmentEvent:
+        title: JsAssignmentEvent
+        type: object
+        required:
+        - source
+        - target
+        - reassignmentId
+        - submitter
+        - reassignmentCounter
+        - createdEvent
+        properties:
+          source:
+            type: string
+          target:
+            type: string
+          reassignmentId:
+            type: string
+          submitter:
+            type: string
+          reassignmentCounter:
+            type: integer
+            format: int64
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+      JsCantonError:
+        title: JsCantonError
+        type: object
+        required:
+        - code
+        - cause
+        - context
+        - errorCategory
+        properties:
+          code:
+            type: string
+          cause:
+            type: string
+          correlationId:
+            type: string
+          traceId:
+            type: string
+          context:
+            $ref: '#/components/schemas/Map_String'
+          resources:
+            type: array
+            items:
+              $ref: '#/components/schemas/Tuple2_String_String'
+          errorCategory:
+            type: integer
+            format: int32
+          grpcCodeValue:
+            type: integer
+            format: int32
+          retryInfo:
+            type: string
+          definiteAnswer:
+            type: boolean
+      JsCommands:
+        title: JsCommands
+        description: A composite command that groups multiple commands together.
+        type: object
+        required:
+        - commandId
+        - commands
+        - actAs
+        properties:
+          commands:
+            description: |-
+              Individual elements of this atomic command. Must be non-empty.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Command'
+          commandId:
+            description: |-
+              Uniquely identifies the command.
+              The triple (user_id, act_as, command_id) constitutes the change ID for the intended ledger change,
+              where act_as is interpreted as a set of party names.
+              The change ID can be used for matching the intended ledger changes with all their completions.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          actAs:
+            description: |-
+              Set of parties on whose behalf the command should be executed.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to act on behalf of each of the given parties.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          userId:
+            description: |-
+              Uniquely identifies the participant user that issued the command.
+              Must be a valid UserIdString (as described in ``value.proto``).
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
+
+              Optional
+            type: string
+          readAs:
+            description: |-
+              Set of parties on whose behalf (in addition to all parties listed in ``act_as``) contracts can be retrieved.
+              This affects Daml operations such as ``fetch``, ``fetchByKey``, ``lookupByKey``, ``exercise``, and ``exerciseByKey``.
+              Note: A participant node of a Daml network can host multiple parties. Each contract present on the participant
+              node is only visible to a subset of these parties. A command can only use contracts that are visible to at least
+              one of the parties in ``act_as`` or ``read_as``. This visibility check is independent from the Daml authorization
+              rules for fetch operations.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to read contract data on behalf of each of the given parties.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          workflowId:
+            description: |-
+              Identifier of the on-ledger workflow that this command is a part of.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod'
+          minLedgerTimeAbs:
+            description: |-
+              Lower bound for the ledger time assigned to the resulting transaction.
+              Note: The ledger time of a transaction is assigned as part of command interpretation.
+              Use this property if you expect that command interpretation will take a considerate amount of time, such that by
+              the time the resulting transaction is sequenced, its assigned ledger time is not valid anymore.
+              Must not be set at the same time as min_ledger_time_rel.
+
+              Optional
+            type: string
+          minLedgerTimeRel:
+            $ref: '#/components/schemas/Duration'
+            description: |-
+              Same as min_ledger_time_abs, but specified as a duration, starting from the time the command is received by the server.
+              Must not be set at the same time as min_ledger_time_abs.
+
+              Optional
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              If omitted, the participant or the committer may set a value of their choice.
+
+              Optional
+            type: string
+          disclosedContracts:
+            description: |-
+              Additional contracts used to resolve contract & contract key lookups.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/DisclosedContract'
+          synchronizerId:
+            description: |-
+              Must be a valid synchronizer id
+
+              Optional
+            type: string
+          packageIdSelectionPreference:
+            description: |-
+              The package-id selection preference of the client for resolving
+              package names and interface instances in command submission and interpretation
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          prefetchContractKeys:
+            description: |-
+              Fetches the contract keys into the caches to speed up the command processing.
+              Should only contain contract keys that are expected to be resolved during interpretation of the commands.
+              Keys of disclosed contracts do not need prefetching.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PrefetchContractKey'
+          tapsMaxPasses:
+            description: |-
+              The maximum number of passes for the Topology-Aware Package Selection (TAPS).
+              Higher values can increase the chance of successful package selection for routing of interpreted transactions.
+              If unset, this defaults to the value defined in the participant configuration.
+              The provided value must not exceed the limit specified in the participant configuration.
+
+              Optional
+            type: integer
+            format: int32
+      JsContractEntry:
+        title: JsContractEntry
+        description: |-
+          For a contract there could be multiple contract_entry-s in the entire snapshot. These together define
+          the state of one contract in the snapshot.
+          A contract_entry is included in the result, if and only if there is at least one stakeholder party of the contract
+          that is hosted on the synchronizer at the time of the event and the party satisfies the
+          ``TransactionFilter`` in the query.
+
+          Required
+        oneOf:
+        - type: object
+          required:
+          - JsActiveContract
+          properties:
+            JsActiveContract:
+              $ref: '#/components/schemas/JsActiveContract'
+        - type: object
+          required:
+          - JsEmpty
+          properties:
+            JsEmpty:
+              $ref: '#/components/schemas/JsEmpty'
+        - type: object
+          required:
+          - JsIncompleteAssigned
+          properties:
+            JsIncompleteAssigned:
+              $ref: '#/components/schemas/JsIncompleteAssigned'
+        - type: object
+          required:
+          - JsIncompleteUnassigned
+          properties:
+            JsIncompleteUnassigned:
+              $ref: '#/components/schemas/JsIncompleteUnassigned'
+      JsCreated:
+        title: JsCreated
+        type: object
+        required:
+        - createdEvent
+        - synchronizerId
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The event as it appeared in the context of its original update (i.e. daml transaction or
+              reassignment) on this participant node. You can use its offset and node_id to find the
+              corresponding update and the node within it.
+
+              Required
+          synchronizerId:
+            description: |-
+              The synchronizer which sequenced the creation of the contract
+
+              Required
+            type: string
+      JsEmpty:
+        title: JsEmpty
+        type: object
+      JsExecuteSubmissionAndWaitForTransactionRequest:
+        title: JsExecuteSubmissionAndWaitForTransactionRequest
+        type: object
+        required:
+        - preparedTransaction
+        - partySignatures
+        - submissionId
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              the prepared transaction
+              Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
+              obtained from calling `prepareSubmission`.
+
+              Required
+            type: string
+          partySignatures:
+            $ref: '#/components/schemas/PartySignatures'
+            description: |-
+              The party(ies) signatures that authorize the prepared submission to be executed by this node.
+              Each party can provide one or more signatures..
+              and one or more parties can sign.
+              Note that currently, only single party submissions are supported.
+
+              Required
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod2'
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          userId:
+            description: |-
+              See [PrepareSubmissionRequest.user_id]
+
+              Optional
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+            - HASHING_SCHEME_VERSION_V3
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: |-
+              If set will influence the chosen ledger effective time but will not result in a submission delay so any override
+              should be scheduled to executed within the window allowed by synchronizer.
+
+              Optional
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              If no ``transaction_format`` is provided, a default will be used where ``transaction_shape`` is set to
+              TRANSACTION_SHAPE_ACS_DELTA, ``event_format`` is defined with ``filters_by_party`` containing wildcard-template
+              filter for all original ``act_as`` and ``read_as`` parties and the ``verbose`` flag is set.
+              When the ``transaction_shape`` TRANSACTION_SHAPE_ACS_DELTA shape is used (explicitly or is defaulted to as explained above),
+              events will only be returned if the submitting party is hosted on this node.
+
+              Optional
+      JsExecuteSubmissionAndWaitForTransactionResponse:
+        title: JsExecuteSubmissionAndWaitForTransactionResponse
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransaction'
+            description: |-
+              The transaction that resulted from the submitted command.
+              The transaction might contain no events (request conditions result in filtering out all of them).
+
+              Required
+      JsExecuteSubmissionAndWaitRequest:
+        title: JsExecuteSubmissionAndWaitRequest
+        type: object
+        required:
+        - preparedTransaction
+        - partySignatures
+        - submissionId
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              the prepared transaction
+              Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
+              obtained from calling `prepareSubmission`.
+
+              Required
+            type: string
+          partySignatures:
+            $ref: '#/components/schemas/PartySignatures'
+            description: |-
+              The party(ies) signatures that authorize the prepared submission to be executed by this node.
+              Each party can provide one or more signatures..
+              and one or more parties can sign.
+              Note that currently, only single party submissions are supported.
+
+              Required
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod2'
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          userId:
+            description: |-
+              See [PrepareSubmissionRequest.user_id]
+
+              Optional
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+            - HASHING_SCHEME_VERSION_V3
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: |-
+              If set will influence the chosen ledger effective time but will not result in a submission delay so any override
+              should be scheduled to executed within the window allowed by synchronizer.
+
+              Optional
+      JsExecuteSubmissionRequest:
+        title: JsExecuteSubmissionRequest
+        type: object
+        required:
+        - preparedTransaction
+        - partySignatures
+        - submissionId
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              the prepared transaction
+              Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
+              obtained from calling `prepareSubmission`.
+
+              Required
+            type: string
+          partySignatures:
+            $ref: '#/components/schemas/PartySignatures'
+            description: |-
+              The party(ies) signatures that authorize the prepared submission to be executed by this node.
+              Each party can provide one or more signatures..
+              and one or more parties can sign.
+              Note that currently, only single party submissions are supported.
+
+              Required
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod2'
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          userId:
+            description: |-
+              See [PrepareSubmissionRequest.user_id]
+
+              Optional
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+            - HASHING_SCHEME_VERSION_V3
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: |-
+              If set will influence the chosen ledger effective time but will not result in a submission delay so any override
+              should be scheduled to executed within the window allowed by synchronizer.
+
+              Optional
+      JsGetActiveContractsResponse:
+        title: JsGetActiveContractsResponse
+        type: object
+        properties:
+          workflowId:
+            description: |-
+              The workflow ID used in command submission which corresponds to the contract_entry. Only set if
+              the ``workflow_id`` for the command was set.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          contractEntry:
+            $ref: '#/components/schemas/JsContractEntry'
+          streamContinuationToken:
+            description: |-
+              Opaque representation of a continuation token which can be used in the request to bypass the already processed part
+              of the active contracts snapshot.
+              Only populated for the streaming ``GetActiveContracts`` rpc call.
+
+              Optional: can be empty
+            type: string
+      JsGetEventsByContractIdResponse:
+        title: JsGetEventsByContractIdResponse
+        type: object
+        properties:
+          created:
+            $ref: '#/components/schemas/JsCreated'
+            description: |-
+              The create event for the contract with the ``contract_id`` given in the request
+              provided it exists and has not yet been pruned.
+
+              Optional
+          archived:
+            $ref: '#/components/schemas/JsArchived'
+            description: |-
+              The archive event for the contract with the ``contract_id`` given in the request
+              provided such an archive event exists and it has not yet been pruned.
+
+              Optional
+      JsGetTransactionResponse:
+        title: JsGetTransactionResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransaction'
+            description: Required
+      JsGetTransactionTreeResponse:
+        title: JsGetTransactionTreeResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransactionTree'
+            description: Required
+      JsGetUpdateResponse:
+        title: JsGetUpdateResponse
+        type: object
+        properties:
+          update:
+            $ref: '#/components/schemas/Update'
+      JsGetUpdateTreesResponse:
+        title: JsGetUpdateTreesResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        properties:
+          update:
+            $ref: '#/components/schemas/Update1'
+      JsGetUpdatesResponse:
+        title: JsGetUpdatesResponse
+        type: object
+        properties:
+          update:
+            $ref: '#/components/schemas/Update'
+      JsIncompleteAssigned:
+        title: JsIncompleteAssigned
+        type: object
+        required:
+        - assignedEvent
+        properties:
+          assignedEvent:
+            $ref: '#/components/schemas/JsAssignedEvent'
+            description: Required
+      JsIncompleteUnassigned:
+        title: JsIncompleteUnassigned
+        type: object
+        required:
+        - createdEvent
+        - unassignedEvent
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The event as it appeared in the context of its last activation update (i.e. daml transaction or
+              reassignment). In particular, the last activation offset, node_id pair is preserved.
+              The last activation update is the most recent update created or assigned this contract on synchronizer_id synchronizer before
+              the unassigned_event.
+              The offset of the CreatedEvent might point to an already pruned update, therefore it cannot necessarily be used
+              for lookups.
+
+              Required
+          unassignedEvent:
+            $ref: '#/components/schemas/UnassignedEvent'
+            description: Required
+      JsInterfaceView:
+        title: JsInterfaceView
+        description: View of a create event matched by an interface filter.
+        type: object
+        required:
+        - interfaceId
+        - viewStatus
+        properties:
+          interfaceId:
+            description: |-
+              The interface implemented by the matched event.
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          viewStatus:
+            $ref: '#/components/schemas/JsStatus'
+            description: |-
+              Whether the view was successfully computed, and if not,
+              the reason for the error. The error is reported using the same rules
+              for error codes and messages as the errors returned for API requests.
+
+              Required
+          viewValue:
+            description: |-
+              The value of the interface's view method on this event.
+              Set if it was requested in the ``InterfaceFilter`` and it could be
+              successfully computed.
+
+              Optional
+          implementationPackageId:
+            description: |-
+              The package defining the interface implementation used to compute the view.
+              Can be different from the package that was used to create the contract itself,
+              as the contract arguments can be upgraded or downgraded using smart-contract upgrading
+              as part of computing the interface view.
+              Populated if the view computation is successful, otherwise empty.
+
+              Optional
+            type: string
+      JsPrepareSubmissionRequest:
+        title: JsPrepareSubmissionRequest
+        type: object
+        required:
+        - commandId
+        - commands
+        - actAs
+        properties:
+          userId:
+            description: |-
+              Uniquely identifies the participant user that prepares the transaction.
+              Must be a valid UserIdString (as described in ``value.proto``).
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
+
+              Optional
+            type: string
+          commandId:
+            description: |-
+              Uniquely identifies the command.
+              The triple (user_id, act_as, command_id) constitutes the change ID for the intended ledger change,
+              where act_as is interpreted as a set of party names.
+              The change ID can be used for matching the intended ledger changes with all their completions.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          commands:
+            description: |-
+              Individual elements of this atomic command. Must be non-empty.
+              Limitation: Only single command transaction are currently supported by the API.
+              The field is marked as repeated in preparation for future support of multiple commands.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Command'
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: Optional
+          actAs:
+            description: |-
+              Set of parties on whose behalf the command should be executed, if submitted.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to **read** (not act) on behalf of each of the given parties. This is because this RPC merely prepares a transaction
+              and does not execute it. Therefore read authorization is sufficient even for actAs parties.
+              Note: This may change, and more specific authorization scope may be introduced in the future.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          readAs:
+            description: |-
+              Set of parties on whose behalf (in addition to all parties listed in ``act_as``) contracts can be retrieved.
+              This affects Daml operations such as ``fetch``, ``fetchByKey``, ``lookupByKey``, ``exercise``, and ``exerciseByKey``.
+              Note: A command can only use contracts that are visible to at least
+              one of the parties in ``act_as`` or ``read_as``. This visibility check is independent from the Daml authorization
+              rules for fetch operations.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to read contract data on behalf of each of the given parties.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          disclosedContracts:
+            description: |-
+              Additional contracts used to resolve contract & contract key lookups.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/DisclosedContract'
+          synchronizerId:
+            description: |-
+              Must be a valid synchronizer id
+              If not set, a suitable synchronizer that this node is connected to will be chosen
+
+              Optional
+            type: string
+          packageIdSelectionPreference:
+            description: |-
+              The package-id selection preference of the client for resolving
+              package names and interface instances in command submission and interpretation
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          verboseHashing:
+            description: |-
+              When true, the response will contain additional details on how the transaction was encoded and hashed
+              This can be useful for troubleshooting of hash mismatches. Should only be used for debugging.
+              Defaults to false
+
+              Optional
+            type: boolean
+          prefetchContractKeys:
+            description: |-
+              Fetches the contract keys into the caches to speed up the command processing.
+              Should only contain contract keys that are expected to be resolved during interpretation of the commands.
+              Keys of disclosed contracts do not need prefetching.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PrefetchContractKey'
+          maxRecordTime:
+            description: |-
+              Maximum timestamp at which the transaction can be recorded onto the ledger via the synchronizer specified in the `PrepareSubmissionResponse`.
+              If submitted after it will be rejected even if otherwise valid, in which case it needs to be prepared and signed again
+              with a new valid max_record_time.
+              Use this to limit the time-to-life of a prepared transaction,
+              which is useful to know when it can definitely not be accepted
+              anymore and resorting to preparing another transaction for the same
+              intent is safe again.
+
+              Optional
+            type: string
+          estimateTrafficCost:
+            $ref: '#/components/schemas/CostEstimationHints'
+            description: |-
+              Hints to improve the accuracy of traffic cost estimation.
+              The estimation logic assumes that this node will be used for the execution of the transaction
+              If another node is used instead, the estimation may be less precise.
+              Request amplification is not accounted for in the estimation: each amplified request will
+              result in the cost of the confirmation request to be charged additionally.
+
+              Traffic cost estimation is enabled by default if this field is not set
+              To turn off cost estimation, set the CostEstimationHints#disabled field to true
+
+              Optional
+          tapsMaxPasses:
+            description: |-
+              The maximum number of passes for the Topology-Aware Package Selection (TAPS).
+              Higher values can increase the chance of successful package selection for routing of interpreted transactions.
+              If unset, this defaults to the value defined in the participant configuration.
+              The provided value must not exceed the limit specified in the participant configuration.
+
+              Optional
+            type: integer
+            format: int32
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version to be used when building the hash.
+              Defaults to HASHING_SCHEME_VERSION_V2.
+
+              Optional
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+            - HASHING_SCHEME_VERSION_V3
+      JsPrepareSubmissionResponse:
+        title: JsPrepareSubmissionResponse
+        description: '[docs-entry-end: HashingSchemeVersion]'
+        type: object
+        required:
+        - preparedTransaction
+        - preparedTransactionHash
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              The interpreted transaction, it represents the ledger changes necessary to execute the commands specified in the request.
+              Clients MUST display the content of the transaction to the user for them to validate before signing the hash if the preparing participant is not trusted.
+
+              Required
+            type: string
+          preparedTransactionHash:
+            description: |-
+              Hash of the transaction, this is what needs to be signed by the party to authorize the transaction.
+              Only provided for convenience, clients MUST recompute the hash from the raw transaction if the preparing participant is not trusted.
+              May be removed in future versions
+
+              Required: must be non-empty
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+            - HASHING_SCHEME_VERSION_V3
+          hashingDetails:
+            description: |-
+              Optional additional details on how the transaction was encoded and hashed. Only set if verbose_hashing = true in the request
+              Note that there are no guarantees on the stability of the format or content of this field.
+              Its content should NOT be parsed and should only be used for troubleshooting purposes.
+
+              Optional
+            type: string
+          costEstimation:
+            $ref: '#/components/schemas/CostEstimation'
+            description: |-
+              Traffic cost estimation of the prepared transaction
+
+              Optional
+      JsReassignment:
+        title: JsReassignment
+        description: Complete view of an on-ledger reassignment.
+        type: object
+        required:
+        - updateId
+        - offset
+        - recordTime
+        - synchronizerId
+        - events
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          commandId:
+            description: |-
+              The ID of the command which resulted in this reassignment. Missing for everyone except the submitting party on the submitting participant.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          workflowId:
+            description: |-
+              The workflow ID used in reassignment command submission. Only set if the ``workflow_id`` for the command was set.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          offset:
+            description: |-
+              The participant's offset. The details of this field are described in ``community/ledger-api/README.md``.
+              Must be a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          events:
+            description: |-
+              The collection of reassignment events.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/JsReassignmentEvent'
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+
+              Optional
+          recordTime:
+            description: |-
+              The time at which the reassignment was recorded. The record time refers to the source/target
+              synchronizer for an unassign/assign event respectively.
+
+              Required
+            type: string
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized this Reassignment.
+
+              Required
+            type: string
+      JsReassignmentEvent:
+        title: JsReassignmentEvent
+        oneOf:
+        - type: object
+          required:
+          - JsAssignmentEvent
+          properties:
+            JsAssignmentEvent:
+              $ref: '#/components/schemas/JsAssignmentEvent'
+        - type: object
+          required:
+          - JsUnassignedEvent
+          properties:
+            JsUnassignedEvent:
+              $ref: '#/components/schemas/JsUnassignedEvent'
+      JsStatus:
+        title: JsStatus
+        type: object
+        required:
+        - code
+        - message
+        properties:
+          code:
+            type: integer
+            format: int32
+          message:
+            type: string
+          details:
+            type: array
+            items:
+              $ref: '#/components/schemas/ProtoAny'
+      JsSubmitAndWaitForReassignmentResponse:
+        title: JsSubmitAndWaitForReassignmentResponse
+        type: object
+        required:
+        - reassignment
+        properties:
+          reassignment:
+            $ref: '#/components/schemas/JsReassignment'
+            description: |-
+              The reassignment that resulted from the submitted reassignment command.
+              The reassignment might contain no events (request conditions result in filtering out all of them).
+
+              Required
+      JsSubmitAndWaitForTransactionRequest:
+        title: JsSubmitAndWaitForTransactionRequest
+        description: These commands are executed as a single atomic transaction.
+        type: object
+        required:
+        - commands
+        properties:
+          commands:
+            $ref: '#/components/schemas/JsCommands'
+            description: |-
+              The commands to be submitted.
+
+              Required
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              If no ``transaction_format`` is provided, a default will be used where ``transaction_shape`` is set to
+              TRANSACTION_SHAPE_ACS_DELTA, ``event_format`` is defined with ``filters_by_party`` containing wildcard-template
+              filter for all original ``act_as`` and ``read_as`` parties and the ``verbose`` flag is set.
+
+              Optional
+      JsSubmitAndWaitForTransactionResponse:
+        title: JsSubmitAndWaitForTransactionResponse
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransaction'
+            description: |-
+              The transaction that resulted from the submitted command.
+              The transaction might contain no events (request conditions result in filtering out all of them).
+
+              Required
+      JsSubmitAndWaitForTransactionTreeResponse:
+        title: JsSubmitAndWaitForTransactionTreeResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        properties:
+          transactionTree:
+            $ref: '#/components/schemas/JsTransactionTree'
+      JsTopologyTransaction:
+        title: JsTopologyTransaction
+        type: object
+        required:
+        - updateId
+        - offset
+        - synchronizerId
+        - recordTime
+        - events
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          offset:
+            description: |-
+              The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
+              It is a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized the topology transaction.
+
+              Required
+            type: string
+          recordTime:
+            description: |-
+              The time at which the changes in the topology transaction become effective. There is a small delay between a
+              topology transaction being sequenced and the changes it contains becoming effective. Topology transactions appear
+              in order relative to a synchronizer based on their effective time rather than their sequencing time.
+
+              Required
+            type: string
+          events:
+            description: |-
+              A non-empty list of topology events.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/TopologyEvent'
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+
+              Optional
+      JsTransaction:
+        title: JsTransaction
+        description: Filtered view of an on-ledger transaction's create and archive
+          events.
+        type: object
+        required:
+        - updateId
+        - effectiveAt
+        - offset
+        - synchronizerId
+        - recordTime
+        - events
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          commandId:
+            description: |-
+              The ID of the command which resulted in this transaction. Missing for everyone except the submitting party.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          workflowId:
+            description: |-
+              The workflow ID used in command submission.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          effectiveAt:
+            description: |-
+              Ledger effective time.
+
+              Required
+            type: string
+          events:
+            description: |-
+              The collection of events.
+              Contains:
+
+              - ``CreatedEvent`` or ``ArchivedEvent`` in case of ACS_DELTA transaction shape
+              - ``CreatedEvent`` or ``ExercisedEvent`` in case of LEDGER_EFFECTS transaction shape
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Event'
+          offset:
+            description: |-
+              The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
+              It is a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized the transaction.
+
+              Required
+            type: string
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+
+              Optional
+          recordTime:
+            description: |-
+              The time at which the transaction was recorded. The record time refers to the synchronizer
+              which synchronized the transaction.
+
+              Required
+            type: string
+          externalTransactionHash:
+            description: |-
+              For transaction externally signed, contains the external transaction hash
+              signed by the external party. Can be used to correlate an external submission with a committed transaction.
+
+              Optional: can be empty
+            type: string
+      JsTransactionTree:
+        title: JsTransactionTree
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Complete view of an on-ledger transaction.
+        type: object
+        required:
+        - updateId
+        - effectiveAt
+        - offset
+        - eventsById
+        - synchronizerId
+        - recordTime
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Required
+            type: string
+          commandId:
+            description: |-
+              The ID of the command which resulted in this transaction. Missing for everyone except the submitting party.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Optional
+            type: string
+          workflowId:
+            description: |-
+              The workflow ID used in command submission. Only set if the ``workflow_id`` for the command was set.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Optional
+            type: string
+          effectiveAt:
+            description: |-
+              Ledger effective time.
+              Required
+            type: string
+          offset:
+            description: |-
+              The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
+              Required, it is a valid absolute offset (positive integer).
+            type: integer
+            format: int64
+          eventsById:
+            $ref: '#/components/schemas/Map_Int_TreeEvent'
+            description: |-
+              Changes to the ledger that were caused by this transaction. Nodes of the transaction tree.
+              Each key must be a valid node ID (non-negative integer).
+              Required
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized the transaction.
+              Required
+            type: string
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Optional; ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+          recordTime:
+            description: |-
+              The time at which the transaction was recorded. The record time refers to the synchronizer
+              which synchronized the transaction.
+              Required
+            type: string
+      JsUnassignedEvent:
+        title: JsUnassignedEvent
+        description: Records that a contract has been unassigned, and it becomes unusable
+          on the source synchronizer
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/UnassignedEvent'
+      Kind:
+        title: Kind
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - CanActAs
+          properties:
+            CanActAs:
+              $ref: '#/components/schemas/CanActAs'
+        - type: object
+          required:
+          - CanExecuteAs
+          properties:
+            CanExecuteAs:
+              $ref: '#/components/schemas/CanExecuteAs'
+        - type: object
+          required:
+          - CanExecuteAsAnyParty
+          properties:
+            CanExecuteAsAnyParty:
+              $ref: '#/components/schemas/CanExecuteAsAnyParty'
+        - type: object
+          required:
+          - CanReadAs
+          properties:
+            CanReadAs:
+              $ref: '#/components/schemas/CanReadAs'
+        - type: object
+          required:
+          - CanReadAsAnyParty
+          properties:
+            CanReadAsAnyParty:
+              $ref: '#/components/schemas/CanReadAsAnyParty'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty8'
+        - type: object
+          required:
+          - IdentityProviderAdmin
+          properties:
+            IdentityProviderAdmin:
+              $ref: '#/components/schemas/IdentityProviderAdmin'
+        - type: object
+          required:
+          - ParticipantAdmin
+          properties:
+            ParticipantAdmin:
+              $ref: '#/components/schemas/ParticipantAdmin'
+      ListIdentityProviderConfigsResponse:
+        title: ListIdentityProviderConfigsResponse
+        type: object
+        required:
+        - identityProviderConfigs
+        properties:
+          identityProviderConfigs:
+            description: |-
+              The list of identity provider configs
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/IdentityProviderConfig'
+      ListKnownPartiesResponse:
+        title: ListKnownPartiesResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
+            description: |-
+              The details of all Daml parties known by the participant.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PartyDetails'
+          nextPageToken:
+            description: |-
+              Pagination token to retrieve the next page.
+              Empty, if there are no further results.
+
+              Optional
+            type: string
+      ListPackagesResponse:
+        title: ListPackagesResponse
+        type: object
+        required:
+        - packageIds
+        properties:
+          packageIds:
+            description: |-
+              The IDs of all Daml-LF packages supported by the server.
+              Each element must be a valid PackageIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+      ListUserRightsResponse:
+        title: ListUserRightsResponse
+        type: object
+        properties:
+          rights:
+            description: |-
+              All rights of the user.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      ListUsersResponse:
+        title: ListUsersResponse
+        type: object
+        properties:
+          users:
+            description: |-
+              A subset of users of the participant node that fit into this page.
+              Can be empty if no more users
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+          nextPageToken:
+            description: |-
+              Pagination token to retrieve the next page.
+              Empty, if there are no further results.
+
+              Optional
+            type: string
+      ListVettedPackagesRequest:
+        title: ListVettedPackagesRequest
+        type: object
+        properties:
+          packageMetadataFilter:
+            $ref: '#/components/schemas/PackageMetadataFilter'
+            description: |-
+              The package metadata filter the returned vetted packages set must satisfy.
+
+              Optional
+          topologyStateFilter:
+            $ref: '#/components/schemas/TopologyStateFilter'
+            description: |-
+              The topology filter the returned vetted packages set must satisfy.
+
+              Optional
+          pageToken:
+            description: |-
+              Pagination token to determine the specific page to fetch. Using the token
+              guarantees that ``VettedPackages`` on a subsequent page are all greater
+              (``VettedPackages`` are sorted by synchronizer ID then participant ID) than
+              the last ``VettedPackages`` on a previous page.
+
+              The server does not store intermediate results between calls chained by a
+              series of page tokens. As a consequence, if new vetted packages are being
+              added and a page is requested twice using the same token, more packages can
+              be returned on the second call.
+
+              Leave unspecified (i.e. as empty string) to fetch the first page.
+
+              Optional
+            type: string
+          pageSize:
+            description: |-
+              Maximum number of ``VettedPackages`` results to return in a single page.
+
+              If the page_size is unspecified (i.e. left as 0), the server will decide
+              the number of results to be returned.
+
+              If the page_size exceeds the maximum supported by the server, an
+              error will be returned.
+
+              To obtain the server's maximum consult the PackageService descriptor
+              available in the VersionService.
+
+              Optional
+            type: integer
+            format: int32
+      ListVettedPackagesResponse:
+        title: ListVettedPackagesResponse
+        type: object
+        properties:
+          vettedPackages:
+            description: |-
+              All ``VettedPackages`` that contain at least one ``VettedPackage`` matching
+              both a ``PackageMetadataFilter`` and a ``TopologyStateFilter``.
+              Sorted by synchronizer_id then participant_id.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackages'
+          nextPageToken:
+            description: |-
+              Pagination token to retrieve the next page.
+              Empty string if there are no further results.
+
+              Optional
+            type: string
+      Map_Filters:
+        title: Map_Filters
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/Filters'
+      Map_Int_Field:
+        title: Map_Int_Field
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/Field'
+      Map_Int_TreeEvent:
+        title: Map_Int_TreeEvent
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/TreeEvent'
+      Map_String:
+        title: Map_String
+        type: object
+        additionalProperties:
+          type: string
+      MinLedgerTime:
+        title: MinLedgerTime
+        type: object
+        properties:
+          time:
+            $ref: '#/components/schemas/Time'
+      MinLedgerTimeAbs:
+        title: MinLedgerTimeAbs
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: string
+      MinLedgerTimeRel:
+        title: MinLedgerTimeRel
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      NoPrior:
+        title: NoPrior
+        type: object
+      ObjectMeta:
+        title: ObjectMeta
+        description: |-
+          Represents metadata corresponding to a participant resource (e.g. a participant user or participant local information about a party).
+
+          Based on ``ObjectMeta`` meta used in Kubernetes API.
+          See https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/generated.proto#L640
+        type: object
+        properties:
+          resourceVersion:
+            description: |-
+              An opaque, non-empty value, populated by a participant server which represents the internal version of the resource
+              this ``ObjectMeta`` message is attached to. The participant server will change it to a unique value each time the corresponding resource is updated.
+              You must not rely on the format of resource version. The participant server might change it without notice.
+              You can obtain the newest resource version value by issuing a read request.
+              You may use it for concurrent change detection by passing it back unmodified in an update request.
+              The participant server will then compare the passed value with the value maintained by the system to determine
+              if any other updates took place since you had read the resource version.
+              Upon a successful update you are guaranteed that no other update took place during your read-modify-write sequence.
+              However, if another update took place during your read-modify-write sequence then your update will fail with an appropriate error.
+              Concurrent change control is optional. It will be applied only if you include a resource version in an update request.
+              When creating a new instance of a resource you must leave the resource version empty.
+              Its value will be populated by the participant server upon successful resource creation.
+
+              Optional
+            type: string
+          annotations:
+            $ref: '#/components/schemas/Map_String'
+            description: |-
+              A set of modifiable key-value pairs that can be used to represent arbitrary, client-specific metadata.
+              Constraints:
+
+              1. The total size over all keys and values cannot exceed 256kb in UTF-8 encoding.
+              2. Keys are composed of an optional prefix segment and a required name segment such that:
+
+                 - key prefix, when present, must be a valid DNS subdomain with at most 253 characters, followed by a '/' (forward slash) character,
+                 - name segment must have at most 63 characters that are either alphanumeric ([a-z0-9A-Z]), or a '.' (dot), '-' (dash) or '_' (underscore);
+                   and it must start and end with an alphanumeric character.
+
+              3. Values can be any non-empty strings.
+
+              Keys with empty prefix are reserved for end-users.
+              Properties set by external tools or internally by the participant server must use non-empty key prefixes.
+              Duplicate keys are disallowed by the semantics of the protobuf3 maps.
+              See: https://developers.google.com/protocol-buffers/docs/proto3#maps
+              Annotations may be a part of a modifiable resource.
+              Use the resource's update RPC to update its annotations.
+              In order to add a new annotation or update an existing one using an update RPC, provide the desired annotation in the update request.
+              In order to remove an annotation using an update RPC, provide the target annotation's key but set its value to the empty string in the update request.
+              Modifiable
+
+              Optional: can be empty
+      OffsetCheckpoint:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/OffsetCheckpoint1'
+      OffsetCheckpoint1:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - offset
+        properties:
+          offset:
+            description: |-
+              The participant's offset, the details of the offset field are described in ``community/ledger-api/README.md``.
+              Must be a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          synchronizerTimes:
+            description: |-
+              The times associated with each synchronizer at this offset.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/SynchronizerTime'
+      OffsetCheckpoint2:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/OffsetCheckpoint1'
+      OffsetCheckpoint3:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/OffsetCheckpoint1'
+      OffsetCheckpointFeature:
+        title: OffsetCheckpointFeature
+        type: object
+        required:
+        - maxOffsetCheckpointEmissionDelay
+        properties:
+          maxOffsetCheckpointEmissionDelay:
+            $ref: '#/components/schemas/Duration'
+            description: |-
+              The maximum delay to emmit a new OffsetCheckpoint if it exists
+
+              Required
+      Operation:
+        title: Operation
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty5'
+        - type: object
+          required:
+          - Unvet
+          properties:
+            Unvet:
+              $ref: '#/components/schemas/Unvet'
+        - type: object
+          required:
+          - Vet
+          properties:
+            Vet:
+              $ref: '#/components/schemas/Vet'
+      PackageFeature:
+        title: PackageFeature
+        type: object
+        required:
+        - maxVettedPackagesPageSize
+        properties:
+          maxVettedPackagesPageSize:
+            description: |-
+              The maximum number of vetted packages the server can return in a single
+              response (page) when listing them.
+
+              Required
+            type: integer
+            format: int32
+      PackageMetadataFilter:
+        title: PackageMetadataFilter
+        description: |-
+          Filter the VettedPackages by package metadata.
+
+          A PackageMetadataFilter without package_ids and without package_name_prefixes
+          matches any vetted package.
+
+          Non-empty fields specify candidate values of which at least one must match.
+          If both fields are set, then a candidate is returned if it matches one of the fields.
+        type: object
+        properties:
+          packageIds:
+            description: |-
+              If this list is non-empty, any vetted package with a package ID in this
+              list will match the filter.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          packageNamePrefixes:
+            description: |-
+              If this list is non-empty, any vetted package with a name matching at least
+              one prefix in this list will match the filter.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      PackagePreference:
+        title: PackagePreference
+        type: object
+        required:
+        - synchronizerId
+        - packageReference
+        properties:
+          packageReference:
+            $ref: '#/components/schemas/PackageReference'
+            description: |-
+              The package reference of the preferred package.
+
+              Required
+          synchronizerId:
+            description: |-
+              The synchronizer for which the preferred package was computed.
+              If the synchronizer_id was specified in the request, then it matches the request synchronizer_id.
+
+              Required
+            type: string
+      PackageReference:
+        title: PackageReference
+        type: object
+        required:
+        - packageId
+        - packageName
+        - packageVersion
+        properties:
+          packageId:
+            description: Required
+            type: string
+          packageName:
+            description: Required
+            type: string
+          packageVersion:
+            description: Required
+            type: string
+      PackageVettingRequirement:
+        title: PackageVettingRequirement
+        description: Defines a package-name for which the commonly vetted package with
+          the highest version must be found.
+        type: object
+        required:
+        - packageName
+        - parties
+        properties:
+          parties:
+            description: |-
+              The parties whose participants' vetting state should be considered when resolving the preferred package.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          packageName:
+            description: |-
+              The package-name for which the preferred package should be resolved.
+
+              Required
+            type: string
+      ParticipantAdmin:
+        title: ParticipantAdmin
+        description: The right to administer the participant node.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAdmin1'
+      ParticipantAdmin1:
+        title: ParticipantAdmin
+        description: The right to administer the participant node.
+        type: object
+      ParticipantAuthorizationAdded:
+        title: ParticipantAuthorizationAdded
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAuthorizationAdded1'
+      ParticipantAuthorizationAdded1:
+        title: ParticipantAuthorizationAdded
+        type: object
+        required:
+        - partyId
+        - participantId
+        - participantPermission
+        properties:
+          partyId:
+            description: Required
+            type: string
+          participantId:
+            description: Required
+            type: string
+          participantPermission:
+            description: Required
+            type: string
+            enum:
+            - PARTICIPANT_PERMISSION_UNSPECIFIED
+            - PARTICIPANT_PERMISSION_SUBMISSION
+            - PARTICIPANT_PERMISSION_CONFIRMATION
+            - PARTICIPANT_PERMISSION_OBSERVATION
+      ParticipantAuthorizationChanged:
+        title: ParticipantAuthorizationChanged
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAuthorizationChanged1'
+      ParticipantAuthorizationChanged1:
+        title: ParticipantAuthorizationChanged
+        type: object
+        required:
+        - partyId
+        - participantId
+        - participantPermission
+        properties:
+          partyId:
+            description: Required
+            type: string
+          participantId:
+            description: Required
+            type: string
+          participantPermission:
+            description: Required
+            type: string
+            enum:
+            - PARTICIPANT_PERMISSION_UNSPECIFIED
+            - PARTICIPANT_PERMISSION_SUBMISSION
+            - PARTICIPANT_PERMISSION_CONFIRMATION
+            - PARTICIPANT_PERMISSION_OBSERVATION
+      ParticipantAuthorizationOnboarding:
+        title: ParticipantAuthorizationOnboarding
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAuthorizationOnboarding1'
+      ParticipantAuthorizationOnboarding1:
+        title: ParticipantAuthorizationOnboarding
+        type: object
+        required:
+        - partyId
+        - participantId
+        - participantPermission
+        properties:
+          partyId:
+            description: Required
+            type: string
+          participantId:
+            description: Required
+            type: string
+          participantPermission:
+            description: Required
+            type: string
+            enum:
+            - PARTICIPANT_PERMISSION_UNSPECIFIED
+            - PARTICIPANT_PERMISSION_SUBMISSION
+            - PARTICIPANT_PERMISSION_CONFIRMATION
+            - PARTICIPANT_PERMISSION_OBSERVATION
+      ParticipantAuthorizationRevoked:
+        title: ParticipantAuthorizationRevoked
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAuthorizationRevoked1'
+      ParticipantAuthorizationRevoked1:
+        title: ParticipantAuthorizationRevoked
+        type: object
+        required:
+        - partyId
+        - participantId
+        properties:
+          partyId:
+            description: Required
+            type: string
+          participantId:
+            description: Required
+            type: string
+      ParticipantAuthorizationTopologyFormat:
+        title: ParticipantAuthorizationTopologyFormat
+        description: A format specifying which participant authorization topology transactions
+          to include and how to render them.
+        type: object
+        properties:
+          parties:
+            description: |-
+              List of parties for which the topology transactions should be sent.
+              Empty means: for all parties.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      PartyDetails:
+        title: PartyDetails
+        type: object
+        required:
+        - party
+        properties:
+          party:
+            description: |-
+              The stable unique identifier of a Daml party.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required
+            type: string
+          isLocal:
+            description: |-
+              true if party is hosted by the participant and the party shares the same identity provider as the user issuing the request.
+
+              Optional
+            type: boolean
+          localMetadata:
+            $ref: '#/components/schemas/ObjectMeta'
+            description: |-
+              Participant-local metadata of this party.
+              Modifiable
+
+              Optional
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              Optional, if not set, there could be 3 options:
+
+              1. the party is managed by the default identity provider.
+              2. party is not hosted by the participant.
+              3. party is hosted by the participant, but is outside of the user's identity provider.
+
+              Optional
+            type: string
+      PartyManagementFeature:
+        title: PartyManagementFeature
+        type: object
+        required:
+        - maxPartiesPageSize
+        properties:
+          maxPartiesPageSize:
+            description: |-
+              The maximum number of parties the server can return in a single response (page).
+
+              Required
+            type: integer
+            format: int32
+      PartySignatures:
+        title: PartySignatures
+        description: Additional signatures provided by the submitting parties
+        type: object
+        required:
+        - signatures
+        properties:
+          signatures:
+            description: |-
+              Additional signatures provided by all individual parties
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/SinglePartySignatures'
+      PrefetchContractKey:
+        title: PrefetchContractKey
+        description: Preload contracts
+        type: object
+        required:
+        - templateId
+        - contractKey
+        properties:
+          templateId:
+            description: |-
+              The template of contract the client wants to prefetch.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          contractKey:
+            description: |-
+              The key of the contract the client wants to prefetch.
+
+              Required
+      Prior:
+        title: Prior
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int32
+      PriorTopologySerial:
+        title: PriorTopologySerial
+        description: |-
+          The serial of last ``VettedPackages`` topology transaction on a given
+          participant and synchronizer.
+        type: object
+        properties:
+          serial:
+            $ref: '#/components/schemas/Serial'
+      ProtoAny:
+        title: ProtoAny
+        type: object
+        required:
+        - typeUrl
+        - value
+        - unknownFields
+        properties:
+          typeUrl:
+            type: string
+          value:
+            type: string
+          unknownFields:
+            $ref: '#/components/schemas/UnknownFieldSet'
+          valueDecoded:
+            type: string
+      Reassignment:
+        title: Reassignment
+        description: Complete view of an on-ledger reassignment.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsReassignment'
+      Reassignment1:
+        title: Reassignment
+        description: Complete view of an on-ledger reassignment.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsReassignment'
+      ReassignmentCommand:
+        title: ReassignmentCommand
+        type: object
+        properties:
+          command:
+            $ref: '#/components/schemas/Command1'
+      ReassignmentCommands:
+        title: ReassignmentCommands
+        type: object
+        required:
+        - commandId
+        - submitter
+        - commands
+        properties:
+          workflowId:
+            description: |-
+              Identifier of the on-ledger workflow that this command is a part of.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          userId:
+            description: |-
+              Uniquely identifies the participant user that issued the command.
+              Must be a valid UserIdString (as described in ``value.proto``).
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
+
+              Optional
+            type: string
+          commandId:
+            description: |-
+              Uniquely identifies the command.
+              The triple (user_id, submitter, command_id) constitutes the change ID for the intended ledger change.
+              The change ID can be used for matching the intended ledger changes with all their completions.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          submitter:
+            description: |-
+              Party on whose behalf the command should be executed.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to act on behalf of the given party.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required
+            type: string
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              If omitted, the participant or the committer may set a value of their choice.
+
+              Optional
+            type: string
+          commands:
+            description: |-
+              Individual elements of this reassignment. Must be non-empty.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/ReassignmentCommand'
+      RevokeUserRightsRequest:
+        title: RevokeUserRightsRequest
+        description: |-
+          Remove the rights from the set of rights granted to the user.
+
+          Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id)``
+        type: object
+        required:
+        - userId
+        properties:
+          userId:
+            description: |-
+              The user from whom to revoke rights.
+
+              Required
+            type: string
+          rights:
+            description: |-
+              The rights to revoke.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the user is managed by the default identity provider.
+
+              Optional
+            type: string
+      RevokeUserRightsResponse:
+        title: RevokeUserRightsResponse
+        type: object
+        properties:
+          newlyRevokedRights:
+            description: |-
+              The rights that were actually revoked by the request.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      Right:
+        title: Right
+        description: A right granted to a user.
+        type: object
+        properties:
+          kind:
+            $ref: '#/components/schemas/Kind'
+      Serial:
+        title: Serial
+        description: Optional
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty6'
+        - type: object
+          required:
+          - NoPrior
+          properties:
+            NoPrior:
+              $ref: '#/components/schemas/NoPrior'
+        - type: object
+          required:
+          - Prior
+          properties:
+            Prior:
+              $ref: '#/components/schemas/Prior'
+      Signature:
+        title: Signature
+        type: object
+        required:
+        - format
+        - signature
+        - signedBy
+        - signingAlgorithmSpec
+        properties:
+          format:
+            description: Required
+            type: string
+          signature:
+            description: 'Required: must be non-empty'
+            type: string
+          signedBy:
+            description: |-
+              The fingerprint/id of the keypair used to create this signature and needed to verify.
+
+              Required
+            type: string
+          signingAlgorithmSpec:
+            description: |-
+              The signing algorithm specification used to produce this signature
+
+              Required
+            type: string
+      SignedTransaction:
+        title: SignedTransaction
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            description: |-
+              The serialized TopologyTransaction
+
+              Required: must be non-empty
+            type: string
+          signatures:
+            description: |-
+              Additional signatures for this transaction specifically
+              Use for transactions that require additional signatures beyond the namespace key signatures
+              e.g: PartyToKeyMapping must be signed by all registered keys
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Signature'
+      SigningPublicKey:
+        title: SigningPublicKey
+        type: object
+        required:
+        - format
+        - keyData
+        - keySpec
+        properties:
+          format:
+            description: |-
+              The serialization format of the public key
+
+              Required
+            example: CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO
+            type: string
+          keyData:
+            description: |-
+              Serialized public key in the format specified above
+
+              Required: must be non-empty
+            type: string
+          keySpec:
+            description: |-
+              The key specification
+
+              Required
+            example: SIGNING_KEY_SPEC_EC_CURVE25519
+            type: string
+      SinglePartySignatures:
+        title: SinglePartySignatures
+        description: Signatures provided by a single party
+        type: object
+        required:
+        - party
+        - signatures
+        properties:
+          party:
+            description: |-
+              Submitting party
+
+              Required
+            type: string
+          signatures:
+            description: |-
+              Signatures
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Signature'
+      SubmitAndWaitForReassignmentRequest:
+        title: SubmitAndWaitForReassignmentRequest
+        description: This reassignment is executed as a single atomic update.
+        type: object
+        required:
+        - reassignmentCommands
+        properties:
+          reassignmentCommands:
+            $ref: '#/components/schemas/ReassignmentCommands'
+            description: |-
+              The reassignment commands to be submitted.
+
+              Required
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              If no event_format provided, the result will contain no events.
+              The events in the result, will take shape TRANSACTION_SHAPE_ACS_DELTA.
+
+              Optional
+      SubmitAndWaitResponse:
+        title: SubmitAndWaitResponse
+        type: object
+        required:
+        - updateId
+        - completionOffset
+        properties:
+          updateId:
+            description: |-
+              The id of the transaction that resulted from the submitted command.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          completionOffset:
+            description: |-
+              The details of the offset field are described in ``community/ledger-api/README.md``.
+
+              Required
+            type: integer
+            format: int64
+      SubmitReassignmentRequest:
+        title: SubmitReassignmentRequest
+        type: object
+        required:
+        - reassignmentCommands
+        properties:
+          reassignmentCommands:
+            $ref: '#/components/schemas/ReassignmentCommands'
+            description: |-
+              The reassignment command to be submitted.
+
+              Required
+      SubmitReassignmentResponse:
+        title: SubmitReassignmentResponse
+        type: object
+      SubmitResponse:
+        title: SubmitResponse
+        type: object
+      SynchronizerTime:
+        title: SynchronizerTime
+        type: object
+        required:
+        - synchronizerId
+        - recordTime
+        properties:
+          synchronizerId:
+            description: |-
+              The id of the synchronizer.
+
+              Required
+            type: string
+          recordTime:
+            description: |-
+              All commands with a maximum record time below this value MUST be considered lost if their completion has not arrived before this checkpoint.
+
+              Required
+            type: string
+      TemplateFilter:
+        title: TemplateFilter
+        description: This filter matches contracts of a specific template.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/TemplateFilter1'
+      TemplateFilter1:
+        title: TemplateFilter
+        description: This filter matches contracts of a specific template.
+        type: object
+        required:
+        - templateId
+        properties:
+          templateId:
+            description: |-
+              A template for which the payload should be included in the response.
+              The ``template_id`` needs to be valid: corresponding template should be defined in
+              one of the available packages at the time of the query.
+              Both package-name and package-id reference formats for the identifier are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          includeCreatedEventBlob:
+            description: |-
+              Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
+              Use this to access the contract event payload in your API client
+              for submitting it as a disclosed contract with future commands.
+
+              Optional
+            type: boolean
+      Time:
+        title: Time
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty9'
+        - type: object
+          required:
+          - MinLedgerTimeAbs
+          properties:
+            MinLedgerTimeAbs:
+              $ref: '#/components/schemas/MinLedgerTimeAbs'
+        - type: object
+          required:
+          - MinLedgerTimeRel
+          properties:
+            MinLedgerTimeRel:
+              $ref: '#/components/schemas/MinLedgerTimeRel'
+      TopologyEvent:
+        title: TopologyEvent
+        type: object
+        properties:
+          event:
+            $ref: '#/components/schemas/TopologyEventEvent'
+      TopologyEventEvent:
+        title: TopologyEventEvent
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty7'
+        - type: object
+          required:
+          - ParticipantAuthorizationAdded
+          properties:
+            ParticipantAuthorizationAdded:
+              $ref: '#/components/schemas/ParticipantAuthorizationAdded'
+        - type: object
+          required:
+          - ParticipantAuthorizationChanged
+          properties:
+            ParticipantAuthorizationChanged:
+              $ref: '#/components/schemas/ParticipantAuthorizationChanged'
+        - type: object
+          required:
+          - ParticipantAuthorizationOnboarding
+          properties:
+            ParticipantAuthorizationOnboarding:
+              $ref: '#/components/schemas/ParticipantAuthorizationOnboarding'
+        - type: object
+          required:
+          - ParticipantAuthorizationRevoked
+          properties:
+            ParticipantAuthorizationRevoked:
+              $ref: '#/components/schemas/ParticipantAuthorizationRevoked'
+      TopologyFormat:
+        title: TopologyFormat
+        description: A format specifying which topology transactions to include and
+          how to render them.
+        type: object
+        properties:
+          includeParticipantAuthorizationEvents:
+            $ref: '#/components/schemas/ParticipantAuthorizationTopologyFormat'
+            description: |-
+              Include participant authorization topology events in streams.
+              If unset, no participant authorization topology events are emitted in the stream.
+
+              Optional
+      TopologyStateFilter:
+        title: TopologyStateFilter
+        description: |-
+          Filter the vetted packages by the participant and synchronizer that they are
+          hosted on.
+
+          Empty fields are ignored, such that a ``TopologyStateFilter`` without
+          participant_ids and without synchronizer_ids matches a vetted package hosted
+          on any participant and synchronizer.
+
+          Non-empty fields specify candidate values of which at least one must match.
+          If both fields are set then at least one candidate value must match from each
+          field.
+        type: object
+        properties:
+          participantIds:
+            description: |-
+              If this list is non-empty, only vetted packages hosted on participants
+              listed in this field match the filter.
+              Query the current Ledger API's participant's ID via the public
+              ``GetParticipantId`` command in ``PartyManagementService``.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          synchronizerIds:
+            description: |-
+              If this list is non-empty, only vetted packages from the topology state of
+              the synchronizers in this list match the filter.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      TopologyTransaction:
+        title: TopologyTransaction
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsTopologyTransaction'
+      TraceContext:
+        title: TraceContext
+        type: object
+        properties:
+          traceparent:
+            description: |-
+              https://www.w3.org/TR/trace-context/
+
+              Optional
+            type: string
+          tracestate:
+            description: Optional
+            type: string
+      Transaction:
+        title: Transaction
+        description: Filtered view of an on-ledger transaction's create and archive
+          events.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsTransaction'
+      TransactionFilter:
+        title: TransactionFilter
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Used both for filtering create and archive events as well as for filtering transaction trees.
+        type: object
+        properties:
+          filtersByParty:
+            $ref: '#/components/schemas/Map_Filters'
+            description: |-
+              Each key must be a valid PartyIdString (as described in ``value.proto``).
+              The interpretation of the filter depends on the transaction-shape being filtered:
+
+              1. For **transaction trees** (used in GetUpdateTreesResponse for backwards compatibility) all party keys used as
+                 wildcard filters, and all subtrees whose root has one of the listed parties as an informee are returned.
+                 If there are ``CumulativeFilter``s, those will control returned ``CreatedEvent`` fields where applicable, but will
+                 not be used for template/interface filtering.
+              2. For **ledger-effects** create and exercise events are returned, for which the witnesses include at least one of
+                 the listed parties and match the per-party filter.
+              3. For **transaction and active-contract-set streams** create and archive events are returned for all contracts whose
+                 stakeholders include at least one of the listed parties and match the per-party filter.
+          filtersForAnyParty:
+            $ref: '#/components/schemas/Filters'
+            description: |-
+              Wildcard filters that apply to all the parties existing on the participant. The interpretation of the filters is the same
+              with the per-party filter as described above.
+      TransactionFormat:
+        title: TransactionFormat
+        description: |-
+          A format that specifies what events to include in Daml transactions
+          and what data to compute and include for them.
+        type: object
+        required:
+        - transactionShape
+        - eventFormat
+        properties:
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: Required
+          transactionShape:
+            description: |-
+              What transaction shape to use for interpreting the filters of the event format.
+
+              Required
+            type: string
+            enum:
+            - TRANSACTION_SHAPE_UNSPECIFIED
+            - TRANSACTION_SHAPE_ACS_DELTA
+            - TRANSACTION_SHAPE_LEDGER_EFFECTS
+      TransactionTree:
+        title: TransactionTree
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Complete view of an on-ledger transaction.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsTransactionTree'
+      TreeEvent:
+        title: TreeEvent
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Each tree event message type below contains a ``witness_parties`` field which
+          indicates the subset of the requested parties that can see the event
+          in question.
+
+          Note that transaction trees might contain events with
+          _no_ witness parties, which were included simply because they were
+          children of events which have witnesses.
+        oneOf:
+        - type: object
+          required:
+          - CreatedTreeEvent
+          properties:
+            CreatedTreeEvent:
+              $ref: '#/components/schemas/CreatedTreeEvent'
+        - type: object
+          required:
+          - ExercisedTreeEvent
+          properties:
+            ExercisedTreeEvent:
+              $ref: '#/components/schemas/ExercisedTreeEvent'
+      Tuple2_String_String:
+        title: Tuple2_String_String
+        type: array
+        maxItems: 2
+        minItems: 2
+        items:
+          type: string
+      UnassignCommand:
+        title: UnassignCommand
+        description: Unassign a contract
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/UnassignCommand1'
+      UnassignCommand1:
+        title: UnassignCommand
+        description: Unassign a contract
+        type: object
+        required:
+        - contractId
+        - source
+        - target
+        properties:
+          contractId:
+            description: |-
+              The ID of the contract the client wants to unassign.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          source:
+            description: |-
+              The ID of the source synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+          target:
+            description: |-
+              The ID of the target synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+      UnassignedEvent:
+        title: UnassignedEvent
+        description: Records that a contract has been unassigned, and it becomes unusable
+          on the source synchronizer
+        type: object
+        required:
+        - reassignmentId
+        - contractId
+        - source
+        - target
+        - reassignmentCounter
+        - packageName
+        - offset
+        - nodeId
+        - templateId
+        - witnessParties
+        properties:
+          reassignmentId:
+            description: |-
+              The ID of the unassignment. This needs to be used as an input for a assign ReassignmentCommand.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          contractId:
+            description: |-
+              The ID of the reassigned contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          templateId:
+            description: |-
+              The template of the reassigned contract.
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          source:
+            description: |-
+              The ID of the source synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+          target:
+            description: |-
+              The ID of the target synchronizer
+              Must be a valid synchronizer id
+
+              Required
+            type: string
+          submitter:
+            description: |-
+              Party on whose behalf the unassign command was executed.
+              Empty if the unassignment happened offline via the repair service.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          reassignmentCounter:
+            description: |-
+              Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
+              with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
+              equals zero.
+
+              Required
+            type: integer
+            format: int64
+          assignmentExclusivity:
+            description: |-
+              Assignment exclusivity
+              Before this time (measured on the target synchronizer), only the submitter of the unassignment can initiate the assignment
+              Defined for reassigning participants.
+
+              Optional
+            type: string
+          witnessParties:
+            description: |-
+              The parties that are notified of this event.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          packageName:
+            description: |-
+              The package name of the contract.
+
+              Required
+            type: string
+          offset:
+            description: |-
+              The offset of origin.
+              Offsets are managed by the participant nodes.
+              Reassignments can thus NOT be assumed to have the same offsets on different participant nodes.
+              Must be a valid absolute offset (positive integer)
+
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating reassignment.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of reassignments.
+              Must be valid node ID (non-negative integer)
+
+              Required
+            type: integer
+            format: int32
+      UnknownFieldSet:
+        title: UnknownFieldSet
+        type: object
+        required:
+        - fields
+        properties:
+          fields:
+            $ref: '#/components/schemas/Map_Int_Field'
+      Unvet:
+        title: Unvet
+        description: Remove packages from the set of vetted packages
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Unvet1'
+      Unvet1:
+        title: Unvet
+        description: Remove packages from the set of vetted packages
+        type: object
+        required:
+        - packages
+        properties:
+          packages:
+            description: |-
+              Packages to be unvetted.
+
+              If a reference in this list matches multiple packages, they are all
+              unvetted.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackagesRef'
+      Update:
+        title: Update
+        oneOf:
+        - type: object
+          required:
+          - OffsetCheckpoint
+          properties:
+            OffsetCheckpoint:
+              $ref: '#/components/schemas/OffsetCheckpoint2'
+        - type: object
+          required:
+          - Reassignment
+          properties:
+            Reassignment:
+              $ref: '#/components/schemas/Reassignment'
+        - type: object
+          required:
+          - TopologyTransaction
+          properties:
+            TopologyTransaction:
+              $ref: '#/components/schemas/TopologyTransaction'
+        - type: object
+          required:
+          - Transaction
+          properties:
+            Transaction:
+              $ref: '#/components/schemas/Transaction'
+      Update1:
+        title: Update
+        oneOf:
+        - type: object
+          required:
+          - OffsetCheckpoint
+          properties:
+            OffsetCheckpoint:
+              $ref: '#/components/schemas/OffsetCheckpoint3'
+        - type: object
+          required:
+          - Reassignment
+          properties:
+            Reassignment:
+              $ref: '#/components/schemas/Reassignment1'
+        - type: object
+          required:
+          - TransactionTree
+          properties:
+            TransactionTree:
+              $ref: '#/components/schemas/TransactionTree'
+      UpdateFormat:
+        title: UpdateFormat
+        description: A format specifying what updates to include and how to render them.
+        type: object
+        properties:
+          includeTransactions:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              Include Daml transactions in streams.
+              If unset, no transactions are emitted in the stream.
+
+              Optional
+          includeReassignments:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              Include (un)assignments in the stream.
+              The events in the result take the shape TRANSACTION_SHAPE_ACS_DELTA.
+              If unset, no (un)assignments are emitted in the stream.
+
+              Optional
+          includeTopologyEvents:
+            $ref: '#/components/schemas/TopologyFormat'
+            description: |-
+              Include topology events in streams.
+              If unset no topology events are emitted in the stream.
+
+              Optional
+      UpdateIdentityProviderConfigRequest:
+        title: UpdateIdentityProviderConfigRequest
+        type: object
+        required:
+        - identityProviderConfig
+        - updateMask
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: |-
+              The identity provider config to update.
+              Modifiable
+
+              Required
+          updateMask:
+            $ref: '#/components/schemas/FieldMask'
+            description: |-
+              An update mask specifies how and which properties of the ``IdentityProviderConfig`` message are to be updated.
+              An update mask consists of a set of update paths.
+              A valid update path points to a field or a subfield relative to the ``IdentityProviderConfig`` message.
+              A valid update mask must:
+
+              1. contain at least one update path,
+              2. contain only valid update paths.
+
+              Fields that can be updated are marked as ``Modifiable``.
+              For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
+
+              Required
+      UpdateIdentityProviderConfigResponse:
+        title: UpdateIdentityProviderConfigResponse
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: |-
+              Updated identity provider config
+
+              Required
+      UpdatePartyDetailsRequest:
+        title: UpdatePartyDetailsRequest
+        description: 'Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(party_details.identity_provider_id)``'
+        type: object
+        required:
+        - partyDetails
+        - updateMask
+        properties:
+          partyDetails:
+            $ref: '#/components/schemas/PartyDetails'
+            description: |-
+              Party to be updated
+              Modifiable
+
+              Required
+          updateMask:
+            $ref: '#/components/schemas/FieldMask'
+            description: |-
+              An update mask specifies how and which properties of the ``PartyDetails`` message are to be updated.
+              An update mask consists of a set of update paths.
+              A valid update path points to a field or a subfield relative to the ``PartyDetails`` message.
+              A valid update mask must:
+
+              1. contain at least one update path,
+              2. contain only valid update paths.
+
+              Fields that can be updated are marked as ``Modifiable``.
+              An update path can also point to non-``Modifiable`` fields such as 'party' and 'local_metadata.resource_version'
+              because they are used:
+
+              1. to identify the party details resource subject to the update,
+              2. for concurrent change control.
+
+              An update path can also point to non-``Modifiable`` fields such as 'is_local'
+              as long as the values provided in the update request match the server values.
+              Examples of update paths: 'local_metadata.annotations', 'local_metadata'.
+              For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
+              For similar Ledger API see ``com.daml.ledger.api.v2.admin.UpdateUserRequest``.
+
+              Required
+      UpdatePartyDetailsResponse:
+        title: UpdatePartyDetailsResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
+            $ref: '#/components/schemas/PartyDetails'
+            description: |-
+              Updated party details
+
+              Required
+      UpdateUserIdentityProviderIdRequest:
+        title: UpdateUserIdentityProviderIdRequest
+        description: 'Required authorization: ``HasRight(ParticipantAdmin)``'
+        type: object
+        required:
+        - userId
+        properties:
+          userId:
+            description: |-
+              User to update
+
+              Required
+            type: string
+          sourceIdentityProviderId:
+            description: |-
+              Current identity provider ID of the user
+              If omitted, the default IDP is assumed
+
+              Optional
+            type: string
+          targetIdentityProviderId:
+            description: |-
+              Target identity provider ID of the user
+              If omitted, the default IDP is assumed
+
+              Optional
+            type: string
+      UpdateUserIdentityProviderIdResponse:
+        title: UpdateUserIdentityProviderIdResponse
+        type: object
+      UpdateUserRequest:
+        title: UpdateUserRequest
+        description: 'Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(user.identity_provider_id)``'
+        type: object
+        required:
+        - user
+        - updateMask
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              The user to update.
+              Modifiable
+
+              Required
+          updateMask:
+            $ref: '#/components/schemas/FieldMask'
+            description: |-
+              An update mask specifies how and which properties of the ``User`` message are to be updated.
+              An update mask consists of a set of update paths.
+              A valid update path points to a field or a subfield relative to the ``User`` message.
+              A valid update mask must:
+
+              1. contain at least one update path,
+              2. contain only valid update paths.
+
+              Fields that can be updated are marked as ``Modifiable``.
+              An update path can also point to a non-``Modifiable`` fields such as 'id' and 'metadata.resource_version'
+              because they are used:
+
+              1. to identify the user resource subject to the update,
+              2. for concurrent change control.
+
+              Examples of valid update paths: 'primary_party', 'metadata', 'metadata.annotations'.
+              For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
+              For similar Ledger API see ``com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest``.
+
+              Required
+      UpdateUserResponse:
+        title: UpdateUserResponse
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              Updated user
+
+              Required
+      UpdateVettedPackagesRequest:
+        title: UpdateVettedPackagesRequest
+        type: object
+        required:
+        - changes
+        properties:
+          changes:
+            description: |-
+              Changes to apply to the current vetting state of the participant on the
+              specified synchronizer. The changes are applied in order.
+              Any package not changed will keep their previous vetting state.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackagesChange'
+          dryRun:
+            description: |-
+              If dry_run is true, then the changes are only prepared, but not applied. If
+              a request would trigger an error when run (e.g. TOPOLOGY_DEPENDENCIES_NOT_VETTED),
+              it will also trigger an error when dry_run.
+
+              Use this flag to preview a change before applying it.
+              Defaults to false.
+
+              Optional
+            type: boolean
+          synchronizerId:
+            description: |-
+              If set, the requested changes will take place on the specified
+              synchronizer. If synchronizer_id is unset and the participant is only
+              connected to a single synchronizer, that synchronizer will be used by
+              default. If synchronizer_id is unset and the participant is connected to
+              multiple synchronizers, the request will error out with
+              PACKAGE_SERVICE_CANNOT_AUTODETECT_SYNCHRONIZER.
+
+              Optional
+            type: string
+          expectedTopologySerial:
+            $ref: '#/components/schemas/PriorTopologySerial'
+            description: |-
+              The serial of the last ``VettedPackages`` topology transaction of this
+              participant and on this synchronizer.
+
+              Execution of the request fails if this is not correct. Use this to guard
+              against concurrent changes.
+
+              If left unspecified, no validation is done against the last transaction's
+              serial.
+
+              Optional
+          updateVettedPackagesForceFlags:
+            description: |-
+              Controls whether potentially unsafe vetting updates are allowed.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+              enum:
+              - UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED
+              - UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES
+              - UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES
+      UpdateVettedPackagesResponse:
+        title: UpdateVettedPackagesResponse
+        type: object
+        required:
+        - newVettedPackages
+        properties:
+          pastVettedPackages:
+            $ref: '#/components/schemas/VettedPackages'
+            description: |-
+              All vetted packages on this participant and synchronizer, before the
+              specified changes. Empty if no vetting state existed beforehand.
+
+              Not populated if no vetted topology state exists prior to the update.
+
+              Optional
+          newVettedPackages:
+            $ref: '#/components/schemas/VettedPackages'
+            description: |-
+              All vetted packages on this participant and synchronizer, after the specified changes.
+
+              Required
+      UploadDarFileResponse:
+        title: UploadDarFileResponse
+        description: A message that is received when the upload operation succeeded.
+        type: object
+      User:
+        title: User
+        description: |2-
+           Users and rights
+          /////////////////
+           Users are used to dynamically manage the rights given to Daml applications.
+           They are stored and managed per participant node.
+        type: object
+        required:
+        - id
+        properties:
+          id:
+            description: |-
+              The user identifier, which must be a non-empty string of at most 128
+              characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:()".
+
+              Required
+            type: string
+          primaryParty:
+            description: |-
+              The primary party as which this user reads and acts by default on the ledger
+              *provided* it has the corresponding ``CanReadAs(primary_party)`` or
+              ``CanActAs(primary_party)`` rights.
+              Ledger API clients SHOULD set this field to a non-empty value for all users to
+              enable the users to act on the ledger using their own Daml party.
+              Users for participant administrators MAY have an associated primary party.
+              Modifiable
+
+              Optional
+            type: string
+          isDeactivated:
+            description: |-
+              When set, then the user is denied all access to the Ledger API.
+              Otherwise, the user has access to the Ledger API as per the user's rights.
+              Modifiable
+
+              Optional
+            type: boolean
+          metadata:
+            $ref: '#/components/schemas/ObjectMeta'
+            description: |-
+              The metadata of this user.
+              Note that the ``metadata.resource_version`` tracks changes to the properties described by the ``User`` message and not the user's rights.
+              Modifiable
+
+              Optional
+          identityProviderId:
+            description: |-
+              The ID of the identity provider configured by ``Identity Provider Config``
+              If not set, assume the user is managed by the default identity provider.
+
+              Optional
+            type: string
+      UserManagementFeature:
+        title: UserManagementFeature
+        type: object
+        required:
+        - supported
+        - maxRightsPerUser
+        - maxUsersPageSize
+        properties:
+          supported:
+            description: |-
+              Whether the Ledger API server provides the user management service.
+
+              Required
+            type: boolean
+          maxRightsPerUser:
+            description: |-
+              The maximum number of rights that can be assigned to a single user.
+              Servers MUST support at least 100 rights per user.
+              A value of 0 means that the server enforces no rights per user limit.
+
+              Required
+            type: integer
+            format: int32
+          maxUsersPageSize:
+            description: |-
+              The maximum number of users the server can return in a single response (page).
+              Servers MUST support at least a 100 users per page.
+              A value of 0 means that the server enforces no page size limit.
+
+              Required
+            type: integer
+            format: int32
+      Vet:
+        title: Vet
+        description: |-
+          Set vetting bounds of a list of packages. Packages that were not previously
+          vetted have their bounds added, previous vetting bounds are overwritten.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Vet1'
+      Vet1:
+        title: Vet
+        description: |-
+          Set vetting bounds of a list of packages. Packages that were not previously
+          vetted have their bounds added, previous vetting bounds are overwritten.
+        type: object
+        required:
+        - packages
+        properties:
+          packages:
+            description: |-
+              Packages to be vetted.
+
+              If a reference in this list matches more than one package, the change is
+              considered ambiguous and the entire update request is rejected. In other
+              words, every reference must match exactly one package.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackagesRef'
+          newValidFromInclusive:
+            description: |-
+              The time from which these packages should be vetted, prior lower bounds
+              are overwritten.
+              Optional
+            type: string
+          newValidUntilExclusive:
+            description: |-
+              The time until which these packages should be vetted, prior upper bounds
+              are overwritten.
+              Optional
+            type: string
+      VettedPackage:
+        title: VettedPackage
+        description: |-
+          A package that is vetting on a given participant and synchronizer,
+          modelled after ``VettedPackage`` in `topology.proto <https://github.com/digital-asset/canton/blob/main/community/base/src/main/protobuf/com/digitalasset/canton/protocol/v30/topology.proto#L206>`_,
+          enriched with the package name and version.
+        type: object
+        required:
+        - packageId
+        properties:
+          packageId:
+            description: |-
+              Package ID of this package
+
+              Required
+            type: string
+          validFromInclusive:
+            description: |-
+              The time from which this package is vetted. Empty if vetting time has no
+              lower bound.
+
+              Optional
+            type: string
+          validUntilExclusive:
+            description: |-
+              The time until which this package is vetted. Empty if vetting time has no
+              upper bound.
+
+              Optional
+            type: string
+          packageName:
+            description: |-
+              Name of this package.
+              Only available if the package has been uploaded to the current participant.
+
+              Optional
+            type: string
+          packageVersion:
+            description: |-
+              Version of this package.
+              Only available if the package has been uploaded to the current participant.
+
+              Optional
+            type: string
+      VettedPackages:
+        title: VettedPackages
+        description: |-
+          The list of packages vetted on a given participant and synchronizer, modelled
+          after ``VettedPackages`` in `topology.proto <https://github.com/digital-asset/canton/blob/main/community/base/src/main/protobuf/com/digitalasset/canton/protocol/v30/topology.proto#L206>`_.
+          The list only contains packages that matched a filter in the query that
+          originated it.
+        type: object
+        required:
+        - participantId
+        - synchronizerId
+        - topologySerial
+        - packages
+        properties:
+          packages:
+            description: |-
+              Sorted by package_name and package_version where known, and package_id as a
+              last resort.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackage'
+          participantId:
+            description: |-
+              Participant on which these packages are vetted.
+
+              Required
+            type: string
+          synchronizerId:
+            description: |-
+              Synchronizer on which these packages are vetted.
+
+              Required
+            type: string
+          topologySerial:
+            description: |-
+              Serial of last ``VettedPackages`` topology transaction of this participant
+              and on this synchronizer.
+
+              Required
+            type: integer
+            format: int32
+      VettedPackagesChange:
+        title: VettedPackagesChange
+        description: A change to the set of vetted packages.
+        type: object
+        properties:
+          operation:
+            $ref: '#/components/schemas/Operation'
+      VettedPackagesRef:
+        title: VettedPackagesRef
+        description: |-
+          A reference to identify one or more packages.
+
+          A reference matches a package if its ``package_id`` matches the package's ID,
+          its ``package_name`` matches the package's name, and its ``package_version``
+          matches the package's version. If an attribute in the reference is left
+          unspecified (i.e. as an empty string), that attribute is treated as a
+          wildcard. At a minimum, ``package_id`` or the ``package_name`` must be
+          specified.
+
+          If a reference does not match any package, the reference is considered
+          unresolved and the entire update request is rejected.
+        type: object
+        properties:
+          packageId:
+            description: |-
+              Package's package id must be the same as this field.
+
+              Optional
+            type: string
+          packageName:
+            description: |-
+              Package's name must be the same as this field.
+
+              Optional
+            type: string
+          packageVersion:
+            description: |-
+              Package's version must be the same as this field.
+
+              Optional
+            type: string
+      WildcardFilter:
+        title: WildcardFilter
+        description: This filter matches all templates.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/WildcardFilter1'
+      WildcardFilter1:
+        title: WildcardFilter
+        description: This filter matches all templates.
+        type: object
+        properties:
+          includeCreatedEventBlob:
+            description: |-
+              Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
+              Use this to access the contract create event payload in your API client
+              for submitting it as a disclosed contract with future commands.
+
+              Optional
+            type: boolean
+    securitySchemes:
+      apiKeyAuth:
+        type: apiKey
+        description: Ledger API standard JWT token (websocket)
+        name: Sec-WebSocket-Protocol
+        in: header
+      httpAuth:
+        type: http
+        description: Ledger API standard JWT token
+        scheme: bearer
+

--- a/config/x2mdx/ledger-api/manifest.json
+++ b/config/x2mdx/ledger-api/manifest.json
@@ -1,0 +1,22 @@
+{
+  "source": "docs.digitalasset.com published JSON Ledger API OpenAPI pages",
+  "captured_on": "2026-03-25",
+  "versions": [
+    {
+      "version": "3.4",
+      "url": "https://docs.digitalasset.com/build/3.4/reference/json-api/openapi.html",
+      "source_path": "published/json-ledger-api/openapi.yaml",
+      "http_status": 200,
+      "status": "captured",
+      "fixture_path": "3.4/openapi.yaml"
+    },
+    {
+      "version": "3.5",
+      "url": "https://docs.digitalasset.com/build/3.5/reference/json-api/openapi.html",
+      "source_path": "published/json-ledger-api/openapi.yaml",
+      "http_status": 200,
+      "status": "captured",
+      "fixture_path": "3.5/openapi.yaml"
+    }
+  ]
+}

--- a/docs-main/appdev/reference/json-api-reference.mdx
+++ b/docs-main/appdev/reference/json-api-reference.mdx
@@ -140,6 +140,27 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `actAs`, `commandId`, `commands` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "commands": [
+    {
+      "CreateAndExerciseCommand": {
+        "templateId": "...",
+        "createArguments": "...",
+        "choice": "...",
+        "choiceArgument": "..."
+      }
+    }
+  ],
+  "commandId": "<string>",
+  "actAs": [
+    "<string>"
+  ]
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -162,6 +183,22 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `reassignmentCommands` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "reassignmentCommands": {
+    "commandId": "<string>",
+    "submitter": "<string>",
+    "commands": [
+      {
+        "command": "..."
+      }
+    ]
+  }
+}
+```
 
 **Responses**
 
@@ -193,6 +230,16 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `parties` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "parties": [
+    "<string>"
+  ]
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -215,6 +262,27 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `actAs`, `commandId`, `commands` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "commands": [
+    {
+      "CreateAndExerciseCommand": {
+        "templateId": "...",
+        "createArguments": "...",
+        "choice": "...",
+        "choiceArgument": "..."
+      }
+    }
+  ],
+  "commandId": "<string>",
+  "actAs": [
+    "<string>"
+  ]
+}
+```
 
 **Responses**
 
@@ -239,6 +307,22 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `reassignmentCommands` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "reassignmentCommands": {
+    "commandId": "<string>",
+    "submitter": "<string>",
+    "commands": [
+      {
+        "command": "..."
+      }
+    ]
+  }
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -261,6 +345,24 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `commands` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "commands": {
+    "commands": [
+      {
+        "CreateAndExerciseCommand": "..."
+      }
+    ],
+    "commandId": "<string>",
+    "actAs": [
+      "<string>"
+    ]
+  }
+}
+```
 
 **Responses**
 
@@ -285,6 +387,27 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `actAs`, `commandId`, `commands` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "commands": [
+    {
+      "CreateAndExerciseCommand": {
+        "templateId": "...",
+        "createArguments": "...",
+        "choice": "...",
+        "choiceArgument": "..."
+      }
+    }
+  ],
+  "commandId": "<string>",
+  "actAs": [
+    "<string>"
+  ]
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -307,6 +430,14 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `contractId` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "contractId": "<string>"
+}
+```
 
 **Responses**
 
@@ -338,6 +469,12 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/octet-stream` | `string` | - |
 
+**Request Example: `application/octet-stream`**
+
+```json
+"<string>"
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -367,6 +504,12 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/octet-stream` | `string` | - |
 
+**Request Example: `application/octet-stream`**
+
+```json
+"<string>"
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -389,6 +532,23 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `contractId`, `eventFormat` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "contractId": "<string>",
+  "eventFormat": {
+    "filtersByParty": {},
+    "filtersForAnyParty": {
+      "cumulative": [
+        "..."
+      ]
+    },
+    "verbose": false
+  }
+}
+```
 
 **Responses**
 
@@ -427,6 +587,18 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `identityProviderConfig` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "identityProviderConfig": {
+    "identityProviderId": "<string>",
+    "issuer": "<string>",
+    "jwksUrl": "<string>"
+  }
+}
+```
 
 **Responses**
 
@@ -499,6 +671,23 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `identityProviderConfig`, `updateMask` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "identityProviderConfig": {
+    "identityProviderId": "<string>",
+    "issuer": "<string>",
+    "jwksUrl": "<string>"
+  },
+  "updateMask": {
+    "unknownFields": {
+      "fields": {}
+    }
+  }
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -521,6 +710,24 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `hashingSchemeVersion`, `partySignatures`, `preparedTransaction`, `submissionId` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "preparedTransaction": "<string>",
+  "partySignatures": {
+    "signatures": [
+      {
+        "party": "...",
+        "signatures": "..."
+      }
+    ]
+  },
+  "submissionId": "<string>",
+  "hashingSchemeVersion": "HASHING_SCHEME_VERSION_UNSPECIFIED"
+}
+```
 
 **Responses**
 
@@ -545,6 +752,24 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `hashingSchemeVersion`, `partySignatures`, `preparedTransaction`, `submissionId` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "preparedTransaction": "<string>",
+  "partySignatures": {
+    "signatures": [
+      {
+        "party": "...",
+        "signatures": "..."
+      }
+    ]
+  },
+  "submissionId": "<string>",
+  "hashingSchemeVersion": "HASHING_SCHEME_VERSION_UNSPECIFIED"
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -567,6 +792,24 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `hashingSchemeVersion`, `partySignatures`, `preparedTransaction`, `submissionId` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "preparedTransaction": "<string>",
+  "partySignatures": {
+    "signatures": [
+      {
+        "party": "...",
+        "signatures": "..."
+      }
+    ]
+  },
+  "submissionId": "<string>",
+  "hashingSchemeVersion": "HASHING_SCHEME_VERSION_UNSPECIFIED"
+}
+```
 
 **Responses**
 
@@ -615,6 +858,21 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `packageVettingRequirements` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "packageVettingRequirements": [
+    {
+      "parties": [
+        "..."
+      ],
+      "packageName": "<string>"
+    }
+  ]
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -637,6 +895,27 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `actAs`, `commandId`, `commands` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "commandId": "<string>",
+  "commands": [
+    {
+      "CreateAndExerciseCommand": {
+        "templateId": "...",
+        "createArguments": "...",
+        "choice": "...",
+        "choiceArgument": "..."
+      }
+    }
+  ],
+  "actAs": [
+    "<string>"
+  ]
+}
+```
 
 **Responses**
 
@@ -661,6 +940,31 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | - |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "packageMetadataFilter": {
+    "packageIds": [
+      "<string>"
+    ],
+    "packageNamePrefixes": [
+      "<string>"
+    ]
+  },
+  "topologyStateFilter": {
+    "participantIds": [
+      "<string>"
+    ],
+    "synchronizerIds": [
+      "<string>"
+    ]
+  },
+  "pageToken": "<string>",
+  "pageSize": 0
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -683,6 +987,20 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `changes` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "changes": [
+    {
+      "operation": {
+        "Empty": "..."
+      }
+    }
+  ]
+}
+```
 
 **Responses**
 
@@ -728,6 +1046,12 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/octet-stream` | `string` | - |
+
+**Request Example: `application/octet-stream`**
+
+```json
+"<string>"
+```
 
 **Responses**
 
@@ -818,6 +1142,21 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | - |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "partyIdHint": "<string>",
+  "localMetadata": {
+    "resourceVersion": "<string>",
+    "annotations": {}
+  },
+  "identityProviderId": "<string>",
+  "synchronizerId": "<string>",
+  "userId": "<string>"
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -841,6 +1180,19 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `onboardingTransactions`, `synchronizer` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "synchronizer": "<string>",
+  "onboardingTransactions": [
+    {
+      "transaction": "<string>"
+    }
+  ]
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -863,6 +1215,20 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `partyHint`, `publicKey`, `synchronizer` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "synchronizer": "<string>",
+  "partyHint": "<string>",
+  "publicKey": {
+    "format": "<string>",
+    "keyData": "<string>",
+    "keySpec": "<string>"
+  }
+}
+```
 
 **Responses**
 
@@ -931,6 +1297,21 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `partyDetails`, `updateMask` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "partyDetails": {
+    "party": "<string>"
+  },
+  "updateMask": {
+    "unknownFields": {
+      "fields": {}
+    }
+  }
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -960,6 +1341,14 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `activeAtOffset` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "activeAtOffset": 0
+}
+```
 
 **Responses**
 
@@ -1044,6 +1433,46 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | - |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "beginExclusive": 0,
+  "endInclusive": 0,
+  "filter": {
+    "filtersByParty": {},
+    "filtersForAnyParty": {
+      "cumulative": [
+        "..."
+      ]
+    }
+  },
+  "verbose": false,
+  "updateFormat": {
+    "includeTransactions": {
+      "eventFormat": {
+        "filtersByParty": "...",
+        "filtersForAnyParty": "...",
+        "verbose": "..."
+      },
+      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+    },
+    "includeReassignments": {
+      "filtersByParty": {},
+      "filtersForAnyParty": {
+        "cumulative": "..."
+      },
+      "verbose": false
+    },
+    "includeTopologyEvents": {
+      "includeParticipantAuthorizationEvents": {
+        "parties": "..."
+      }
+    }
+  }
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -1074,6 +1503,46 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | - |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "beginExclusive": 0,
+  "endInclusive": 0,
+  "filter": {
+    "filtersByParty": {},
+    "filtersForAnyParty": {
+      "cumulative": [
+        "..."
+      ]
+    }
+  },
+  "verbose": false,
+  "updateFormat": {
+    "includeTransactions": {
+      "eventFormat": {
+        "filtersByParty": "...",
+        "filtersForAnyParty": "...",
+        "verbose": "..."
+      },
+      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+    },
+    "includeReassignments": {
+      "filtersByParty": {},
+      "filtersForAnyParty": {
+        "cumulative": "..."
+      },
+      "verbose": false
+    },
+    "includeTopologyEvents": {
+      "includeParticipantAuthorizationEvents": {
+        "parties": "..."
+      }
+    }
+  }
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -1097,6 +1566,14 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `updateId` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "updateId": "<string>"
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -1119,6 +1596,14 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `offset` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "offset": 0
+}
+```
 
 **Responses**
 
@@ -1194,6 +1679,46 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | - |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "beginExclusive": 0,
+  "endInclusive": 0,
+  "filter": {
+    "filtersByParty": {},
+    "filtersForAnyParty": {
+      "cumulative": [
+        "..."
+      ]
+    }
+  },
+  "verbose": false,
+  "updateFormat": {
+    "includeTransactions": {
+      "eventFormat": {
+        "filtersByParty": "...",
+        "filtersForAnyParty": "...",
+        "verbose": "..."
+      },
+      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+    },
+    "includeReassignments": {
+      "filtersByParty": {},
+      "filtersForAnyParty": {
+        "cumulative": "..."
+      },
+      "verbose": false
+    },
+    "includeTopologyEvents": {
+      "includeParticipantAuthorizationEvents": {
+        "parties": "..."
+      }
+    }
+  }
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -1217,6 +1742,36 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `updateFormat`, `updateId` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "updateId": "<string>",
+  "updateFormat": {
+    "includeTransactions": {
+      "eventFormat": {
+        "filtersByParty": "...",
+        "filtersForAnyParty": "...",
+        "verbose": "..."
+      },
+      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+    },
+    "includeReassignments": {
+      "filtersByParty": {},
+      "filtersForAnyParty": {
+        "cumulative": "..."
+      },
+      "verbose": false
+    },
+    "includeTopologyEvents": {
+      "includeParticipantAuthorizationEvents": {
+        "parties": "..."
+      }
+    }
+  }
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -1239,6 +1794,36 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `offset`, `updateFormat` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "offset": 0,
+  "updateFormat": {
+    "includeTransactions": {
+      "eventFormat": {
+        "filtersByParty": "...",
+        "filtersForAnyParty": "...",
+        "verbose": "..."
+      },
+      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+    },
+    "includeReassignments": {
+      "filtersByParty": {},
+      "filtersForAnyParty": {
+        "cumulative": "..."
+      },
+      "verbose": false
+    },
+    "includeTopologyEvents": {
+      "includeParticipantAuthorizationEvents": {
+        "parties": "..."
+      }
+    }
+  }
+}
+```
 
 **Responses**
 
@@ -1284,6 +1869,16 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `user` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "user": {
+    "id": "<string>"
+  }
+}
+```
 
 **Responses**
 
@@ -1357,6 +1952,21 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `updateMask`, `user` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "user": {
+    "id": "<string>"
+  },
+  "updateMask": {
+    "unknownFields": {
+      "fields": {}
+    }
+  }
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -1385,6 +1995,14 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `userId` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "userId": "<string>"
+}
+```
 
 **Responses**
 
@@ -1436,6 +2054,14 @@ Generated from supplied versioned OpenAPI artifacts.
 | --- | --- | --- |
 | `application/json` | `object` | `userId` |
 
+**Request Example: `application/json`**
+
+```json
+{
+  "userId": "<string>"
+}
+```
+
 **Responses**
 
 | Code | Description | Content Types | Schemas |
@@ -1464,6 +2090,14 @@ Generated from supplied versioned OpenAPI artifacts.
 | Content Type | Schema | Required Fields |
 | --- | --- | --- |
 | `application/json` | `object` | `userId` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "userId": "<string>"
+}
+```
 
 **Responses**
 

--- a/docs-main/appdev/reference/json-api-reference.mdx
+++ b/docs-main/appdev/reference/json-api-reference.mdx
@@ -73,69 +73,6 @@ Generated from supplied versioned OpenAPI artifacts.
 
 ## Endpoint Reference (Latest)
 
-| Endpoint | Operation ID | Summary | Tags |
-| --- | --- | --- | --- |
-| [`GET /livez`](#endpoint-get-livez) | `getLivez` | - | `-` |
-| [`GET /readyz`](#endpoint-get-readyz) | `getReadyz` | - | `-` |
-| [`GET /v2/authenticated-user`](#endpoint-get-v2-authenticated-user) | `getV2Authenticated-user` | - | `-` |
-| [`POST /v2/commands/async/submit`](#endpoint-post-v2-commands-async-submit) | `postV2CommandsAsyncSubmit` | - | `-` |
-| [`POST /v2/commands/async/submit-reassignment`](#endpoint-post-v2-commands-async-submit-reassignment) | `postV2CommandsAsyncSubmit-reassignment` | - | `-` |
-| [`POST /v2/commands/completions`](#endpoint-post-v2-commands-completions) | `postV2CommandsCompletions` | - | `-` |
-| [`POST /v2/commands/submit-and-wait`](#endpoint-post-v2-commands-submit-and-wait) | `postV2CommandsSubmit-and-wait` | - | `-` |
-| [`POST /v2/commands/submit-and-wait-for-reassignment`](#endpoint-post-v2-commands-submit-and-wait-for-reassignment) | `postV2CommandsSubmit-and-wait-for-reassignment` | - | `-` |
-| [`POST /v2/commands/submit-and-wait-for-transaction`](#endpoint-post-v2-commands-submit-and-wait-for-transaction) | `postV2CommandsSubmit-and-wait-for-transaction` | - | `-` |
-| [`POST /v2/commands/submit-and-wait-for-transaction-tree`](#endpoint-post-v2-commands-submit-and-wait-for-transaction-tree) | `postV2CommandsSubmit-and-wait-for-transaction-tree` | - | `-` |
-| [`POST /v2/contracts/contract-by-id`](#endpoint-post-v2-contracts-contract-by-id) | `postV2ContractsContract-by-id` | - | `-` |
-| [`POST /v2/dars`](#endpoint-post-v2-dars) | `postV2Dars` | - | `-` |
-| [`POST /v2/dars/validate`](#endpoint-post-v2-dars-validate) | `postV2DarsValidate` | - | `-` |
-| [`POST /v2/events/events-by-contract-id`](#endpoint-post-v2-events-events-by-contract-id) | `postV2EventsEvents-by-contract-id` | - | `-` |
-| [`GET /v2/idps`](#endpoint-get-v2-idps) | `getV2Idps` | - | `-` |
-| [`POST /v2/idps`](#endpoint-post-v2-idps) | `postV2Idps` | - | `-` |
-| [`DELETE /v2/idps/{idp-id}`](#endpoint-delete-v2-idps-idp-id) | `deleteV2IdpsIdp-id` | - | `-` |
-| [`GET /v2/idps/{idp-id}`](#endpoint-get-v2-idps-idp-id) | `getV2IdpsIdp-id` | - | `-` |
-| [`PATCH /v2/idps/{idp-id}`](#endpoint-patch-v2-idps-idp-id) | `patchV2IdpsIdp-id` | - | `-` |
-| [`POST /v2/interactive-submission/execute`](#endpoint-post-v2-interactive-submission-execute) | `postV2Interactive-submissionExecute` | - | `-` |
-| [`POST /v2/interactive-submission/executeAndWait`](#endpoint-post-v2-interactive-submission-executeandwait) | `postV2Interactive-submissionExecuteandwait` | - | `-` |
-| [`POST /v2/interactive-submission/executeAndWaitForTransaction`](#endpoint-post-v2-interactive-submission-executeandwaitfortransaction) | `postV2Interactive-submissionExecuteandwaitfortransaction` | - | `-` |
-| [`GET /v2/interactive-submission/preferred-package-version`](#endpoint-get-v2-interactive-submission-preferred-package-version) | `getV2Interactive-submissionPreferred-package-version` | - | `-` |
-| [`POST /v2/interactive-submission/preferred-packages`](#endpoint-post-v2-interactive-submission-preferred-packages) | `postV2Interactive-submissionPreferred-packages` | - | `-` |
-| [`POST /v2/interactive-submission/prepare`](#endpoint-post-v2-interactive-submission-prepare) | `postV2Interactive-submissionPrepare` | - | `-` |
-| [`GET /v2/package-vetting`](#endpoint-get-v2-package-vetting) | `getV2Package-vetting` | - | `-` |
-| [`POST /v2/package-vetting`](#endpoint-post-v2-package-vetting) | `postV2Package-vetting` | - | `-` |
-| [`GET /v2/packages`](#endpoint-get-v2-packages) | `getV2Packages` | - | `-` |
-| [`POST /v2/packages`](#endpoint-post-v2-packages) | `postV2Packages` | - | `-` |
-| [`GET /v2/packages/{package-id}`](#endpoint-get-v2-packages-package-id) | `getV2PackagesPackage-id` | - | `-` |
-| [`GET /v2/packages/{package-id}/status`](#endpoint-get-v2-packages-package-id-status) | `getV2PackagesPackage-idStatus` | - | `-` |
-| [`GET /v2/parties`](#endpoint-get-v2-parties) | `getV2Parties` | - | `-` |
-| [`POST /v2/parties`](#endpoint-post-v2-parties) | `postV2Parties` | - | `-` |
-| [`POST /v2/parties/external/allocate`](#endpoint-post-v2-parties-external-allocate) | `postV2PartiesExternalAllocate` | - | `-` |
-| [`POST /v2/parties/external/generate-topology`](#endpoint-post-v2-parties-external-generate-topology) | `postV2PartiesExternalGenerate-topology` | - | `-` |
-| [`GET /v2/parties/participant-id`](#endpoint-get-v2-parties-participant-id) | `getV2PartiesParticipant-id` | - | `-` |
-| [`GET /v2/parties/{party}`](#endpoint-get-v2-parties-party) | `getV2PartiesParty` | - | `-` |
-| [`PATCH /v2/parties/{party}`](#endpoint-patch-v2-parties-party) | `patchV2PartiesParty` | - | `-` |
-| [`POST /v2/state/active-contracts`](#endpoint-post-v2-state-active-contracts) | `postV2StateActive-contracts` | - | `-` |
-| [`GET /v2/state/connected-synchronizers`](#endpoint-get-v2-state-connected-synchronizers) | `getV2StateConnected-synchronizers` | - | `-` |
-| [`GET /v2/state/latest-pruned-offsets`](#endpoint-get-v2-state-latest-pruned-offsets) | `getV2StateLatest-pruned-offsets` | - | `-` |
-| [`GET /v2/state/ledger-end`](#endpoint-get-v2-state-ledger-end) | `getV2StateLedger-end` | - | `-` |
-| [`POST /v2/updates`](#endpoint-post-v2-updates) | `postV2Updates` | - | `-` |
-| [`POST /v2/updates/flats`](#endpoint-post-v2-updates-flats) | `postV2UpdatesFlats` | - | `-` |
-| [`POST /v2/updates/transaction-by-id`](#endpoint-post-v2-updates-transaction-by-id) | `postV2UpdatesTransaction-by-id` | - | `-` |
-| [`POST /v2/updates/transaction-by-offset`](#endpoint-post-v2-updates-transaction-by-offset) | `postV2UpdatesTransaction-by-offset` | - | `-` |
-| [`GET /v2/updates/transaction-tree-by-id/{update-id}`](#endpoint-get-v2-updates-transaction-tree-by-id-update-id) | `getV2UpdatesTransaction-tree-by-idUpdate-id` | - | `-` |
-| [`GET /v2/updates/transaction-tree-by-offset/{offset}`](#endpoint-get-v2-updates-transaction-tree-by-offset-offset) | `getV2UpdatesTransaction-tree-by-offsetOffset` | - | `-` |
-| [`POST /v2/updates/trees`](#endpoint-post-v2-updates-trees) | `postV2UpdatesTrees` | - | `-` |
-| [`POST /v2/updates/update-by-id`](#endpoint-post-v2-updates-update-by-id) | `postV2UpdatesUpdate-by-id` | - | `-` |
-| [`POST /v2/updates/update-by-offset`](#endpoint-post-v2-updates-update-by-offset) | `postV2UpdatesUpdate-by-offset` | - | `-` |
-| [`GET /v2/users`](#endpoint-get-v2-users) | `getV2Users` | - | `-` |
-| [`POST /v2/users`](#endpoint-post-v2-users) | `postV2Users` | - | `-` |
-| [`DELETE /v2/users/{user-id}`](#endpoint-delete-v2-users-user-id) | `deleteV2UsersUser-id` | - | `-` |
-| [`GET /v2/users/{user-id}`](#endpoint-get-v2-users-user-id) | `getV2UsersUser-id` | - | `-` |
-| [`PATCH /v2/users/{user-id}`](#endpoint-patch-v2-users-user-id) | `patchV2UsersUser-id` | - | `-` |
-| [`PATCH /v2/users/{user-id}/identity-provider-id`](#endpoint-patch-v2-users-user-id-identity-provider-id) | `patchV2UsersUser-idIdentity-provider-id` | - | `-` |
-| [`GET /v2/users/{user-id}/rights`](#endpoint-get-v2-users-user-id-rights) | `getV2UsersUser-idRights` | - | `-` |
-| [`PATCH /v2/users/{user-id}/rights`](#endpoint-patch-v2-users-user-id-rights) | `patchV2UsersUser-idRights` | - | `-` |
-| [`POST /v2/users/{user-id}/rights`](#endpoint-post-v2-users-user-id-rights) | `postV2UsersUser-idRights` | - | `-` |
-| [`GET /v2/version`](#endpoint-get-v2-version) | `getV2Version` | - | `-` |
 
 <a id="endpoint-get-livez"></a>
 
@@ -198,8 +135,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `actAs`, `commandId`, `commands` |
 
 **Responses**
 
@@ -219,8 +158,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `reassignmentCommands` |
 
 **Responses**
 
@@ -247,8 +188,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `parties` |
 
 **Responses**
 
@@ -268,8 +211,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `actAs`, `commandId`, `commands` |
 
 **Responses**
 
@@ -289,8 +234,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `reassignmentCommands` |
 
 **Responses**
 
@@ -310,8 +257,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `commands` |
 
 **Responses**
 
@@ -331,8 +280,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `actAs`, `commandId`, `commands` |
 
 **Responses**
 
@@ -352,8 +303,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `contractId` |
 
 **Responses**
 
@@ -380,8 +333,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/octet-stream` -> `string`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/octet-stream` | `string` | - |
 
 **Responses**
 
@@ -407,8 +362,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/octet-stream` -> `string`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/octet-stream` | `string` | - |
 
 **Responses**
 
@@ -428,8 +385,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `contractId`, `eventFormat` |
 
 **Responses**
 
@@ -464,8 +423,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `identityProviderConfig` |
 
 **Responses**
 
@@ -533,8 +494,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `identityProviderConfig`, `updateMask` |
 
 **Responses**
 
@@ -554,8 +517,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `hashingSchemeVersion`, `partySignatures`, `preparedTransaction`, `submissionId` |
 
 **Responses**
 
@@ -575,8 +540,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `hashingSchemeVersion`, `partySignatures`, `preparedTransaction`, `submissionId` |
 
 **Responses**
 
@@ -596,8 +563,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `hashingSchemeVersion`, `partySignatures`, `preparedTransaction`, `submissionId` |
 
 **Responses**
 
@@ -641,8 +610,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `packageVettingRequirements` |
 
 **Responses**
 
@@ -662,8 +633,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `actAs`, `commandId`, `commands` |
 
 **Responses**
 
@@ -683,8 +656,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | - |
 
 **Responses**
 
@@ -704,8 +679,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `changes` |
 
 **Responses**
 
@@ -747,8 +724,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/octet-stream` -> `string`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/octet-stream` | `string` | - |
 
 **Responses**
 
@@ -834,8 +813,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | - |
 
 **Responses**
 
@@ -855,8 +836,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `onboardingTransactions`, `synchronizer` |
 
 **Responses**
 
@@ -876,8 +859,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `partyHint`, `publicKey`, `synchronizer` |
 
 **Responses**
 
@@ -941,8 +926,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `partyDetails`, `updateMask` |
 
 **Responses**
 
@@ -969,8 +956,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `activeAtOffset` |
 
 **Responses**
 
@@ -1050,8 +1039,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | - |
 
 **Responses**
 
@@ -1078,8 +1069,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | - |
 
 **Responses**
 
@@ -1099,8 +1092,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `updateId` |
 
 **Responses**
 
@@ -1120,8 +1115,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `offset` |
 
 **Responses**
 
@@ -1192,8 +1189,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | - |
 
 **Responses**
 
@@ -1213,8 +1212,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `updateFormat`, `updateId` |
 
 **Responses**
 
@@ -1234,8 +1235,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `offset`, `updateFormat` |
 
 **Responses**
 
@@ -1277,8 +1280,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `user` |
 
 **Responses**
 
@@ -1347,8 +1352,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `updateMask`, `user` |
 
 **Responses**
 
@@ -1374,8 +1381,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `userId` |
 
 **Responses**
 
@@ -1422,8 +1431,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `userId` |
 
 **Responses**
 
@@ -1449,8 +1460,10 @@ Generated from supplied versioned OpenAPI artifacts.
 **Request Body**
 
 - Required: `yes`
-- Content:
-  - `application/json` -> `object`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `userId` |
 
 **Responses**
 

--- a/docs-main/appdev/reference/json-api-reference.mdx
+++ b/docs-main/appdev/reference/json-api-reference.mdx
@@ -147,10 +147,10 @@ Generated from supplied versioned OpenAPI artifacts.
   "commands": [
     {
       "CreateAndExerciseCommand": {
-        "templateId": "...",
-        "createArguments": "...",
-        "choice": "...",
-        "choiceArgument": "..."
+        "templateId": "<string>",
+        "createArguments": "<value>",
+        "choice": "<string>",
+        "choiceArgument": "<value>"
       }
     }
   ],
@@ -193,7 +193,7 @@ Generated from supplied versioned OpenAPI artifacts.
     "submitter": "<string>",
     "commands": [
       {
-        "command": "..."
+        "command": "<object>"
       }
     ]
   }
@@ -270,10 +270,10 @@ Generated from supplied versioned OpenAPI artifacts.
   "commands": [
     {
       "CreateAndExerciseCommand": {
-        "templateId": "...",
-        "createArguments": "...",
-        "choice": "...",
-        "choiceArgument": "..."
+        "templateId": "<string>",
+        "createArguments": "<value>",
+        "choice": "<string>",
+        "choiceArgument": "<value>"
       }
     }
   ],
@@ -316,7 +316,7 @@ Generated from supplied versioned OpenAPI artifacts.
     "submitter": "<string>",
     "commands": [
       {
-        "command": "..."
+        "command": "<object>"
       }
     ]
   }
@@ -353,7 +353,7 @@ Generated from supplied versioned OpenAPI artifacts.
   "commands": {
     "commands": [
       {
-        "CreateAndExerciseCommand": "..."
+        "CreateAndExerciseCommand": "<object>"
       }
     ],
     "commandId": "<string>",
@@ -394,10 +394,10 @@ Generated from supplied versioned OpenAPI artifacts.
   "commands": [
     {
       "CreateAndExerciseCommand": {
-        "templateId": "...",
-        "createArguments": "...",
-        "choice": "...",
-        "choiceArgument": "..."
+        "templateId": "<string>",
+        "createArguments": "<value>",
+        "choice": "<string>",
+        "choiceArgument": "<value>"
       }
     }
   ],
@@ -542,10 +542,10 @@ Generated from supplied versioned OpenAPI artifacts.
     "filtersByParty": {},
     "filtersForAnyParty": {
       "cumulative": [
-        "..."
+        "<object>"
       ]
     },
-    "verbose": false
+    "verbose": "<boolean>"
   }
 }
 ```
@@ -719,13 +719,15 @@ Generated from supplied versioned OpenAPI artifacts.
   "partySignatures": {
     "signatures": [
       {
-        "party": "...",
-        "signatures": "..."
+        "party": "<string>",
+        "signatures": [
+          "<object>"
+        ]
       }
     ]
   },
   "submissionId": "<string>",
-  "hashingSchemeVersion": "HASHING_SCHEME_VERSION_UNSPECIFIED"
+  "hashingSchemeVersion": "<string>"
 }
 ```
 
@@ -760,13 +762,15 @@ Generated from supplied versioned OpenAPI artifacts.
   "partySignatures": {
     "signatures": [
       {
-        "party": "...",
-        "signatures": "..."
+        "party": "<string>",
+        "signatures": [
+          "<object>"
+        ]
       }
     ]
   },
   "submissionId": "<string>",
-  "hashingSchemeVersion": "HASHING_SCHEME_VERSION_UNSPECIFIED"
+  "hashingSchemeVersion": "<string>"
 }
 ```
 
@@ -801,13 +805,15 @@ Generated from supplied versioned OpenAPI artifacts.
   "partySignatures": {
     "signatures": [
       {
-        "party": "...",
-        "signatures": "..."
+        "party": "<string>",
+        "signatures": [
+          "<object>"
+        ]
       }
     ]
   },
   "submissionId": "<string>",
-  "hashingSchemeVersion": "HASHING_SCHEME_VERSION_UNSPECIFIED"
+  "hashingSchemeVersion": "<string>"
 }
 ```
 
@@ -865,7 +871,7 @@ Generated from supplied versioned OpenAPI artifacts.
   "packageVettingRequirements": [
     {
       "parties": [
-        "..."
+        "<string>"
       ],
       "packageName": "<string>"
     }
@@ -904,10 +910,10 @@ Generated from supplied versioned OpenAPI artifacts.
   "commands": [
     {
       "CreateAndExerciseCommand": {
-        "templateId": "...",
-        "createArguments": "...",
-        "choice": "...",
-        "choiceArgument": "..."
+        "templateId": "<string>",
+        "createArguments": "<value>",
+        "choice": "<string>",
+        "choiceArgument": "<value>"
       }
     }
   ],
@@ -961,7 +967,7 @@ Generated from supplied versioned OpenAPI artifacts.
     ]
   },
   "pageToken": "<string>",
-  "pageSize": 0
+  "pageSize": "<integer>"
 }
 ```
 
@@ -995,7 +1001,7 @@ Generated from supplied versioned OpenAPI artifacts.
   "changes": [
     {
       "operation": {
-        "Empty": "..."
+        "Empty": "<object>"
       }
     }
   ]
@@ -1346,7 +1352,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 ```json
 {
-  "activeAtOffset": 0
+  "activeAtOffset": "<integer>"
 }
 ```
 
@@ -1437,36 +1443,40 @@ Generated from supplied versioned OpenAPI artifacts.
 
 ```json
 {
-  "beginExclusive": 0,
-  "endInclusive": 0,
+  "beginExclusive": "<integer>",
+  "endInclusive": "<integer>",
   "filter": {
     "filtersByParty": {},
     "filtersForAnyParty": {
       "cumulative": [
-        "..."
+        "<object>"
       ]
     }
   },
-  "verbose": false,
+  "verbose": "<boolean>",
   "updateFormat": {
     "includeTransactions": {
       "eventFormat": {
-        "filtersByParty": "...",
-        "filtersForAnyParty": "...",
-        "verbose": "..."
+        "filtersByParty": "<object>",
+        "filtersForAnyParty": "<object>",
+        "verbose": "<boolean>"
       },
-      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+      "transactionShape": "<string>"
     },
     "includeReassignments": {
       "filtersByParty": {},
       "filtersForAnyParty": {
-        "cumulative": "..."
+        "cumulative": [
+          "<object>"
+        ]
       },
-      "verbose": false
+      "verbose": "<boolean>"
     },
     "includeTopologyEvents": {
       "includeParticipantAuthorizationEvents": {
-        "parties": "..."
+        "parties": [
+          "<string>"
+        ]
       }
     }
   }
@@ -1507,36 +1517,40 @@ Generated from supplied versioned OpenAPI artifacts.
 
 ```json
 {
-  "beginExclusive": 0,
-  "endInclusive": 0,
+  "beginExclusive": "<integer>",
+  "endInclusive": "<integer>",
   "filter": {
     "filtersByParty": {},
     "filtersForAnyParty": {
       "cumulative": [
-        "..."
+        "<object>"
       ]
     }
   },
-  "verbose": false,
+  "verbose": "<boolean>",
   "updateFormat": {
     "includeTransactions": {
       "eventFormat": {
-        "filtersByParty": "...",
-        "filtersForAnyParty": "...",
-        "verbose": "..."
+        "filtersByParty": "<object>",
+        "filtersForAnyParty": "<object>",
+        "verbose": "<boolean>"
       },
-      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+      "transactionShape": "<string>"
     },
     "includeReassignments": {
       "filtersByParty": {},
       "filtersForAnyParty": {
-        "cumulative": "..."
+        "cumulative": [
+          "<object>"
+        ]
       },
-      "verbose": false
+      "verbose": "<boolean>"
     },
     "includeTopologyEvents": {
       "includeParticipantAuthorizationEvents": {
-        "parties": "..."
+        "parties": [
+          "<string>"
+        ]
       }
     }
   }
@@ -1601,7 +1615,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 ```json
 {
-  "offset": 0
+  "offset": "<integer>"
 }
 ```
 
@@ -1683,36 +1697,40 @@ Generated from supplied versioned OpenAPI artifacts.
 
 ```json
 {
-  "beginExclusive": 0,
-  "endInclusive": 0,
+  "beginExclusive": "<integer>",
+  "endInclusive": "<integer>",
   "filter": {
     "filtersByParty": {},
     "filtersForAnyParty": {
       "cumulative": [
-        "..."
+        "<object>"
       ]
     }
   },
-  "verbose": false,
+  "verbose": "<boolean>",
   "updateFormat": {
     "includeTransactions": {
       "eventFormat": {
-        "filtersByParty": "...",
-        "filtersForAnyParty": "...",
-        "verbose": "..."
+        "filtersByParty": "<object>",
+        "filtersForAnyParty": "<object>",
+        "verbose": "<boolean>"
       },
-      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+      "transactionShape": "<string>"
     },
     "includeReassignments": {
       "filtersByParty": {},
       "filtersForAnyParty": {
-        "cumulative": "..."
+        "cumulative": [
+          "<object>"
+        ]
       },
-      "verbose": false
+      "verbose": "<boolean>"
     },
     "includeTopologyEvents": {
       "includeParticipantAuthorizationEvents": {
-        "parties": "..."
+        "parties": [
+          "<string>"
+        ]
       }
     }
   }
@@ -1750,22 +1768,26 @@ Generated from supplied versioned OpenAPI artifacts.
   "updateFormat": {
     "includeTransactions": {
       "eventFormat": {
-        "filtersByParty": "...",
-        "filtersForAnyParty": "...",
-        "verbose": "..."
+        "filtersByParty": "<object>",
+        "filtersForAnyParty": "<object>",
+        "verbose": "<boolean>"
       },
-      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+      "transactionShape": "<string>"
     },
     "includeReassignments": {
       "filtersByParty": {},
       "filtersForAnyParty": {
-        "cumulative": "..."
+        "cumulative": [
+          "<object>"
+        ]
       },
-      "verbose": false
+      "verbose": "<boolean>"
     },
     "includeTopologyEvents": {
       "includeParticipantAuthorizationEvents": {
-        "parties": "..."
+        "parties": [
+          "<string>"
+        ]
       }
     }
   }
@@ -1799,26 +1821,30 @@ Generated from supplied versioned OpenAPI artifacts.
 
 ```json
 {
-  "offset": 0,
+  "offset": "<integer>",
   "updateFormat": {
     "includeTransactions": {
       "eventFormat": {
-        "filtersByParty": "...",
-        "filtersForAnyParty": "...",
-        "verbose": "..."
+        "filtersByParty": "<object>",
+        "filtersForAnyParty": "<object>",
+        "verbose": "<boolean>"
       },
-      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+      "transactionShape": "<string>"
     },
     "includeReassignments": {
       "filtersByParty": {},
       "filtersForAnyParty": {
-        "cumulative": "..."
+        "cumulative": [
+          "<object>"
+        ]
       },
-      "verbose": false
+      "verbose": "<boolean>"
     },
     "includeTopologyEvents": {
       "includeParticipantAuthorizationEvents": {
-        "parties": "..."
+        "parties": [
+          "<string>"
+        ]
       }
     }
   }

--- a/docs-main/appdev/reference/json-api-reference.mdx
+++ b/docs-main/appdev/reference/json-api-reference.mdx
@@ -1473,6 +1473,72 @@ Generated from supplied versioned OpenAPI artifacts.
 | `/v2/users/{user-id}/rights` | `path` | `3.4` | `3.5` | - |
 | `/v2/version` | `path` | `3.4` | `3.5` | - |
 
+## Endpoint Diff Summary
+
+| Endpoint | Version | Event | Changes |
+| --- | --- | --- | --- |
+| `DELETE /v2/idps/{idp-id}` | `3.5` | `changed` | description updated; response `400` description updated |
+| `DELETE /v2/users/{user-id}` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /livez` | `3.5` | `added` | added endpoint |
+| `GET /readyz` | `3.5` | `added` | added endpoint |
+| `GET /v2/authenticated-user` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/idps` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/idps/{idp-id}` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/interactive-submission/preferred-package-version` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/package-vetting` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/packages` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/packages/{package-id}` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/packages/{package-id}/status` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/parties` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/parties/participant-id` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/parties/{party}` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/state/connected-synchronizers` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/state/latest-pruned-offsets` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/state/ledger-end` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/updates/transaction-tree-by-id/{update-id}` | `3.5` | `changed` | response `400` description updated |
+| `GET /v2/updates/transaction-tree-by-offset/{offset}` | `3.5` | `changed` | response `400` description updated |
+| `GET /v2/users` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/users/{user-id}` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/users/{user-id}/rights` | `3.5` | `changed` | description updated; response `400` description updated |
+| `GET /v2/version` | `3.5` | `changed` | description updated; response `400` description updated |
+| `PATCH /v2/idps/{idp-id}` | `3.5` | `changed` | description updated; response `400` description updated |
+| `PATCH /v2/parties/{party}` | `3.5` | `changed` | description updated; response `400` description updated |
+| `PATCH /v2/users/{user-id}` | `3.5` | `changed` | description updated; response `400` description updated |
+| `PATCH /v2/users/{user-id}/identity-provider-id` | `3.5` | `changed` | description updated; response `400` description updated |
+| `PATCH /v2/users/{user-id}/rights` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/commands/async/submit` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/commands/async/submit-reassignment` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/commands/completions` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/commands/submit-and-wait` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/commands/submit-and-wait-for-reassignment` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/commands/submit-and-wait-for-transaction` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/commands/submit-and-wait-for-transaction-tree` | `3.5` | `changed` | response `400` description updated |
+| `POST /v2/contracts/contract-by-id` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/dars` | `3.5` | `changed` | response `400` description updated |
+| `POST /v2/dars/validate` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/events/events-by-contract-id` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/idps` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/interactive-submission/execute` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/interactive-submission/executeAndWait` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/interactive-submission/executeAndWaitForTransaction` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/interactive-submission/preferred-packages` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/interactive-submission/prepare` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/package-vetting` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/packages` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/parties` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/parties/external/allocate` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/parties/external/generate-topology` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/state/active-contracts` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/updates` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/updates/flats` | `3.5` | `changed` | response `400` description updated |
+| `POST /v2/updates/transaction-by-id` | `3.5` | `changed` | response `400` description updated |
+| `POST /v2/updates/transaction-by-offset` | `3.5` | `changed` | response `400` description updated |
+| `POST /v2/updates/trees` | `3.5` | `changed` | response `400` description updated |
+| `POST /v2/updates/update-by-id` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/updates/update-by-offset` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/users` | `3.5` | `changed` | description updated; response `400` description updated |
+| `POST /v2/users/{user-id}/rights` | `3.5` | `changed` | description updated; response `400` description updated |
+
 ## Latest Operations
 
 | Operation | Introduced | Changed In | Removed |

--- a/docs-main/appdev/reference/json-api-reference.mdx
+++ b/docs-main/appdev/reference/json-api-reference.mdx
@@ -1,0 +1,1797 @@
+---
+title: "JSON Ledger API HTTP endpoints"
+description: "Generated API reference from versioned OpenAPI artifacts"
+---
+
+Generated from supplied versioned OpenAPI artifacts.
+
+## Spec Metadata
+
+- Canonical spec id: `json-ledger-api/openapi.yaml`
+- Latest source path: `published/json-ledger-api/openapi.yaml`
+- OpenAPI version (latest): `3.0.3`
+- Introduced: `3.4`
+- Changed in versions: `3.5`
+- Removed: -
+
+## Entity Summary
+
+- Total entities tracked: `363`
+- Entities introduced after spec introduction: `6`
+- Entities changed at least once: `147`
+- Entities removed: `1`
+- Latest operations: `61`
+- Latest paths: `49`
+- Latest components: `252`
+- Latest tags: `0`
+
+## Endpoint Reference (Latest)
+
+| Endpoint | Operation ID | Summary | Tags |
+| --- | --- | --- | --- |
+| `GET /livez` | `getLivez` | - | `-` |
+| `GET /readyz` | `getReadyz` | - | `-` |
+| `GET /v2/authenticated-user` | `getV2Authenticated-user` | - | `-` |
+| `POST /v2/commands/async/submit` | `postV2CommandsAsyncSubmit` | - | `-` |
+| `POST /v2/commands/async/submit-reassignment` | `postV2CommandsAsyncSubmit-reassignment` | - | `-` |
+| `POST /v2/commands/completions` | `postV2CommandsCompletions` | - | `-` |
+| `POST /v2/commands/submit-and-wait` | `postV2CommandsSubmit-and-wait` | - | `-` |
+| `POST /v2/commands/submit-and-wait-for-reassignment` | `postV2CommandsSubmit-and-wait-for-reassignment` | - | `-` |
+| `POST /v2/commands/submit-and-wait-for-transaction` | `postV2CommandsSubmit-and-wait-for-transaction` | - | `-` |
+| `POST /v2/commands/submit-and-wait-for-transaction-tree` | `postV2CommandsSubmit-and-wait-for-transaction-tree` | - | `-` |
+| `POST /v2/contracts/contract-by-id` | `postV2ContractsContract-by-id` | - | `-` |
+| `POST /v2/dars` | `postV2Dars` | - | `-` |
+| `POST /v2/dars/validate` | `postV2DarsValidate` | - | `-` |
+| `POST /v2/events/events-by-contract-id` | `postV2EventsEvents-by-contract-id` | - | `-` |
+| `GET /v2/idps` | `getV2Idps` | - | `-` |
+| `POST /v2/idps` | `postV2Idps` | - | `-` |
+| `DELETE /v2/idps/{idp-id}` | `deleteV2IdpsIdp-id` | - | `-` |
+| `GET /v2/idps/{idp-id}` | `getV2IdpsIdp-id` | - | `-` |
+| `PATCH /v2/idps/{idp-id}` | `patchV2IdpsIdp-id` | - | `-` |
+| `POST /v2/interactive-submission/execute` | `postV2Interactive-submissionExecute` | - | `-` |
+| `POST /v2/interactive-submission/executeAndWait` | `postV2Interactive-submissionExecuteandwait` | - | `-` |
+| `POST /v2/interactive-submission/executeAndWaitForTransaction` | `postV2Interactive-submissionExecuteandwaitfortransaction` | - | `-` |
+| `GET /v2/interactive-submission/preferred-package-version` | `getV2Interactive-submissionPreferred-package-version` | - | `-` |
+| `POST /v2/interactive-submission/preferred-packages` | `postV2Interactive-submissionPreferred-packages` | - | `-` |
+| `POST /v2/interactive-submission/prepare` | `postV2Interactive-submissionPrepare` | - | `-` |
+| `GET /v2/package-vetting` | `getV2Package-vetting` | - | `-` |
+| `POST /v2/package-vetting` | `postV2Package-vetting` | - | `-` |
+| `GET /v2/packages` | `getV2Packages` | - | `-` |
+| `POST /v2/packages` | `postV2Packages` | - | `-` |
+| `GET /v2/packages/{package-id}` | `getV2PackagesPackage-id` | - | `-` |
+| `GET /v2/packages/{package-id}/status` | `getV2PackagesPackage-idStatus` | - | `-` |
+| `GET /v2/parties` | `getV2Parties` | - | `-` |
+| `POST /v2/parties` | `postV2Parties` | - | `-` |
+| `POST /v2/parties/external/allocate` | `postV2PartiesExternalAllocate` | - | `-` |
+| `POST /v2/parties/external/generate-topology` | `postV2PartiesExternalGenerate-topology` | - | `-` |
+| `GET /v2/parties/participant-id` | `getV2PartiesParticipant-id` | - | `-` |
+| `GET /v2/parties/{party}` | `getV2PartiesParty` | - | `-` |
+| `PATCH /v2/parties/{party}` | `patchV2PartiesParty` | - | `-` |
+| `POST /v2/state/active-contracts` | `postV2StateActive-contracts` | - | `-` |
+| `GET /v2/state/connected-synchronizers` | `getV2StateConnected-synchronizers` | - | `-` |
+| `GET /v2/state/latest-pruned-offsets` | `getV2StateLatest-pruned-offsets` | - | `-` |
+| `GET /v2/state/ledger-end` | `getV2StateLedger-end` | - | `-` |
+| `POST /v2/updates` | `postV2Updates` | - | `-` |
+| `POST /v2/updates/flats` | `postV2UpdatesFlats` | - | `-` |
+| `POST /v2/updates/transaction-by-id` | `postV2UpdatesTransaction-by-id` | - | `-` |
+| `POST /v2/updates/transaction-by-offset` | `postV2UpdatesTransaction-by-offset` | - | `-` |
+| `GET /v2/updates/transaction-tree-by-id/{update-id}` | `getV2UpdatesTransaction-tree-by-idUpdate-id` | - | `-` |
+| `GET /v2/updates/transaction-tree-by-offset/{offset}` | `getV2UpdatesTransaction-tree-by-offsetOffset` | - | `-` |
+| `POST /v2/updates/trees` | `postV2UpdatesTrees` | - | `-` |
+| `POST /v2/updates/update-by-id` | `postV2UpdatesUpdate-by-id` | - | `-` |
+| `POST /v2/updates/update-by-offset` | `postV2UpdatesUpdate-by-offset` | - | `-` |
+| `GET /v2/users` | `getV2Users` | - | `-` |
+| `POST /v2/users` | `postV2Users` | - | `-` |
+| `DELETE /v2/users/{user-id}` | `deleteV2UsersUser-id` | - | `-` |
+| `GET /v2/users/{user-id}` | `getV2UsersUser-id` | - | `-` |
+| `PATCH /v2/users/{user-id}` | `patchV2UsersUser-id` | - | `-` |
+| `PATCH /v2/users/{user-id}/identity-provider-id` | `patchV2UsersUser-idIdentity-provider-id` | - | `-` |
+| `GET /v2/users/{user-id}/rights` | `getV2UsersUser-idRights` | - | `-` |
+| `PATCH /v2/users/{user-id}/rights` | `patchV2UsersUser-idRights` | - | `-` |
+| `POST /v2/users/{user-id}/rights` | `postV2UsersUser-idRights` | - | `-` |
+| `GET /v2/version` | `getV2Version` | - | `-` |
+
+### `GET /livez`
+
+- Operation ID: `getLivez`
+- Description: Checks if the service is alive
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | OK: service is alive | `-` | `-` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /readyz`
+
+- Operation ID: `getReadyz`
+- Description: Checks if the service is ready to serve requests
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | OK: readiness message | `text/plain` | `text/plain:string` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/authenticated-user`
+
+- Operation ID: `getV2Authenticated-user`
+- Description: Get the user data of the current authenticated user.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `identity-provider-id` | `query` | `no` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: query parameter identity-provider-id | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/commands/async/submit`
+
+- Operation ID: `postV2CommandsAsyncSubmit`
+- Description: Submit a single composite command.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/commands/async/submit-reassignment`
+
+- Operation ID: `postV2CommandsAsyncSubmit-reassignment`
+- Description: Submit a single reassignment.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/commands/completions`
+
+- Operation ID: `postV2CommandsCompletions`
+- Description: Query completions list (blocking call)  Subscribe to command completion events. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `limit` | `query` | `no` | `integer` | maximum number of elements to return, this param is ignored if is bigger than server setting |
+| `stream_idle_timeout_ms` | `query` | `no` | `integer` | timeout to complete and send result if no new elements are received (for open ended streams) |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:array[object]` |
+| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/commands/submit-and-wait`
+
+- Operation ID: `postV2CommandsSubmit-and-wait`
+- Description: Submits a single composite command and waits for its result. Propagates the gRPC error of failed submissions including Daml interpretation errors.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/commands/submit-and-wait-for-reassignment`
+
+- Operation ID: `postV2CommandsSubmit-and-wait-for-reassignment`
+- Description: Submits a single composite reassignment command, waits for its result, and returns the reassignment. Propagates the gRPC error of failed submission.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/commands/submit-and-wait-for-transaction`
+
+- Operation ID: `postV2CommandsSubmit-and-wait-for-transaction`
+- Description: Submits a single composite command, waits for its result, and returns the transaction. Propagates the gRPC error of failed submissions including Daml interpretation errors.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/commands/submit-and-wait-for-transaction-tree`
+
+- Operation ID: `postV2CommandsSubmit-and-wait-for-transaction-tree`
+- Description: Submit a batch of commands and wait for the transaction trees response. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use submit-and-wait-for-transaction instead.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/contracts/contract-by-id`
+
+- Operation ID: `postV2ContractsContract-by-id`
+- Description: Looking up contract data by contract ID. This endpoint is experimental / alpha, therefore no backwards compatibility is guaranteed. This endpoint must not be used to look up contracts which entered the participant via party replication or repair service.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/dars`
+
+- Operation ID: `postV2Dars`
+- Description: Upload a DAR to the participant node
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `vetAllPackages` | `query` | `no` | `boolean` | - |
+| `synchronizerId` | `query` | `no` | `string` | - |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/octet-stream` -> `string`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter vetAllPackages, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/dars/validate`
+
+- Operation ID: `postV2DarsValidate`
+- Description: Validates the DAR and checks the upgrade compatibility of the DAR's packages with the set of the already vetted packages on the target vetting synchronizer. See ValidateDarFileRequest for details regarding the target vetting synchronizer.  The operation has no effect on the state of the participant or the Canton ledger: the DAR payload and its packages are not persisted neither are the packages vetted.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `synchronizerId` | `query` | `no` | `string` | - |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/octet-stream` -> `string`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `-` | `-` |
+| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/events/events-by-contract-id`
+
+- Operation ID: `postV2EventsEvents-by-contract-id`
+- Description: Get the create and the consuming exercise event for the contract with the provided ID. No events will be returned for contracts that have been pruned because they have already been archived before the latest pruning offset. If the contract cannot be found for the request, or all the contract-events are filtered, a CONTRACT_EVENTS_NOT_FOUND error will be raised.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/idps`
+
+- Operation ID: `getV2Idps`
+- Description: List all existing identity provider configurations.
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/idps`
+
+- Operation ID: `postV2Idps`
+- Description: Create a new identity provider configuration. The request will fail if the maximum allowed number of separate configurations is reached.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `DELETE /v2/idps/{idp-id}`
+
+- Operation ID: `deleteV2IdpsIdp-id`
+- Description: Delete an existing identity provider configuration.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `idp-id` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/idps/{idp-id}`
+
+- Operation ID: `getV2IdpsIdp-id`
+- Description: Get the identity provider configuration data by id.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `idp-id` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `PATCH /v2/idps/{idp-id}`
+
+- Operation ID: `patchV2IdpsIdp-id`
+- Description: Update selected modifiable attribute of an identity provider config resource described by the ``IdentityProviderConfig`` message.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `idp-id` | `path` | `yes` | `string` | - |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/interactive-submission/execute`
+
+- Operation ID: `postV2Interactive-submissionExecute`
+- Description: Execute a prepared submission _asynchronously_ on the ledger. Requires a signature of the transaction from the submitting external party.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/interactive-submission/executeAndWait`
+
+- Operation ID: `postV2Interactive-submissionExecuteandwait`
+- Description: Similar to ExecuteSubmission but _synchronously_ wait for the completion of the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appeared failed and vice versa
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/interactive-submission/executeAndWaitForTransaction`
+
+- Operation ID: `postV2Interactive-submissionExecuteandwaitfortransaction`
+- Description: Similar to ExecuteSubmissionAndWait but additionally returns the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appear as failed and vice versa
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/interactive-submission/preferred-package-version`
+
+- Operation ID: `getV2Interactive-submissionPreferred-package-version`
+- Description: A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred package, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Provided for backwards compatibility, it will be removed in the Canton version 3.4.0
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `parties` | `query` | `no` | `array[string]` | - |
+| `package-name` | `query` | `yes` | `string` | - |
+| `vetting_valid_at` | `query` | `no` | `string` | - |
+| `synchronizer-id` | `query` | `no` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: query parameter parties, Invalid value for: query parameter package-name, Invalid value for: query parameter vetting_valid_at, Invalid value for: query parameter synchronizer-id | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/interactive-submission/preferred-packages`
+
+- Operation ID: `postV2Interactive-submissionPreferred-packages`
+- Description: Compute the preferred packages for the vetting requirements in the request. A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred packages, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  If the package preferences could not be computed due to no selection satisfying the requirements, a `FAILED_PRECONDITION` error will be returned.  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Experimental API: this endpoint is not guaranteed to provide backwards compatibility in future releases
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/interactive-submission/prepare`
+
+- Operation ID: `postV2Interactive-submissionPrepare`
+- Description: Requires `readAs` scope for the submitting party when LAPI User authorization is enabled
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/package-vetting`
+
+- Operation ID: `getV2Package-vetting`
+- Description: Lists which participant node vetted what packages on which synchronizer. Can be called by any authenticated user.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/package-vetting`
+
+- Operation ID: `postV2Package-vetting`
+- Description: Update the vetted packages of this participant
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/packages`
+
+- Operation ID: `getV2Packages`
+- Description: Returns the identifiers of all supported packages.
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/packages`
+
+- Operation ID: `postV2Packages`
+- Description: Behaves the same as /dars. This endpoint will be deprecated and removed in a future release. Upload a DAR file to the participant.  If vetting is enabled in the request, the DAR is checked for upgrade compatibility with the set of the already vetted packages on the target vetting synchronizer See UploadDarFileRequest for details regarding vetting and the target vetting synchronizer.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `vetAllPackages` | `query` | `no` | `boolean` | - |
+| `synchronizerId` | `query` | `no` | `string` | - |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/octet-stream` -> `string`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter vetAllPackages, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/packages/{package-id}`
+
+- Operation ID: `getV2PackagesPackage-id`
+- Description: Returns the contents of a single package.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `package-id` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/octet-stream` | `application/octet-stream:string` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/packages/{package-id}/status`
+
+- Operation ID: `getV2PackagesPackage-idStatus`
+- Description: Returns the status of a single package.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `package-id` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/parties`
+
+- Operation ID: `getV2Parties`
+- Description: List the parties known by the participant. The list returned contains parties whose ledger access is facilitated by the participant and the ones maintained elsewhere.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `identity-provider-id` | `query` | `no` | `string` | - |
+| `filter-party` | `query` | `no` | `string` | - |
+| `pageSize` | `query` | `no` | `integer` | maximum number of elements in a returned page |
+| `pageToken` | `query` | `no` | `string` | token - to continue results from a given page, leave empty to start from the beginning of the list, obtain token from the result of previous page |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: query parameter identity-provider-id, Invalid value for: query parameter filter-party, Invalid value for: query parameter pageSize, Invalid value for: query parameter pageToken | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/parties`
+
+- Operation ID: `postV2Parties`
+- Description: Allocates a new party on a ledger and adds it to the set managed by the participant. Caller specifies a party identifier suggestion, the actual identifier allocated might be different and is implementation specific. Caller can specify party metadata that is stored locally on the participant. This call may:  - Succeed, in which case the actual allocated identifier is visible in   the response. - Respond with a gRPC error  daml-on-kv-ledger: suggestion's uniqueness is checked by the validators in the consensus layer and call rejected if the identifier is already present. canton: completely different globally unique identifier is allocated. Behind the scenes calls to an internal protocol are made. As that protocol is richer than the surface protocol, the arguments take implicit values The party identifier suggestion must be a valid party name. Party names are required to be non-empty US-ASCII strings built from letters, digits, space, colon, minus and underscore limited to 255 chars
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/parties/external/allocate`
+
+- Operation ID: `postV2PartiesExternalAllocate`
+- Description: Alpha 3.3: Endpoint to allocate a new external party on a synchronizer  Expected to be stable in 3.5  The external party must be hosted (at least) on this node with either confirmation or observation permissions It can optionally be hosted on other nodes (then called a multi-hosted party). If hosted on additional nodes, explicit authorization of the hosting relationship must be performed on those nodes before the party can be used. Decentralized namespaces are supported but must be provided fully authorized by their owners. The individual owner namespace transactions can be submitted in the same call (fully authorized as well). In the simple case of a non-multi hosted, non-decentralized party, the RPC will return once the party is effectively allocated and ready to use, similarly to the AllocateParty behavior. For more complex scenarios applications may need to query the party status explicitly (only through the admin API as of now).
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/parties/external/generate-topology`
+
+- Operation ID: `postV2PartiesExternalGenerate-topology`
+- Description: Alpha 3.3: Convenience endpoint to generate topology transactions for external signing  Expected to be stable in 3.5  You may use this endpoint to generate the common external topology transactions which can be signed externally and uploaded as part of the allocate party process  Note that this request will create a normal namespace using the same key for the identity as for signing. More elaborate schemes such as multi-signature or decentralized parties require you to construct the topology transactions yourself.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/parties/participant-id`
+
+- Operation ID: `getV2PartiesParticipant-id`
+- Description: Return the identifier of the participant. All horizontally scaled replicas should return the same id. daml-on-kv-ledger: returns an identifier supplied on command line at launch time canton: returns globally unique identifier of the participant
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/parties/{party}`
+
+- Operation ID: `getV2PartiesParty`
+- Description: Get the party details of the given parties. Only known parties will be returned in the list.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `party` | `path` | `yes` | `string` | - |
+| `identity-provider-id` | `query` | `no` | `string` | - |
+| `parties` | `query` | `no` | `array[string]` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: query parameter identity-provider-id, Invalid value for: query parameter parties | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `PATCH /v2/parties/{party}`
+
+- Operation ID: `patchV2PartiesParty`
+- Description: Update selected modifiable participant-local attributes of a party details resource. Can update the participant's local information for local parties.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `party` | `path` | `yes` | `string` | - |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/state/active-contracts`
+
+- Operation ID: `postV2StateActive-contracts`
+- Description: Query active contracts list (blocking call). Querying active contracts is an expensive operation and if possible should not be repeated often. Consider querying active contracts initially (for a given offset) and then repeatedly call one of `/v2/updates/...`endpoints  to get subsequent modifications. You can also use websockets to get updates with better performance.  Returns a stream of the snapshot of the active contracts and incomplete (un)assignments at a ledger offset. Once the stream of GetActiveContractsResponses completes, the client SHOULD begin streaming updates from the update service, starting at the GetActiveContractsRequest.active_at_offset specified in this request. Clients SHOULD NOT assume that the set of active contracts they receive reflects the state at the ledger end.  Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `limit` | `query` | `no` | `integer` | maximum number of elements to return, this param is ignored if is bigger than server setting |
+| `stream_idle_timeout_ms` | `query` | `no` | `integer` | timeout to complete and send result if no new elements are received (for open ended streams) |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:array[object]` |
+| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/state/connected-synchronizers`
+
+- Operation ID: `getV2StateConnected-synchronizers`
+- Description: Get the list of connected synchronizers at the time of the query.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `party` | `query` | `no` | `string` | - |
+| `participantId` | `query` | `no` | `string` | - |
+| `identityProviderId` | `query` | `no` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: query parameter party, Invalid value for: query parameter participantId, Invalid value for: query parameter identityProviderId | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/state/latest-pruned-offsets`
+
+- Operation ID: `getV2StateLatest-pruned-offsets`
+- Description: Get the latest successfully pruned ledger offsets
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/state/ledger-end`
+
+- Operation ID: `getV2StateLedger-end`
+- Description: Get the current ledger end. Subscriptions started with the returned offset will serve events after this RPC was called.
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/updates`
+
+- Operation ID: `postV2Updates`
+- Description: Read the ledger's filtered update stream for the specified contents and filters. It returns the event types in accordance with the stream contents selected. Also the selection criteria for individual events depends on the transaction shape chosen.  - ACS delta: a requesting party must be a stakeholder of an event for it to be included. - ledger effects: a requesting party must be a witness of an event for it to be included. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `limit` | `query` | `no` | `integer` | maximum number of elements to return, this param is ignored if is bigger than server setting |
+| `stream_idle_timeout_ms` | `query` | `no` | `integer` | timeout to complete and send result if no new elements are received (for open ended streams) |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:array[object]` |
+| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/updates/flats`
+
+- Operation ID: `postV2UpdatesFlats`
+- Description: Query flat transactions update list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `limit` | `query` | `no` | `integer` | maximum number of elements to return, this param is ignored if is bigger than server setting |
+| `stream_idle_timeout_ms` | `query` | `no` | `integer` | timeout to complete and send result if no new elements are received (for open ended streams) |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:array[object]` |
+| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/updates/transaction-by-id`
+
+- Operation ID: `postV2UpdatesTransaction-by-id`
+- Description: Get transaction by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/updates/transaction-by-offset`
+
+- Operation ID: `postV2UpdatesTransaction-by-offset`
+- Description: Get transaction by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/updates/transaction-tree-by-id/{update-id}`
+
+- Operation ID: `getV2UpdatesTransaction-tree-by-idUpdate-id`
+- Description: Get transaction tree by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `update-id` | `path` | `yes` | `string` | - |
+| `parties` | `query` | `no` | `array[string]` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: query parameter parties | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/updates/transaction-tree-by-offset/{offset}`
+
+- Operation ID: `getV2UpdatesTransaction-tree-by-offsetOffset`
+- Description: Get transaction tree by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `offset` | `path` | `yes` | `integer` | - |
+| `parties` | `query` | `no` | `array[string]` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: path parameter offset, Invalid value for: query parameter parties | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/updates/trees`
+
+- Operation ID: `postV2UpdatesTrees`
+- Description: Query update transactions tree list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `limit` | `query` | `no` | `integer` | maximum number of elements to return, this param is ignored if is bigger than server setting |
+| `stream_idle_timeout_ms` | `query` | `no` | `integer` | timeout to complete and send result if no new elements are received (for open ended streams) |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:array[object]` |
+| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/updates/update-by-id`
+
+- Operation ID: `postV2UpdatesUpdate-by-id`
+- Description: Lookup an update by its ID. If there is no update with this ID, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/updates/update-by-offset`
+
+- Operation ID: `postV2UpdatesUpdate-by-offset`
+- Description: Lookup an update by its offset. If there is no update with this offset, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/users`
+
+- Operation ID: `getV2Users`
+- Description: List all existing users.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `pageSize` | `query` | `no` | `integer` | maximum number of elements in a returned page |
+| `pageToken` | `query` | `no` | `string` | token - to continue results from a given page, leave empty to start from the beginning of the list, obtain token from the result of previous page |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: query parameter pageSize, Invalid value for: query parameter pageToken | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/users`
+
+- Operation ID: `postV2Users`
+- Description: Create a new user.
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `DELETE /v2/users/{user-id}`
+
+- Operation ID: `deleteV2UsersUser-id`
+- Description: Delete an existing user and all its rights.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `user-id` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/users/{user-id}`
+
+- Operation ID: `getV2UsersUser-id`
+- Description: Get the user data of a specific user or the authenticated user.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `user-id` | `path` | `yes` | `string` | - |
+| `identity-provider-id` | `query` | `no` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: query parameter identity-provider-id | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `PATCH /v2/users/{user-id}`
+
+- Operation ID: `patchV2UsersUser-id`
+- Description: Update selected modifiable attribute of a user resource described by the ``User`` message.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `user-id` | `path` | `yes` | `string` | - |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `PATCH /v2/users/{user-id}/identity-provider-id`
+
+- Operation ID: `patchV2UsersUser-idIdentity-provider-id`
+- Description: Update the assignment of a user from one IDP to another.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `user-id` | `path` | `yes` | `string` | - |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/users/{user-id}/rights`
+
+- Operation ID: `getV2UsersUser-idRights`
+- Description: List the set of all rights granted to a user.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `user-id` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `PATCH /v2/users/{user-id}/rights`
+
+- Operation ID: `patchV2UsersUser-idRights`
+- Description: Revoke rights from a user. Revoking rights does not affect the resource version of the corresponding user.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `user-id` | `path` | `yes` | `string` | - |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `POST /v2/users/{user-id}/rights`
+
+- Operation ID: `postV2UsersUser-idRights`
+- Description: Grant rights to a user. Granting rights does not affect the resource version of the corresponding user.
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `user-id` | `path` | `yes` | `string` | - |
+
+**Request Body**
+
+- Required: `yes`
+- Content:
+  - `application/json` -> `object`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+### `GET /v2/version`
+
+- Operation ID: `getV2Version`
+- Description: Read the Ledger API version
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | - | `application/json` | `application/json:object` |
+| `400` | Invalid value | `text/plain` | `text/plain:string` |
+| `default` | - | `application/json` | `application/json:object` |
+
+## Version Change Timeline
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `3.4` | `357` | `0` | `0` |
+| `3.5` | `6` | `147` | `1` |
+
+## Changed Entities
+
+| Entity | Type | Introduced | Changed In | Removed |
+| --- | --- | --- | --- | --- |
+| `schemas.AllocateExternalPartyRequest` | `component` | `3.4` | `3.5` | - |
+| `schemas.AllocatePartyRequest` | `component` | `3.4` | `3.5` | - |
+| `schemas.ArchivedEvent` | `component` | `3.4` | `3.5` | - |
+| `schemas.CanActAs1` | `component` | `3.4` | `3.5` | - |
+| `schemas.CanExecuteAs1` | `component` | `3.4` | `3.5` | - |
+| `schemas.CanExecuteAsAnyParty` | `component` | `3.4` | `3.5` | - |
+| `schemas.CanExecuteAsAnyParty1` | `component` | `3.4` | `3.5` | - |
+| `schemas.CanReadAs1` | `component` | `3.4` | `3.5` | - |
+| `schemas.CanReadAsAnyParty` | `component` | `3.4` | `3.5` | - |
+| `schemas.CanReadAsAnyParty1` | `component` | `3.4` | `3.5` | - |
+| `schemas.Completion1` | `component` | `3.4` | `3.5` | - |
+| `schemas.ConnectedSynchronizer` | `component` | `3.4` | `3.5` | - |
+| `schemas.CreatedEvent` | `component` | `3.4` | `3.5` | - |
+| `schemas.ExercisedEvent` | `component` | `3.4` | `3.5` | - |
+| `schemas.GetActiveContractsRequest` | `component` | `3.4` | `3.5` | - |
+| `schemas.GetPartiesResponse` | `component` | `3.4` | `3.5` | - |
+| `schemas.GetPreferredPackagesRequest` | `component` | `3.4` | `3.5` | - |
+| `schemas.GetUpdatesRequest` | `component` | `3.4` | `3.5` | - |
+| `schemas.Identifier` | `component` | `3.4` | - | ❌ `3.5` |
+| `schemas.IdentifierFilter` | `component` | `3.4` | `3.5` | - |
+| `schemas.IdentityProviderAdmin` | `component` | `3.4` | `3.5` | - |
+| `schemas.IdentityProviderAdmin1` | `component` | `3.4` | `3.5` | - |
+| `schemas.JsExecuteSubmissionAndWaitForTransactionRequest` | `component` | `3.4` | `3.5` | - |
+| `schemas.JsExecuteSubmissionAndWaitRequest` | `component` | `3.4` | `3.5` | - |
+| `schemas.JsExecuteSubmissionRequest` | `component` | `3.4` | `3.5` | - |
+| `schemas.JsGetActiveContractsResponse` | `component` | `3.4` | `3.5` | - |
+| `schemas.JsInterfaceView` | `component` | `3.4` | `3.5` | - |
+| `schemas.JsPrepareSubmissionRequest` | `component` | `3.4` | `3.5` | - |
+| `schemas.JsPrepareSubmissionResponse` | `component` | `3.4` | `3.5` | - |
+| `schemas.JsReassignment` | `component` | `3.4` | `3.5` | - |
+| `schemas.JsTransaction` | `component` | `3.4` | `3.5` | - |
+| `schemas.ParticipantAdmin` | `component` | `3.4` | `3.5` | - |
+| `schemas.ParticipantAdmin1` | `component` | `3.4` | `3.5` | - |
+| `schemas.ParticipantAuthorizationOnboarding` | `component` | `3.5` | - | - |
+| `schemas.ParticipantAuthorizationOnboarding1` | `component` | `3.5` | - | - |
+| `schemas.PrefetchContractKey` | `component` | `3.4` | `3.5` | - |
+| `schemas.ReassignmentCommands` | `component` | `3.4` | `3.5` | - |
+| `schemas.SignedTransaction` | `component` | `3.4` | `3.5` | - |
+| `schemas.TopologyEventEvent` | `component` | `3.4` | `3.5` | - |
+| `schemas.TraceContext` | `component` | `3.4` | `3.5` | - |
+| `schemas.Unvet` | `component` | `3.4` | `3.5` | - |
+| `schemas.Unvet1` | `component` | `3.4` | `3.5` | - |
+| `schemas.Vet` | `component` | `3.4` | `3.5` | - |
+| `schemas.Vet1` | `component` | `3.4` | `3.5` | - |
+| `DELETE /v2/idps/{idp-id}` | `operation` | `3.4` | `3.5` | - |
+| `DELETE /v2/users/{user-id}` | `operation` | `3.4` | `3.5` | - |
+| `GET /livez` | `operation` | `3.5` | - | - |
+| `GET /readyz` | `operation` | `3.5` | - | - |
+| `GET /v2/authenticated-user` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/idps` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/idps/{idp-id}` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/interactive-submission/preferred-package-version` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/package-vetting` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/packages` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/packages/{package-id}` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/packages/{package-id}/status` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/parties` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/parties/participant-id` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/parties/{party}` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/state/connected-synchronizers` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/state/latest-pruned-offsets` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/state/ledger-end` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/updates/transaction-tree-by-id/{update-id}` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/updates/transaction-tree-by-offset/{offset}` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/users` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/users/{user-id}` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/users/{user-id}/rights` | `operation` | `3.4` | `3.5` | - |
+| `GET /v2/version` | `operation` | `3.4` | `3.5` | - |
+| `PATCH /v2/idps/{idp-id}` | `operation` | `3.4` | `3.5` | - |
+| `PATCH /v2/parties/{party}` | `operation` | `3.4` | `3.5` | - |
+| `PATCH /v2/users/{user-id}` | `operation` | `3.4` | `3.5` | - |
+| `PATCH /v2/users/{user-id}/identity-provider-id` | `operation` | `3.4` | `3.5` | - |
+| `PATCH /v2/users/{user-id}/rights` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/commands/async/submit` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/commands/async/submit-reassignment` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/commands/completions` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/commands/submit-and-wait` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/commands/submit-and-wait-for-reassignment` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/commands/submit-and-wait-for-transaction` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/commands/submit-and-wait-for-transaction-tree` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/contracts/contract-by-id` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/dars` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/dars/validate` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/events/events-by-contract-id` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/idps` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/interactive-submission/execute` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/interactive-submission/executeAndWait` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/interactive-submission/executeAndWaitForTransaction` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/interactive-submission/preferred-packages` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/interactive-submission/prepare` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/package-vetting` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/packages` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/parties` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/parties/external/allocate` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/parties/external/generate-topology` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/state/active-contracts` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/updates` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/updates/flats` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/updates/transaction-by-id` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/updates/transaction-by-offset` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/updates/trees` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/updates/update-by-id` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/updates/update-by-offset` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/users` | `operation` | `3.4` | `3.5` | - |
+| `POST /v2/users/{user-id}/rights` | `operation` | `3.4` | `3.5` | - |
+| `/livez` | `path` | `3.5` | - | - |
+| `/readyz` | `path` | `3.5` | - | - |
+| `/v2/authenticated-user` | `path` | `3.4` | `3.5` | - |
+| `/v2/commands/async/submit` | `path` | `3.4` | `3.5` | - |
+| `/v2/commands/async/submit-reassignment` | `path` | `3.4` | `3.5` | - |
+| `/v2/commands/completions` | `path` | `3.4` | `3.5` | - |
+| `/v2/commands/submit-and-wait` | `path` | `3.4` | `3.5` | - |
+| `/v2/commands/submit-and-wait-for-reassignment` | `path` | `3.4` | `3.5` | - |
+| `/v2/commands/submit-and-wait-for-transaction` | `path` | `3.4` | `3.5` | - |
+| `/v2/commands/submit-and-wait-for-transaction-tree` | `path` | `3.4` | `3.5` | - |
+| `/v2/contracts/contract-by-id` | `path` | `3.4` | `3.5` | - |
+| `/v2/dars` | `path` | `3.4` | `3.5` | - |
+| `/v2/dars/validate` | `path` | `3.4` | `3.5` | - |
+| `/v2/events/events-by-contract-id` | `path` | `3.4` | `3.5` | - |
+| `/v2/idps` | `path` | `3.4` | `3.5` | - |
+| `/v2/idps/{idp-id}` | `path` | `3.4` | `3.5` | - |
+| `/v2/interactive-submission/execute` | `path` | `3.4` | `3.5` | - |
+| `/v2/interactive-submission/executeAndWait` | `path` | `3.4` | `3.5` | - |
+| `/v2/interactive-submission/executeAndWaitForTransaction` | `path` | `3.4` | `3.5` | - |
+| `/v2/interactive-submission/preferred-package-version` | `path` | `3.4` | `3.5` | - |
+| `/v2/interactive-submission/preferred-packages` | `path` | `3.4` | `3.5` | - |
+| `/v2/interactive-submission/prepare` | `path` | `3.4` | `3.5` | - |
+| `/v2/package-vetting` | `path` | `3.4` | `3.5` | - |
+| `/v2/packages` | `path` | `3.4` | `3.5` | - |
+| `/v2/packages/{package-id}` | `path` | `3.4` | `3.5` | - |
+| `/v2/packages/{package-id}/status` | `path` | `3.4` | `3.5` | - |
+| `/v2/parties` | `path` | `3.4` | `3.5` | - |
+| `/v2/parties/external/allocate` | `path` | `3.4` | `3.5` | - |
+| `/v2/parties/external/generate-topology` | `path` | `3.4` | `3.5` | - |
+| `/v2/parties/participant-id` | `path` | `3.4` | `3.5` | - |
+| `/v2/parties/{party}` | `path` | `3.4` | `3.5` | - |
+| `/v2/state/active-contracts` | `path` | `3.4` | `3.5` | - |
+| `/v2/state/connected-synchronizers` | `path` | `3.4` | `3.5` | - |
+| `/v2/state/latest-pruned-offsets` | `path` | `3.4` | `3.5` | - |
+| `/v2/state/ledger-end` | `path` | `3.4` | `3.5` | - |
+| `/v2/updates` | `path` | `3.4` | `3.5` | - |
+| `/v2/updates/flats` | `path` | `3.4` | `3.5` | - |
+| `/v2/updates/transaction-by-id` | `path` | `3.4` | `3.5` | - |
+| `/v2/updates/transaction-by-offset` | `path` | `3.4` | `3.5` | - |
+| `/v2/updates/transaction-tree-by-id/{update-id}` | `path` | `3.4` | `3.5` | - |
+| `/v2/updates/transaction-tree-by-offset/{offset}` | `path` | `3.4` | `3.5` | - |
+| `/v2/updates/trees` | `path` | `3.4` | `3.5` | - |
+| `/v2/updates/update-by-id` | `path` | `3.4` | `3.5` | - |
+| `/v2/updates/update-by-offset` | `path` | `3.4` | `3.5` | - |
+| `/v2/users` | `path` | `3.4` | `3.5` | - |
+| `/v2/users/{user-id}` | `path` | `3.4` | `3.5` | - |
+| `/v2/users/{user-id}/identity-provider-id` | `path` | `3.4` | `3.5` | - |
+| `/v2/users/{user-id}/rights` | `path` | `3.4` | `3.5` | - |
+| `/v2/version` | `path` | `3.4` | `3.5` | - |
+
+## Latest Operations
+
+| Operation | Introduced | Changed In | Removed |
+| --- | --- | --- | --- |
+| `DELETE /v2/idps/{idp-id}` | `3.4` | `3.5` | - |
+| `DELETE /v2/users/{user-id}` | `3.4` | `3.5` | - |
+| `GET /livez` | `3.5` | - | - |
+| `GET /readyz` | `3.5` | - | - |
+| `GET /v2/authenticated-user` | `3.4` | `3.5` | - |
+| `GET /v2/idps` | `3.4` | `3.5` | - |
+| `GET /v2/idps/{idp-id}` | `3.4` | `3.5` | - |
+| `GET /v2/interactive-submission/preferred-package-version` | `3.4` | `3.5` | - |
+| `GET /v2/package-vetting` | `3.4` | `3.5` | - |
+| `GET /v2/packages` | `3.4` | `3.5` | - |
+| `GET /v2/packages/{package-id}` | `3.4` | `3.5` | - |
+| `GET /v2/packages/{package-id}/status` | `3.4` | `3.5` | - |
+| `GET /v2/parties` | `3.4` | `3.5` | - |
+| `GET /v2/parties/participant-id` | `3.4` | `3.5` | - |
+| `GET /v2/parties/{party}` | `3.4` | `3.5` | - |
+| `GET /v2/state/connected-synchronizers` | `3.4` | `3.5` | - |
+| `GET /v2/state/latest-pruned-offsets` | `3.4` | `3.5` | - |
+| `GET /v2/state/ledger-end` | `3.4` | `3.5` | - |
+| `GET /v2/updates/transaction-tree-by-id/{update-id}` | `3.4` | `3.5` | - |
+| `GET /v2/updates/transaction-tree-by-offset/{offset}` | `3.4` | `3.5` | - |
+| `GET /v2/users` | `3.4` | `3.5` | - |
+| `GET /v2/users/{user-id}` | `3.4` | `3.5` | - |
+| `GET /v2/users/{user-id}/rights` | `3.4` | `3.5` | - |
+| `GET /v2/version` | `3.4` | `3.5` | - |
+| `PATCH /v2/idps/{idp-id}` | `3.4` | `3.5` | - |
+| `PATCH /v2/parties/{party}` | `3.4` | `3.5` | - |
+| `PATCH /v2/users/{user-id}` | `3.4` | `3.5` | - |
+| `PATCH /v2/users/{user-id}/identity-provider-id` | `3.4` | `3.5` | - |
+| `PATCH /v2/users/{user-id}/rights` | `3.4` | `3.5` | - |
+| `POST /v2/commands/async/submit` | `3.4` | `3.5` | - |
+| `POST /v2/commands/async/submit-reassignment` | `3.4` | `3.5` | - |
+| `POST /v2/commands/completions` | `3.4` | `3.5` | - |
+| `POST /v2/commands/submit-and-wait` | `3.4` | `3.5` | - |
+| `POST /v2/commands/submit-and-wait-for-reassignment` | `3.4` | `3.5` | - |
+| `POST /v2/commands/submit-and-wait-for-transaction` | `3.4` | `3.5` | - |
+| `POST /v2/commands/submit-and-wait-for-transaction-tree` | `3.4` | `3.5` | - |
+| `POST /v2/contracts/contract-by-id` | `3.4` | `3.5` | - |
+| `POST /v2/dars` | `3.4` | `3.5` | - |
+| `POST /v2/dars/validate` | `3.4` | `3.5` | - |
+| `POST /v2/events/events-by-contract-id` | `3.4` | `3.5` | - |
+| `POST /v2/idps` | `3.4` | `3.5` | - |
+| `POST /v2/interactive-submission/execute` | `3.4` | `3.5` | - |
+| `POST /v2/interactive-submission/executeAndWait` | `3.4` | `3.5` | - |
+| `POST /v2/interactive-submission/executeAndWaitForTransaction` | `3.4` | `3.5` | - |
+| `POST /v2/interactive-submission/preferred-packages` | `3.4` | `3.5` | - |
+| `POST /v2/interactive-submission/prepare` | `3.4` | `3.5` | - |
+| `POST /v2/package-vetting` | `3.4` | `3.5` | - |
+| `POST /v2/packages` | `3.4` | `3.5` | - |
+| `POST /v2/parties` | `3.4` | `3.5` | - |
+| `POST /v2/parties/external/allocate` | `3.4` | `3.5` | - |
+| `POST /v2/parties/external/generate-topology` | `3.4` | `3.5` | - |
+| `POST /v2/state/active-contracts` | `3.4` | `3.5` | - |
+| `POST /v2/updates` | `3.4` | `3.5` | - |
+| `POST /v2/updates/flats` | `3.4` | `3.5` | - |
+| `POST /v2/updates/transaction-by-id` | `3.4` | `3.5` | - |
+| `POST /v2/updates/transaction-by-offset` | `3.4` | `3.5` | - |
+| `POST /v2/updates/trees` | `3.4` | `3.5` | - |
+| `POST /v2/updates/update-by-id` | `3.4` | `3.5` | - |
+| `POST /v2/updates/update-by-offset` | `3.4` | `3.5` | - |
+| `POST /v2/users` | `3.4` | `3.5` | - |
+| `POST /v2/users/{user-id}/rights` | `3.4` | `3.5` | - |
+
+## Latest Components
+
+| Component | Introduced | Changed In | Removed |
+| --- | --- | --- | --- |
+| `schemas.AllocateExternalPartyRequest` | `3.4` | `3.5` | - |
+| `schemas.AllocateExternalPartyResponse` | `3.4` | - | - |
+| `schemas.AllocatePartyRequest` | `3.4` | `3.5` | - |
+| `schemas.AllocatePartyResponse` | `3.4` | - | - |
+| `schemas.ArchivedEvent` | `3.4` | `3.5` | - |
+| `schemas.AssignCommand` | `3.4` | - | - |
+| `schemas.AssignCommand1` | `3.4` | - | - |
+| `schemas.CanActAs` | `3.4` | - | - |
+| `schemas.CanActAs1` | `3.4` | `3.5` | - |
+| `schemas.CanExecuteAs` | `3.4` | - | - |
+| `schemas.CanExecuteAs1` | `3.4` | `3.5` | - |
+| `schemas.CanExecuteAsAnyParty` | `3.4` | `3.5` | - |
+| `schemas.CanExecuteAsAnyParty1` | `3.4` | `3.5` | - |
+| `schemas.CanReadAs` | `3.4` | - | - |
+| `schemas.CanReadAs1` | `3.4` | `3.5` | - |
+| `schemas.CanReadAsAnyParty` | `3.4` | `3.5` | - |
+| `schemas.CanReadAsAnyParty1` | `3.4` | `3.5` | - |
+| `schemas.Command` | `3.4` | - | - |
+| `schemas.Command1` | `3.4` | - | - |
+| `schemas.Completion` | `3.4` | - | - |
+| `schemas.Completion1` | `3.4` | `3.5` | - |
+| `schemas.CompletionResponse` | `3.4` | - | - |
+| `schemas.CompletionStreamRequest` | `3.4` | - | - |
+| `schemas.CompletionStreamResponse` | `3.4` | - | - |
+| `schemas.ConnectedSynchronizer` | `3.4` | `3.5` | - |
+| `schemas.CostEstimation` | `3.4` | - | - |
+| `schemas.CostEstimationHints` | `3.4` | - | - |
+| `schemas.CreateAndExerciseCommand` | `3.4` | - | - |
+| `schemas.CreateCommand` | `3.4` | - | - |
+| `schemas.CreateIdentityProviderConfigRequest` | `3.4` | - | - |
+| `schemas.CreateIdentityProviderConfigResponse` | `3.4` | - | - |
+| `schemas.CreateUserRequest` | `3.4` | - | - |
+| `schemas.CreateUserResponse` | `3.4` | - | - |
+| `schemas.CreatedEvent` | `3.4` | `3.5` | - |
+| `schemas.CreatedTreeEvent` | `3.4` | - | - |
+| `schemas.CumulativeFilter` | `3.4` | - | - |
+| `schemas.DeduplicationDuration` | `3.4` | - | - |
+| `schemas.DeduplicationDuration1` | `3.4` | - | - |
+| `schemas.DeduplicationDuration2` | `3.4` | - | - |
+| `schemas.DeduplicationOffset` | `3.4` | - | - |
+| `schemas.DeduplicationOffset1` | `3.4` | - | - |
+| `schemas.DeduplicationOffset2` | `3.4` | - | - |
+| `schemas.DeduplicationPeriod` | `3.4` | - | - |
+| `schemas.DeduplicationPeriod1` | `3.4` | - | - |
+| `schemas.DeduplicationPeriod2` | `3.4` | - | - |
+| `schemas.DeleteIdentityProviderConfigResponse` | `3.4` | - | - |
+| `schemas.DisclosedContract` | `3.4` | - | - |
+| `schemas.Duration` | `3.4` | - | - |
+| `schemas.Empty` | `3.4` | - | - |
+| `schemas.Empty1` | `3.4` | - | - |
+| `schemas.Empty10` | `3.4` | - | - |
+| `schemas.Empty2` | `3.4` | - | - |
+| `schemas.Empty3` | `3.4` | - | - |
+| `schemas.Empty4` | `3.4` | - | - |
+| `schemas.Empty5` | `3.4` | - | - |
+| `schemas.Empty6` | `3.4` | - | - |
+| `schemas.Empty7` | `3.4` | - | - |
+| `schemas.Empty8` | `3.4` | - | - |
+| `schemas.Empty9` | `3.4` | - | - |
+| `schemas.Event` | `3.4` | - | - |
+| `schemas.EventFormat` | `3.4` | - | - |
+| `schemas.ExecuteSubmissionAndWaitResponse` | `3.4` | - | - |
+| `schemas.ExecuteSubmissionResponse` | `3.4` | - | - |
+| `schemas.ExerciseByKeyCommand` | `3.4` | - | - |
+| `schemas.ExerciseCommand` | `3.4` | - | - |
+| `schemas.ExercisedEvent` | `3.4` | `3.5` | - |
+| `schemas.ExercisedTreeEvent` | `3.4` | - | - |
+| `schemas.ExperimentalCommandInspectionService` | `3.4` | - | - |
+| `schemas.ExperimentalFeatures` | `3.4` | - | - |
+| `schemas.ExperimentalStaticTime` | `3.4` | - | - |
+| `schemas.FeaturesDescriptor` | `3.4` | - | - |
+| `schemas.Field` | `3.4` | - | - |
+| `schemas.FieldMask` | `3.4` | - | - |
+| `schemas.Filters` | `3.4` | - | - |
+| `schemas.GenerateExternalPartyTopologyRequest` | `3.4` | - | - |
+| `schemas.GenerateExternalPartyTopologyResponse` | `3.4` | - | - |
+| `schemas.GetActiveContractsRequest` | `3.4` | `3.5` | - |
+| `schemas.GetConnectedSynchronizersResponse` | `3.4` | - | - |
+| `schemas.GetContractRequest` | `3.4` | - | - |
+| `schemas.GetContractResponse` | `3.4` | - | - |
+| `schemas.GetEventsByContractIdRequest` | `3.4` | - | - |
+| `schemas.GetIdentityProviderConfigResponse` | `3.4` | - | - |
+| `schemas.GetLatestPrunedOffsetsResponse` | `3.4` | - | - |
+| `schemas.GetLedgerApiVersionResponse` | `3.4` | - | - |
+| `schemas.GetLedgerEndResponse` | `3.4` | - | - |
+| `schemas.GetPackageStatusResponse` | `3.4` | - | - |
+| `schemas.GetParticipantIdResponse` | `3.4` | - | - |
+| `schemas.GetPartiesResponse` | `3.4` | `3.5` | - |
+| `schemas.GetPreferredPackageVersionResponse` | `3.4` | - | - |
+| `schemas.GetPreferredPackagesRequest` | `3.4` | `3.5` | - |
+| `schemas.GetPreferredPackagesResponse` | `3.4` | - | - |
+| `schemas.GetTransactionByIdRequest` | `3.4` | - | - |
+| `schemas.GetTransactionByOffsetRequest` | `3.4` | - | - |
+| `schemas.GetUpdateByIdRequest` | `3.4` | - | - |
+| `schemas.GetUpdateByOffsetRequest` | `3.4` | - | - |
+| `schemas.GetUpdatesRequest` | `3.4` | `3.5` | - |
+| `schemas.GetUserResponse` | `3.4` | - | - |
+| `schemas.GrantUserRightsRequest` | `3.4` | - | - |
+| `schemas.GrantUserRightsResponse` | `3.4` | - | - |
+| `schemas.IdentifierFilter` | `3.4` | `3.5` | - |
+| `schemas.IdentityProviderAdmin` | `3.4` | `3.5` | - |
+| `schemas.IdentityProviderAdmin1` | `3.4` | `3.5` | - |
+| `schemas.IdentityProviderConfig` | `3.4` | - | - |
+| `schemas.InterfaceFilter` | `3.4` | - | - |
+| `schemas.InterfaceFilter1` | `3.4` | - | - |
+| `schemas.JsActiveContract` | `3.4` | - | - |
+| `schemas.JsArchived` | `3.4` | - | - |
+| `schemas.JsAssignedEvent` | `3.4` | - | - |
+| `schemas.JsAssignmentEvent` | `3.4` | - | - |
+| `schemas.JsCantonError` | `3.4` | - | - |
+| `schemas.JsCommands` | `3.4` | - | - |
+| `schemas.JsContractEntry` | `3.4` | - | - |
+| `schemas.JsCreated` | `3.4` | - | - |
+| `schemas.JsEmpty` | `3.4` | - | - |
+| `schemas.JsExecuteSubmissionAndWaitForTransactionRequest` | `3.4` | `3.5` | - |
+| `schemas.JsExecuteSubmissionAndWaitForTransactionResponse` | `3.4` | - | - |
+| `schemas.JsExecuteSubmissionAndWaitRequest` | `3.4` | `3.5` | - |
+| `schemas.JsExecuteSubmissionRequest` | `3.4` | `3.5` | - |
+| `schemas.JsGetActiveContractsResponse` | `3.4` | `3.5` | - |
+| `schemas.JsGetEventsByContractIdResponse` | `3.4` | - | - |
+| `schemas.JsGetTransactionResponse` | `3.4` | - | - |
+| `schemas.JsGetTransactionTreeResponse` | `3.4` | - | - |
+| `schemas.JsGetUpdateResponse` | `3.4` | - | - |
+| `schemas.JsGetUpdateTreesResponse` | `3.4` | - | - |
+| `schemas.JsGetUpdatesResponse` | `3.4` | - | - |
+| `schemas.JsIncompleteAssigned` | `3.4` | - | - |
+| `schemas.JsIncompleteUnassigned` | `3.4` | - | - |
+| `schemas.JsInterfaceView` | `3.4` | `3.5` | - |
+| `schemas.JsPrepareSubmissionRequest` | `3.4` | `3.5` | - |
+| `schemas.JsPrepareSubmissionResponse` | `3.4` | `3.5` | - |
+| `schemas.JsReassignment` | `3.4` | `3.5` | - |
+| `schemas.JsReassignmentEvent` | `3.4` | - | - |
+| `schemas.JsStatus` | `3.4` | - | - |
+| `schemas.JsSubmitAndWaitForReassignmentResponse` | `3.4` | - | - |
+| `schemas.JsSubmitAndWaitForTransactionRequest` | `3.4` | - | - |
+| `schemas.JsSubmitAndWaitForTransactionResponse` | `3.4` | - | - |
+| `schemas.JsSubmitAndWaitForTransactionTreeResponse` | `3.4` | - | - |
+| `schemas.JsTopologyTransaction` | `3.4` | - | - |
+| `schemas.JsTransaction` | `3.4` | `3.5` | - |
+| `schemas.JsTransactionTree` | `3.4` | - | - |
+| `schemas.JsUnassignedEvent` | `3.4` | - | - |
+| `schemas.Kind` | `3.4` | - | - |
+| `schemas.ListIdentityProviderConfigsResponse` | `3.4` | - | - |
+| `schemas.ListKnownPartiesResponse` | `3.4` | - | - |
+| `schemas.ListPackagesResponse` | `3.4` | - | - |
+| `schemas.ListUserRightsResponse` | `3.4` | - | - |
+| `schemas.ListUsersResponse` | `3.4` | - | - |
+| `schemas.ListVettedPackagesRequest` | `3.4` | - | - |
+| `schemas.ListVettedPackagesResponse` | `3.4` | - | - |
+| `schemas.Map_Filters` | `3.4` | - | - |
+| `schemas.Map_Int_Field` | `3.4` | - | - |
+| `schemas.Map_Int_TreeEvent` | `3.4` | - | - |
+| `schemas.Map_String` | `3.4` | - | - |
+| `schemas.MinLedgerTime` | `3.4` | - | - |
+| `schemas.MinLedgerTimeAbs` | `3.4` | - | - |
+| `schemas.MinLedgerTimeRel` | `3.4` | - | - |
+| `schemas.NoPrior` | `3.4` | - | - |
+| `schemas.ObjectMeta` | `3.4` | - | - |
+| `schemas.OffsetCheckpoint` | `3.4` | - | - |
+| `schemas.OffsetCheckpoint1` | `3.4` | - | - |
+| `schemas.OffsetCheckpoint2` | `3.4` | - | - |
+| `schemas.OffsetCheckpoint3` | `3.4` | - | - |
+| `schemas.OffsetCheckpointFeature` | `3.4` | - | - |
+| `schemas.Operation` | `3.4` | - | - |
+| `schemas.PackageFeature` | `3.4` | - | - |
+| `schemas.PackageMetadataFilter` | `3.4` | - | - |
+| `schemas.PackagePreference` | `3.4` | - | - |
+| `schemas.PackageReference` | `3.4` | - | - |
+| `schemas.PackageVettingRequirement` | `3.4` | - | - |
+| `schemas.ParticipantAdmin` | `3.4` | `3.5` | - |
+| `schemas.ParticipantAdmin1` | `3.4` | `3.5` | - |
+| `schemas.ParticipantAuthorizationAdded` | `3.4` | - | - |
+| `schemas.ParticipantAuthorizationAdded1` | `3.4` | - | - |
+| `schemas.ParticipantAuthorizationChanged` | `3.4` | - | - |
+| `schemas.ParticipantAuthorizationChanged1` | `3.4` | - | - |
+| `schemas.ParticipantAuthorizationOnboarding` | `3.5` | - | - |
+| `schemas.ParticipantAuthorizationOnboarding1` | `3.5` | - | - |
+| `schemas.ParticipantAuthorizationRevoked` | `3.4` | - | - |
+| `schemas.ParticipantAuthorizationRevoked1` | `3.4` | - | - |
+| `schemas.ParticipantAuthorizationTopologyFormat` | `3.4` | - | - |
+| `schemas.PartyDetails` | `3.4` | - | - |
+| `schemas.PartyManagementFeature` | `3.4` | - | - |
+| `schemas.PartySignatures` | `3.4` | - | - |
+| `schemas.PrefetchContractKey` | `3.4` | `3.5` | - |
+| `schemas.Prior` | `3.4` | - | - |
+| `schemas.PriorTopologySerial` | `3.4` | - | - |
+| `schemas.ProtoAny` | `3.4` | - | - |
+| `schemas.Reassignment` | `3.4` | - | - |
+| `schemas.Reassignment1` | `3.4` | - | - |
+| `schemas.ReassignmentCommand` | `3.4` | - | - |
+| `schemas.ReassignmentCommands` | `3.4` | `3.5` | - |
+| `schemas.RevokeUserRightsRequest` | `3.4` | - | - |
+| `schemas.RevokeUserRightsResponse` | `3.4` | - | - |
+| `schemas.Right` | `3.4` | - | - |
+| `schemas.Serial` | `3.4` | - | - |
+| `schemas.Signature` | `3.4` | - | - |
+| `schemas.SignedTransaction` | `3.4` | `3.5` | - |
+| `schemas.SigningPublicKey` | `3.4` | - | - |
+| `schemas.SinglePartySignatures` | `3.4` | - | - |
+| `schemas.SubmitAndWaitForReassignmentRequest` | `3.4` | - | - |
+| `schemas.SubmitAndWaitResponse` | `3.4` | - | - |
+| `schemas.SubmitReassignmentRequest` | `3.4` | - | - |
+| `schemas.SubmitReassignmentResponse` | `3.4` | - | - |
+| `schemas.SubmitResponse` | `3.4` | - | - |
+| `schemas.SynchronizerTime` | `3.4` | - | - |
+| `schemas.TemplateFilter` | `3.4` | - | - |
+| `schemas.TemplateFilter1` | `3.4` | - | - |
+| `schemas.Time` | `3.4` | - | - |
+| `schemas.TopologyEvent` | `3.4` | - | - |
+| `schemas.TopologyEventEvent` | `3.4` | `3.5` | - |
+| `schemas.TopologyFormat` | `3.4` | - | - |
+| `schemas.TopologyStateFilter` | `3.4` | - | - |
+| `schemas.TopologyTransaction` | `3.4` | - | - |
+| `schemas.TraceContext` | `3.4` | `3.5` | - |
+| `schemas.Transaction` | `3.4` | - | - |
+| `schemas.TransactionFilter` | `3.4` | - | - |
+| `schemas.TransactionFormat` | `3.4` | - | - |
+| `schemas.TransactionTree` | `3.4` | - | - |
+| `schemas.TreeEvent` | `3.4` | - | - |
+| `schemas.Tuple2_String_String` | `3.4` | - | - |
+| `schemas.UnassignCommand` | `3.4` | - | - |
+| `schemas.UnassignCommand1` | `3.4` | - | - |
+| `schemas.UnassignedEvent` | `3.4` | - | - |
+| `schemas.UnknownFieldSet` | `3.4` | - | - |
+| `schemas.Unvet` | `3.4` | `3.5` | - |
+| `schemas.Unvet1` | `3.4` | `3.5` | - |
+| `schemas.Update` | `3.4` | - | - |
+| `schemas.Update1` | `3.4` | - | - |
+| `schemas.UpdateFormat` | `3.4` | - | - |
+| `schemas.UpdateIdentityProviderConfigRequest` | `3.4` | - | - |
+| `schemas.UpdateIdentityProviderConfigResponse` | `3.4` | - | - |
+| `schemas.UpdatePartyDetailsRequest` | `3.4` | - | - |
+| `schemas.UpdatePartyDetailsResponse` | `3.4` | - | - |
+| `schemas.UpdateUserIdentityProviderIdRequest` | `3.4` | - | - |
+| `schemas.UpdateUserIdentityProviderIdResponse` | `3.4` | - | - |
+| `schemas.UpdateUserRequest` | `3.4` | - | - |
+| `schemas.UpdateUserResponse` | `3.4` | - | - |
+| `schemas.UpdateVettedPackagesRequest` | `3.4` | - | - |
+| `schemas.UpdateVettedPackagesResponse` | `3.4` | - | - |
+| `schemas.UploadDarFileResponse` | `3.4` | - | - |
+| `schemas.User` | `3.4` | - | - |
+| `schemas.UserManagementFeature` | `3.4` | - | - |
+| `schemas.Vet` | `3.4` | `3.5` | - |
+| `schemas.Vet1` | `3.4` | `3.5` | - |
+| `schemas.VettedPackage` | `3.4` | - | - |
+| `schemas.VettedPackages` | `3.4` | - | - |
+| `schemas.VettedPackagesChange` | `3.4` | - | - |
+| `schemas.VettedPackagesRef` | `3.4` | - | - |
+| `schemas.WildcardFilter` | `3.4` | - | - |
+| `schemas.WildcardFilter1` | `3.4` | - | - |
+| `securitySchemes.apiKeyAuth` | `3.4` | - | - |
+| `securitySchemes.httpAuth` | `3.4` | - | - |

--- a/docs-main/appdev/reference/json-api-reference.mdx
+++ b/docs-main/appdev/reference/json-api-reference.mdx
@@ -5,91 +5,139 @@ description: "Generated API reference from versioned OpenAPI artifacts"
 
 Generated from supplied versioned OpenAPI artifacts.
 
-## Spec Metadata
+## Endpoint Diff Summary
 
-- Canonical spec id: `json-ledger-api/openapi.yaml`
-- Latest source path: `published/json-ledger-api/openapi.yaml`
-- OpenAPI version (latest): `3.0.3`
-- Introduced: `3.4`
-- Changed in versions: `3.5`
-- Removed: -
-
-## Entity Summary
-
-- Total entities tracked: `363`
-- Entities introduced after spec introduction: `6`
-- Entities changed at least once: `147`
-- Entities removed: `1`
-- Latest operations: `61`
-- Latest paths: `49`
-- Latest components: `252`
-- Latest tags: `0`
+| Endpoint | Version | Event | Changes |
+| --- | --- | --- | --- |
+| [`DELETE /v2/idps/{idp-id}`](#endpoint-delete-v2-idps-idp-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`DELETE /v2/users/{user-id}`](#endpoint-delete-v2-users-user-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /livez`](#endpoint-get-livez) | `3.5` | `added` | added endpoint |
+| [`GET /readyz`](#endpoint-get-readyz) | `3.5` | `added` | added endpoint |
+| [`GET /v2/authenticated-user`](#endpoint-get-v2-authenticated-user) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/idps`](#endpoint-get-v2-idps) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/idps/{idp-id}`](#endpoint-get-v2-idps-idp-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/interactive-submission/preferred-package-version`](#endpoint-get-v2-interactive-submission-preferred-package-version) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/package-vetting`](#endpoint-get-v2-package-vetting) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/packages`](#endpoint-get-v2-packages) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/packages/{package-id}`](#endpoint-get-v2-packages-package-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/packages/{package-id}/status`](#endpoint-get-v2-packages-package-id-status) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/parties`](#endpoint-get-v2-parties) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/parties/participant-id`](#endpoint-get-v2-parties-participant-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/parties/{party}`](#endpoint-get-v2-parties-party) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/state/connected-synchronizers`](#endpoint-get-v2-state-connected-synchronizers) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/state/latest-pruned-offsets`](#endpoint-get-v2-state-latest-pruned-offsets) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/state/ledger-end`](#endpoint-get-v2-state-ledger-end) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/updates/transaction-tree-by-id/{update-id}`](#endpoint-get-v2-updates-transaction-tree-by-id-update-id) | `3.5` | `changed` | response `400` description updated |
+| [`GET /v2/updates/transaction-tree-by-offset/{offset}`](#endpoint-get-v2-updates-transaction-tree-by-offset-offset) | `3.5` | `changed` | response `400` description updated |
+| [`GET /v2/users`](#endpoint-get-v2-users) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/users/{user-id}`](#endpoint-get-v2-users-user-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/users/{user-id}/rights`](#endpoint-get-v2-users-user-id-rights) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`GET /v2/version`](#endpoint-get-v2-version) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`PATCH /v2/idps/{idp-id}`](#endpoint-patch-v2-idps-idp-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`PATCH /v2/parties/{party}`](#endpoint-patch-v2-parties-party) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`PATCH /v2/users/{user-id}`](#endpoint-patch-v2-users-user-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`PATCH /v2/users/{user-id}/identity-provider-id`](#endpoint-patch-v2-users-user-id-identity-provider-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`PATCH /v2/users/{user-id}/rights`](#endpoint-patch-v2-users-user-id-rights) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/commands/async/submit`](#endpoint-post-v2-commands-async-submit) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/commands/async/submit-reassignment`](#endpoint-post-v2-commands-async-submit-reassignment) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/commands/completions`](#endpoint-post-v2-commands-completions) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/commands/submit-and-wait`](#endpoint-post-v2-commands-submit-and-wait) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/commands/submit-and-wait-for-reassignment`](#endpoint-post-v2-commands-submit-and-wait-for-reassignment) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/commands/submit-and-wait-for-transaction`](#endpoint-post-v2-commands-submit-and-wait-for-transaction) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/commands/submit-and-wait-for-transaction-tree`](#endpoint-post-v2-commands-submit-and-wait-for-transaction-tree) | `3.5` | `changed` | response `400` description updated |
+| [`POST /v2/contracts/contract-by-id`](#endpoint-post-v2-contracts-contract-by-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/dars`](#endpoint-post-v2-dars) | `3.5` | `changed` | response `400` description updated |
+| [`POST /v2/dars/validate`](#endpoint-post-v2-dars-validate) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/events/events-by-contract-id`](#endpoint-post-v2-events-events-by-contract-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/idps`](#endpoint-post-v2-idps) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/interactive-submission/execute`](#endpoint-post-v2-interactive-submission-execute) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/interactive-submission/executeAndWait`](#endpoint-post-v2-interactive-submission-executeandwait) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/interactive-submission/executeAndWaitForTransaction`](#endpoint-post-v2-interactive-submission-executeandwaitfortransaction) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/interactive-submission/preferred-packages`](#endpoint-post-v2-interactive-submission-preferred-packages) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/interactive-submission/prepare`](#endpoint-post-v2-interactive-submission-prepare) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/package-vetting`](#endpoint-post-v2-package-vetting) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/packages`](#endpoint-post-v2-packages) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/parties`](#endpoint-post-v2-parties) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/parties/external/allocate`](#endpoint-post-v2-parties-external-allocate) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/parties/external/generate-topology`](#endpoint-post-v2-parties-external-generate-topology) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/state/active-contracts`](#endpoint-post-v2-state-active-contracts) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/updates`](#endpoint-post-v2-updates) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/updates/flats`](#endpoint-post-v2-updates-flats) | `3.5` | `changed` | response `400` description updated |
+| [`POST /v2/updates/transaction-by-id`](#endpoint-post-v2-updates-transaction-by-id) | `3.5` | `changed` | response `400` description updated |
+| [`POST /v2/updates/transaction-by-offset`](#endpoint-post-v2-updates-transaction-by-offset) | `3.5` | `changed` | response `400` description updated |
+| [`POST /v2/updates/trees`](#endpoint-post-v2-updates-trees) | `3.5` | `changed` | response `400` description updated |
+| [`POST /v2/updates/update-by-id`](#endpoint-post-v2-updates-update-by-id) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/updates/update-by-offset`](#endpoint-post-v2-updates-update-by-offset) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/users`](#endpoint-post-v2-users) | `3.5` | `changed` | description updated; response `400` description updated |
+| [`POST /v2/users/{user-id}/rights`](#endpoint-post-v2-users-user-id-rights) | `3.5` | `changed` | description updated; response `400` description updated |
 
 ## Endpoint Reference (Latest)
 
 | Endpoint | Operation ID | Summary | Tags |
 | --- | --- | --- | --- |
-| `GET /livez` | `getLivez` | - | `-` |
-| `GET /readyz` | `getReadyz` | - | `-` |
-| `GET /v2/authenticated-user` | `getV2Authenticated-user` | - | `-` |
-| `POST /v2/commands/async/submit` | `postV2CommandsAsyncSubmit` | - | `-` |
-| `POST /v2/commands/async/submit-reassignment` | `postV2CommandsAsyncSubmit-reassignment` | - | `-` |
-| `POST /v2/commands/completions` | `postV2CommandsCompletions` | - | `-` |
-| `POST /v2/commands/submit-and-wait` | `postV2CommandsSubmit-and-wait` | - | `-` |
-| `POST /v2/commands/submit-and-wait-for-reassignment` | `postV2CommandsSubmit-and-wait-for-reassignment` | - | `-` |
-| `POST /v2/commands/submit-and-wait-for-transaction` | `postV2CommandsSubmit-and-wait-for-transaction` | - | `-` |
-| `POST /v2/commands/submit-and-wait-for-transaction-tree` | `postV2CommandsSubmit-and-wait-for-transaction-tree` | - | `-` |
-| `POST /v2/contracts/contract-by-id` | `postV2ContractsContract-by-id` | - | `-` |
-| `POST /v2/dars` | `postV2Dars` | - | `-` |
-| `POST /v2/dars/validate` | `postV2DarsValidate` | - | `-` |
-| `POST /v2/events/events-by-contract-id` | `postV2EventsEvents-by-contract-id` | - | `-` |
-| `GET /v2/idps` | `getV2Idps` | - | `-` |
-| `POST /v2/idps` | `postV2Idps` | - | `-` |
-| `DELETE /v2/idps/{idp-id}` | `deleteV2IdpsIdp-id` | - | `-` |
-| `GET /v2/idps/{idp-id}` | `getV2IdpsIdp-id` | - | `-` |
-| `PATCH /v2/idps/{idp-id}` | `patchV2IdpsIdp-id` | - | `-` |
-| `POST /v2/interactive-submission/execute` | `postV2Interactive-submissionExecute` | - | `-` |
-| `POST /v2/interactive-submission/executeAndWait` | `postV2Interactive-submissionExecuteandwait` | - | `-` |
-| `POST /v2/interactive-submission/executeAndWaitForTransaction` | `postV2Interactive-submissionExecuteandwaitfortransaction` | - | `-` |
-| `GET /v2/interactive-submission/preferred-package-version` | `getV2Interactive-submissionPreferred-package-version` | - | `-` |
-| `POST /v2/interactive-submission/preferred-packages` | `postV2Interactive-submissionPreferred-packages` | - | `-` |
-| `POST /v2/interactive-submission/prepare` | `postV2Interactive-submissionPrepare` | - | `-` |
-| `GET /v2/package-vetting` | `getV2Package-vetting` | - | `-` |
-| `POST /v2/package-vetting` | `postV2Package-vetting` | - | `-` |
-| `GET /v2/packages` | `getV2Packages` | - | `-` |
-| `POST /v2/packages` | `postV2Packages` | - | `-` |
-| `GET /v2/packages/{package-id}` | `getV2PackagesPackage-id` | - | `-` |
-| `GET /v2/packages/{package-id}/status` | `getV2PackagesPackage-idStatus` | - | `-` |
-| `GET /v2/parties` | `getV2Parties` | - | `-` |
-| `POST /v2/parties` | `postV2Parties` | - | `-` |
-| `POST /v2/parties/external/allocate` | `postV2PartiesExternalAllocate` | - | `-` |
-| `POST /v2/parties/external/generate-topology` | `postV2PartiesExternalGenerate-topology` | - | `-` |
-| `GET /v2/parties/participant-id` | `getV2PartiesParticipant-id` | - | `-` |
-| `GET /v2/parties/{party}` | `getV2PartiesParty` | - | `-` |
-| `PATCH /v2/parties/{party}` | `patchV2PartiesParty` | - | `-` |
-| `POST /v2/state/active-contracts` | `postV2StateActive-contracts` | - | `-` |
-| `GET /v2/state/connected-synchronizers` | `getV2StateConnected-synchronizers` | - | `-` |
-| `GET /v2/state/latest-pruned-offsets` | `getV2StateLatest-pruned-offsets` | - | `-` |
-| `GET /v2/state/ledger-end` | `getV2StateLedger-end` | - | `-` |
-| `POST /v2/updates` | `postV2Updates` | - | `-` |
-| `POST /v2/updates/flats` | `postV2UpdatesFlats` | - | `-` |
-| `POST /v2/updates/transaction-by-id` | `postV2UpdatesTransaction-by-id` | - | `-` |
-| `POST /v2/updates/transaction-by-offset` | `postV2UpdatesTransaction-by-offset` | - | `-` |
-| `GET /v2/updates/transaction-tree-by-id/{update-id}` | `getV2UpdatesTransaction-tree-by-idUpdate-id` | - | `-` |
-| `GET /v2/updates/transaction-tree-by-offset/{offset}` | `getV2UpdatesTransaction-tree-by-offsetOffset` | - | `-` |
-| `POST /v2/updates/trees` | `postV2UpdatesTrees` | - | `-` |
-| `POST /v2/updates/update-by-id` | `postV2UpdatesUpdate-by-id` | - | `-` |
-| `POST /v2/updates/update-by-offset` | `postV2UpdatesUpdate-by-offset` | - | `-` |
-| `GET /v2/users` | `getV2Users` | - | `-` |
-| `POST /v2/users` | `postV2Users` | - | `-` |
-| `DELETE /v2/users/{user-id}` | `deleteV2UsersUser-id` | - | `-` |
-| `GET /v2/users/{user-id}` | `getV2UsersUser-id` | - | `-` |
-| `PATCH /v2/users/{user-id}` | `patchV2UsersUser-id` | - | `-` |
-| `PATCH /v2/users/{user-id}/identity-provider-id` | `patchV2UsersUser-idIdentity-provider-id` | - | `-` |
-| `GET /v2/users/{user-id}/rights` | `getV2UsersUser-idRights` | - | `-` |
-| `PATCH /v2/users/{user-id}/rights` | `patchV2UsersUser-idRights` | - | `-` |
-| `POST /v2/users/{user-id}/rights` | `postV2UsersUser-idRights` | - | `-` |
-| `GET /v2/version` | `getV2Version` | - | `-` |
+| [`GET /livez`](#endpoint-get-livez) | `getLivez` | - | `-` |
+| [`GET /readyz`](#endpoint-get-readyz) | `getReadyz` | - | `-` |
+| [`GET /v2/authenticated-user`](#endpoint-get-v2-authenticated-user) | `getV2Authenticated-user` | - | `-` |
+| [`POST /v2/commands/async/submit`](#endpoint-post-v2-commands-async-submit) | `postV2CommandsAsyncSubmit` | - | `-` |
+| [`POST /v2/commands/async/submit-reassignment`](#endpoint-post-v2-commands-async-submit-reassignment) | `postV2CommandsAsyncSubmit-reassignment` | - | `-` |
+| [`POST /v2/commands/completions`](#endpoint-post-v2-commands-completions) | `postV2CommandsCompletions` | - | `-` |
+| [`POST /v2/commands/submit-and-wait`](#endpoint-post-v2-commands-submit-and-wait) | `postV2CommandsSubmit-and-wait` | - | `-` |
+| [`POST /v2/commands/submit-and-wait-for-reassignment`](#endpoint-post-v2-commands-submit-and-wait-for-reassignment) | `postV2CommandsSubmit-and-wait-for-reassignment` | - | `-` |
+| [`POST /v2/commands/submit-and-wait-for-transaction`](#endpoint-post-v2-commands-submit-and-wait-for-transaction) | `postV2CommandsSubmit-and-wait-for-transaction` | - | `-` |
+| [`POST /v2/commands/submit-and-wait-for-transaction-tree`](#endpoint-post-v2-commands-submit-and-wait-for-transaction-tree) | `postV2CommandsSubmit-and-wait-for-transaction-tree` | - | `-` |
+| [`POST /v2/contracts/contract-by-id`](#endpoint-post-v2-contracts-contract-by-id) | `postV2ContractsContract-by-id` | - | `-` |
+| [`POST /v2/dars`](#endpoint-post-v2-dars) | `postV2Dars` | - | `-` |
+| [`POST /v2/dars/validate`](#endpoint-post-v2-dars-validate) | `postV2DarsValidate` | - | `-` |
+| [`POST /v2/events/events-by-contract-id`](#endpoint-post-v2-events-events-by-contract-id) | `postV2EventsEvents-by-contract-id` | - | `-` |
+| [`GET /v2/idps`](#endpoint-get-v2-idps) | `getV2Idps` | - | `-` |
+| [`POST /v2/idps`](#endpoint-post-v2-idps) | `postV2Idps` | - | `-` |
+| [`DELETE /v2/idps/{idp-id}`](#endpoint-delete-v2-idps-idp-id) | `deleteV2IdpsIdp-id` | - | `-` |
+| [`GET /v2/idps/{idp-id}`](#endpoint-get-v2-idps-idp-id) | `getV2IdpsIdp-id` | - | `-` |
+| [`PATCH /v2/idps/{idp-id}`](#endpoint-patch-v2-idps-idp-id) | `patchV2IdpsIdp-id` | - | `-` |
+| [`POST /v2/interactive-submission/execute`](#endpoint-post-v2-interactive-submission-execute) | `postV2Interactive-submissionExecute` | - | `-` |
+| [`POST /v2/interactive-submission/executeAndWait`](#endpoint-post-v2-interactive-submission-executeandwait) | `postV2Interactive-submissionExecuteandwait` | - | `-` |
+| [`POST /v2/interactive-submission/executeAndWaitForTransaction`](#endpoint-post-v2-interactive-submission-executeandwaitfortransaction) | `postV2Interactive-submissionExecuteandwaitfortransaction` | - | `-` |
+| [`GET /v2/interactive-submission/preferred-package-version`](#endpoint-get-v2-interactive-submission-preferred-package-version) | `getV2Interactive-submissionPreferred-package-version` | - | `-` |
+| [`POST /v2/interactive-submission/preferred-packages`](#endpoint-post-v2-interactive-submission-preferred-packages) | `postV2Interactive-submissionPreferred-packages` | - | `-` |
+| [`POST /v2/interactive-submission/prepare`](#endpoint-post-v2-interactive-submission-prepare) | `postV2Interactive-submissionPrepare` | - | `-` |
+| [`GET /v2/package-vetting`](#endpoint-get-v2-package-vetting) | `getV2Package-vetting` | - | `-` |
+| [`POST /v2/package-vetting`](#endpoint-post-v2-package-vetting) | `postV2Package-vetting` | - | `-` |
+| [`GET /v2/packages`](#endpoint-get-v2-packages) | `getV2Packages` | - | `-` |
+| [`POST /v2/packages`](#endpoint-post-v2-packages) | `postV2Packages` | - | `-` |
+| [`GET /v2/packages/{package-id}`](#endpoint-get-v2-packages-package-id) | `getV2PackagesPackage-id` | - | `-` |
+| [`GET /v2/packages/{package-id}/status`](#endpoint-get-v2-packages-package-id-status) | `getV2PackagesPackage-idStatus` | - | `-` |
+| [`GET /v2/parties`](#endpoint-get-v2-parties) | `getV2Parties` | - | `-` |
+| [`POST /v2/parties`](#endpoint-post-v2-parties) | `postV2Parties` | - | `-` |
+| [`POST /v2/parties/external/allocate`](#endpoint-post-v2-parties-external-allocate) | `postV2PartiesExternalAllocate` | - | `-` |
+| [`POST /v2/parties/external/generate-topology`](#endpoint-post-v2-parties-external-generate-topology) | `postV2PartiesExternalGenerate-topology` | - | `-` |
+| [`GET /v2/parties/participant-id`](#endpoint-get-v2-parties-participant-id) | `getV2PartiesParticipant-id` | - | `-` |
+| [`GET /v2/parties/{party}`](#endpoint-get-v2-parties-party) | `getV2PartiesParty` | - | `-` |
+| [`PATCH /v2/parties/{party}`](#endpoint-patch-v2-parties-party) | `patchV2PartiesParty` | - | `-` |
+| [`POST /v2/state/active-contracts`](#endpoint-post-v2-state-active-contracts) | `postV2StateActive-contracts` | - | `-` |
+| [`GET /v2/state/connected-synchronizers`](#endpoint-get-v2-state-connected-synchronizers) | `getV2StateConnected-synchronizers` | - | `-` |
+| [`GET /v2/state/latest-pruned-offsets`](#endpoint-get-v2-state-latest-pruned-offsets) | `getV2StateLatest-pruned-offsets` | - | `-` |
+| [`GET /v2/state/ledger-end`](#endpoint-get-v2-state-ledger-end) | `getV2StateLedger-end` | - | `-` |
+| [`POST /v2/updates`](#endpoint-post-v2-updates) | `postV2Updates` | - | `-` |
+| [`POST /v2/updates/flats`](#endpoint-post-v2-updates-flats) | `postV2UpdatesFlats` | - | `-` |
+| [`POST /v2/updates/transaction-by-id`](#endpoint-post-v2-updates-transaction-by-id) | `postV2UpdatesTransaction-by-id` | - | `-` |
+| [`POST /v2/updates/transaction-by-offset`](#endpoint-post-v2-updates-transaction-by-offset) | `postV2UpdatesTransaction-by-offset` | - | `-` |
+| [`GET /v2/updates/transaction-tree-by-id/{update-id}`](#endpoint-get-v2-updates-transaction-tree-by-id-update-id) | `getV2UpdatesTransaction-tree-by-idUpdate-id` | - | `-` |
+| [`GET /v2/updates/transaction-tree-by-offset/{offset}`](#endpoint-get-v2-updates-transaction-tree-by-offset-offset) | `getV2UpdatesTransaction-tree-by-offsetOffset` | - | `-` |
+| [`POST /v2/updates/trees`](#endpoint-post-v2-updates-trees) | `postV2UpdatesTrees` | - | `-` |
+| [`POST /v2/updates/update-by-id`](#endpoint-post-v2-updates-update-by-id) | `postV2UpdatesUpdate-by-id` | - | `-` |
+| [`POST /v2/updates/update-by-offset`](#endpoint-post-v2-updates-update-by-offset) | `postV2UpdatesUpdate-by-offset` | - | `-` |
+| [`GET /v2/users`](#endpoint-get-v2-users) | `getV2Users` | - | `-` |
+| [`POST /v2/users`](#endpoint-post-v2-users) | `postV2Users` | - | `-` |
+| [`DELETE /v2/users/{user-id}`](#endpoint-delete-v2-users-user-id) | `deleteV2UsersUser-id` | - | `-` |
+| [`GET /v2/users/{user-id}`](#endpoint-get-v2-users-user-id) | `getV2UsersUser-id` | - | `-` |
+| [`PATCH /v2/users/{user-id}`](#endpoint-patch-v2-users-user-id) | `patchV2UsersUser-id` | - | `-` |
+| [`PATCH /v2/users/{user-id}/identity-provider-id`](#endpoint-patch-v2-users-user-id-identity-provider-id) | `patchV2UsersUser-idIdentity-provider-id` | - | `-` |
+| [`GET /v2/users/{user-id}/rights`](#endpoint-get-v2-users-user-id-rights) | `getV2UsersUser-idRights` | - | `-` |
+| [`PATCH /v2/users/{user-id}/rights`](#endpoint-patch-v2-users-user-id-rights) | `patchV2UsersUser-idRights` | - | `-` |
+| [`POST /v2/users/{user-id}/rights`](#endpoint-post-v2-users-user-id-rights) | `postV2UsersUser-idRights` | - | `-` |
+| [`GET /v2/version`](#endpoint-get-v2-version) | `getV2Version` | - | `-` |
+
+<a id="endpoint-get-livez"></a>
 
 ### `GET /livez`
 
@@ -104,6 +152,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-readyz"></a>
+
 ### `GET /readyz`
 
 - Operation ID: `getReadyz`
@@ -116,6 +166,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | OK: readiness message | `text/plain` | `text/plain:string` |
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-get-v2-authenticated-user"></a>
 
 ### `GET /v2/authenticated-user`
 
@@ -136,6 +188,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: query parameter identity-provider-id | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-commands-async-submit"></a>
+
 ### `POST /v2/commands/async/submit`
 
 - Operation ID: `postV2CommandsAsyncSubmit`
@@ -155,6 +209,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-commands-async-submit-reassignment"></a>
+
 ### `POST /v2/commands/async/submit-reassignment`
 
 - Operation ID: `postV2CommandsAsyncSubmit-reassignment`
@@ -173,6 +229,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-commands-completions"></a>
 
 ### `POST /v2/commands/completions`
 
@@ -200,6 +258,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-commands-submit-and-wait"></a>
+
 ### `POST /v2/commands/submit-and-wait`
 
 - Operation ID: `postV2CommandsSubmit-and-wait`
@@ -218,6 +278,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-commands-submit-and-wait-for-reassignment"></a>
 
 ### `POST /v2/commands/submit-and-wait-for-reassignment`
 
@@ -238,6 +300,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-commands-submit-and-wait-for-transaction"></a>
+
 ### `POST /v2/commands/submit-and-wait-for-transaction`
 
 - Operation ID: `postV2CommandsSubmit-and-wait-for-transaction`
@@ -256,6 +320,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-commands-submit-and-wait-for-transaction-tree"></a>
 
 ### `POST /v2/commands/submit-and-wait-for-transaction-tree`
 
@@ -276,6 +342,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-contracts-contract-by-id"></a>
+
 ### `POST /v2/contracts/contract-by-id`
 
 - Operation ID: `postV2ContractsContract-by-id`
@@ -294,6 +362,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-dars"></a>
 
 ### `POST /v2/dars`
 
@@ -321,6 +391,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter vetAllPackages, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-dars-validate"></a>
+
 ### `POST /v2/dars/validate`
 
 - Operation ID: `postV2DarsValidate`
@@ -346,6 +418,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-events-events-by-contract-id"></a>
+
 ### `POST /v2/events/events-by-contract-id`
 
 - Operation ID: `postV2EventsEvents-by-contract-id`
@@ -365,6 +439,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-idps"></a>
+
 ### `GET /v2/idps`
 
 - Operation ID: `getV2Idps`
@@ -377,6 +453,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-idps"></a>
 
 ### `POST /v2/idps`
 
@@ -397,6 +475,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-delete-v2-idps-idp-id"></a>
+
 ### `DELETE /v2/idps/{idp-id}`
 
 - Operation ID: `deleteV2IdpsIdp-id`
@@ -416,6 +496,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-idps-idp-id"></a>
+
 ### `GET /v2/idps/{idp-id}`
 
 - Operation ID: `getV2IdpsIdp-id`
@@ -434,6 +516,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-patch-v2-idps-idp-id"></a>
 
 ### `PATCH /v2/idps/{idp-id}`
 
@@ -460,6 +544,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-interactive-submission-execute"></a>
+
 ### `POST /v2/interactive-submission/execute`
 
 - Operation ID: `postV2Interactive-submissionExecute`
@@ -478,6 +564,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-interactive-submission-executeandwait"></a>
 
 ### `POST /v2/interactive-submission/executeAndWait`
 
@@ -498,6 +586,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-interactive-submission-executeandwaitfortransaction"></a>
+
 ### `POST /v2/interactive-submission/executeAndWaitForTransaction`
 
 - Operation ID: `postV2Interactive-submissionExecuteandwaitfortransaction`
@@ -516,6 +606,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-get-v2-interactive-submission-preferred-package-version"></a>
 
 ### `GET /v2/interactive-submission/preferred-package-version`
 
@@ -539,6 +631,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: query parameter parties, Invalid value for: query parameter package-name, Invalid value for: query parameter vetting_valid_at, Invalid value for: query parameter synchronizer-id | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-interactive-submission-preferred-packages"></a>
+
 ### `POST /v2/interactive-submission/preferred-packages`
 
 - Operation ID: `postV2Interactive-submissionPreferred-packages`
@@ -557,6 +651,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-interactive-submission-prepare"></a>
 
 ### `POST /v2/interactive-submission/prepare`
 
@@ -577,6 +673,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-package-vetting"></a>
+
 ### `GET /v2/package-vetting`
 
 - Operation ID: `getV2Package-vetting`
@@ -595,6 +693,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-package-vetting"></a>
 
 ### `POST /v2/package-vetting`
 
@@ -615,6 +715,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-packages"></a>
+
 ### `GET /v2/packages`
 
 - Operation ID: `getV2Packages`
@@ -627,6 +729,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-packages"></a>
 
 ### `POST /v2/packages`
 
@@ -654,6 +758,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter vetAllPackages, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-packages-package-id"></a>
+
 ### `GET /v2/packages/{package-id}`
 
 - Operation ID: `getV2PackagesPackage-id`
@@ -673,6 +779,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-packages-package-id-status"></a>
+
 ### `GET /v2/packages/{package-id}/status`
 
 - Operation ID: `getV2PackagesPackage-idStatus`
@@ -691,6 +799,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-get-v2-parties"></a>
 
 ### `GET /v2/parties`
 
@@ -714,6 +824,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: query parameter identity-provider-id, Invalid value for: query parameter filter-party, Invalid value for: query parameter pageSize, Invalid value for: query parameter pageToken | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-parties"></a>
+
 ### `POST /v2/parties`
 
 - Operation ID: `postV2Parties`
@@ -732,6 +844,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-parties-external-allocate"></a>
 
 ### `POST /v2/parties/external/allocate`
 
@@ -752,6 +866,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-parties-external-generate-topology"></a>
+
 ### `POST /v2/parties/external/generate-topology`
 
 - Operation ID: `postV2PartiesExternalGenerate-topology`
@@ -771,6 +887,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-parties-participant-id"></a>
+
 ### `GET /v2/parties/participant-id`
 
 - Operation ID: `getV2PartiesParticipant-id`
@@ -783,6 +901,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-get-v2-parties-party"></a>
 
 ### `GET /v2/parties/{party}`
 
@@ -804,6 +924,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: query parameter identity-provider-id, Invalid value for: query parameter parties | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-patch-v2-parties-party"></a>
 
 ### `PATCH /v2/parties/{party}`
 
@@ -829,6 +951,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-state-active-contracts"></a>
 
 ### `POST /v2/state/active-contracts`
 
@@ -856,6 +980,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-state-connected-synchronizers"></a>
+
 ### `GET /v2/state/connected-synchronizers`
 
 - Operation ID: `getV2StateConnected-synchronizers`
@@ -877,6 +1003,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: query parameter party, Invalid value for: query parameter participantId, Invalid value for: query parameter identityProviderId | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-state-latest-pruned-offsets"></a>
+
 ### `GET /v2/state/latest-pruned-offsets`
 
 - Operation ID: `getV2StateLatest-pruned-offsets`
@@ -890,6 +1018,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-state-ledger-end"></a>
+
 ### `GET /v2/state/ledger-end`
 
 - Operation ID: `getV2StateLedger-end`
@@ -902,6 +1032,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-updates"></a>
 
 ### `POST /v2/updates`
 
@@ -929,6 +1061,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-updates-flats"></a>
+
 ### `POST /v2/updates/flats`
 
 - Operation ID: `postV2UpdatesFlats`
@@ -955,6 +1089,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-updates-transaction-by-id"></a>
+
 ### `POST /v2/updates/transaction-by-id`
 
 - Operation ID: `postV2UpdatesTransaction-by-id`
@@ -974,6 +1110,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-updates-transaction-by-offset"></a>
+
 ### `POST /v2/updates/transaction-by-offset`
 
 - Operation ID: `postV2UpdatesTransaction-by-offset`
@@ -992,6 +1130,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-get-v2-updates-transaction-tree-by-id-update-id"></a>
 
 ### `GET /v2/updates/transaction-tree-by-id/{update-id}`
 
@@ -1013,6 +1153,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: query parameter parties | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-updates-transaction-tree-by-offset-offset"></a>
+
 ### `GET /v2/updates/transaction-tree-by-offset/{offset}`
 
 - Operation ID: `getV2UpdatesTransaction-tree-by-offsetOffset`
@@ -1032,6 +1174,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: path parameter offset, Invalid value for: query parameter parties | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-post-v2-updates-trees"></a>
 
 ### `POST /v2/updates/trees`
 
@@ -1059,6 +1203,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-updates-update-by-id"></a>
+
 ### `POST /v2/updates/update-by-id`
 
 - Operation ID: `postV2UpdatesUpdate-by-id`
@@ -1078,6 +1224,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-updates-update-by-offset"></a>
+
 ### `POST /v2/updates/update-by-offset`
 
 - Operation ID: `postV2UpdatesUpdate-by-offset`
@@ -1096,6 +1244,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-get-v2-users"></a>
 
 ### `GET /v2/users`
 
@@ -1117,6 +1267,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: query parameter pageSize, Invalid value for: query parameter pageToken | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-users"></a>
+
 ### `POST /v2/users`
 
 - Operation ID: `postV2Users`
@@ -1135,6 +1287,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-delete-v2-users-user-id"></a>
 
 ### `DELETE /v2/users/{user-id}`
 
@@ -1155,6 +1309,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-users-user-id"></a>
+
 ### `GET /v2/users/{user-id}`
 
 - Operation ID: `getV2UsersUser-id`
@@ -1174,6 +1330,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: query parameter identity-provider-id | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-patch-v2-users-user-id"></a>
 
 ### `PATCH /v2/users/{user-id}`
 
@@ -1200,6 +1358,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-patch-v2-users-user-id-identity-provider-id"></a>
+
 ### `PATCH /v2/users/{user-id}/identity-provider-id`
 
 - Operation ID: `patchV2UsersUser-idIdentity-provider-id`
@@ -1225,6 +1385,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-get-v2-users-user-id-rights"></a>
+
 ### `GET /v2/users/{user-id}/rights`
 
 - Operation ID: `getV2UsersUser-idRights`
@@ -1243,6 +1405,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-patch-v2-users-user-id-rights"></a>
 
 ### `PATCH /v2/users/{user-id}/rights`
 
@@ -1269,6 +1433,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="endpoint-post-v2-users-user-id-rights"></a>
+
 ### `POST /v2/users/{user-id}/rights`
 
 - Operation ID: `postV2UsersUser-idRights`
@@ -1293,6 +1459,8 @@ Generated from supplied versioned OpenAPI artifacts.
 | `200` | - | `application/json` | `application/json:object` |
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
+
+<a id="endpoint-get-v2-version"></a>
 
 ### `GET /v2/version`
 
@@ -1472,72 +1640,6 @@ Generated from supplied versioned OpenAPI artifacts.
 | `/v2/users/{user-id}/identity-provider-id` | `path` | `3.4` | `3.5` | - |
 | `/v2/users/{user-id}/rights` | `path` | `3.4` | `3.5` | - |
 | `/v2/version` | `path` | `3.4` | `3.5` | - |
-
-## Endpoint Diff Summary
-
-| Endpoint | Version | Event | Changes |
-| --- | --- | --- | --- |
-| `DELETE /v2/idps/{idp-id}` | `3.5` | `changed` | description updated; response `400` description updated |
-| `DELETE /v2/users/{user-id}` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /livez` | `3.5` | `added` | added endpoint |
-| `GET /readyz` | `3.5` | `added` | added endpoint |
-| `GET /v2/authenticated-user` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/idps` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/idps/{idp-id}` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/interactive-submission/preferred-package-version` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/package-vetting` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/packages` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/packages/{package-id}` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/packages/{package-id}/status` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/parties` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/parties/participant-id` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/parties/{party}` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/state/connected-synchronizers` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/state/latest-pruned-offsets` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/state/ledger-end` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/updates/transaction-tree-by-id/{update-id}` | `3.5` | `changed` | response `400` description updated |
-| `GET /v2/updates/transaction-tree-by-offset/{offset}` | `3.5` | `changed` | response `400` description updated |
-| `GET /v2/users` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/users/{user-id}` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/users/{user-id}/rights` | `3.5` | `changed` | description updated; response `400` description updated |
-| `GET /v2/version` | `3.5` | `changed` | description updated; response `400` description updated |
-| `PATCH /v2/idps/{idp-id}` | `3.5` | `changed` | description updated; response `400` description updated |
-| `PATCH /v2/parties/{party}` | `3.5` | `changed` | description updated; response `400` description updated |
-| `PATCH /v2/users/{user-id}` | `3.5` | `changed` | description updated; response `400` description updated |
-| `PATCH /v2/users/{user-id}/identity-provider-id` | `3.5` | `changed` | description updated; response `400` description updated |
-| `PATCH /v2/users/{user-id}/rights` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/commands/async/submit` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/commands/async/submit-reassignment` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/commands/completions` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/commands/submit-and-wait` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/commands/submit-and-wait-for-reassignment` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/commands/submit-and-wait-for-transaction` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/commands/submit-and-wait-for-transaction-tree` | `3.5` | `changed` | response `400` description updated |
-| `POST /v2/contracts/contract-by-id` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/dars` | `3.5` | `changed` | response `400` description updated |
-| `POST /v2/dars/validate` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/events/events-by-contract-id` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/idps` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/interactive-submission/execute` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/interactive-submission/executeAndWait` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/interactive-submission/executeAndWaitForTransaction` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/interactive-submission/preferred-packages` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/interactive-submission/prepare` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/package-vetting` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/packages` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/parties` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/parties/external/allocate` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/parties/external/generate-topology` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/state/active-contracts` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/updates` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/updates/flats` | `3.5` | `changed` | response `400` description updated |
-| `POST /v2/updates/transaction-by-id` | `3.5` | `changed` | response `400` description updated |
-| `POST /v2/updates/transaction-by-offset` | `3.5` | `changed` | response `400` description updated |
-| `POST /v2/updates/trees` | `3.5` | `changed` | response `400` description updated |
-| `POST /v2/updates/update-by-id` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/updates/update-by-offset` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/users` | `3.5` | `changed` | description updated; response `400` description updated |
-| `POST /v2/users/{user-id}/rights` | `3.5` | `changed` | description updated; response `400` description updated |
 
 ## Latest Operations
 
@@ -1861,3 +1963,23 @@ Generated from supplied versioned OpenAPI artifacts.
 | `schemas.WildcardFilter1` | `3.4` | - | - |
 | `securitySchemes.apiKeyAuth` | `3.4` | - | - |
 | `securitySchemes.httpAuth` | `3.4` | - | - |
+
+## Spec Metadata
+
+- Canonical spec id: `json-ledger-api/openapi.yaml`
+- Latest source path: `published/json-ledger-api/openapi.yaml`
+- OpenAPI version (latest): `3.0.3`
+- Introduced: `3.4`
+- Changed in versions: `3.5`
+- Removed: -
+
+## Entity Summary
+
+- Total entities tracked: `363`
+- Entities introduced after spec introduction: `6`
+- Entities changed at least once: `147`
+- Entities removed: `1`
+- Latest operations: `61`
+- Latest paths: `49`
+- Latest components: `252`
+- Latest tags: `0`

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -290,6 +290,12 @@
                   "appdev/faq",
                   "appdev/troubleshooting"
                 ]
+              },
+              {
+                "group": "Reference",
+                "pages": [
+                  "appdev/reference/json-api-reference"
+                ]
               }
             ]
           },
@@ -365,6 +371,12 @@
                   "appdev/faq",
                   "appdev/troubleshooting"
                 ]
+              },
+              {
+                "group": "Reference",
+                "pages": [
+                  "appdev/reference/json-api-reference"
+                ]
               }
             ]
           },
@@ -439,6 +451,12 @@
                 "pages": [
                   "appdev/faq",
                   "appdev/troubleshooting"
+                ]
+              },
+              {
+                "group": "Reference",
+                "pages": [
+                  "appdev/reference/json-api-reference"
                 ]
               }
             ]

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -448,25 +448,8 @@
       {
         "dropdown": "Reference",
         "icon": "book-open",
-        "versions": [
-          {
-            "version": "MainNet",
-            "pages": [
-              "appdev/reference/json-api-reference"
-            ]
-          },
-          {
-            "version": "TestNet",
-            "pages": [
-              "appdev/reference/json-api-reference"
-            ]
-          },
-          {
-            "version": "DevNet",
-            "pages": [
-              "appdev/reference/json-api-reference"
-            ]
-          }
+        "pages": [
+          "appdev/reference/json-api-reference"
         ]
       },
       {

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -290,12 +290,6 @@
                   "appdev/faq",
                   "appdev/troubleshooting"
                 ]
-              },
-              {
-                "group": "Reference",
-                "pages": [
-                  "appdev/reference/json-api-reference"
-                ]
               }
             ]
           },
@@ -370,12 +364,6 @@
                 "pages": [
                   "appdev/faq",
                   "appdev/troubleshooting"
-                ]
-              },
-              {
-                "group": "Reference",
-                "pages": [
-                  "appdev/reference/json-api-reference"
                 ]
               }
             ]
@@ -452,13 +440,31 @@
                   "appdev/faq",
                   "appdev/troubleshooting"
                 ]
-              },
-              {
-                "group": "Reference",
-                "pages": [
-                  "appdev/reference/json-api-reference"
-                ]
               }
+            ]
+          }
+        ]
+      },
+      {
+        "dropdown": "Reference",
+        "icon": "book-open",
+        "versions": [
+          {
+            "version": "MainNet",
+            "pages": [
+              "appdev/reference/json-api-reference"
+            ]
+          },
+          {
+            "version": "TestNet",
+            "pages": [
+              "appdev/reference/json-api-reference"
+            ]
+          },
+          {
+            "version": "DevNet",
+            "pages": [
+              "appdev/reference/json-api-reference"
             ]
           }
         ]

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "generate:json-api-reference": "python3 scripts/generate_json_api_reference.py"
+  },
   "dependencies": {
     "mintlify": "^4.2.301"
   }

--- a/scripts/generate_json_api_reference.py
+++ b/scripts/generate_json_api_reference.py
@@ -46,7 +46,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--nav-dropdown",
-        default="App Development",
+        default="Reference",
         help="Top-level Mintlify dropdown to update.",
     )
     parser.add_argument(
@@ -73,7 +73,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def build_command(args: argparse.Namespace) -> list[str]:
-    nav_groups = args.nav_group or ["Reference"]
+    nav_groups = args.nav_group or []
     versions = args.version or DEFAULT_VERSIONS
 
     command = [

--- a/scripts/generate_json_api_reference.py
+++ b/scripts/generate_json_api_reference.py
@@ -12,7 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_MANIFEST = REPO_ROOT / "config" / "x2mdx" / "ledger-api" / "manifest.json"
 DEFAULT_OUTPUT_FILE = REPO_ROOT / "docs-main" / "appdev" / "reference" / "json-api-reference.mdx"
 DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
-DEFAULT_VERSIONS = ["3.4", "3.5"]
+DEFAULT_SNAPSHOT_VERSIONS = ["3.4", "3.5"]
 
 
 def parse_args() -> argparse.Namespace:
@@ -57,7 +57,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--version",
         action="append",
-        help="Docs-site versions to include. Repeat to override the defaults.",
+        help="OpenAPI snapshot versions to include in the generated page. Repeat to override the defaults.",
     )
     parser.add_argument(
         "--source-name",
@@ -74,7 +74,7 @@ def parse_args() -> argparse.Namespace:
 
 def build_command(args: argparse.Namespace) -> list[str]:
     nav_groups = args.nav_group or []
-    versions = args.version or DEFAULT_VERSIONS
+    versions = args.version or DEFAULT_SNAPSHOT_VERSIONS
 
     command = [
         "x2mdx",

--- a/scripts/generate_json_api_reference.py
+++ b/scripts/generate_json_api_reference.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPO_ROOT / "config" / "x2mdx" / "ledger-api" / "manifest.json"
+DEFAULT_OUTPUT_FILE = REPO_ROOT / "docs-main" / "appdev" / "reference" / "json-api-reference.mdx"
+DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
+DEFAULT_VERSIONS = ["3.4", "3.5"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the Mintlify JSON API reference page from checked-in OpenAPI snapshots."
+    )
+    parser.add_argument(
+        "--manifest",
+        default=str(DEFAULT_MANIFEST),
+        help="Path to the x2mdx snapshot manifest.",
+    )
+    parser.add_argument(
+        "--output-file",
+        default=str(DEFAULT_OUTPUT_FILE),
+        help="Path to the generated MDX page.",
+    )
+    parser.add_argument(
+        "--docs-json",
+        default=str(DEFAULT_DOCS_JSON),
+        help="Path to the Mintlify docs.json file to update.",
+    )
+    parser.add_argument(
+        "--root",
+        default="published",
+        help="Root prefix used in manifest source paths.",
+    )
+    parser.add_argument(
+        "--include-spec-pattern",
+        default=r"^json-ledger-api/openapi\.yaml$",
+        help="Regex selecting the Ledger API spec inside the manifest.",
+    )
+    parser.add_argument(
+        "--nav-dropdown",
+        default="App Development",
+        help="Top-level Mintlify dropdown to update.",
+    )
+    parser.add_argument(
+        "--nav-group",
+        action="append",
+        help="Mintlify group path to update. Repeat for nested groups.",
+    )
+    parser.add_argument(
+        "--version",
+        action="append",
+        help="Docs-site versions to include. Repeat to override the defaults.",
+    )
+    parser.add_argument(
+        "--source-name",
+        default="docs.digitalasset.com JSON Ledger API OpenAPI fixtures",
+        help="Source label embedded in generated content.",
+    )
+    parser.add_argument(
+        "--version-filter",
+        default="published docs major versions",
+        help="Version-filter label embedded in generated content.",
+    )
+    return parser.parse_args()
+
+
+def build_command(args: argparse.Namespace) -> list[str]:
+    nav_groups = args.nav_group or ["Reference"]
+    versions = args.version or DEFAULT_VERSIONS
+
+    command = [
+        "x2mdx",
+        "openapi",
+        "build-api-pages-from-manifest",
+        "--manifest",
+        str(Path(args.manifest).resolve()),
+        "--root",
+        args.root,
+        "--include-spec-pattern",
+        args.include_spec_pattern,
+        "--output-file",
+        str(Path(args.output_file).resolve()),
+        "--docs-json",
+        str(Path(args.docs_json).resolve()),
+        "--nav-dropdown",
+        args.nav_dropdown,
+        "--source-name",
+        args.source_name,
+        "--version-filter",
+        args.version_filter,
+    ]
+
+    for version in versions:
+        command.extend(["--version", version])
+
+    for nav_group in nav_groups:
+        command.extend(["--nav-group", nav_group])
+
+    return command
+
+
+def main() -> int:
+    args = parse_args()
+    command = build_command(args)
+    print("Running:", " ".join(command))
+    completed = subprocess.run(command, cwd=REPO_ROOT)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,32 @@
 { pkgs ? import <nixpkgs> {} }:
 
+let
+  python = pkgs.python311;
+  x2mdx = python.pkgs.buildPythonApplication rec {
+    pname = "x2mdx";
+    version = "0.1.0+git-1a8a0c4";
+    pyproject = true;
+    src = pkgs.fetchFromGitHub {
+      owner = "danielporterda";
+      repo = "x2mdx";
+      rev = "1a8a0c44790f7cfaf26407b41c371cc2cbb02a64";
+      sha256 = "sha256-GUOx27QBFgZKDIhaPrUfrsNuclDKTSyEy0EQvUM0CDw=";
+    };
+    nativeBuildInputs = with python.pkgs; [
+      setuptools
+      wheel
+    ];
+    propagatedBuildInputs = with python.pkgs; [
+      pyyaml
+    ];
+    doCheck = false;
+  };
+in
 pkgs.mkShell {
   packages = [
     pkgs.nodejs_22
+    python
+    x2mdx
   ];
 
   shellHook = ''


### PR DESCRIPTION
This PR adds a page for openapi specs for the ledger JSON API.

It uses [the x2mdx tool](https://github.com/danielporterda/x2mdx) to convert multiple versions of the spec into a single MDX page.

To view page, navigate here: https://cantonfoundation-x2mdx-json-api-reference.mintlify.io/appdev/reference/json-api-reference