### PR TITLE
use shared table layout for wallet gateway openrpc and canton protobuf tables

### DIFF
--- a/docs-main/reference/protobuf/index.mdx
+++ b/docs-main/reference/protobuf/index.mdx
@@ -7,60 +7,72 @@ description: "Descriptor-backed protobuf API history grouped by package."
 
 This page is generated from local descriptor-image snapshots with source info.
 
+## Source
+
+- Source name: `Canton protobuf trees from published release bundles`
+- Version filter: `selected Canton release bundles`
+- Latest release: `v3.4.11`
+- Source repo: `https://github.com/DACH-NY/canton.git`
+- Generated at: `2026-04-14T21:44:31.788950+00:00`
+
+## Latest Snapshot
+
+- Packages: `37`
+- Services: `53`
+- Endpoints: `250`
+- Messages: `943`
+- Enums: `48`
+
 ## Table of Contents
 
-| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`com.daml.ledger.api.v2`](protobuf/packages/com-daml-ledger-api-v2) | `Package` | 9 services, 20 endpoints, 115 messages, 8 enums | `3.4.4` | - | - | - |
-| [`com.daml.ledger.api.v2.admin`](protobuf/packages/com-daml-ledger-api-v2-admin) | `Package` | 6 services, 28 endpoints, 78 messages, 3 enums | `3.4.4` | - | - | - |
-| [`com.daml.ledger.api.v2.interactive`](protobuf/packages/com-daml-ledger-api-v2-interactive) | `Package` | 1 services, 6 endpoints, 28 messages, 1 enums | `3.4.4` | - | - | - |
-| [`com.daml.ledger.api.v2.testing`](protobuf/packages/com-daml-ledger-api-v2-testing) | `Package` | 1 services, 2 endpoints, 3 messages, 0 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.admin.participant.v30`](protobuf/packages/com-digitalasset-canton-admin-participant-v30) | `Package` | 11 services, 69 endpoints, 169 messages, 7 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.admin.sequencer.v30`](protobuf/packages/com-digitalasset-canton-admin-sequencer-v30) | `Package` | 1 services, 1 endpoints, 12 messages, 1 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.sequencer.admin.v30`](protobuf/packages/com-digitalasset-canton-sequencer-admin-v30) | `Package` | 5 services, 37 endpoints, 81 messages, 1 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.sequencer.api.v30`](protobuf/packages/com-digitalasset-canton-sequencer-api-v30) | `Package` | 4 services, 17 endpoints, 48 messages, 0 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.standalone.v1`](protobuf/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-standalone-v1) | `Package` | 1 services, 2 endpoints, 5 messages, 0 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-v30) | `Package` | 1 services, 1 endpoints, 37 messages, 0 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.admin.mediator.v30`](protobuf/packages/com-digitalasset-canton-admin-mediator-v30) | `Package` | 1 services, 1 endpoints, 3 messages, 0 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.mediator.admin.v30`](protobuf/packages/com-digitalasset-canton-mediator-admin-v30) | `Package` | 4 services, 13 endpoints, 17 messages, 1 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.admin.health.v30`](protobuf/packages/com-digitalasset-canton-admin-health-v30) | `Package` | 1 services, 4 endpoints, 14 messages, 1 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.connection.v30`](protobuf/packages/com-digitalasset-canton-connection-v30) | `Package` | 1 services, 1 endpoints, 2 messages, 0 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.crypto.admin.v30`](protobuf/packages/com-digitalasset-canton-crypto-admin-v30) | `Package` | 1 services, 12 endpoints, 33 messages, 0 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.time.admin.v30`](protobuf/packages/com-digitalasset-canton-time-admin-v30) | `Package` | 1 services, 2 endpoints, 4 messages, 0 enums | `3.4.4` | - | - | - |
-| [`com.digitalasset.canton.topology.admin.v30`](protobuf/packages/com-digitalasset-canton-topology-admin-v30) | `Package` | 4 services, 34 endpoints, 100 messages, 1 enums | `3.4.4` | - | - | - |
-| [`com.daml.ledger.api`](protobuf/packages/com-daml-ledger-api) | `Package` | 0 services, 0 endpoints, 0 messages, 0 enums | - | - | - | - |
-| [`com.daml.ledger.api.v2.interactive.transaction.v1`](protobuf/packages/com-daml-ledger-api-v2-interactive-transaction-v1) | `Package` | 0 services, 0 endpoints, 5 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton`](protobuf/packages/com-digitalasset-canton) | `Package` | 0 services, 0 endpoints, 0 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.admin`](protobuf/packages/com-digitalasset-canton-admin) | `Package` | 0 services, 0 endpoints, 0 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.admin.crypto.v30`](protobuf/packages/com-digitalasset-canton-admin-crypto-v30) | `Package` | 0 services, 0 endpoints, 1 messages, 1 enums | - | - | - | - |
-| [`com.digitalasset.canton.admin.pruning.v30`](protobuf/packages/com-digitalasset-canton-admin-pruning-v30) | `Package` | 0 services, 0 endpoints, 28 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.admin.time.v30`](protobuf/packages/com-digitalasset-canton-admin-time-v30) | `Package` | 0 services, 0 endpoints, 2 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.crypto.v30`](protobuf/packages/com-digitalasset-canton-crypto-v30) | `Package` | 0 services, 0 endpoints, 20 messages, 14 enums | - | - | - | - |
-| [`com.digitalasset.canton.mediator`](protobuf/packages/com-digitalasset-canton-mediator) | `Package` | 0 services, 0 endpoints, 0 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.participant`](protobuf/packages/com-digitalasset-canton-participant) | `Package` | 0 services, 0 endpoints, 0 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.participant.protocol.v30`](protobuf/packages/com-digitalasset-canton-participant-protocol-v30) | `Package` | 0 services, 0 endpoints, 12 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.protocol.v30`](protobuf/packages/com-digitalasset-canton-protocol-v30) | `Package` | 0 services, 0 endpoints, 120 messages, 9 enums | - | - | - | - |
-| [`com.digitalasset.canton.protocol.v31`](protobuf/packages/com-digitalasset-canton-protocol-v31) | `Package` | 0 services, 0 endpoints, 1 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.sequencer`](protobuf/packages/com-digitalasset-canton-sequencer) | `Package` | 0 services, 0 endpoints, 0 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.synchronizer`](protobuf/packages/com-digitalasset-canton-synchronizer) | `Package` | 0 services, 0 endpoints, 0 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.synchronizer.protocol.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-protocol-v30) | `Package` | 0 services, 0 endpoints, 2 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.synchronizer.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-v30) | `Package` | 0 services, 0 endpoints, 1 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.v30`](protobuf/packages/com-digitalasset-canton-v30) | `Package` | 0 services, 0 endpoints, 1 messages, 0 enums | - | - | - | - |
-| [`com.digitalasset.canton.version.v1`](protobuf/packages/com-digitalasset-canton-version-v1) | `Package` | 0 services, 0 endpoints, 1 messages, 0 enums | - | - | - | - |
-| [`google.rpc`](protobuf/packages/google-rpc) | `Package` | 0 services, 0 endpoints, 0 messages, 0 enums | - | - | - | - |
+🟢 Active Since  🔵 Changed  🔴 Removed
 
