### PR TITLE
Update JSON API page for path-first OpenAPI

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -480,9 +480,7 @@
               "reference/wallet-gateway-json-rpc/specs/signing-api",
               "reference/wallet-gateway-json-rpc/specs/user-api"
             ]
-          }
-        ],
-        "groups": [
+          },
           {
             "group": "Ledger API Endpoints",
             "pages": [

--- a/docs-main/reference/json-api-reference.mdx
+++ b/docs-main/reference/json-api-reference.mdx
@@ -9,74 +9,66 @@ Generated from supplied versioned OpenAPI artifacts.
 
 | Name | Summary | Introduced | Changed | Deprecated | Removed |
 | --- | --- | --- | --- | --- | --- |
-| [`GET /livez`](#endpoint-get-livez) | Checks if the service is alive | `3.5` | - | - | - |
-| [`GET /readyz`](#endpoint-get-readyz) | Checks if the service is ready to serve requests | `3.5` | - | - | - |
-| [`GET /v2/authenticated-user`](#endpoint-get-v2-authenticated-user) | Get the user data of the current authenticated user. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/commands/async/submit`](#endpoint-post-v2-commands-async-submit) | Submit a single composite command. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/commands/async/submit-reassignment`](#endpoint-post-v2-commands-async-submit-reassignment) | Submit a single reassignment. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/commands/completions`](#endpoint-post-v2-commands-completions) | Query completions list (blocking call)  Subscribe to command completion events. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/commands/submit-and-wait`](#endpoint-post-v2-commands-submit-and-wait) | Submits a single composite command and waits for its result. Propagates the gRPC error of failed submissions including Daml interpretation errors. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/commands/submit-and-wait-for-reassignment`](#endpoint-post-v2-commands-submit-and-wait-for-reassignment) | Submits a single composite reassignment command, waits for its result, and returns the reassignment. Propagates the gRPC error of failed submission. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/commands/submit-and-wait-for-transaction`](#endpoint-post-v2-commands-submit-and-wait-for-transaction) | Submits a single composite command, waits for its result, and returns the transaction. Propagates the gRPC error of failed submissions including Daml interpretation errors. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/commands/submit-and-wait-for-transaction-tree`](#endpoint-post-v2-commands-submit-and-wait-for-transaction-tree) | Submit a batch of commands and wait for the transaction trees response. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use submit-and-wait-for-transaction instead. | `3.4` | 3.5: response `400` description updated | - | - |
-| [`POST /v2/contracts/contract-by-id`](#endpoint-post-v2-contracts-contract-by-id) | Looking up contract data by contract ID. This endpoint is experimental / alpha, therefore no backwards compatibility is guaranteed. This endpoint must not be used to look up contracts which entered the participant via party replication or repair service. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/dars`](#endpoint-post-v2-dars) | Upload a DAR to the participant node | `3.4` | 3.5: response `400` description updated | - | - |
-| [`POST /v2/dars/validate`](#endpoint-post-v2-dars-validate) | Validates the DAR and checks the upgrade compatibility of the DAR's packages with the set of the already vetted packages on the target vetting synchronizer. See ValidateDarFileRequest for details regarding the target vetting synchronizer.  The operation has no effect on the state of the participant or the Canton ledger: the DAR payload and its packages are not persisted neither are the packages vetted. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/events/events-by-contract-id`](#endpoint-post-v2-events-events-by-contract-id) | Get the create and the consuming exercise event for the contract with the provided ID. No events will be returned for contracts that have been pruned because they have already been archived before the latest pruning offset. If the contract cannot be found for the request, or all the contract-events are filtered, a CONTRACT_EVENTS_NOT_FOUND error will be raised. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/idps`](#endpoint-get-v2-idps) | List all existing identity provider configurations. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/idps`](#endpoint-post-v2-idps) | Create a new identity provider configuration. The request will fail if the maximum allowed number of separate configurations is reached. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`DELETE /v2/idps/{idp-id}`](#endpoint-delete-v2-idps-idp-id) | Delete an existing identity provider configuration. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/idps/{idp-id}`](#endpoint-get-v2-idps-idp-id) | Get the identity provider configuration data by id. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`PATCH /v2/idps/{idp-id}`](#endpoint-patch-v2-idps-idp-id) | Update selected modifiable attribute of an identity provider config resource described by the ``IdentityProviderConfig`` message. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/interactive-submission/execute`](#endpoint-post-v2-interactive-submission-execute) | Execute a prepared submission _asynchronously_ on the ledger. Requires a signature of the transaction from the submitting external party. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/interactive-submission/executeAndWait`](#endpoint-post-v2-interactive-submission-executeandwait) | Similar to ExecuteSubmission but _synchronously_ wait for the completion of the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appeared failed and vice versa | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/interactive-submission/executeAndWaitForTransaction`](#endpoint-post-v2-interactive-submission-executeandwaitfortransaction) | Similar to ExecuteSubmissionAndWait but additionally returns the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appear as failed and vice versa | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/interactive-submission/preferred-package-version`](#endpoint-get-v2-interactive-submission-preferred-package-version) | A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred package, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Provided for backwards compatibility, it will be removed in the Canton version 3.4.0 | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/interactive-submission/preferred-packages`](#endpoint-post-v2-interactive-submission-preferred-packages) | Compute the preferred packages for the vetting requirements in the request. A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred packages, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  If the package preferences could not be computed due to no selection satisfying the requirements, a `FAILED_PRECONDITION` error will be returned.  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Experimental API: this endpoint is not guaranteed to provide backwards compatibility in future releases | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/interactive-submission/prepare`](#endpoint-post-v2-interactive-submission-prepare) | Requires `readAs` scope for the submitting party when LAPI User authorization is enabled | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/package-vetting`](#endpoint-get-v2-package-vetting) | Lists which participant node vetted what packages on which synchronizer. Can be called by any authenticated user. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/package-vetting`](#endpoint-post-v2-package-vetting) | Update the vetted packages of this participant | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/packages`](#endpoint-get-v2-packages) | Returns the identifiers of all supported packages. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/packages`](#endpoint-post-v2-packages) | Behaves the same as /dars. This endpoint will be deprecated and removed in a future release. Upload a DAR file to the participant.  If vetting is enabled in the request, the DAR is checked for upgrade compatibility with the set of the already vetted packages on the target vetting synchronizer See UploadDarFileRequest for details regarding vetting and the target vetting synchronizer. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/packages/{package-id}`](#endpoint-get-v2-packages-package-id) | Returns the contents of a single package. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/packages/{package-id}/status`](#endpoint-get-v2-packages-package-id-status) | Returns the status of a single package. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/parties`](#endpoint-get-v2-parties) | List the parties known by the participant. The list returned contains parties whose ledger access is facilitated by the participant and the ones maintained elsewhere. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/parties`](#endpoint-post-v2-parties) | Allocates a new party on a ledger and adds it to the set managed by the participant. Caller specifies a party identifier suggestion, the actual identifier allocated might be different and is implementation specific. Caller can specify party metadata that is stored locally on the participant. This call may:  - Succeed, in which case the actual allocated identifier is visible in   the response. - Respond with a gRPC error  daml-on-kv-ledger: suggestion's uniqueness is checked by the validators in the consensus layer and call rejected if the identifier is already present. canton: completely different globally unique identifier is allocated. Behind the scenes calls to an internal protocol are made. As that protocol is richer than the surface protocol, the arguments take implicit values The party identifier suggestion must be a valid party name. Party names are required to be non-empty US-ASCII strings built from letters, digits, space, colon, minus and underscore limited to 255 chars | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/parties/external/allocate`](#endpoint-post-v2-parties-external-allocate) | Alpha 3.3: Endpoint to allocate a new external party on a synchronizer  Expected to be stable in 3.5  The external party must be hosted (at least) on this node with either confirmation or observation permissions It can optionally be hosted on other nodes (then called a multi-hosted party). If hosted on additional nodes, explicit authorization of the hosting relationship must be performed on those nodes before the party can be used. Decentralized namespaces are supported but must be provided fully authorized by their owners. The individual owner namespace transactions can be submitted in the same call (fully authorized as well). In the simple case of a non-multi hosted, non-decentralized party, the RPC will return once the party is effectively allocated and ready to use, similarly to the AllocateParty behavior. For more complex scenarios applications may need to query the party status explicitly (only through the admin API as of now). | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/parties/external/generate-topology`](#endpoint-post-v2-parties-external-generate-topology) | Alpha 3.3: Convenience endpoint to generate topology transactions for external signing  Expected to be stable in 3.5  You may use this endpoint to generate the common external topology transactions which can be signed externally and uploaded as part of the allocate party process  Note that this request will create a normal namespace using the same key for the identity as for signing. More elaborate schemes such as multi-signature or decentralized parties require you to construct the topology transactions yourself. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/parties/participant-id`](#endpoint-get-v2-parties-participant-id) | Return the identifier of the participant. All horizontally scaled replicas should return the same id. daml-on-kv-ledger: returns an identifier supplied on command line at launch time canton: returns globally unique identifier of the participant | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/parties/{party}`](#endpoint-get-v2-parties-party) | Get the party details of the given parties. Only known parties will be returned in the list. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`PATCH /v2/parties/{party}`](#endpoint-patch-v2-parties-party) | Update selected modifiable participant-local attributes of a party details resource. Can update the participant's local information for local parties. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/state/active-contracts`](#endpoint-post-v2-state-active-contracts) | Query active contracts list (blocking call). Querying active contracts is an expensive operation and if possible should not be repeated often. Consider querying active contracts initially (for a given offset) and then repeatedly call one of `/v2/updates/...`endpoints  to get subsequent modifications. You can also use websockets to get updates with better performance.  Returns a stream of the snapshot of the active contracts and incomplete (un)assignments at a ledger offset. Once the stream of GetActiveContractsResponses completes, the client SHOULD begin streaming updates from the update service, starting at the GetActiveContractsRequest.active_at_offset specified in this request. Clients SHOULD NOT assume that the set of active contracts they receive reflects the state at the ledger end.  Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/state/connected-synchronizers`](#endpoint-get-v2-state-connected-synchronizers) | Get the list of connected synchronizers at the time of the query. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/state/latest-pruned-offsets`](#endpoint-get-v2-state-latest-pruned-offsets) | Get the latest successfully pruned ledger offsets | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/state/ledger-end`](#endpoint-get-v2-state-ledger-end) | Get the current ledger end. Subscriptions started with the returned offset will serve events after this RPC was called. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/updates`](#endpoint-post-v2-updates) | Read the ledger's filtered update stream for the specified contents and filters. It returns the event types in accordance with the stream contents selected. Also the selection criteria for individual events depends on the transaction shape chosen.  - ACS delta: a requesting party must be a stakeholder of an event for it to be included. - ledger effects: a requesting party must be a witness of an event for it to be included. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/updates/flats`](#endpoint-post-v2-updates-flats) | Query flat transactions update list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. | `3.4` | 3.5: response `400` description updated | - | - |
-| [`POST /v2/updates/transaction-by-id`](#endpoint-post-v2-updates-transaction-by-id) | Get transaction by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead. | `3.4` | 3.5: response `400` description updated | - | - |
-| [`POST /v2/updates/transaction-by-offset`](#endpoint-post-v2-updates-transaction-by-offset) | Get transaction by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead. | `3.4` | 3.5: response `400` description updated | - | - |
-| [`GET /v2/updates/transaction-tree-by-id/{update-id}`](#endpoint-get-v2-updates-transaction-tree-by-id-update-id) | Get transaction tree by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead. | `3.4` | 3.5: response `400` description updated | - | - |
-| [`GET /v2/updates/transaction-tree-by-offset/{offset}`](#endpoint-get-v2-updates-transaction-tree-by-offset-offset) | Get transaction tree by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead. | `3.4` | 3.5: response `400` description updated | - | - |
-| [`POST /v2/updates/trees`](#endpoint-post-v2-updates-trees) | Query update transactions tree list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. | `3.4` | 3.5: response `400` description updated | - | - |
-| [`POST /v2/updates/update-by-id`](#endpoint-post-v2-updates-update-by-id) | Lookup an update by its ID. If there is no update with this ID, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/updates/update-by-offset`](#endpoint-post-v2-updates-update-by-offset) | Lookup an update by its offset. If there is no update with this offset, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/users`](#endpoint-get-v2-users) | List all existing users. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/users`](#endpoint-post-v2-users) | Create a new user. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`DELETE /v2/users/{user-id}`](#endpoint-delete-v2-users-user-id) | Delete an existing user and all its rights. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/users/{user-id}`](#endpoint-get-v2-users-user-id) | Get the user data of a specific user or the authenticated user. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`PATCH /v2/users/{user-id}`](#endpoint-patch-v2-users-user-id) | Update selected modifiable attribute of a user resource described by the ``User`` message. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`PATCH /v2/users/{user-id}/identity-provider-id`](#endpoint-patch-v2-users-user-id-identity-provider-id) | Update the assignment of a user from one IDP to another. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/users/{user-id}/rights`](#endpoint-get-v2-users-user-id-rights) | List the set of all rights granted to a user. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`PATCH /v2/users/{user-id}/rights`](#endpoint-patch-v2-users-user-id-rights) | Revoke rights from a user. Revoking rights does not affect the resource version of the corresponding user. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`POST /v2/users/{user-id}/rights`](#endpoint-post-v2-users-user-id-rights) | Grant rights to a user. Granting rights does not affect the resource version of the corresponding user. | `3.4` | 3.5: description updated; response `400` description updated | - | - |
-| [`GET /v2/version`](#endpoint-get-v2-version) | Read the Ledger API version | `3.4` | 3.5: description updated; response `400` description updated | - | - |
+| [`/livez`](#path-livez) | Checks if the service is alive | `3.5` | - | - | - |
+| [`/readyz`](#path-readyz) | Checks if the service is ready to serve requests | `3.5` | - | - | - |
+| [`/v2/authenticated-user`](#path-v2-authenticated-user) | Get the user data of the current authenticated user. | `3.4` | GET 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/commands/async/submit`](#path-v2-commands-async-submit) | Submit a single composite command. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/commands/async/submit-reassignment`](#path-v2-commands-async-submit-reassignment) | Submit a single reassignment. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/commands/completions`](#path-v2-commands-completions) | Query completions list (blocking call)  Subscribe to command completion events. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/commands/submit-and-wait`](#path-v2-commands-submit-and-wait) | Submits a single composite command and waits for its result. Propagates the gRPC error of failed submissions including Daml interpretation errors. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/commands/submit-and-wait-for-reassignment`](#path-v2-commands-submit-and-wait-for-reassignment) | Submits a single composite reassignment command, waits for its result, and returns the reassignment. Propagates the gRPC error of failed submission. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/commands/submit-and-wait-for-transaction`](#path-v2-commands-submit-and-wait-for-transaction) | Submits a single composite command, waits for its result, and returns the transaction. Propagates the gRPC error of failed submissions including Daml interpretation errors. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/commands/submit-and-wait-for-transaction-tree`](#path-v2-commands-submit-and-wait-for-transaction-tree) | Submit a batch of commands and wait for the transaction trees response. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use submit-and-wait-for-transaction instead. | `3.4` | POST 3.5: response `400` description updated | - | - |
+| [`/v2/contracts/contract-by-id`](#path-v2-contracts-contract-by-id) | Looking up contract data by contract ID. This endpoint is experimental / alpha, therefore no backwards compatibility is guaranteed. This endpoint must not be used to look up contracts which entered the participant via party replication or repair service. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/dars`](#path-v2-dars) | Upload a DAR to the participant node | `3.4` | POST 3.5: response `400` description updated | - | - |
+| [`/v2/dars/validate`](#path-v2-dars-validate) | Validates the DAR and checks the upgrade compatibility of the DAR's packages with the set of the already vetted packages on the target vetting synchronizer. See ValidateDarFileRequest for details regarding the target vetting synchronizer.  The operation has no effect on the state of the participant or the Canton ledger: the DAR payload and its packages are not persisted neither are the packages vetted. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/events/events-by-contract-id`](#path-v2-events-events-by-contract-id) | Get the create and the consuming exercise event for the contract with the provided ID. No events will be returned for contracts that have been pruned because they have already been archived before the latest pruning offset. If the contract cannot be found for the request, or all the contract-events are filtered, a CONTRACT_EVENTS_NOT_FOUND error will be raised. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/idps`](#path-v2-idps) | GET: List all existing identity provider configurations.; POST: Create a new identity provider configuration. The request will fail if the maximum allowed number of separate configurations is reached. | `3.4` | GET 3.5: description updated; response `400` description updated; POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/idps/{idp-id}`](#path-v2-idps-idp-id) | DELETE: Delete an existing identity provider configuration.; GET: Get the identity provider configuration data by id.; +1 more | `3.4` | DELETE 3.5: description updated; response `400` description updated; GET 3.5: description updated; response `400` description updated; PATCH 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/interactive-submission/execute`](#path-v2-interactive-submission-execute) | Execute a prepared submission _asynchronously_ on the ledger. Requires a signature of the transaction from the submitting external party. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/interactive-submission/executeAndWait`](#path-v2-interactive-submission-executeandwait) | Similar to ExecuteSubmission but _synchronously_ wait for the completion of the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appeared failed and vice versa | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/interactive-submission/executeAndWaitForTransaction`](#path-v2-interactive-submission-executeandwaitfortransaction) | Similar to ExecuteSubmissionAndWait but additionally returns the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appear as failed and vice versa | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/interactive-submission/preferred-package-version`](#path-v2-interactive-submission-preferred-package-version) | A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred package, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Provided for backwards compatibility, it will be removed in the Canton version 3.4.0 | `3.4` | GET 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/interactive-submission/preferred-packages`](#path-v2-interactive-submission-preferred-packages) | Compute the preferred packages for the vetting requirements in the request. A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred packages, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  If the package preferences could not be computed due to no selection satisfying the requirements, a `FAILED_PRECONDITION` error will be returned.  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Experimental API: this endpoint is not guaranteed to provide backwards compatibility in future releases | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/interactive-submission/prepare`](#path-v2-interactive-submission-prepare) | Requires `readAs` scope for the submitting party when LAPI User authorization is enabled | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/package-vetting`](#path-v2-package-vetting) | GET: Lists which participant node vetted what packages on which synchronizer. Can be called by any authenticated user.; POST: Update the vetted packages of this participant | `3.4` | GET 3.5: description updated; response `400` description updated; POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/packages`](#path-v2-packages) | GET: Returns the identifiers of all supported packages.; POST: Behaves the same as /dars. This endpoint will be deprecated and removed in a future release. Upload a DAR file to the participant.  If vetting is enabled in the request, the DAR is checked for upgrade compatibility with the set of the already vetted packages on the target vetting synchronizer See UploadDarFileRequest for details regarding vetting and the target vetting synchronizer. | `3.4` | GET 3.5: description updated; response `400` description updated; POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/packages/{package-id}`](#path-v2-packages-package-id) | Returns the contents of a single package. | `3.4` | GET 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/packages/{package-id}/status`](#path-v2-packages-package-id-status) | Returns the status of a single package. | `3.4` | GET 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/parties`](#path-v2-parties) | GET: List the parties known by the participant. The list returned contains parties whose ledger access is facilitated by the participant and the ones maintained elsewhere.; POST: Allocates a new party on a ledger and adds it to the set managed by the participant. Caller specifies a party identifier suggestion, the actual identifier allocated might be different and is implementation specific. Caller can specify party metadata that is stored locally on the participant. This call may:  - Succeed, in which case the actual allocated identifier is visible in   the response. - Respond with a gRPC error  daml-on-kv-ledger: suggestion's uniqueness is checked by the validators in the consensus layer and call rejected if the identifier is already present. canton: completely different globally unique identifier is allocated. Behind the scenes calls to an internal protocol are made. As that protocol is richer than the surface protocol, the arguments take implicit values The party identifier suggestion must be a valid party name. Party names are required to be non-empty US-ASCII strings built from letters, digits, space, colon, minus and underscore limited to 255 chars | `3.4` | GET 3.5: description updated; response `400` description updated; POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/parties/external/allocate`](#path-v2-parties-external-allocate) | Alpha 3.3: Endpoint to allocate a new external party on a synchronizer  Expected to be stable in 3.5  The external party must be hosted (at least) on this node with either confirmation or observation permissions It can optionally be hosted on other nodes (then called a multi-hosted party). If hosted on additional nodes, explicit authorization of the hosting relationship must be performed on those nodes before the party can be used. Decentralized namespaces are supported but must be provided fully authorized by their owners. The individual owner namespace transactions can be submitted in the same call (fully authorized as well). In the simple case of a non-multi hosted, non-decentralized party, the RPC will return once the party is effectively allocated and ready to use, similarly to the AllocateParty behavior. For more complex scenarios applications may need to query the party status explicitly (only through the admin API as of now). | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/parties/external/generate-topology`](#path-v2-parties-external-generate-topology) | Alpha 3.3: Convenience endpoint to generate topology transactions for external signing  Expected to be stable in 3.5  You may use this endpoint to generate the common external topology transactions which can be signed externally and uploaded as part of the allocate party process  Note that this request will create a normal namespace using the same key for the identity as for signing. More elaborate schemes such as multi-signature or decentralized parties require you to construct the topology transactions yourself. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/parties/participant-id`](#path-v2-parties-participant-id) | Return the identifier of the participant. All horizontally scaled replicas should return the same id. daml-on-kv-ledger: returns an identifier supplied on command line at launch time canton: returns globally unique identifier of the participant | `3.4` | GET 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/parties/{party}`](#path-v2-parties-party) | GET: Get the party details of the given parties. Only known parties will be returned in the list.; PATCH: Update selected modifiable participant-local attributes of a party details resource. Can update the participant's local information for local parties. | `3.4` | GET 3.5: description updated; response `400` description updated; PATCH 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/state/active-contracts`](#path-v2-state-active-contracts) | Query active contracts list (blocking call). Querying active contracts is an expensive operation and if possible should not be repeated often. Consider querying active contracts initially (for a given offset) and then repeatedly call one of `/v2/updates/...`endpoints  to get subsequent modifications. You can also use websockets to get updates with better performance.  Returns a stream of the snapshot of the active contracts and incomplete (un)assignments at a ledger offset. Once the stream of GetActiveContractsResponses completes, the client SHOULD begin streaming updates from the update service, starting at the GetActiveContractsRequest.active_at_offset specified in this request. Clients SHOULD NOT assume that the set of active contracts they receive reflects the state at the ledger end.  Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/state/connected-synchronizers`](#path-v2-state-connected-synchronizers) | Get the list of connected synchronizers at the time of the query. | `3.4` | GET 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/state/latest-pruned-offsets`](#path-v2-state-latest-pruned-offsets) | Get the latest successfully pruned ledger offsets | `3.4` | GET 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/state/ledger-end`](#path-v2-state-ledger-end) | Get the current ledger end. Subscriptions started with the returned offset will serve events after this RPC was called. | `3.4` | GET 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/updates`](#path-v2-updates) | Read the ledger's filtered update stream for the specified contents and filters. It returns the event types in accordance with the stream contents selected. Also the selection criteria for individual events depends on the transaction shape chosen.  - ACS delta: a requesting party must be a stakeholder of an event for it to be included. - ledger effects: a requesting party must be a witness of an event for it to be included. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/updates/flats`](#path-v2-updates-flats) | Query flat transactions update list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. | `3.4` | POST 3.5: response `400` description updated | - | - |
+| [`/v2/updates/transaction-by-id`](#path-v2-updates-transaction-by-id) | Get transaction by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead. | `3.4` | POST 3.5: response `400` description updated | - | - |
+| [`/v2/updates/transaction-by-offset`](#path-v2-updates-transaction-by-offset) | Get transaction by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead. | `3.4` | POST 3.5: response `400` description updated | - | - |
+| [`/v2/updates/transaction-tree-by-id/{update-id}`](#path-v2-updates-transaction-tree-by-id-update-id) | Get transaction tree by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead. | `3.4` | GET 3.5: response `400` description updated | - | - |
+| [`/v2/updates/transaction-tree-by-offset/{offset}`](#path-v2-updates-transaction-tree-by-offset-offset) | Get transaction tree by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead. | `3.4` | GET 3.5: response `400` description updated | - | - |
+| [`/v2/updates/trees`](#path-v2-updates-trees) | Query update transactions tree list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. | `3.4` | POST 3.5: response `400` description updated | - | - |
+| [`/v2/updates/update-by-id`](#path-v2-updates-update-by-id) | Lookup an update by its ID. If there is no update with this ID, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/updates/update-by-offset`](#path-v2-updates-update-by-offset) | Lookup an update by its offset. If there is no update with this offset, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised. | `3.4` | POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/users`](#path-v2-users) | GET: List all existing users.; POST: Create a new user. | `3.4` | GET 3.5: description updated; response `400` description updated; POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/users/{user-id}`](#path-v2-users-user-id) | DELETE: Delete an existing user and all its rights.; GET: Get the user data of a specific user or the authenticated user.; +1 more | `3.4` | DELETE 3.5: description updated; response `400` description updated; GET 3.5: description updated; response `400` description updated; PATCH 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/users/{user-id}/identity-provider-id`](#path-v2-users-user-id-identity-provider-id) | Update the assignment of a user from one IDP to another. | `3.4` | PATCH 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/users/{user-id}/rights`](#path-v2-users-user-id-rights) | GET: List the set of all rights granted to a user.; PATCH: Revoke rights from a user. Revoking rights does not affect the resource version of the corresponding user.; +1 more | `3.4` | GET 3.5: description updated; response `400` description updated; PATCH 3.5: description updated; response `400` description updated; POST 3.5: description updated; response `400` description updated | - | - |
+| [`/v2/version`](#path-v2-version) | Read the Ledger API version | `3.4` | GET 3.5: description updated; response `400` description updated | - | - |
 
 ## Endpoint Reference (Latest)
 
 
+<a id="path-livez"></a>
+
+### `/livez`
+
 <a id="endpoint-get-livez"></a>
 
-### `GET /livez`
+**Method:** `GET`
 
 - Operation ID: `getLivez`
 - Description: Checks if the service is alive
@@ -89,9 +81,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-readyz"></a>
+
+### `/readyz`
+
 <a id="endpoint-get-readyz"></a>
 
-### `GET /readyz`
+**Method:** `GET`
 
 - Operation ID: `getReadyz`
 - Description: Checks if the service is ready to serve requests
@@ -104,9 +100,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-authenticated-user"></a>
+
+### `/v2/authenticated-user`
+
 <a id="endpoint-get-v2-authenticated-user"></a>
 
-### `GET /v2/authenticated-user`
+**Method:** `GET`
 
 - Operation ID: `getV2Authenticated-user`
 - Description: Get the user data of the current authenticated user.
@@ -125,9 +125,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: query parameter identity-provider-id | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-commands-async-submit"></a>
+
+### `/v2/commands/async/submit`
+
 <a id="endpoint-post-v2-commands-async-submit"></a>
 
-### `POST /v2/commands/async/submit`
+**Method:** `POST`
 
 - Operation ID: `postV2CommandsAsyncSubmit`
 - Description: Submit a single composite command.
@@ -169,9 +173,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-commands-async-submit-reassignment"></a>
+
+### `/v2/commands/async/submit-reassignment`
+
 <a id="endpoint-post-v2-commands-async-submit-reassignment"></a>
 
-### `POST /v2/commands/async/submit-reassignment`
+**Method:** `POST`
 
 - Operation ID: `postV2CommandsAsyncSubmit-reassignment`
 - Description: Submit a single reassignment.
@@ -208,9 +216,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-commands-completions"></a>
+
+### `/v2/commands/completions`
+
 <a id="endpoint-post-v2-commands-completions"></a>
 
-### `POST /v2/commands/completions`
+**Method:** `POST`
 
 - Operation ID: `postV2CommandsCompletions`
 - Description: Query completions list (blocking call)  Subscribe to command completion events. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
@@ -248,9 +260,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-commands-submit-and-wait"></a>
+
+### `/v2/commands/submit-and-wait`
+
 <a id="endpoint-post-v2-commands-submit-and-wait"></a>
 
-### `POST /v2/commands/submit-and-wait`
+**Method:** `POST`
 
 - Operation ID: `postV2CommandsSubmit-and-wait`
 - Description: Submits a single composite command and waits for its result. Propagates the gRPC error of failed submissions including Daml interpretation errors.
@@ -292,9 +308,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-commands-submit-and-wait-for-reassignment"></a>
+
+### `/v2/commands/submit-and-wait-for-reassignment`
+
 <a id="endpoint-post-v2-commands-submit-and-wait-for-reassignment"></a>
 
-### `POST /v2/commands/submit-and-wait-for-reassignment`
+**Method:** `POST`
 
 - Operation ID: `postV2CommandsSubmit-and-wait-for-reassignment`
 - Description: Submits a single composite reassignment command, waits for its result, and returns the reassignment. Propagates the gRPC error of failed submission.
@@ -331,9 +351,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-commands-submit-and-wait-for-transaction"></a>
+
+### `/v2/commands/submit-and-wait-for-transaction`
+
 <a id="endpoint-post-v2-commands-submit-and-wait-for-transaction"></a>
 
-### `POST /v2/commands/submit-and-wait-for-transaction`
+**Method:** `POST`
 
 - Operation ID: `postV2CommandsSubmit-and-wait-for-transaction`
 - Description: Submits a single composite command, waits for its result, and returns the transaction. Propagates the gRPC error of failed submissions including Daml interpretation errors.
@@ -372,9 +396,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-commands-submit-and-wait-for-transaction-tree"></a>
+
+### `/v2/commands/submit-and-wait-for-transaction-tree`
+
 <a id="endpoint-post-v2-commands-submit-and-wait-for-transaction-tree"></a>
 
-### `POST /v2/commands/submit-and-wait-for-transaction-tree`
+**Method:** `POST`
 
 - Operation ID: `postV2CommandsSubmit-and-wait-for-transaction-tree`
 - Description: Submit a batch of commands and wait for the transaction trees response. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use submit-and-wait-for-transaction instead.
@@ -416,9 +444,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-contracts-contract-by-id"></a>
+
+### `/v2/contracts/contract-by-id`
+
 <a id="endpoint-post-v2-contracts-contract-by-id"></a>
 
-### `POST /v2/contracts/contract-by-id`
+**Method:** `POST`
 
 - Operation ID: `postV2ContractsContract-by-id`
 - Description: Looking up contract data by contract ID. This endpoint is experimental / alpha, therefore no backwards compatibility is guaranteed. This endpoint must not be used to look up contracts which entered the participant via party replication or repair service.
@@ -447,9 +479,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-dars"></a>
+
+### `/v2/dars`
+
 <a id="endpoint-post-v2-dars"></a>
 
-### `POST /v2/dars`
+**Method:** `POST`
 
 - Operation ID: `postV2Dars`
 - Description: Upload a DAR to the participant node
@@ -483,9 +519,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter vetAllPackages, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-dars-validate"></a>
+
+### `/v2/dars/validate`
+
 <a id="endpoint-post-v2-dars-validate"></a>
 
-### `POST /v2/dars/validate`
+**Method:** `POST`
 
 - Operation ID: `postV2DarsValidate`
 - Description: Validates the DAR and checks the upgrade compatibility of the DAR's packages with the set of the already vetted packages on the target vetting synchronizer. See ValidateDarFileRequest for details regarding the target vetting synchronizer.  The operation has no effect on the state of the participant or the Canton ledger: the DAR payload and its packages are not persisted neither are the packages vetted.
@@ -518,9 +558,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-events-events-by-contract-id"></a>
+
+### `/v2/events/events-by-contract-id`
+
 <a id="endpoint-post-v2-events-events-by-contract-id"></a>
 
-### `POST /v2/events/events-by-contract-id`
+**Method:** `POST`
 
 - Operation ID: `postV2EventsEvents-by-contract-id`
 - Description: Get the create and the consuming exercise event for the contract with the provided ID. No events will be returned for contracts that have been pruned because they have already been archived before the latest pruning offset. If the contract cannot be found for the request, or all the contract-events are filtered, a CONTRACT_EVENTS_NOT_FOUND error will be raised.
@@ -558,9 +602,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-idps"></a>
+
+### `/v2/idps`
+
 <a id="endpoint-get-v2-idps"></a>
 
-### `GET /v2/idps`
+#### `GET`
 
 - Operation ID: `getV2Idps`
 - Description: List all existing identity provider configurations.
@@ -575,7 +623,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-post-v2-idps"></a>
 
-### `POST /v2/idps`
+#### `POST`
 
 - Operation ID: `postV2Idps`
 - Description: Create a new identity provider configuration. The request will fail if the maximum allowed number of separate configurations is reached.
@@ -608,9 +656,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-idps-idp-id"></a>
+
+### `/v2/idps/{idp-id}`
+
 <a id="endpoint-delete-v2-idps-idp-id"></a>
 
-### `DELETE /v2/idps/{idp-id}`
+#### `DELETE`
 
 - Operation ID: `deleteV2IdpsIdp-id`
 - Description: Delete an existing identity provider configuration.
@@ -631,7 +683,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-get-v2-idps-idp-id"></a>
 
-### `GET /v2/idps/{idp-id}`
+#### `GET`
 
 - Operation ID: `getV2IdpsIdp-id`
 - Description: Get the identity provider configuration data by id.
@@ -652,7 +704,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-patch-v2-idps-idp-id"></a>
 
-### `PATCH /v2/idps/{idp-id}`
+#### `PATCH`
 
 - Operation ID: `patchV2IdpsIdp-id`
 - Description: Update selected modifiable attribute of an identity provider config resource described by the ``IdentityProviderConfig`` message.
@@ -696,9 +748,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-interactive-submission-execute"></a>
+
+### `/v2/interactive-submission/execute`
+
 <a id="endpoint-post-v2-interactive-submission-execute"></a>
 
-### `POST /v2/interactive-submission/execute`
+**Method:** `POST`
 
 - Operation ID: `postV2Interactive-submissionExecute`
 - Description: Execute a prepared submission _asynchronously_ on the ledger. Requires a signature of the transaction from the submitting external party.
@@ -739,9 +795,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-interactive-submission-executeandwait"></a>
+
+### `/v2/interactive-submission/executeAndWait`
+
 <a id="endpoint-post-v2-interactive-submission-executeandwait"></a>
 
-### `POST /v2/interactive-submission/executeAndWait`
+**Method:** `POST`
 
 - Operation ID: `postV2Interactive-submissionExecuteandwait`
 - Description: Similar to ExecuteSubmission but _synchronously_ wait for the completion of the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appeared failed and vice versa
@@ -782,9 +842,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-interactive-submission-executeandwaitfortransaction"></a>
+
+### `/v2/interactive-submission/executeAndWaitForTransaction`
+
 <a id="endpoint-post-v2-interactive-submission-executeandwaitfortransaction"></a>
 
-### `POST /v2/interactive-submission/executeAndWaitForTransaction`
+**Method:** `POST`
 
 - Operation ID: `postV2Interactive-submissionExecuteandwaitfortransaction`
 - Description: Similar to ExecuteSubmissionAndWait but additionally returns the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appear as failed and vice versa
@@ -825,9 +889,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-interactive-submission-preferred-package-version"></a>
+
+### `/v2/interactive-submission/preferred-package-version`
+
 <a id="endpoint-get-v2-interactive-submission-preferred-package-version"></a>
 
-### `GET /v2/interactive-submission/preferred-package-version`
+**Method:** `GET`
 
 - Operation ID: `getV2Interactive-submissionPreferred-package-version`
 - Description: A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred package, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Provided for backwards compatibility, it will be removed in the Canton version 3.4.0
@@ -849,9 +917,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: query parameter parties, Invalid value for: query parameter package-name, Invalid value for: query parameter vetting_valid_at, Invalid value for: query parameter synchronizer-id | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-interactive-submission-preferred-packages"></a>
+
+### `/v2/interactive-submission/preferred-packages`
+
 <a id="endpoint-post-v2-interactive-submission-preferred-packages"></a>
 
-### `POST /v2/interactive-submission/preferred-packages`
+**Method:** `POST`
 
 - Operation ID: `postV2Interactive-submissionPreferred-packages`
 - Description: Compute the preferred packages for the vetting requirements in the request. A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred packages, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  If the package preferences could not be computed due to no selection satisfying the requirements, a `FAILED_PRECONDITION` error will be returned.  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Experimental API: this endpoint is not guaranteed to provide backwards compatibility in future releases
@@ -887,9 +959,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-interactive-submission-prepare"></a>
+
+### `/v2/interactive-submission/prepare`
+
 <a id="endpoint-post-v2-interactive-submission-prepare"></a>
 
-### `POST /v2/interactive-submission/prepare`
+**Method:** `POST`
 
 - Operation ID: `postV2Interactive-submissionPrepare`
 - Description: Requires `readAs` scope for the submitting party when LAPI User authorization is enabled
@@ -931,9 +1007,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-package-vetting"></a>
+
+### `/v2/package-vetting`
+
 <a id="endpoint-get-v2-package-vetting"></a>
 
-### `GET /v2/package-vetting`
+#### `GET`
 
 - Operation ID: `getV2Package-vetting`
 - Description: Lists which participant node vetted what packages on which synchronizer. Can be called by any authenticated user.
@@ -981,7 +1061,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-post-v2-package-vetting"></a>
 
-### `POST /v2/package-vetting`
+#### `POST`
 
 - Operation ID: `postV2Package-vetting`
 - Description: Update the vetted packages of this participant
@@ -1016,9 +1096,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-packages"></a>
+
+### `/v2/packages`
+
 <a id="endpoint-get-v2-packages"></a>
 
-### `GET /v2/packages`
+#### `GET`
 
 - Operation ID: `getV2Packages`
 - Description: Returns the identifiers of all supported packages.
@@ -1033,7 +1117,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-post-v2-packages"></a>
 
-### `POST /v2/packages`
+#### `POST`
 
 - Operation ID: `postV2Packages`
 - Description: Behaves the same as /dars. This endpoint will be deprecated and removed in a future release. Upload a DAR file to the participant.  If vetting is enabled in the request, the DAR is checked for upgrade compatibility with the set of the already vetted packages on the target vetting synchronizer See UploadDarFileRequest for details regarding vetting and the target vetting synchronizer.
@@ -1067,9 +1151,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter vetAllPackages, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-packages-package-id"></a>
+
+### `/v2/packages/{package-id}`
+
 <a id="endpoint-get-v2-packages-package-id"></a>
 
-### `GET /v2/packages/{package-id}`
+**Method:** `GET`
 
 - Operation ID: `getV2PackagesPackage-id`
 - Description: Returns the contents of a single package.
@@ -1088,9 +1176,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-packages-package-id-status"></a>
+
+### `/v2/packages/{package-id}/status`
+
 <a id="endpoint-get-v2-packages-package-id-status"></a>
 
-### `GET /v2/packages/{package-id}/status`
+**Method:** `GET`
 
 - Operation ID: `getV2PackagesPackage-idStatus`
 - Description: Returns the status of a single package.
@@ -1109,9 +1201,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-parties"></a>
+
+### `/v2/parties`
+
 <a id="endpoint-get-v2-parties"></a>
 
-### `GET /v2/parties`
+#### `GET`
 
 - Operation ID: `getV2Parties`
 - Description: List the parties known by the participant. The list returned contains parties whose ledger access is facilitated by the participant and the ones maintained elsewhere.
@@ -1135,7 +1231,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-post-v2-parties"></a>
 
-### `POST /v2/parties`
+#### `POST`
 
 - Operation ID: `postV2Parties`
 - Description: Allocates a new party on a ledger and adds it to the set managed by the participant. Caller specifies a party identifier suggestion, the actual identifier allocated might be different and is implementation specific. Caller can specify party metadata that is stored locally on the participant. This call may:  - Succeed, in which case the actual allocated identifier is visible in   the response. - Respond with a gRPC error  daml-on-kv-ledger: suggestion's uniqueness is checked by the validators in the consensus layer and call rejected if the identifier is already present. canton: completely different globally unique identifier is allocated. Behind the scenes calls to an internal protocol are made. As that protocol is richer than the surface protocol, the arguments take implicit values The party identifier suggestion must be a valid party name. Party names are required to be non-empty US-ASCII strings built from letters, digits, space, colon, minus and underscore limited to 255 chars
@@ -1171,9 +1267,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-parties-external-allocate"></a>
+
+### `/v2/parties/external/allocate`
+
 <a id="endpoint-post-v2-parties-external-allocate"></a>
 
-### `POST /v2/parties/external/allocate`
+**Method:** `POST`
 
 - Operation ID: `postV2PartiesExternalAllocate`
 - Description: Alpha 3.3: Endpoint to allocate a new external party on a synchronizer  Expected to be stable in 3.5  The external party must be hosted (at least) on this node with either confirmation or observation permissions It can optionally be hosted on other nodes (then called a multi-hosted party). If hosted on additional nodes, explicit authorization of the hosting relationship must be performed on those nodes before the party can be used. Decentralized namespaces are supported but must be provided fully authorized by their owners. The individual owner namespace transactions can be submitted in the same call (fully authorized as well). In the simple case of a non-multi hosted, non-decentralized party, the RPC will return once the party is effectively allocated and ready to use, similarly to the AllocateParty behavior. For more complex scenarios applications may need to query the party status explicitly (only through the admin API as of now).
@@ -1207,9 +1307,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-parties-external-generate-topology"></a>
+
+### `/v2/parties/external/generate-topology`
+
 <a id="endpoint-post-v2-parties-external-generate-topology"></a>
 
-### `POST /v2/parties/external/generate-topology`
+**Method:** `POST`
 
 - Operation ID: `postV2PartiesExternalGenerate-topology`
 - Description: Alpha 3.3: Convenience endpoint to generate topology transactions for external signing  Expected to be stable in 3.5  You may use this endpoint to generate the common external topology transactions which can be signed externally and uploaded as part of the allocate party process  Note that this request will create a normal namespace using the same key for the identity as for signing. More elaborate schemes such as multi-signature or decentralized parties require you to construct the topology transactions yourself.
@@ -1244,9 +1348,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-parties-participant-id"></a>
+
+### `/v2/parties/participant-id`
+
 <a id="endpoint-get-v2-parties-participant-id"></a>
 
-### `GET /v2/parties/participant-id`
+**Method:** `GET`
 
 - Operation ID: `getV2PartiesParticipant-id`
 - Description: Return the identifier of the participant. All horizontally scaled replicas should return the same id. daml-on-kv-ledger: returns an identifier supplied on command line at launch time canton: returns globally unique identifier of the participant
@@ -1259,9 +1367,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-parties-party"></a>
+
+### `/v2/parties/{party}`
+
 <a id="endpoint-get-v2-parties-party"></a>
 
-### `GET /v2/parties/{party}`
+#### `GET`
 
 - Operation ID: `getV2PartiesParty`
 - Description: Get the party details of the given parties. Only known parties will be returned in the list.
@@ -1284,7 +1396,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-patch-v2-parties-party"></a>
 
-### `PATCH /v2/parties/{party}`
+#### `PATCH`
 
 - Operation ID: `patchV2PartiesParty`
 - Description: Update selected modifiable participant-local attributes of a party details resource. Can update the participant's local information for local parties.
@@ -1326,9 +1438,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-state-active-contracts"></a>
+
+### `/v2/state/active-contracts`
+
 <a id="endpoint-post-v2-state-active-contracts"></a>
 
-### `POST /v2/state/active-contracts`
+**Method:** `POST`
 
 - Operation ID: `postV2StateActive-contracts`
 - Description: Query active contracts list (blocking call). Querying active contracts is an expensive operation and if possible should not be repeated often. Consider querying active contracts initially (for a given offset) and then repeatedly call one of `/v2/updates/...`endpoints  to get subsequent modifications. You can also use websockets to get updates with better performance.  Returns a stream of the snapshot of the active contracts and incomplete (un)assignments at a ledger offset. Once the stream of GetActiveContractsResponses completes, the client SHOULD begin streaming updates from the update service, starting at the GetActiveContractsRequest.active_at_offset specified in this request. Clients SHOULD NOT assume that the set of active contracts they receive reflects the state at the ledger end.  Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
@@ -1364,9 +1480,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-state-connected-synchronizers"></a>
+
+### `/v2/state/connected-synchronizers`
+
 <a id="endpoint-get-v2-state-connected-synchronizers"></a>
 
-### `GET /v2/state/connected-synchronizers`
+**Method:** `GET`
 
 - Operation ID: `getV2StateConnected-synchronizers`
 - Description: Get the list of connected synchronizers at the time of the query.
@@ -1387,9 +1507,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: query parameter party, Invalid value for: query parameter participantId, Invalid value for: query parameter identityProviderId | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-state-latest-pruned-offsets"></a>
+
+### `/v2/state/latest-pruned-offsets`
+
 <a id="endpoint-get-v2-state-latest-pruned-offsets"></a>
 
-### `GET /v2/state/latest-pruned-offsets`
+**Method:** `GET`
 
 - Operation ID: `getV2StateLatest-pruned-offsets`
 - Description: Get the latest successfully pruned ledger offsets
@@ -1402,9 +1526,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-state-ledger-end"></a>
+
+### `/v2/state/ledger-end`
+
 <a id="endpoint-get-v2-state-ledger-end"></a>
 
-### `GET /v2/state/ledger-end`
+**Method:** `GET`
 
 - Operation ID: `getV2StateLedger-end`
 - Description: Get the current ledger end. Subscriptions started with the returned offset will serve events after this RPC was called.
@@ -1417,9 +1545,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-updates"></a>
+
+### `/v2/updates`
+
 <a id="endpoint-post-v2-updates"></a>
 
-### `POST /v2/updates`
+**Method:** `POST`
 
 - Operation ID: `postV2Updates`
 - Description: Read the ledger's filtered update stream for the specified contents and filters. It returns the event types in accordance with the stream contents selected. Also the selection criteria for individual events depends on the transaction shape chosen.  - ACS delta: a requesting party must be a stakeholder of an event for it to be included. - ledger effects: a requesting party must be a witness of an event for it to be included. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
@@ -1491,9 +1623,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-updates-flats"></a>
+
+### `/v2/updates/flats`
+
 <a id="endpoint-post-v2-updates-flats"></a>
 
-### `POST /v2/updates/flats`
+**Method:** `POST`
 
 - Operation ID: `postV2UpdatesFlats`
 - Description: Query flat transactions update list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
@@ -1565,9 +1701,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-updates-transaction-by-id"></a>
+
+### `/v2/updates/transaction-by-id`
+
 <a id="endpoint-post-v2-updates-transaction-by-id"></a>
 
-### `POST /v2/updates/transaction-by-id`
+**Method:** `POST`
 
 - Operation ID: `postV2UpdatesTransaction-by-id`
 - Description: Get transaction by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.
@@ -1596,9 +1736,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-updates-transaction-by-offset"></a>
+
+### `/v2/updates/transaction-by-offset`
+
 <a id="endpoint-post-v2-updates-transaction-by-offset"></a>
 
-### `POST /v2/updates/transaction-by-offset`
+**Method:** `POST`
 
 - Operation ID: `postV2UpdatesTransaction-by-offset`
 - Description: Get transaction by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead.
@@ -1627,9 +1771,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-updates-transaction-tree-by-id-update-id"></a>
+
+### `/v2/updates/transaction-tree-by-id/{update-id}`
+
 <a id="endpoint-get-v2-updates-transaction-tree-by-id-update-id"></a>
 
-### `GET /v2/updates/transaction-tree-by-id/{update-id}`
+**Method:** `GET`
 
 - Operation ID: `getV2UpdatesTransaction-tree-by-idUpdate-id`
 - Description: Get transaction tree by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.
@@ -1649,9 +1797,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: query parameter parties | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-updates-transaction-tree-by-offset-offset"></a>
+
+### `/v2/updates/transaction-tree-by-offset/{offset}`
+
 <a id="endpoint-get-v2-updates-transaction-tree-by-offset-offset"></a>
 
-### `GET /v2/updates/transaction-tree-by-offset/{offset}`
+**Method:** `GET`
 
 - Operation ID: `getV2UpdatesTransaction-tree-by-offsetOffset`
 - Description: Get transaction tree by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead.
@@ -1671,9 +1823,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: path parameter offset, Invalid value for: query parameter parties | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-updates-trees"></a>
+
+### `/v2/updates/trees`
+
 <a id="endpoint-post-v2-updates-trees"></a>
 
-### `POST /v2/updates/trees`
+**Method:** `POST`
 
 - Operation ID: `postV2UpdatesTrees`
 - Description: Query update transactions tree list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
@@ -1745,9 +1901,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-updates-update-by-id"></a>
+
+### `/v2/updates/update-by-id`
+
 <a id="endpoint-post-v2-updates-update-by-id"></a>
 
-### `POST /v2/updates/update-by-id`
+**Method:** `POST`
 
 - Operation ID: `postV2UpdatesUpdate-by-id`
 - Description: Lookup an update by its ID. If there is no update with this ID, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
@@ -1802,9 +1962,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-updates-update-by-offset"></a>
+
+### `/v2/updates/update-by-offset`
+
 <a id="endpoint-post-v2-updates-update-by-offset"></a>
 
-### `POST /v2/updates/update-by-offset`
+**Method:** `POST`
 
 - Operation ID: `postV2UpdatesUpdate-by-offset`
 - Description: Lookup an update by its offset. If there is no update with this offset, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
@@ -1859,9 +2023,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-users"></a>
+
+### `/v2/users`
+
 <a id="endpoint-get-v2-users"></a>
 
-### `GET /v2/users`
+#### `GET`
 
 - Operation ID: `getV2Users`
 - Description: List all existing users.
@@ -1883,7 +2051,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-post-v2-users"></a>
 
-### `POST /v2/users`
+#### `POST`
 
 - Operation ID: `postV2Users`
 - Description: Create a new user.
@@ -1914,9 +2082,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-users-user-id"></a>
+
+### `/v2/users/{user-id}`
+
 <a id="endpoint-delete-v2-users-user-id"></a>
 
-### `DELETE /v2/users/{user-id}`
+#### `DELETE`
 
 - Operation ID: `deleteV2UsersUser-id`
 - Description: Delete an existing user and all its rights.
@@ -1937,7 +2109,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-get-v2-users-user-id"></a>
 
-### `GET /v2/users/{user-id}`
+#### `GET`
 
 - Operation ID: `getV2UsersUser-id`
 - Description: Get the user data of a specific user or the authenticated user.
@@ -1959,7 +2131,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-patch-v2-users-user-id"></a>
 
-### `PATCH /v2/users/{user-id}`
+#### `PATCH`
 
 - Operation ID: `patchV2UsersUser-id`
 - Description: Update selected modifiable attribute of a user resource described by the ``User`` message.
@@ -2001,9 +2173,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-users-user-id-identity-provider-id"></a>
+
+### `/v2/users/{user-id}/identity-provider-id`
+
 <a id="endpoint-patch-v2-users-user-id-identity-provider-id"></a>
 
-### `PATCH /v2/users/{user-id}/identity-provider-id`
+**Method:** `PATCH`
 
 - Operation ID: `patchV2UsersUser-idIdentity-provider-id`
 - Description: Update the assignment of a user from one IDP to another.
@@ -2038,9 +2214,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-users-user-id-rights"></a>
+
+### `/v2/users/{user-id}/rights`
+
 <a id="endpoint-get-v2-users-user-id-rights"></a>
 
-### `GET /v2/users/{user-id}/rights`
+#### `GET`
 
 - Operation ID: `getV2UsersUser-idRights`
 - Description: List the set of all rights granted to a user.
@@ -2061,7 +2241,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-patch-v2-users-user-id-rights"></a>
 
-### `PATCH /v2/users/{user-id}/rights`
+#### `PATCH`
 
 - Operation ID: `patchV2UsersUser-idRights`
 - Description: Revoke rights from a user. Revoking rights does not affect the resource version of the corresponding user.
@@ -2098,7 +2278,7 @@ Generated from supplied versioned OpenAPI artifacts.
 
 <a id="endpoint-post-v2-users-user-id-rights"></a>
 
-### `POST /v2/users/{user-id}/rights`
+#### `POST`
 
 - Operation ID: `postV2UsersUser-idRights`
 - Description: Grant rights to a user. Granting rights does not affect the resource version of the corresponding user.
@@ -2133,9 +2313,13 @@ Generated from supplied versioned OpenAPI artifacts.
 | `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
 | `default` | - | `application/json` | `application/json:object` |
 
+<a id="path-v2-version"></a>
+
+### `/v2/version`
+
 <a id="endpoint-get-v2-version"></a>
 
-### `GET /v2/version`
+**Method:** `GET`
 
 - Operation ID: `getV2Version`
 - Description: Read the Ledger API version

--- a/scripts/generate_json_api_asyncapi_reference.py
+++ b/scripts/generate_json_api_asyncapi_reference.py
@@ -22,6 +22,10 @@ DEFAULT_OUTPUT_FILE = REPO_ROOT / "docs-main" / "reference" / "json-api-asyncapi
 LEGACY_OUTPUT_FILE = REPO_ROOT / "docs-main" / "appdev" / "reference" / "json-api-asyncapi-reference.mdx"
 DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
 DEFAULT_NAV_GROUP = "Ledger API Endpoints"
+DEFAULT_NAV_PAGE_ORDER = [
+    "reference/json-api-reference",
+    "reference/json-api-asyncapi-reference",
+]
 
 
 def parse_args() -> argparse.Namespace:
@@ -175,6 +179,107 @@ def cleanup_legacy_docs_ref(*, docs_json_path: Path) -> None:
     docs_json_path.write_text(json.dumps(cleaned, indent=2) + "\n", encoding="utf-8")
 
 
+def _find_group(items: list[object], label: str) -> dict[str, object] | None:
+    for item in items:
+        if isinstance(item, dict) and item.get("group") == label:
+            return item
+    return None
+
+
+def _merge_group_entries(target: dict[str, object], source: dict[str, object]) -> None:
+    target_pages = target.setdefault("pages", [])
+    if not isinstance(target_pages, list):
+        target_pages = []
+        target["pages"] = target_pages
+
+    for item in source.get("pages", []):
+        if isinstance(item, str):
+            if item not in target_pages:
+                target_pages.append(item)
+            continue
+        if isinstance(item, dict) and item.get("group"):
+            existing = _find_group(target_pages, str(item["group"]))
+            if existing is None:
+                target_pages.append(item)
+            else:
+                _merge_group_entries(existing, item)
+
+    source_groups = source.get("groups", [])
+    if isinstance(source_groups, list):
+        target_groups = target.setdefault("groups", [])
+        if not isinstance(target_groups, list):
+            target_groups = []
+            target["groups"] = target_groups
+        for group in source_groups:
+            if not isinstance(group, dict) or not group.get("group"):
+                continue
+            existing = _find_group(target_groups, str(group["group"]))
+            if existing is None:
+                target_groups.append(group)
+            else:
+                _merge_group_entries(existing, group)
+
+
+def normalize_nav_group_into_pages(*, docs_json_path: Path, dropdown_label: str, group_label: str) -> None:
+    payload = load_json(docs_json_path)
+    navigation = payload.get("navigation")
+    if not isinstance(navigation, dict):
+        raise ValueError(f"docs.json missing navigation object: {docs_json_path}")
+
+    dropdowns = navigation.get("dropdowns")
+    if not isinstance(dropdowns, list):
+        raise ValueError(f"docs.json navigation.dropdowns must be a list: {docs_json_path}")
+
+    dropdown = next(
+        (item for item in dropdowns if isinstance(item, dict) and item.get("dropdown") == dropdown_label),
+        None,
+    )
+    if dropdown is None:
+        raise ValueError(f"Dropdown not found in docs.json: {dropdown_label}")
+
+    raw_groups = dropdown.get("groups", [])
+    if not isinstance(raw_groups, list):
+        return
+
+    moved_groups: list[dict[str, object]] = []
+    remaining_groups: list[object] = []
+    for item in raw_groups:
+        if isinstance(item, dict) and item.get("group") == group_label:
+            moved_groups.append(item)
+        else:
+            remaining_groups.append(item)
+
+    if not moved_groups:
+        return
+
+    if remaining_groups:
+        dropdown["groups"] = remaining_groups
+    else:
+        dropdown.pop("groups", None)
+
+    pages = dropdown.setdefault("pages", [])
+    if not isinstance(pages, list):
+        raise ValueError(f"docs.json dropdown.pages must be a list: {docs_json_path}")
+
+    existing = _find_group(pages, group_label)
+    if existing is None:
+        existing = {"group": group_label, "pages": []}
+        pages.append(existing)
+
+    for group in moved_groups:
+        _merge_group_entries(existing, group)
+
+    existing_pages = existing.get("pages")
+    if isinstance(existing_pages, list):
+        reordered = [page for page in DEFAULT_NAV_PAGE_ORDER if page in existing_pages]
+        reordered.extend(page for page in existing_pages if page not in reordered)
+        existing["pages"] = reordered
+    if existing.get("groups") == []:
+        existing.pop("groups", None)
+
+    docs_json_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
 def build_command(args: argparse.Namespace, manifest_path: Path, publish_version: str, versions: list[str]) -> list[str]:
     nav_groups = args.nav_group if args.nav_group is not None else [DEFAULT_NAV_GROUP]
     command = [
@@ -272,7 +377,15 @@ def main() -> int:
     print("Running:", " ".join(command))
     completed = subprocess.run(command, cwd=REPO_ROOT)
     if completed.returncode == 0:
-        cleanup_legacy_docs_ref(docs_json_path=Path(args.docs_json).resolve())
+        docs_json_path = Path(args.docs_json).resolve()
+        nav_groups = args.nav_group if args.nav_group is not None else [DEFAULT_NAV_GROUP]
+        cleanup_legacy_docs_ref(docs_json_path=docs_json_path)
+        if nav_groups:
+            normalize_nav_group_into_pages(
+                docs_json_path=docs_json_path,
+                dropdown_label=args.nav_dropdown,
+                group_label=nav_groups[0],
+            )
         remove_legacy_output(output_file=Path(args.output_file).resolve())
     return completed.returncode
 

--- a/scripts/generate_json_api_reference.py
+++ b/scripts/generate_json_api_reference.py
@@ -16,6 +16,10 @@ LEGACY_OUTPUT_FILE = REPO_ROOT / "docs-main" / "appdev" / "reference" / "json-ap
 DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
 DEFAULT_SNAPSHOT_VERSIONS = ["3.4", "3.5"]
 DEFAULT_NAV_GROUP = "Ledger API Endpoints"
+DEFAULT_NAV_PAGE_ORDER = [
+    "reference/json-api-reference",
+    "reference/json-api-asyncapi-reference",
+]
 
 
 def parse_args() -> argparse.Namespace:
@@ -151,6 +155,107 @@ def cleanup_legacy_docs_ref(*, docs_json_path: Path) -> None:
     docs_json_path.write_text(json.dumps(cleaned, indent=2) + "\n", encoding="utf-8")
 
 
+def _find_group(items: list[object], label: str) -> dict[str, object] | None:
+    for item in items:
+        if isinstance(item, dict) and item.get("group") == label:
+            return item
+    return None
+
+
+def _merge_group_entries(target: dict[str, object], source: dict[str, object]) -> None:
+    target_pages = target.setdefault("pages", [])
+    if not isinstance(target_pages, list):
+        target_pages = []
+        target["pages"] = target_pages
+
+    for item in source.get("pages", []):
+        if isinstance(item, str):
+            if item not in target_pages:
+                target_pages.append(item)
+            continue
+        if isinstance(item, dict) and item.get("group"):
+            existing = _find_group(target_pages, str(item["group"]))
+            if existing is None:
+                target_pages.append(item)
+            else:
+                _merge_group_entries(existing, item)
+
+    source_groups = source.get("groups", [])
+    if isinstance(source_groups, list):
+        target_groups = target.setdefault("groups", [])
+        if not isinstance(target_groups, list):
+            target_groups = []
+            target["groups"] = target_groups
+        for group in source_groups:
+            if not isinstance(group, dict) or not group.get("group"):
+                continue
+            existing = _find_group(target_groups, str(group["group"]))
+            if existing is None:
+                target_groups.append(group)
+            else:
+                _merge_group_entries(existing, group)
+
+
+def normalize_nav_group_into_pages(*, docs_json_path: Path, dropdown_label: str, group_label: str) -> None:
+    payload = load_json(docs_json_path)
+    navigation = payload.get("navigation")
+    if not isinstance(navigation, dict):
+        raise ValueError(f"docs.json missing navigation object: {docs_json_path}")
+
+    dropdowns = navigation.get("dropdowns")
+    if not isinstance(dropdowns, list):
+        raise ValueError(f"docs.json navigation.dropdowns must be a list: {docs_json_path}")
+
+    dropdown = next(
+        (item for item in dropdowns if isinstance(item, dict) and item.get("dropdown") == dropdown_label),
+        None,
+    )
+    if dropdown is None:
+        raise ValueError(f"Dropdown not found in docs.json: {dropdown_label}")
+
+    raw_groups = dropdown.get("groups", [])
+    if not isinstance(raw_groups, list):
+        return
+
+    moved_groups: list[dict[str, object]] = []
+    remaining_groups: list[object] = []
+    for item in raw_groups:
+        if isinstance(item, dict) and item.get("group") == group_label:
+            moved_groups.append(item)
+        else:
+            remaining_groups.append(item)
+
+    if not moved_groups:
+        return
+
+    if remaining_groups:
+        dropdown["groups"] = remaining_groups
+    else:
+        dropdown.pop("groups", None)
+
+    pages = dropdown.setdefault("pages", [])
+    if not isinstance(pages, list):
+        raise ValueError(f"docs.json dropdown.pages must be a list: {docs_json_path}")
+
+    existing = _find_group(pages, group_label)
+    if existing is None:
+        existing = {"group": group_label, "pages": []}
+        pages.append(existing)
+
+    for group in moved_groups:
+        _merge_group_entries(existing, group)
+
+    existing_pages = existing.get("pages")
+    if isinstance(existing_pages, list):
+        reordered = [page for page in DEFAULT_NAV_PAGE_ORDER if page in existing_pages]
+        reordered.extend(page for page in existing_pages if page not in reordered)
+        existing["pages"] = reordered
+    if existing.get("groups") == []:
+        existing.pop("groups", None)
+
+    docs_json_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
 def remove_legacy_output(*, output_file: Path) -> None:
     legacy_output = LEGACY_OUTPUT_FILE.resolve()
     if output_file == legacy_output:
@@ -166,7 +271,15 @@ def main() -> int:
     print("Running:", " ".join(command))
     completed = subprocess.run(command, cwd=REPO_ROOT)
     if completed.returncode == 0:
-        cleanup_legacy_docs_ref(docs_json_path=Path(args.docs_json).resolve())
+        docs_json_path = Path(args.docs_json).resolve()
+        nav_groups = args.nav_group if args.nav_group is not None else [DEFAULT_NAV_GROUP]
+        cleanup_legacy_docs_ref(docs_json_path=docs_json_path)
+        if nav_groups:
+            normalize_nav_group_into_pages(
+                docs_json_path=docs_json_path,
+                dropdown_label=args.nav_dropdown,
+                group_label=nav_groups[0],
+            )
         remove_legacy_output(output_file=Path(args.output_file).resolve())
     return completed.returncode
 

--- a/shell.nix
+++ b/shell.nix
@@ -4,11 +4,11 @@ let
   python = pkgs.python311;
   x2mdx = python.pkgs.buildPythonApplication rec {
     pname = "x2mdx";
-    version = "0.1.0+git-6db616f";
+    version = "0.1.0+git-13a2087";
     pyproject = true;
     src = builtins.fetchGit {
       url = "https://github.com/danielporterda/x2mdx.git";
-      rev = "6db616fcc48fdf1e2a15ad0972a07553a1dea7c4";
+      rev = "13a208757db742edc4c225a6f4c86e930623f73c";
     };
     nativeBuildInputs = with python.pkgs; [
       setuptools


### PR DESCRIPTION
## Summary
- pin the docs shell to x2mdx commit 13a2087, which contains the path-first JSON HTTP API rendering changes
- regenerate docs-main/reference/json-api-reference.mdx from the checked-in Ledger API OpenAPI snapshots
- carry the new path-first TOC and endpoint layout into the downstream docs page, including inline method labels for single-verb paths

## Validation
- TMPDIR=/tmp nix-shell --run 'python3 scripts/generate_json_api_reference.py'