-## Version Change Summary
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`com.daml.ledger.api.v2`](protobuf/packages/com-daml-ledger-api-v2) | 🟢 `v3.4` | 9 services, 20 endpoints, 115 messages, 8 enums |
+| [`com.daml.ledger.api.v2.admin`](protobuf/packages/com-daml-ledger-api-v2-admin) | 🟢 `v3.4` | 6 services, 28 endpoints, 78 messages, 3 enums |
+| [`com.daml.ledger.api.v2.interactive`](protobuf/packages/com-daml-ledger-api-v2-interactive) | 🟢 `v3.4` | 1 services, 6 endpoints, 28 messages, 1 enums |
+| [`com.daml.ledger.api.v2.testing`](protobuf/packages/com-daml-ledger-api-v2-testing) | 🟢 `v3.4` | 1 services, 2 endpoints, 3 messages |
+| [`com.digitalasset.canton.admin.participant.v30`](protobuf/packages/com-digitalasset-canton-admin-participant-v30) | 🟢 `v3.4` | 11 services, 69 endpoints, 169 messages, 7 enums |
+| [`com.digitalasset.canton.admin.sequencer.v30`](protobuf/packages/com-digitalasset-canton-admin-sequencer-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 12 messages, 1 enums |
+| [`com.digitalasset.canton.sequencer.admin.v30`](protobuf/packages/com-digitalasset-canton-sequencer-admin-v30) | 🟢 `v3.4` | 5 services, 37 endpoints, 81 messages, 1 enums |
+| [`com.digitalasset.canton.sequencer.api.v30`](protobuf/packages/com-digitalasset-canton-sequencer-api-v30) | 🟢 `v3.4` | 4 services, 17 endpoints, 48 messages |
+| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.standalone.v1`](protobuf/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-standalone-v1) | 🟢 `v3.4` | 1 services, 2 endpoints, 5 messages |
+| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 37 messages |
+| [`com.digitalasset.canton.admin.mediator.v30`](protobuf/packages/com-digitalasset-canton-admin-mediator-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 3 messages |
+| [`com.digitalasset.canton.mediator.admin.v30`](protobuf/packages/com-digitalasset-canton-mediator-admin-v30) | 🟢 `v3.4` | 4 services, 13 endpoints, 17 messages, 1 enums |
+| [`com.digitalasset.canton.admin.health.v30`](protobuf/packages/com-digitalasset-canton-admin-health-v30) | 🟢 `v3.4` | 1 services, 4 endpoints, 14 messages, 1 enums |
+| [`com.digitalasset.canton.connection.v30`](protobuf/packages/com-digitalasset-canton-connection-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 2 messages |
+| [`com.digitalasset.canton.crypto.admin.v30`](protobuf/packages/com-digitalasset-canton-crypto-admin-v30) | 🟢 `v3.4` | 1 services, 12 endpoints, 33 messages |
+| [`com.digitalasset.canton.time.admin.v30`](protobuf/packages/com-digitalasset-canton-time-admin-v30) | 🟢 `v3.4` | 1 services, 2 endpoints, 4 messages |
+| [`com.digitalasset.canton.topology.admin.v30`](protobuf/packages/com-digitalasset-canton-topology-admin-v30) | 🟢 `v3.4` | 4 services, 34 endpoints, 100 messages, 1 enums |
+| [`com.daml.ledger.api`](protobuf/packages/com-daml-ledger-api) | - | 0 services, 0 endpoints, 0 messages |
+| [`com.daml.ledger.api.v2.interactive.transaction.v1`](protobuf/packages/com-daml-ledger-api-v2-interactive-transaction-v1) | - | 0 services, 0 endpoints, 5 messages |
+| [`com.digitalasset.canton`](protobuf/packages/com-digitalasset-canton) | - | 0 services, 0 endpoints, 0 messages |
+| [`com.digitalasset.canton.admin`](protobuf/packages/com-digitalasset-canton-admin) | - | 0 services, 0 endpoints, 0 messages |
+| [`com.digitalasset.canton.admin.crypto.v30`](protobuf/packages/com-digitalasset-canton-admin-crypto-v30) | - | 0 services, 0 endpoints, 1 messages, 1 enums |
+| [`com.digitalasset.canton.admin.pruning.v30`](protobuf/packages/com-digitalasset-canton-admin-pruning-v30) | - | 0 services, 0 endpoints, 28 messages |
+| [`com.digitalasset.canton.admin.time.v30`](protobuf/packages/com-digitalasset-canton-admin-time-v30) | - | 0 services, 0 endpoints, 2 messages |
+| [`com.digitalasset.canton.crypto.v30`](protobuf/packages/com-digitalasset-canton-crypto-v30) | - | 0 services, 0 endpoints, 20 messages, 14 enums |
+| [`com.digitalasset.canton.mediator`](protobuf/packages/com-digitalasset-canton-mediator) | - | 0 services, 0 endpoints, 0 messages |
+| [`com.digitalasset.canton.participant`](protobuf/packages/com-digitalasset-canton-participant) | - | 0 services, 0 endpoints, 0 messages |
+| [`com.digitalasset.canton.participant.protocol.v30`](protobuf/packages/com-digitalasset-canton-participant-protocol-v30) | - | 0 services, 0 endpoints, 12 messages |
+| [`com.digitalasset.canton.protocol.v30`](protobuf/packages/com-digitalasset-canton-protocol-v30) | - | 0 services, 0 endpoints, 120 messages, 9 enums |
+| [`com.digitalasset.canton.protocol.v31`](protobuf/packages/com-digitalasset-canton-protocol-v31) | - | 0 services, 0 endpoints, 1 messages |
+| [`com.digitalasset.canton.sequencer`](protobuf/packages/com-digitalasset-canton-sequencer) | - | 0 services, 0 endpoints, 0 messages |
+| [`com.digitalasset.canton.synchronizer`](protobuf/packages/com-digitalasset-canton-synchronizer) | - | 0 services, 0 endpoints, 0 messages |
+| [`com.digitalasset.canton.synchronizer.protocol.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-protocol-v30) | - | 0 services, 0 endpoints, 2 messages |
+| [`com.digitalasset.canton.synchronizer.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-v30) | - | 0 services, 0 endpoints, 1 messages |
+| [`com.digitalasset.canton.v30`](protobuf/packages/com-digitalasset-canton-v30) | - | 0 services, 0 endpoints, 1 messages |
+| [`com.digitalasset.canton.version.v1`](protobuf/packages/com-digitalasset-canton-version-v1) | - | 0 services, 0 endpoints, 1 messages |
+| [`google.rpc`](protobuf/packages/google-rpc) | - | 0 services, 0 endpoints, 0 messages |
 
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `3.4.4` | 248 | 0 | 0 |
-| `3.4.5` | 0 | 0 | 0 |
-| `3.4.6` | 0 | 0 | 0 |
-| `3.4.7` | 0 | 0 | 0 |
-| `3.4.8` | 0 | 0 | 0 |
-| `3.4.9` | 0 | 0 | 0 |
-| `3.4.10` | 0 | 0 | 0 |
-| `3.4.11` | 2 | 0 | 0 |
+## Release Summary
+
+| Version | Endpoints +/~/- | Messages +/~/- | Enums +/~/- | Files +/~/- |
+| --- | --- | --- | --- | --- |
+| `3.4.0` | `248/0/0` | `939/0/0` | `47/0/0` | `115/0/0` |
+| `3.4.11` | `2/0/0` | `4/5/0` | `1/1/0` | `1/6/0` |
 
 ## Reference
 

--- a/docs-main/reference/wallet-gateway-json-rpc/index.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/index.mdx
@@ -7,31 +7,19 @@ description: "Versioned OpenRPC reference docs."
 
 Generated from versioned OpenRPC snapshots.
 
+- Publish version: `0.25.0`
+- Versions compared: `0.22.0`, `0.23.0`, `0.23.1`, `0.24.0`, `0.25.0`
+- Source: `splice-wallet-kernel Wallet Gateway OpenRPC specs from wallet-gateway-remote releases`
+- Version filter: `@canton-network/wallet-gateway-remote@ GitHub releases`
+- Generated at: `2026-04-14T21:40:04Z`
+
 ## Table of Contents
 
-| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-api) | `Spec` | Splice Wallet JSON-RPC dApp API | `0.21.0` | `0.23.0` | - | - |
-| [`Remote dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-remote-api) | `Spec` | Splice Wallet JSON-RPC Remote dApp API | `0.21.0` | `0.23.0` | - | - |
-| [`Signing API`](/reference/wallet-gateway-json-rpc/specs/signing-api) | `Spec` | Wallet JSON-RPC Signing API | `0.21.0` | - | - | - |
-| [`User API`](/reference/wallet-gateway-json-rpc/specs/user-api) | `Spec` | Splice Wallet JSON-RPC User API | `0.21.0` | `0.22.0`, `0.23.0` | - | - |
+🟢 Active Since  🔵 Changed  🔴 Removed
 
-## Version Change Summary
-
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `0.21.0` | 4 | 0 | 0 |
-| `0.22.0` | 0 | 1 | 0 |
-| `0.23.0` | 0 | 3 | 0 |
-| `0.23.1` | 0 | 0 | 0 |
-| `0.24.0` | 0 | 0 | 0 |
-| `0.25.0` | 0 | 0 | 0 |
-
-## Reference
-
-| Spec | Title | Methods |
+| NAME | STATUS | SUMMARY |
 | --- | --- | --- |
-| [`dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-api) | Splice Wallet JSON-RPC dApp API | `12` |
-| [`Remote dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-remote-api) | Splice Wallet JSON-RPC Remote dApp API | `13` |
-| [`Signing API`](/reference/wallet-gateway-json-rpc/specs/signing-api) | Wallet JSON-RPC Signing API | `8` |
-| [`User API`](/reference/wallet-gateway-json-rpc/specs/user-api) | Splice Wallet JSON-RPC User API | `22` |
+| [`dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-api) | 🟢 `v0.22` 🔵 `v0.23` | Splice Wallet JSON-RPC dApp API. 12 methods |
+| [`Remote dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-remote-api) | 🟢 `v0.22` 🔵 `v0.23` | Splice Wallet JSON-RPC Remote dApp API. 13 methods |
+| [`Signing API`](/reference/wallet-gateway-json-rpc/specs/signing-api) | 🟢 `v0.22` | Wallet JSON-RPC Signing API. 8 methods |
+| [`User API`](/reference/wallet-gateway-json-rpc/specs/user-api) | 🟢 `v0.22` 🔵 `v0.23` | Splice Wallet JSON-RPC User API. 22 methods |

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-api.mdx
@@ -9,40 +9,46 @@ description: "Splice Wallet JSON-RPC dApp API"
 
 An OpenRPC specification for the dapp to interact with a Wallet Provider.
 
+- Latest source path: `api-specs/openrpc-dapp-api.json`
+- Publish version: `0.25.0`
+- OpenRPC version: `1.2.6`
+- Spec info.version: `0.5.0`
+
+## Version Change Timeline
+
+| Version | Active Methods | Added | Changed | Removed |
+| --- | --- | --- | --- | --- |
+| `0.22.0` | 12 | 0 | 0 | 0 |
+| `0.23.0` | 12 | 0 | 1 | 0 |
+| `0.23.1` | 12 | 0 | 0 | 0 |
+| `0.24.0` | 12 | 0 | 0 | 0 |
+| `0.25.0` | 12 | 0 | 0 | 0 |
+
 ## Table of Contents
 
-| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`accountsChanged`](#method-accountschanged) | `Method` | - | `0.21.0` | - | - | - |
-| [`connect`](#method-connect) | `Method` | Ensures ledger connectivity and returns the connected network information along with the session information. | `0.21.0` | - | - | - |
-| [`disconnect`](#method-disconnect) | `Method` | Invoke a disconnect of the wallet provider session. | `0.21.0` | - | - | - |
-| [`getActiveNetwork`](#method-getactivenetwork) | `Method` | Returns the active network. | `0.21.0` | - | - | - |
-| [`getPrimaryAccount`](#method-getprimaryaccount) | `Method` | Returns the primary account. | `0.21.0` | - | - | - |
-| [`ledgerApi`](#method-ledgerapi) | `Method` | Proxy for the JSON-API endpoints. Injects authorization headers automatically. | `0.21.0` | `0.23.0`: result updated (required fields) | - | - |
-| [`listAccounts`](#method-listaccounts) | `Method` | Lists the addresses (wallets) with their properties; including which network they are associated to and with signing... | `0.21.0` | - | - | - |
-| [`prepareExecute`](#method-prepareexecute) | `Method` | Prepares a transaction for subsequent signing & execution. | `0.21.0` | - | - | - |
-| [`prepareExecuteAndWait`](#method-prepareexecuteandwait) | `Method` | Like prepareExecute, but waits for the transaction to be executed on the ledger. | `0.21.0` | - | - | - |
-| [`signMessage`](#method-signmessage) | `Method` | Signs a message. | `0.21.0` | - | - | - |
-| [`status`](#method-status) | `Method` | Returns the current status of the wallet provider session. | `0.21.0` | - | - | - |
-| [`txChanged`](#method-txchanged) | `Method` | - | `0.21.0` | - | - | - |
+🟢 Active Since  🔵 Changed  🔴 Removed
 
-## Version Change Summary
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`accountsChanged`](#method-accountschanged) | 🟢 `v0.22` | - |
+| [`connect`](#method-connect) | 🟢 `v0.22` | Ensures ledger connectivity and returns the connected network information along with the session information. |
+| [`disconnect`](#method-disconnect) | 🟢 `v0.22` | Invoke a disconnect of the wallet provider session. |
+| [`getActiveNetwork`](#method-getactivenetwork) | 🟢 `v0.22` | Returns the active network. |
+| [`getPrimaryAccount`](#method-getprimaryaccount) | 🟢 `v0.22` | Returns the primary account. |
+| [`ledgerApi`](#method-ledgerapi) | 🟢 `v0.22` 🔵 `v0.23` | Proxy for the JSON-API endpoints. Injects authorization headers automatically. |
+| [`listAccounts`](#method-listaccounts) | 🟢 `v0.22` | Lists the addresses (wallets) with their properties; including which network they are associated to and with signing provider is used. |
+| [`prepareExecute`](#method-prepareexecute) | 🟢 `v0.22` | Prepares a transaction for subsequent signing & execution. |
+| [`prepareExecuteAndWait`](#method-prepareexecuteandwait) | 🟢 `v0.22` | Like prepareExecute, but waits for the transaction to be executed on the ledger. |
+| [`signMessage`](#method-signmessage) | 🟢 `v0.22` | Signs a message. |
+| [`status`](#method-status) | 🟢 `v0.22` | Returns the current status of the wallet provider session. |
+| [`txChanged`](#method-txchanged) | 🟢 `v0.22` | - |
 
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `0.21.0` | 0 | 0 | 0 |
-| `0.22.0` | 0 | 0 | 0 |
-| `0.23.0` | 0 | 1 | 0 |
-| `0.23.1` | 0 | 0 | 0 |
-| `0.24.0` | 0 | 0 | 0 |
-| `0.25.0` | 0 | 0 | 0 |
-
-## Reference
+## Methods
 
 <a id="method-accountschanged"></a>
 ### `accountsChanged`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 **Parameters**
 
@@ -74,7 +80,7 @@ _No parameters._
 <a id="method-connect"></a>
 ### `connect`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Ensures ledger connectivity and returns the connected network information along with the session information.
 
@@ -100,7 +106,7 @@ _No parameters._
 <a id="method-disconnect"></a>
 ### `disconnect`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Invoke a disconnect of the wallet provider session.
 
@@ -123,7 +129,7 @@ _No parameters._
 <a id="method-getactivenetwork"></a>
 ### `getActiveNetwork`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Returns the active network.
 
@@ -148,7 +154,7 @@ _No parameters._
 <a id="method-getprimaryaccount"></a>
 ### `getPrimaryAccount`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Returns the primary account.
 
@@ -180,7 +186,7 @@ _No parameters._
 <a id="method-ledgerapi"></a>
 ### `ledgerApi`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 Changed in: `0.23.0`
 
 Proxy for the JSON-API endpoints. Injects authorization headers automatically.
@@ -223,7 +229,7 @@ Proxy for the JSON-API endpoints. Injects authorization headers automatically.
 <a id="method-listaccounts"></a>
 ### `listAccounts`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Lists the addresses (wallets) with their properties; including which network they are associated to and with signing provider is used.
 
@@ -257,7 +263,7 @@ _No parameters._
 <a id="method-prepareexecute"></a>
 ### `prepareExecute`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Prepares a transaction for subsequent signing & execution.
 
@@ -292,7 +298,7 @@ Prepares a transaction for subsequent signing & execution.
 <a id="method-prepareexecuteandwait"></a>
 ### `prepareExecuteAndWait`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Like prepareExecute, but waits for the transaction to be executed on the ledger.
 
@@ -336,7 +342,7 @@ Like prepareExecute, but waits for the transaction to be executed on the ledger.
 <a id="method-signmessage"></a>
 ### `signMessage`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Signs a message.
 
@@ -373,7 +379,7 @@ Signs a message.
 <a id="method-status"></a>
 ### `status`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Returns the current status of the wallet provider session.
 
@@ -404,7 +410,7 @@ _No parameters._
 <a id="method-txchanged"></a>
 ### `txChanged`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 **Parameters**
 

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-remote-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-remote-api.mdx
@@ -9,41 +9,47 @@ description: "Splice Wallet JSON-RPC Remote dApp API"
 
 An OpenRPC specification for remotely hosted Wallet Providers. Due to the remote nature, an implementing provider must bridge certain functionality on the client-side to satisfy the general dApp API spec.
 
+- Latest source path: `api-specs/openrpc-dapp-remote-api.json`
+- Publish version: `0.25.0`
+- OpenRPC version: `1.2.6`
+- Spec info.version: `0.1.0`
+
+## Version Change Timeline
+
+| Version | Active Methods | Added | Changed | Removed |
+| --- | --- | --- | --- | --- |
+| `0.22.0` | 13 | 0 | 0 | 0 |
+| `0.23.0` | 13 | 0 | 2 | 0 |
+| `0.23.1` | 13 | 0 | 0 | 0 |
+| `0.24.0` | 13 | 0 | 0 | 0 |
+| `0.25.0` | 13 | 0 | 0 | 0 |
+
 ## Table of Contents
 
-| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`accountsChanged`](#method-accountschanged) | `Method` | - | `0.21.0` | - | - | - |
-| [`connect`](#method-connect) | `Method` | Ensures ledger connectivity and returns the connected network information. | `0.21.0` | - | - | - |
-| [`connected`](#method-connected) | `Method` | Informs when the user connects to a network. | `0.21.0` | - | - | - |
-| [`disconnect`](#method-disconnect) | `Method` | Invoke a disconnect of the wallet gateway session. | `0.21.0` | - | - | - |
-| [`getActiveNetwork`](#method-getactivenetwork) | `Method` | Returns the active network. | `0.21.0` | - | - | - |
-| [`getPrimaryAccount`](#method-getprimaryaccount) | `Method` | Returns the primary account. | `0.21.0` | `0.23.0`: result updated (required fields) | - | - |
-| [`ledgerApi`](#method-ledgerapi) | `Method` | Proxy for the JSON-API endpoints. Injects authorization headers automatically. | `0.21.0` | `0.23.0`: result updated (required fields) | - | - |
-| [`listAccounts`](#method-listaccounts) | `Method` | - | `0.21.0` | - | - | - |
-| [`onStatusChanged`](#method-onstatuschanged) | `Method` | - | `0.21.0` | - | - | - |
-| [`prepareExecute`](#method-prepareexecute) | `Method` | Prepares, signs, and executes a transaction. | `0.21.0` | - | - | - |
-| [`signMessage`](#method-signmessage) | `Method` | Signs a message. | `0.21.0` | - | - | - |
-| [`status`](#method-status) | `Method` | Returns the current status of the wallet provider session. | `0.21.0` | - | - | - |
-| [`txChanged`](#method-txchanged) | `Method` | - | `0.21.0` | - | - | - |
+🟢 Active Since  🔵 Changed  🔴 Removed
 
-## Version Change Summary
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`accountsChanged`](#method-accountschanged) | 🟢 `v0.22` | - |
+| [`connect`](#method-connect) | 🟢 `v0.22` | Ensures ledger connectivity and returns the connected network information. |
+| [`connected`](#method-connected) | 🟢 `v0.22` | Informs when the user connects to a network. |
+| [`disconnect`](#method-disconnect) | 🟢 `v0.22` | Invoke a disconnect of the wallet gateway session. |
+| [`getActiveNetwork`](#method-getactivenetwork) | 🟢 `v0.22` | Returns the active network. |
+| [`getPrimaryAccount`](#method-getprimaryaccount) | 🟢 `v0.22` 🔵 `v0.23` | Returns the primary account. |
+| [`ledgerApi`](#method-ledgerapi) | 🟢 `v0.22` 🔵 `v0.23` | Proxy for the JSON-API endpoints. Injects authorization headers automatically. |
+| [`listAccounts`](#method-listaccounts) | 🟢 `v0.22` | - |
+| [`onStatusChanged`](#method-onstatuschanged) | 🟢 `v0.22` | - |
+| [`prepareExecute`](#method-prepareexecute) | 🟢 `v0.22` | Prepares, signs, and executes a transaction. |
+| [`signMessage`](#method-signmessage) | 🟢 `v0.22` | Signs a message. |
+| [`status`](#method-status) | 🟢 `v0.22` | Returns the current status of the wallet provider session. |
+| [`txChanged`](#method-txchanged) | 🟢 `v0.22` | - |
 
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `0.21.0` | 0 | 0 | 0 |
-| `0.22.0` | 0 | 0 | 0 |
-| `0.23.0` | 0 | 2 | 0 |
-| `0.23.1` | 0 | 0 | 0 |
-| `0.24.0` | 0 | 0 | 0 |
-| `0.25.0` | 0 | 0 | 0 |
-
-## Reference
+## Methods
 
 <a id="method-accountschanged"></a>
 ### `accountsChanged`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 **Parameters**
 
@@ -75,7 +81,7 @@ _No parameters._
 <a id="method-connect"></a>
 ### `connect`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Ensures ledger connectivity and returns the connected network information.
 
@@ -101,7 +107,7 @@ _No parameters._
 <a id="method-connected"></a>
 ### `connected`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Informs when the user connects to a network.
 
@@ -132,7 +138,7 @@ _No parameters._
 <a id="method-disconnect"></a>
 ### `disconnect`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Invoke a disconnect of the wallet gateway session.
 
@@ -155,7 +161,7 @@ _No parameters._
 <a id="method-getactivenetwork"></a>
 ### `getActiveNetwork`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Returns the active network.
 
@@ -180,7 +186,7 @@ _No parameters._
 <a id="method-getprimaryaccount"></a>
 ### `getPrimaryAccount`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 Changed in: `0.23.0`
 
 Returns the primary account.
@@ -219,7 +225,7 @@ _No parameters._
 <a id="method-ledgerapi"></a>
 ### `ledgerApi`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 Changed in: `0.23.0`
 
 Proxy for the JSON-API endpoints. Injects authorization headers automatically.
@@ -262,7 +268,7 @@ Proxy for the JSON-API endpoints. Injects authorization headers automatically.
 <a id="method-listaccounts"></a>
 ### `listAccounts`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 **Parameters**
 
@@ -294,7 +300,7 @@ _No parameters._
 <a id="method-onstatuschanged"></a>
 ### `onStatusChanged`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 **Parameters**
 
@@ -323,7 +329,7 @@ _No parameters._
 <a id="method-prepareexecute"></a>
 ### `prepareExecute`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Prepares, signs, and executes a transaction.
 
@@ -360,7 +366,7 @@ Prepares, signs, and executes a transaction.
 <a id="method-signmessage"></a>
 ### `signMessage`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Signs a message.
 
@@ -397,7 +403,7 @@ Signs a message.
 <a id="method-status"></a>
 ### `status`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Returns the current status of the wallet provider session.
 
@@ -428,7 +434,7 @@ _No parameters._
 <a id="method-txchanged"></a>
 ### `txChanged`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 **Parameters**
 

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/signing-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/signing-api.mdx
@@ -9,36 +9,42 @@ description: "Wallet JSON-RPC Signing API"
 
 An OpenRPC specification for the Signing API which allows the Wallet Gateway to interact with a Wallet Providers.
 
+- Latest source path: `api-specs/openrpc-signing-api.json`
+- Publish version: `0.25.0`
+- OpenRPC version: `1.2.6`
+- Spec info.version: `0.1.0`
+
+## Version Change Timeline
+
+| Version | Active Methods | Added | Changed | Removed |
+| --- | --- | --- | --- | --- |
+| `0.22.0` | 8 | 0 | 0 | 0 |
+| `0.23.0` | 8 | 0 | 0 | 0 |
+| `0.23.1` | 8 | 0 | 0 | 0 |
+| `0.24.0` | 8 | 0 | 0 | 0 |
+| `0.25.0` | 8 | 0 | 0 | 0 |
+
 ## Table of Contents
 
-| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`createKey`](#method-createkey) | `Method` | Create a new key at the Wallet Provider. | `0.21.0` | - | - | - |
-| [`getConfiguration`](#method-getconfiguration) | `Method` | - | `0.21.0` | - | - | - |
-| [`getKeys`](#method-getkeys) | `Method` | Get a list of public keys availabile for signing. | `0.21.0` | - | - | - |
-| [`getTransaction`](#method-gettransaction) | `Method` | Get the status of a single transaction by its ID. | `0.21.0` | - | - | - |
-| [`getTransactions`](#method-gettransactions) | `Method` | Get the status of multiple transactions, filtering by txIds or publicKeys. Either publicKeys or txIds must be provided. | `0.21.0` | - | - | - |
-| [`setConfiguration`](#method-setconfiguration) | `Method` | Set configuration parameters for the Wallet Provider. The paramaters will change depending on the Wallet Provider imp... | `0.21.0` | - | - | - |
-| [`signTransaction`](#method-signtransaction) | `Method` | Uses the Wallet Provider to sign a transaction. This will likely be an asynchronous operation. | `0.21.0` | - | - | - |
-| [`subscribeTransactions`](#method-subscribetransactions) | `Method` | Subscribe to updates for specific transactions. The server will emit updates when the status of the specified transac... | `0.21.0` | - | - | - |
+🟢 Active Since  🔵 Changed  🔴 Removed
 
-## Version Change Summary
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`createKey`](#method-createkey) | 🟢 `v0.22` | Create a new key at the Wallet Provider. |
+| [`getConfiguration`](#method-getconfiguration) | 🟢 `v0.22` | - |
+| [`getKeys`](#method-getkeys) | 🟢 `v0.22` | Get a list of public keys availabile for signing. |
+| [`getTransaction`](#method-gettransaction) | 🟢 `v0.22` | Get the status of a single transaction by its ID. |
+| [`getTransactions`](#method-gettransactions) | 🟢 `v0.22` | Get the status of multiple transactions, filtering by txIds or publicKeys. Either publicKeys or txIds must be provided. |
+| [`setConfiguration`](#method-setconfiguration) | 🟢 `v0.22` | Set configuration parameters for the Wallet Provider. The paramaters will change depending on the Wallet Provider implementation |
+| [`signTransaction`](#method-signtransaction) | 🟢 `v0.22` | Uses the Wallet Provider to sign a transaction. This will likely be an asynchronous operation. |
+| [`subscribeTransactions`](#method-subscribetransactions) | 🟢 `v0.22` | Subscribe to updates for specific transactions. The server will emit updates when the status of the specified transactions have changed. On initial subscription, the server will emit the current status of all subscribed transactions. |
 
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `0.21.0` | 0 | 0 | 0 |
-| `0.22.0` | 0 | 0 | 0 |
-| `0.23.0` | 0 | 0 | 0 |
-| `0.23.1` | 0 | 0 | 0 |
-| `0.24.0` | 0 | 0 | 0 |
-| `0.25.0` | 0 | 0 | 0 |
-
-## Reference
+## Methods
 
 <a id="method-createkey"></a>
 ### `createKey`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Create a new key at the Wallet Provider.
 
@@ -76,7 +82,7 @@ Create a new key at the Wallet Provider.
 <a id="method-getconfiguration"></a>
 ### `getConfiguration`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 **Parameters**
 
@@ -97,7 +103,7 @@ _No parameters._
 <a id="method-getkeys"></a>
 ### `getKeys`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Get a list of public keys availabile for signing.
 
@@ -123,7 +129,7 @@ _No parameters._
 <a id="method-gettransaction"></a>
 ### `getTransaction`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Get the status of a single transaction by its ID.
 
@@ -161,7 +167,7 @@ Get the status of a single transaction by its ID.
 <a id="method-gettransactions"></a>
 ### `getTransactions`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Get the status of multiple transactions, filtering by txIds or publicKeys. Either publicKeys or txIds must be provided.
 
@@ -204,7 +210,7 @@ Get the status of multiple transactions, filtering by txIds or publicKeys. Eithe
 <a id="method-setconfiguration"></a>
 ### `setConfiguration`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Set configuration parameters for the Wallet Provider. The paramaters will change depending on the Wallet Provider implementation
 
@@ -237,7 +243,7 @@ Set configuration parameters for the Wallet Provider. The paramaters will change
 <a id="method-signtransaction"></a>
 ### `signTransaction`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Uses the Wallet Provider to sign a transaction. This will likely be an asynchronous operation.
 
@@ -279,7 +285,7 @@ Uses the Wallet Provider to sign a transaction. This will likely be an asynchron
 <a id="method-subscribetransactions"></a>
 ### `subscribeTransactions`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Subscribe to updates for specific transactions. The server will emit updates when the status of the specified transactions have changed. On initial subscription, the server will emit the current status of all subscribed transactions.
 

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/user-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/user-api.mdx
@@ -9,50 +9,56 @@ description: "Splice Wallet JSON-RPC User API"
 
 An OpenRPC specification for the user to interact with the Wallet Gateway.
 
+- Latest source path: `api-specs/openrpc-user-api.json`
+- Publish version: `0.25.0`
+- OpenRPC version: `1.2.6`
+- Spec info.version: `0.1.0`
+
+## Version Change Timeline
+
+| Version | Active Methods | Added | Changed | Removed |
+| --- | --- | --- | --- | --- |
+| `0.22.0` | 22 | 0 | 0 | 0 |
+| `0.23.0` | 22 | 0 | 2 | 0 |
+| `0.23.1` | 22 | 0 | 0 | 0 |
+| `0.24.0` | 22 | 0 | 0 | 0 |
+| `0.25.0` | 22 | 0 | 0 | 0 |
+
 ## Table of Contents
 
-| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`addIdp`](#method-addidp) | `Method` | Adds a new identity provider. | `0.21.0` | - | - | - |
-| [`addNetwork`](#method-addnetwork) | `Method` | Adds a new network configuration (similar to EIP-3085). | `0.21.0` | - | - | - |
-| [`addSession`](#method-addsession) | `Method` | Adds a network session. | `0.21.0` | `0.23.0`: result updated (required fields) | - | - |
-| [`allocatePartyForWallet`](#method-allocatepartyforwallet) | `Method` | Allocates a party for an already initialized wallet if external signing is complete. | `0.21.0` | - | - | - |
-| [`createWallet`](#method-createwallet) | `Method` | Creates a new wallet and party with the given hint. | `0.21.0` | - | - | - |
-| [`deleteTransaction`](#method-deletetransaction) | `Method` | Deletes a pending transaction. Only transactions with status 'pending' can be deleted. | `0.21.0` | - | - | - |
-| [`execute`](#method-execute) | `Method` | Executes a signed transaction. | `0.21.0` | - | - | - |
-| [`getTransaction`](#method-gettransaction) | `Method` | - | `0.21.0` | - | - | - |
-| [`getUser`](#method-getuser) | `Method` | Returns information about the current user, including whether they are an admin. | `0.21.0` | - | - | - |
-| [`isWalletSyncNeeded`](#method-iswalletsyncneeded) | `Method` | Checks if wallet sync is needed (disabled wallets or new parties on ledger). | `0.21.0` | - | - | - |
-| [`listIdps`](#method-listidps) | `Method` | - | `0.21.0` | - | - | - |
-| [`listNetworks`](#method-listnetworks) | `Method` | - | `0.21.0` | - | - | - |
-| [`listSessions`](#method-listsessions) | `Method` | - | `0.21.0` | `0.23.0`: details updated | - | - |
-| [`listTransactions`](#method-listtransactions) | `Method` | - | `0.21.0` | - | - | - |
-| [`listWallets`](#method-listwallets) | `Method` | Lists wallets. | `0.21.0` | - | - | - |
-| [`removeIdp`](#method-removeidp) | `Method` | Removes an identity provider. Fails if an existing network is using the identity provider. | `0.21.0` | - | - | - |
-| [`removeNetwork`](#method-removenetwork) | `Method` | Removes a new network configuration (similar to EIP-3085). | `0.21.0` | - | - | - |
-| [`removeSession`](#method-removesession) | `Method` | Removes the current network session. | `0.21.0` | - | - | - |
-| [`removeWallet`](#method-removewallet) | `Method` | Removes a party with the given hint. | `0.21.0` | - | - | - |
-| [`setPrimaryWallet`](#method-setprimarywallet) | `Method` | Sets the specified wallet as the primary wallet for dApp usage. | `0.21.0` | - | - | - |
-| [`sign`](#method-sign) | `Method` | Signs the provided data with the private key of the specified or active party. | `0.21.0` | `0.22.0`: result updated (schema, required fields) | - | - |
-| [`syncWallets`](#method-syncwallets) | `Method` | Synchronizes wallets with the connected network. | `0.21.0` | - | - | - |
+🟢 Active Since  🔵 Changed  🔴 Removed
 
-## Version Change Summary
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`addIdp`](#method-addidp) | 🟢 `v0.22` | Adds a new identity provider. |
+| [`addNetwork`](#method-addnetwork) | 🟢 `v0.22` | Adds a new network configuration (similar to EIP-3085). |
+| [`addSession`](#method-addsession) | 🟢 `v0.22` 🔵 `v0.23` | Adds a network session. |
+| [`allocatePartyForWallet`](#method-allocatepartyforwallet) | 🟢 `v0.22` | Allocates a party for an already initialized wallet if external signing is complete. |
+| [`createWallet`](#method-createwallet) | 🟢 `v0.22` | Creates a new wallet and party with the given hint. |
+| [`deleteTransaction`](#method-deletetransaction) | 🟢 `v0.22` | Deletes a pending transaction. Only transactions with status 'pending' can be deleted. |
+| [`execute`](#method-execute) | 🟢 `v0.22` | Executes a signed transaction. |
+| [`getTransaction`](#method-gettransaction) | 🟢 `v0.22` | - |
+| [`getUser`](#method-getuser) | 🟢 `v0.22` | Returns information about the current user, including whether they are an admin. |
+| [`isWalletSyncNeeded`](#method-iswalletsyncneeded) | 🟢 `v0.22` | Checks if wallet sync is needed (disabled wallets or new parties on ledger). |
+| [`listIdps`](#method-listidps) | 🟢 `v0.22` | - |
+| [`listNetworks`](#method-listnetworks) | 🟢 `v0.22` | - |
+| [`listSessions`](#method-listsessions) | 🟢 `v0.22` 🔵 `v0.23` | - |
+| [`listTransactions`](#method-listtransactions) | 🟢 `v0.22` | - |
+| [`listWallets`](#method-listwallets) | 🟢 `v0.22` | Lists wallets. |
+| [`removeIdp`](#method-removeidp) | 🟢 `v0.22` | Removes an identity provider. Fails if an existing network is using the identity provider. |
+| [`removeNetwork`](#method-removenetwork) | 🟢 `v0.22` | Removes a new network configuration (similar to EIP-3085). |
+| [`removeSession`](#method-removesession) | 🟢 `v0.22` | Removes the current network session. |
+| [`removeWallet`](#method-removewallet) | 🟢 `v0.22` | Removes a party with the given hint. |
+| [`setPrimaryWallet`](#method-setprimarywallet) | 🟢 `v0.22` | Sets the specified wallet as the primary wallet for dApp usage. |
+| [`sign`](#method-sign) | 🟢 `v0.22` | Signs the provided data with the private key of the specified or active party. |
+| [`syncWallets`](#method-syncwallets) | 🟢 `v0.22` | Synchronizes wallets with the connected network. |
 
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `0.21.0` | 0 | 0 | 0 |
-| `0.22.0` | 0 | 1 | 0 |
-| `0.23.0` | 0 | 2 | 0 |
-| `0.23.1` | 0 | 0 | 0 |
-| `0.24.0` | 0 | 0 | 0 |
-| `0.25.0` | 0 | 0 | 0 |
-
-## Reference
+## Methods
 
 <a id="method-addidp"></a>
 ### `addIdp`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Adds a new identity provider.
 
@@ -91,7 +97,7 @@ Adds a new identity provider.
 <a id="method-addnetwork"></a>
 ### `addNetwork`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Adds a new network configuration (similar to EIP-3085).
 
@@ -138,7 +144,7 @@ Adds a new network configuration (similar to EIP-3085).
 <a id="method-addsession"></a>
 ### `addSession`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 Changed in: `0.23.0`
 
 Adds a network session.
@@ -205,7 +211,7 @@ Adds a network session.
 <a id="method-allocatepartyforwallet"></a>
 ### `allocatePartyForWallet`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Allocates a party for an already initialized wallet if external signing is complete.
 
@@ -251,7 +257,7 @@ Allocates a party for an already initialized wallet if external signing is compl
 <a id="method-createwallet"></a>
 ### `createWallet`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Creates a new wallet and party with the given hint.
 
@@ -298,7 +304,7 @@ Creates a new wallet and party with the given hint.
 <a id="method-deletetransaction"></a>
 ### `deleteTransaction`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Deletes a pending transaction. Only transactions with status 'pending' can be deleted.
 
@@ -333,7 +339,7 @@ Deletes a pending transaction. Only transactions with status 'pending' can be de
 <a id="method-execute"></a>
 ### `execute`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Executes a signed transaction.
 
@@ -371,7 +377,7 @@ Executes a signed transaction.
 <a id="method-gettransaction"></a>
 ### `getTransaction`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 **Parameters**
 
@@ -409,7 +415,7 @@ Executes a signed transaction.
 <a id="method-getuser"></a>
 ### `getUser`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Returns information about the current user, including whether they are an admin.
 
@@ -435,7 +441,7 @@ _No parameters._
 <a id="method-iswalletsyncneeded"></a>
 ### `isWalletSyncNeeded`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Checks if wallet sync is needed (disabled wallets or new parties on ledger).
 
@@ -460,7 +466,7 @@ _No parameters._
 <a id="method-listidps"></a>
 ### `listIdps`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 **Parameters**
 
@@ -489,7 +495,7 @@ _No parameters._
 <a id="method-listnetworks"></a>
 ### `listNetworks`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 **Parameters**
 
@@ -526,7 +532,7 @@ _No parameters._
 <a id="method-listsessions"></a>
 ### `listSessions`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 Changed in: `0.23.0`
 
 **Version Changes**
@@ -578,7 +584,7 @@ _No parameters._
 <a id="method-listtransactions"></a>
 ### `listTransactions`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 **Parameters**
 
@@ -608,7 +614,7 @@ _No parameters._
 <a id="method-listwallets"></a>
 ### `listWallets`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Lists wallets.
 
@@ -661,7 +667,7 @@ Lists wallets.
 <a id="method-removeidp"></a>
 ### `removeIdp`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Removes an identity provider. Fails if an existing network is using the identity provider.
 
@@ -696,7 +702,7 @@ Removes an identity provider. Fails if an existing network is using the identity
 <a id="method-removenetwork"></a>
 ### `removeNetwork`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Removes a new network configuration (similar to EIP-3085).
 
@@ -731,7 +737,7 @@ Removes a new network configuration (similar to EIP-3085).
 <a id="method-removesession"></a>
 ### `removeSession`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Removes the current network session.
 
@@ -754,7 +760,7 @@ _No parameters._
 <a id="method-removewallet"></a>
 ### `removeWallet`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Removes a party with the given hint.
 
@@ -789,7 +795,7 @@ Removes a party with the given hint.
 <a id="method-setprimarywallet"></a>
 ### `setPrimaryWallet`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Sets the specified wallet as the primary wallet for dApp usage.
 
@@ -824,16 +830,9 @@ Sets the specified wallet as the primary wallet for dApp usage.
 <a id="method-sign"></a>
 ### `sign`
 
-- Introduced: `0.21.0`
-Changed in: `0.22.0`
+- Introduced: `0.22.0`
 
 Signs the provided data with the private key of the specified or active party.
-
-**Version Changes**
-
-| Version | Changes |
-| --- | --- |
-| `0.22.0` | result updated (schema, required fields) |
 
 **Parameters**
 
@@ -874,7 +873,7 @@ Signs the provided data with the private key of the specified or active party.
 <a id="method-syncwallets"></a>
 ### `syncWallets`
 
-- Introduced: `0.21.0`
+- Introduced: `0.22.0`
 
 Synchronizes wallets with the connected network.
 

--- a/shell.nix
+++ b/shell.nix
@@ -7,11 +7,13 @@ let
   ]);
   x2mdx = pythonBase.pkgs.buildPythonApplication rec {
     pname = "x2mdx";
-    version = "0.1.0+git-4de8e6c";
+    version = "0.1.0+git-66042c5";
     pyproject = true;
     src = builtins.fetchGit {
       url = "https://github.com/danielporterda/x2mdx.git";
-      rev = "4de8e6ce4bbd9f203839a3722e79d1ab9feb35e0";
+      ref = "refs/heads/version-table-ui-align";
+      rev = "66042c54124932036a0c84a0c4ea690fa14a86e9";
+      allRefs = true;
     };
     nativeBuildInputs = with pythonBase.pkgs; [
       setuptools


### PR DESCRIPTION
## Summary
- use shared table layout for Wallet Gateway OpenRPC overview/spec tables
- use shared table layout Canton Protobuf overview tables
- pin docs shell.nix to the x2mdx commit that contains the renderer changes