### PR TITLE
Align reference version tables on PR 156 base

### DIFF
--- a/docs-main/reference/protobuf/index.mdx
+++ b/docs-main/reference/protobuf/index.mdx
@@ -1,7 +1,27 @@
 ---
-title: "Canton Protobuf"
-description: "Descriptor-backed protobuf API grouped by package."
+title: "Canton Protobuf History"
+description: "Descriptor-backed protobuf API history grouped by package."
 ---
+
+# Canton Protobuf History
+
+This page is generated from local descriptor-image snapshots with source info.
+
+## Source
+
+- Source name: `Canton protobuf descriptor snapshots from release tags`
+- Version filter: `selected stable Canton release tags`
+- Latest release: `v3.4.11`
+- Source repo: `https://github.com/DACH-NY/canton.git`
+- Generated at: `2026-04-14T22:03:22.932547+00:00`
+
+## Latest Snapshot
+
+- Packages: `29`
+- Services: `52`
+- Endpoints: `248`
+- Messages: `932`
+- Enums: `48`
 
 ## Table of Contents
 
@@ -9,35 +29,35 @@ description: "Descriptor-backed protobuf API grouped by package."
 
 | NAME | STATUS | SUMMARY |
 | --- | --- | --- |
-| [`com.daml.ledger.api.v2`](/reference/protobuf/packages/com-daml-ledger-api-v2) | 🟢 `v3.4` | 9 services, 20 endpoints, 103 messages, 8 enums |
-| [`com.daml.ledger.api.v2.admin`](/reference/protobuf/packages/com-daml-ledger-api-v2-admin) | 🟢 `v3.4` | 6 services, 28 endpoints, 78 messages, 3 enums |
-| [`com.daml.ledger.api.v2.interactive`](/reference/protobuf/packages/com-daml-ledger-api-v2-interactive) | 🟢 `v3.4` | 1 services, 6 endpoints, 28 messages, 1 enums |
-| [`com.digitalasset.canton.admin.participant.v30`](/reference/protobuf/packages/com-digitalasset-canton-admin-participant-v30) | 🟢 `v3.4` | 11 services, 69 endpoints, 169 messages, 7 enums |
-| [`com.digitalasset.canton.admin.sequencer.v30`](/reference/protobuf/packages/com-digitalasset-canton-admin-sequencer-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 12 messages, 1 enums |
-| [`com.digitalasset.canton.sequencer.admin.v30`](/reference/protobuf/packages/com-digitalasset-canton-sequencer-admin-v30) | 🟢 `v3.4` | 5 services, 37 endpoints, 81 messages, 1 enums |
-| [`com.digitalasset.canton.sequencer.api.v30`](/reference/protobuf/packages/com-digitalasset-canton-sequencer-api-v30) | 🟢 `v3.4` | 4 services, 17 endpoints, 48 messages |
-| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.standalone.v1`](/reference/protobuf/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-standalone-v1) | 🟢 `v3.4` | 1 services, 2 endpoints, 5 messages |
-| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.v30`](/reference/protobuf/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 37 messages |
-| [`com.digitalasset.canton.admin.mediator.v30`](/reference/protobuf/packages/com-digitalasset-canton-admin-mediator-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 3 messages |
-| [`com.digitalasset.canton.mediator.admin.v30`](/reference/protobuf/packages/com-digitalasset-canton-mediator-admin-v30) | 🟢 `v3.4` | 4 services, 13 endpoints, 17 messages, 1 enums |
-| [`com.digitalasset.canton.admin.health.v30`](/reference/protobuf/packages/com-digitalasset-canton-admin-health-v30) | 🟢 `v3.4` | 1 services, 4 endpoints, 14 messages, 1 enums |
-| [`com.digitalasset.canton.connection.v30`](/reference/protobuf/packages/com-digitalasset-canton-connection-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 2 messages |
-| [`com.digitalasset.canton.crypto.admin.v30`](/reference/protobuf/packages/com-digitalasset-canton-crypto-admin-v30) | 🟢 `v3.4` | 1 services, 12 endpoints, 33 messages |
-| [`com.digitalasset.canton.time.admin.v30`](/reference/protobuf/packages/com-digitalasset-canton-time-admin-v30) | 🟢 `v3.4` | 1 services, 2 endpoints, 4 messages |
-| [`com.digitalasset.canton.topology.admin.v30`](/reference/protobuf/packages/com-digitalasset-canton-topology-admin-v30) | 🟢 `v3.4` | 4 services, 34 endpoints, 100 messages, 1 enums |
-| [`com.daml.ledger.api.v2.interactive.transaction.v1`](/reference/protobuf/packages/com-daml-ledger-api-v2-interactive-transaction-v1) | - | 0 services, 0 endpoints, 5 messages |
-| [`com.digitalasset.canton.admin.crypto.v30`](/reference/protobuf/packages/com-digitalasset-canton-admin-crypto-v30) | - | 0 services, 0 endpoints, 1 messages, 1 enums |
-| [`com.digitalasset.canton.admin.pruning.v30`](/reference/protobuf/packages/com-digitalasset-canton-admin-pruning-v30) | - | 0 services, 0 endpoints, 28 messages |
-| [`com.digitalasset.canton.admin.time.v30`](/reference/protobuf/packages/com-digitalasset-canton-admin-time-v30) | - | 0 services, 0 endpoints, 2 messages |
-| [`com.digitalasset.canton.crypto.v30`](/reference/protobuf/packages/com-digitalasset-canton-crypto-v30) | - | 0 services, 0 endpoints, 20 messages, 14 enums |
-| [`com.digitalasset.canton.participant.protocol.v30`](/reference/protobuf/packages/com-digitalasset-canton-participant-protocol-v30) | - | 0 services, 0 endpoints, 12 messages |
-| [`com.digitalasset.canton.protocol.v30`](/reference/protobuf/packages/com-digitalasset-canton-protocol-v30) | - | 0 services, 0 endpoints, 120 messages, 9 enums |
-| [`com.digitalasset.canton.protocol.v31`](/reference/protobuf/packages/com-digitalasset-canton-protocol-v31) | - | 0 services, 0 endpoints, 1 messages |
-| [`com.digitalasset.canton.synchronizer.protocol.v30`](/reference/protobuf/packages/com-digitalasset-canton-synchronizer-protocol-v30) | - | 0 services, 0 endpoints, 2 messages |
-| [`com.digitalasset.canton.synchronizer.v30`](/reference/protobuf/packages/com-digitalasset-canton-synchronizer-v30) | - | 0 services, 0 endpoints, 1 messages |
-| [`com.digitalasset.canton.v30`](/reference/protobuf/packages/com-digitalasset-canton-v30) | - | 0 services, 0 endpoints, 1 messages |
-| [`com.digitalasset.canton.version.v1`](/reference/protobuf/packages/com-digitalasset-canton-version-v1) | - | 0 services, 0 endpoints, 1 messages |
-| [`daml.platform.v1`](/reference/protobuf/packages/daml-platform-v1) | - | 0 services, 0 endpoints, 4 messages |
+| [`com.daml.ledger.api.v2`](protobuf/packages/com-daml-ledger-api-v2) | 🟢 `v3.4` | 9 services, 20 endpoints, 103 messages, 8 enums |
+| [`com.daml.ledger.api.v2.admin`](protobuf/packages/com-daml-ledger-api-v2-admin) | 🟢 `v3.4` | 6 services, 28 endpoints, 78 messages, 3 enums |
+| [`com.daml.ledger.api.v2.interactive`](protobuf/packages/com-daml-ledger-api-v2-interactive) | 🟢 `v3.4` | 1 services, 6 endpoints, 28 messages, 1 enums |
+| [`com.digitalasset.canton.admin.participant.v30`](protobuf/packages/com-digitalasset-canton-admin-participant-v30) | 🟢 `v3.4` | 11 services, 69 endpoints, 169 messages, 7 enums |
+| [`com.digitalasset.canton.admin.sequencer.v30`](protobuf/packages/com-digitalasset-canton-admin-sequencer-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 12 messages, 1 enums |
+| [`com.digitalasset.canton.sequencer.admin.v30`](protobuf/packages/com-digitalasset-canton-sequencer-admin-v30) | 🟢 `v3.4` | 5 services, 37 endpoints, 81 messages, 1 enums |
+| [`com.digitalasset.canton.sequencer.api.v30`](protobuf/packages/com-digitalasset-canton-sequencer-api-v30) | 🟢 `v3.4` | 4 services, 17 endpoints, 48 messages |
+| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.standalone.v1`](protobuf/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-standalone-v1) | 🟢 `v3.4` | 1 services, 2 endpoints, 5 messages |
+| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 37 messages |
+| [`com.digitalasset.canton.admin.mediator.v30`](protobuf/packages/com-digitalasset-canton-admin-mediator-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 3 messages |
+| [`com.digitalasset.canton.mediator.admin.v30`](protobuf/packages/com-digitalasset-canton-mediator-admin-v30) | 🟢 `v3.4` | 4 services, 13 endpoints, 17 messages, 1 enums |
+| [`com.digitalasset.canton.admin.health.v30`](protobuf/packages/com-digitalasset-canton-admin-health-v30) | 🟢 `v3.4` | 1 services, 4 endpoints, 14 messages, 1 enums |
+| [`com.digitalasset.canton.connection.v30`](protobuf/packages/com-digitalasset-canton-connection-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 2 messages |
+| [`com.digitalasset.canton.crypto.admin.v30`](protobuf/packages/com-digitalasset-canton-crypto-admin-v30) | 🟢 `v3.4` | 1 services, 12 endpoints, 33 messages |
+| [`com.digitalasset.canton.time.admin.v30`](protobuf/packages/com-digitalasset-canton-time-admin-v30) | 🟢 `v3.4` | 1 services, 2 endpoints, 4 messages |
+| [`com.digitalasset.canton.topology.admin.v30`](protobuf/packages/com-digitalasset-canton-topology-admin-v30) | 🟢 `v3.4` | 4 services, 34 endpoints, 100 messages, 1 enums |
+| [`com.daml.ledger.api.v2.interactive.transaction.v1`](protobuf/packages/com-daml-ledger-api-v2-interactive-transaction-v1) | - | 0 services, 0 endpoints, 5 messages |
+| [`com.digitalasset.canton.admin.crypto.v30`](protobuf/packages/com-digitalasset-canton-admin-crypto-v30) | - | 0 services, 0 endpoints, 1 messages, 1 enums |
+| [`com.digitalasset.canton.admin.pruning.v30`](protobuf/packages/com-digitalasset-canton-admin-pruning-v30) | - | 0 services, 0 endpoints, 28 messages |
+| [`com.digitalasset.canton.admin.time.v30`](protobuf/packages/com-digitalasset-canton-admin-time-v30) | - | 0 services, 0 endpoints, 2 messages |
+| [`com.digitalasset.canton.crypto.v30`](protobuf/packages/com-digitalasset-canton-crypto-v30) | - | 0 services, 0 endpoints, 20 messages, 14 enums |
+| [`com.digitalasset.canton.participant.protocol.v30`](protobuf/packages/com-digitalasset-canton-participant-protocol-v30) | - | 0 services, 0 endpoints, 12 messages |
+| [`com.digitalasset.canton.protocol.v30`](protobuf/packages/com-digitalasset-canton-protocol-v30) | - | 0 services, 0 endpoints, 120 messages, 9 enums |
+| [`com.digitalasset.canton.protocol.v31`](protobuf/packages/com-digitalasset-canton-protocol-v31) | - | 0 services, 0 endpoints, 1 messages |
+| [`com.digitalasset.canton.synchronizer.protocol.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-protocol-v30) | - | 0 services, 0 endpoints, 2 messages |
+| [`com.digitalasset.canton.synchronizer.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-v30) | - | 0 services, 0 endpoints, 1 messages |
+| [`com.digitalasset.canton.v30`](protobuf/packages/com-digitalasset-canton-v30) | - | 0 services, 0 endpoints, 1 messages |
+| [`com.digitalasset.canton.version.v1`](protobuf/packages/com-digitalasset-canton-version-v1) | - | 0 services, 0 endpoints, 1 messages |
+| [`daml.platform.v1`](protobuf/packages/daml-platform-v1) | - | 0 services, 0 endpoints, 4 messages |
 
 ## Release Summary
 
@@ -45,3 +65,66 @@ description: "Descriptor-backed protobuf API grouped by package."
 | --- | --- | --- | --- | --- |
 | `3.4.0` | `246/0/0` | `928/0/0` | `47/0/0` | `107/0/0` |
 | `3.4.11` | `2/0/0` | `4/14/0` | `1/1/0` | `1/10/0` |
+
+## Reference
+
+Packages are grouped by API area. Each package page contains its services, endpoint history, and shared type reference.
+
+### Ledger API
+
+| Package | Services | Endpoints | Messages | Enums |
+| --- | --- | --- | --- | --- |
+| [`com.daml.ledger.api.v2`](protobuf/packages/com-daml-ledger-api-v2) | `9` | `20` | `103` | `8` |
+| [`com.daml.ledger.api.v2.admin`](protobuf/packages/com-daml-ledger-api-v2-admin) | `6` | `28` | `78` | `3` |
+| [`com.daml.ledger.api.v2.interactive`](protobuf/packages/com-daml-ledger-api-v2-interactive) | `1` | `6` | `28` | `1` |
+
+### Participant Administration
+
+| Package | Services | Endpoints | Messages | Enums |
+| --- | --- | --- | --- | --- |
+| [`com.digitalasset.canton.admin.participant.v30`](protobuf/packages/com-digitalasset-canton-admin-participant-v30) | `11` | `69` | `169` | `7` |
+
+### Sequencer
+
+| Package | Services | Endpoints | Messages | Enums |
+| --- | --- | --- | --- | --- |
+| [`com.digitalasset.canton.admin.sequencer.v30`](protobuf/packages/com-digitalasset-canton-admin-sequencer-v30) | `1` | `1` | `12` | `1` |
+| [`com.digitalasset.canton.sequencer.admin.v30`](protobuf/packages/com-digitalasset-canton-sequencer-admin-v30) | `5` | `37` | `81` | `1` |
+| [`com.digitalasset.canton.sequencer.api.v30`](protobuf/packages/com-digitalasset-canton-sequencer-api-v30) | `4` | `17` | `48` | `0` |
+| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.standalone.v1`](protobuf/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-standalone-v1) | `1` | `2` | `5` | `0` |
+| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-v30) | `1` | `1` | `37` | `0` |
+
+### Mediator
+
+| Package | Services | Endpoints | Messages | Enums |
+| --- | --- | --- | --- | --- |
+| [`com.digitalasset.canton.admin.mediator.v30`](protobuf/packages/com-digitalasset-canton-admin-mediator-v30) | `1` | `1` | `3` | `0` |
+| [`com.digitalasset.canton.mediator.admin.v30`](protobuf/packages/com-digitalasset-canton-mediator-admin-v30) | `4` | `13` | `17` | `1` |
+
+### Shared Administration
+
+| Package | Services | Endpoints | Messages | Enums |
+| --- | --- | --- | --- | --- |
+| [`com.digitalasset.canton.admin.health.v30`](protobuf/packages/com-digitalasset-canton-admin-health-v30) | `1` | `4` | `14` | `1` |
+| [`com.digitalasset.canton.connection.v30`](protobuf/packages/com-digitalasset-canton-connection-v30) | `1` | `1` | `2` | `0` |
+| [`com.digitalasset.canton.crypto.admin.v30`](protobuf/packages/com-digitalasset-canton-crypto-admin-v30) | `1` | `12` | `33` | `0` |
+| [`com.digitalasset.canton.time.admin.v30`](protobuf/packages/com-digitalasset-canton-time-admin-v30) | `1` | `2` | `4` | `0` |
+| [`com.digitalasset.canton.topology.admin.v30`](protobuf/packages/com-digitalasset-canton-topology-admin-v30) | `4` | `34` | `100` | `1` |
+
+### Schema Packages
+
+| Package | Services | Endpoints | Messages | Enums |
+| --- | --- | --- | --- | --- |
+| [`com.daml.ledger.api.v2.interactive.transaction.v1`](protobuf/packages/com-daml-ledger-api-v2-interactive-transaction-v1) | `0` | `0` | `5` | `0` |
+| [`com.digitalasset.canton.admin.crypto.v30`](protobuf/packages/com-digitalasset-canton-admin-crypto-v30) | `0` | `0` | `1` | `1` |
+| [`com.digitalasset.canton.admin.pruning.v30`](protobuf/packages/com-digitalasset-canton-admin-pruning-v30) | `0` | `0` | `28` | `0` |
+| [`com.digitalasset.canton.admin.time.v30`](protobuf/packages/com-digitalasset-canton-admin-time-v30) | `0` | `0` | `2` | `0` |
+| [`com.digitalasset.canton.crypto.v30`](protobuf/packages/com-digitalasset-canton-crypto-v30) | `0` | `0` | `20` | `14` |
+| [`com.digitalasset.canton.participant.protocol.v30`](protobuf/packages/com-digitalasset-canton-participant-protocol-v30) | `0` | `0` | `12` | `0` |
+| [`com.digitalasset.canton.protocol.v30`](protobuf/packages/com-digitalasset-canton-protocol-v30) | `0` | `0` | `120` | `9` |
+| [`com.digitalasset.canton.protocol.v31`](protobuf/packages/com-digitalasset-canton-protocol-v31) | `0` | `0` | `1` | `0` |
+| [`com.digitalasset.canton.synchronizer.protocol.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-protocol-v30) | `0` | `0` | `2` | `0` |
+| [`com.digitalasset.canton.synchronizer.v30`](protobuf/packages/com-digitalasset-canton-synchronizer-v30) | `0` | `0` | `1` | `0` |
+| [`com.digitalasset.canton.v30`](protobuf/packages/com-digitalasset-canton-v30) | `0` | `0` | `1` | `0` |
+| [`com.digitalasset.canton.version.v1`](protobuf/packages/com-digitalasset-canton-version-v1) | `0` | `0` | `1` | `0` |
+| [`daml.platform.v1`](protobuf/packages/daml-platform-v1) | `0` | `0` | `4` | `0` |

--- a/docs-main/reference/wallet-gateway-json-rpc/index.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/index.mdx
@@ -3,13 +3,23 @@ title: "Wallet Gateway JSON-RPC"
 description: "Versioned OpenRPC reference docs."
 ---
 
+# Wallet Gateway JSON-RPC
+
+Generated from versioned OpenRPC snapshots.
+
+- Publish version: `0.24.0`
+- Versions compared: `0.20.0`, `0.21.0`, `0.22.0`, `0.23.0`, `0.23.1`, `0.24.0`
+- Source: `splice-wallet-kernel Wallet Gateway OpenRPC release-tag snapshots`
+- Version filter: `@canton-network/wallet-gateway-remote@ release tags`
+- Generated at: `2026-04-14T22:03:23Z`
+
 ## Table of Contents
 
 🟢 Active Since  🔵 Changed  🔴 Removed
 
 | NAME | STATUS | SUMMARY |
 | --- | --- | --- |
-| [`dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-api) | 🟢 `v0.20` | Splice Wallet JSON-RPC dApp API. 12 methods |
-| [`Remote dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-remote-api) | 🟢 `v0.20` | Splice Wallet JSON-RPC Remote dApp API. 13 methods |
+| [`dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-api) | 🟢 `v0.20` 🔵 `v0.23` | Splice Wallet JSON-RPC dApp API. 12 methods |
+| [`Remote dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-remote-api) | 🟢 `v0.20` 🔵 `v0.23` | Splice Wallet JSON-RPC Remote dApp API. 13 methods |
 | [`Signing API`](/reference/wallet-gateway-json-rpc/specs/signing-api) | 🟢 `v0.20` | Wallet JSON-RPC Signing API. 8 methods |
-| [`User API`](/reference/wallet-gateway-json-rpc/specs/user-api) | 🟢 `v0.20` 🔵 `v0.21` | Splice Wallet JSON-RPC User API. 22 methods |
+| [`User API`](/reference/wallet-gateway-json-rpc/specs/user-api) | 🟢 `v0.20` 🔵 `v0.23 +2` | Splice Wallet JSON-RPC User API. 22 methods |

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-api.mdx
@@ -3,6 +3,28 @@ title: "dApp API"
 description: "Splice Wallet JSON-RPC dApp API"
 ---
 
+# dApp API
+
+[Back to overview](/reference/wallet-gateway-json-rpc)
+
+An OpenRPC specification for the dapp to interact with a Wallet Provider.
+
+- Latest source path: `api-specs/openrpc-dapp-api.json`
+- Publish version: `0.24.0`
+- OpenRPC version: `1.2.6`
+- Spec info.version: `0.5.0`
+
+## Version Change Timeline
+
+| Version | Active Methods | Added | Changed | Removed |
+| --- | --- | --- | --- | --- |
+| `0.20.0` | 12 | 0 | 0 | 0 |
+| `0.21.0` | 12 | 0 | 0 | 0 |
+| `0.22.0` | 12 | 0 | 0 | 0 |
+| `0.23.0` | 12 | 0 | 1 | 0 |
+| `0.23.1` | 12 | 0 | 0 | 0 |
+| `0.24.0` | 12 | 0 | 0 | 0 |
+
 ## Table of Contents
 
 🟢 Active Since  🔵 Changed  🔴 Removed
@@ -14,7 +36,7 @@ description: "Splice Wallet JSON-RPC dApp API"
 | [`disconnect`](#method-disconnect) | 🟢 `v0.20` | Invoke a disconnect of the wallet provider session. |
 | [`getActiveNetwork`](#method-getactivenetwork) | 🟢 `v0.20` | Returns the active network. |
 | [`getPrimaryAccount`](#method-getprimaryaccount) | 🟢 `v0.20` | Returns the primary account. |
-| [`ledgerApi`](#method-ledgerapi) | 🟢 `v0.20` | Proxy for the JSON-API endpoints. Injects authorization headers automatically. |
+| [`ledgerApi`](#method-ledgerapi) | 🟢 `v0.20` 🔵 `v0.23` | Proxy for the JSON-API endpoints. Injects authorization headers automatically. |
 | [`listAccounts`](#method-listaccounts) | 🟢 `v0.20` | Lists the addresses (wallets) with their properties; including which network they are associated to and with signing provider is used. |
 | [`prepareExecute`](#method-prepareexecute) | 🟢 `v0.20` | Prepares a transaction for subsequent signing & execution. |
 | [`prepareExecuteAndWait`](#method-prepareexecuteandwait) | 🟢 `v0.20` | Like prepareExecute, but waits for the transaction to be executed on the ledger. |
@@ -166,8 +188,15 @@ _No parameters._
 ### `ledgerApi`
 
 - Introduced: `0.20.0`
+Changed in: `0.23.0`
 
 Proxy for the JSON-API endpoints. Injects authorization headers automatically.
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `0.23.0` | result updated (required fields) |
 
 **Parameters**
 
@@ -179,7 +208,7 @@ Proxy for the JSON-API endpoints. Injects authorization headers automatically.
 
 | Schema | Required Fields | Description |
 | --- | --- | --- |
-| `object` | `response` | - |
+| `object` | - | - |
 
 **Params Example**
 
@@ -195,9 +224,7 @@ Proxy for the JSON-API endpoints. Injects authorization headers automatically.
 **Result Example**
 
 ```json
-{
-  "response": "<string>"
-}
+{}
 ```
 
 <a id="method-listaccounts"></a>

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-remote-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-remote-api.mdx
@@ -3,6 +3,28 @@ title: "Remote dApp API"
 description: "Splice Wallet JSON-RPC Remote dApp API"
 ---
 
+# Remote dApp API
+
+[Back to overview](/reference/wallet-gateway-json-rpc)
+
+An OpenRPC specification for remotely hosted Wallet Providers. Due to the remote nature, an implementing provider must bridge certain functionality on the client-side to satisfy the general dApp API spec.
+
+- Latest source path: `api-specs/openrpc-dapp-remote-api.json`
+- Publish version: `0.24.0`
+- OpenRPC version: `1.2.6`
+- Spec info.version: `0.1.0`
+
+## Version Change Timeline
+
+| Version | Active Methods | Added | Changed | Removed |
+| --- | --- | --- | --- | --- |
+| `0.20.0` | 13 | 0 | 0 | 0 |
+| `0.21.0` | 13 | 0 | 0 | 0 |
+| `0.22.0` | 13 | 0 | 0 | 0 |
+| `0.23.0` | 13 | 0 | 2 | 0 |
+| `0.23.1` | 13 | 0 | 0 | 0 |
+| `0.24.0` | 13 | 0 | 0 | 0 |
+
 ## Table of Contents
 
 🟢 Active Since  🔵 Changed  🔴 Removed
@@ -14,8 +36,8 @@ description: "Splice Wallet JSON-RPC Remote dApp API"
 | [`connected`](#method-connected) | 🟢 `v0.20` | Informs when the user connects to a network. |
 | [`disconnect`](#method-disconnect) | 🟢 `v0.20` | Invoke a disconnect of the wallet gateway session. |
 | [`getActiveNetwork`](#method-getactivenetwork) | 🟢 `v0.20` | Returns the active network. |
-| [`getPrimaryAccount`](#method-getprimaryaccount) | 🟢 `v0.20` | Returns the primary account. |
-| [`ledgerApi`](#method-ledgerapi) | 🟢 `v0.20` | Proxy for the JSON-API endpoints. Injects authorization headers automatically. |
+| [`getPrimaryAccount`](#method-getprimaryaccount) | 🟢 `v0.20` 🔵 `v0.23` | Returns the primary account. |
+| [`ledgerApi`](#method-ledgerapi) | 🟢 `v0.20` 🔵 `v0.23` | Proxy for the JSON-API endpoints. Injects authorization headers automatically. |
 | [`listAccounts`](#method-listaccounts) | 🟢 `v0.20` | - |
 | [`onStatusChanged`](#method-onstatuschanged) | 🟢 `v0.20` | - |
 | [`prepareExecute`](#method-prepareexecute) | 🟢 `v0.20` | Prepares, signs, and executes a transaction. |
@@ -166,8 +188,15 @@ _No parameters._
 ### `getPrimaryAccount`
 
 - Introduced: `0.20.0`
+Changed in: `0.23.0`
 
 Returns the primary account.
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `0.23.0` | result updated (required fields) |
 
 **Parameters**
 
@@ -177,7 +206,7 @@ _No parameters._
 
 | Schema | Required Fields | Description |
 | --- | --- | --- |
-| `object` | `hint`, `namespace`, `networkId`, `partyId`, `primary`, `publicKey`, `signingProviderId`, `status` | - |
+| `object` | `hint`, `namespace`, `networkId`, `partyId`, `primary`, `publicKey`, `rights`, `signingProviderId`, `status` | - |
 
 **Result Example**
 
@@ -198,8 +227,15 @@ _No parameters._
 ### `ledgerApi`
 
 - Introduced: `0.20.0`
+Changed in: `0.23.0`
 
 Proxy for the JSON-API endpoints. Injects authorization headers automatically.
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `0.23.0` | result updated (required fields) |
 
 **Parameters**
 
@@ -211,7 +247,7 @@ Proxy for the JSON-API endpoints. Injects authorization headers automatically.
 
 | Schema | Required Fields | Description |
 | --- | --- | --- |
-| `object` | `response` | - |
+| `object` | - | - |
 
 **Params Example**
 
@@ -227,9 +263,7 @@ Proxy for the JSON-API endpoints. Injects authorization headers automatically.
 **Result Example**
 
 ```json
-{
-  "response": "<string>"
-}
+{}
 ```
 
 <a id="method-listaccounts"></a>

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/signing-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/signing-api.mdx
@@ -3,6 +3,28 @@ title: "Signing API"
 description: "Wallet JSON-RPC Signing API"
 ---
 
+# Signing API
+
+[Back to overview](/reference/wallet-gateway-json-rpc)
+
+An OpenRPC specification for the Signing API which allows the Wallet Gateway to interact with a Wallet Providers.
+
+- Latest source path: `api-specs/openrpc-signing-api.json`
+- Publish version: `0.24.0`
+- OpenRPC version: `1.2.6`
+- Spec info.version: `0.1.0`
+
+## Version Change Timeline
+
+| Version | Active Methods | Added | Changed | Removed |
+| --- | --- | --- | --- | --- |
+| `0.20.0` | 8 | 0 | 0 | 0 |
+| `0.21.0` | 8 | 0 | 0 | 0 |
+| `0.22.0` | 8 | 0 | 0 | 0 |
+| `0.23.0` | 8 | 0 | 0 | 0 |
+| `0.23.1` | 8 | 0 | 0 | 0 |
+| `0.24.0` | 8 | 0 | 0 | 0 |
+
 ## Table of Contents
 
 🟢 Active Since  🔵 Changed  🔴 Removed

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/user-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/user-api.mdx
@@ -3,6 +3,28 @@ title: "User API"
 description: "Splice Wallet JSON-RPC User API"
 ---
 
+# User API
+
+[Back to overview](/reference/wallet-gateway-json-rpc)
+
+An OpenRPC specification for the user to interact with the Wallet Gateway.
+
+- Latest source path: `api-specs/openrpc-user-api.json`
+- Publish version: `0.24.0`
+- OpenRPC version: `1.2.6`
+- Spec info.version: `0.1.0`
+
+## Version Change Timeline
+
+| Version | Active Methods | Added | Changed | Removed |
+| --- | --- | --- | --- | --- |
+| `0.20.0` | 21 | 0 | 0 | 0 |
+| `0.21.0` | 22 | 1 | 2 | 0 |
+| `0.22.0` | 22 | 0 | 1 | 0 |
+| `0.23.0` | 22 | 0 | 2 | 0 |
+| `0.23.1` | 22 | 0 | 0 | 0 |
+| `0.24.0` | 22 | 0 | 0 | 0 |
+
 ## Table of Contents
 
 🟢 Active Since  🔵 Changed  🔴 Removed
@@ -11,7 +33,7 @@ description: "Splice Wallet JSON-RPC User API"
 | --- | --- | --- |
 | [`addIdp`](#method-addidp) | 🟢 `v0.20` | Adds a new identity provider. |
 | [`addNetwork`](#method-addnetwork) | 🟢 `v0.20` | Adds a new network configuration (similar to EIP-3085). |
-| [`addSession`](#method-addsession) | 🟢 `v0.20` | Adds a network session. |
+| [`addSession`](#method-addsession) | 🟢 `v0.20` 🔵 `v0.23` | Adds a network session. |
 | [`allocatePartyForWallet`](#method-allocatepartyforwallet) | 🟢 `v0.21` | Allocates a party for an already initialized wallet if external signing is complete. |
 | [`createWallet`](#method-createwallet) | 🟢 `v0.20` 🔵 `v0.21` | Creates a new wallet and party with the given hint. |
 | [`deleteTransaction`](#method-deletetransaction) | 🟢 `v0.20` | Deletes a pending transaction. Only transactions with status 'pending' can be deleted. |
@@ -21,7 +43,7 @@ description: "Splice Wallet JSON-RPC User API"
 | [`isWalletSyncNeeded`](#method-iswalletsyncneeded) | 🟢 `v0.20` | Checks if wallet sync is needed (disabled wallets or new parties on ledger). |
 | [`listIdps`](#method-listidps) | 🟢 `v0.20` | - |
 | [`listNetworks`](#method-listnetworks) | 🟢 `v0.20` | - |
-| [`listSessions`](#method-listsessions) | 🟢 `v0.20` | - |
+| [`listSessions`](#method-listsessions) | 🟢 `v0.20` 🔵 `v0.23` | - |
 | [`listTransactions`](#method-listtransactions) | 🟢 `v0.20` | - |
 | [`listWallets`](#method-listwallets) | 🟢 `v0.20` | Lists wallets. |
 | [`removeIdp`](#method-removeidp) | 🟢 `v0.20` | Removes an identity provider. Fails if an existing network is using the identity provider. |
@@ -29,7 +51,7 @@ description: "Splice Wallet JSON-RPC User API"
 | [`removeSession`](#method-removesession) | 🟢 `v0.20` | Removes the current network session. |
 | [`removeWallet`](#method-removewallet) | 🟢 `v0.20` | Removes a party with the given hint. |
 | [`setPrimaryWallet`](#method-setprimarywallet) | 🟢 `v0.20` | Sets the specified wallet as the primary wallet for dApp usage. |
-| [`sign`](#method-sign) | 🟢 `v0.20` | Signs the provided data with the private key of the specified or active party. |
+| [`sign`](#method-sign) | 🟢 `v0.20` 🔵 `v0.22` | Signs the provided data with the private key of the specified or active party. |
 | [`syncWallets`](#method-syncwallets) | 🟢 `v0.20` 🔵 `v0.21` | Synchronizes wallets with the connected network. |
 
 ## Methods
@@ -124,8 +146,15 @@ Adds a new network configuration (similar to EIP-3085).
 ### `addSession`
 
 - Introduced: `0.20.0`
+Changed in: `0.23.0`
 
 Adds a network session.
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `0.23.0` | result updated (required fields) |
 
 **Parameters**
 
@@ -137,7 +166,7 @@ Adds a network session.
 
 | Schema | Required Fields | Description |
 | --- | --- | --- |
-| `object` | `accessToken`, `id`, `idp`, `network`, `status` | - |
+| `object` | `accessToken`, `id`, `idp`, `network`, `rights`, `status` | - |
 
 **Params Example**
 
@@ -173,7 +202,10 @@ Adds a network session.
     "issuer": "<string>"
   },
   "accessToken": "<string>",
-  "status": "<string>"
+  "status": "<string>",
+  "rights": [
+    "<value>"
+  ]
 }
 ```
 
@@ -509,6 +541,13 @@ _No parameters._
 ### `listSessions`
 
 - Introduced: `0.20.0`
+Changed in: `0.23.0`
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `0.23.0` | details updated |
 
 **Parameters**
 
@@ -541,7 +580,10 @@ _No parameters._
         "issuer": "<string>"
       },
       "accessToken": "<string>",
-      "status": "<string>"
+      "status": "<string>",
+      "rights": [
+        "<value>"
+      ]
     }
   ]
 }
@@ -797,8 +839,15 @@ Sets the specified wallet as the primary wallet for dApp usage.
 ### `sign`
 
 - Introduced: `0.20.0`
+Changed in: `0.22.0`
 
 Signs the provided data with the private key of the specified or active party.
+
+**Version Changes**
+
+| Version | Changes |
+| --- | --- |
+| `0.22.0` | result updated (schema, required fields) |
 
 **Parameters**
 
@@ -810,7 +859,7 @@ Signs the provided data with the private key of the specified or active party.
 
 | Schema | Required Fields | Description |
 | --- | --- | --- |
-| `object` | `partyId`, `signature`, `signedBy` | - |
+| `oneOf` | - | - |
 
 **Params Example**
 
@@ -829,9 +878,10 @@ Signs the provided data with the private key of the specified or active party.
 
 ```json
 {
+  "status": "<string>",
   "signature": "<string>",
-  "partyId": "<string>",
-  "signedBy": "<string>"
+  "signedBy": "<string>",
+  "partyId": "<string>"
 }
 ```
 

--- a/shell.nix
+++ b/shell.nix
@@ -4,11 +4,13 @@ let
   python = pkgs.python311;
   x2mdx = python.pkgs.buildPythonApplication rec {
     pname = "x2mdx";
-    version = "0.1.0+git-4de8e6c";
+    version = "0.1.0+git-66042c5";
     pyproject = true;
     src = builtins.fetchGit {
       url = "https://github.com/danielporterda/x2mdx.git";
-      rev = "4de8e6ce4bbd9f203839a3722e79d1ab9feb35e0";
+      ref = "refs/heads/version-table-ui-align";
+      rev = "66042c54124932036a0c84a0c4ea690fa14a86e9";
+      allRefs = true;
     };
     nativeBuildInputs = with python.pkgs; [
       setuptools


### PR DESCRIPTION
## Summary
- align the design-compatible Wallet Gateway OpenRPC tables on top of the PR 156 branch stack
- align the design-compatible Canton Protobuf overview table on the same base branch
- pin docs shell.nix to the x2mdx commit that contains the renderer changes

## Verification
- direnv exec /Users/danielporter/control/worktrees/docs-target-validation python3 /Users/danielporter/control/worktrees/docs-target-validation/scripts/generate_wallet_gateway_openrpc_reference.py --repo-dir /Users/danielporter/control/splice-wallet-kernel --skip-fetch
- direnv exec /Users/danielporter/control/worktrees/docs-target-validation python3 /Users/danielporter/control/worktrees/docs-target-validation/scripts/generate_canton_protobuf_history.py --repo-dir /Users/danielporter/control/.worktrees/docs-preview-staged/.internal/cache/x2mdx/protobuf-history/repos/canton --skip-fetch --version 3.4.0 --version 3.4.11 --output-dir /Users/danielporter/control/worktrees/docs-target-validation/docs-main/reference/protobuf --docs-json /Users/danielporter/control/worktrees/docs-target-validation/docs-main/docs.json
- git diff --check

## Notes
- this is the same version-table alignment work, but rebased onto the PR 156 branch `x2mdx/canton-scaladoc-archives` instead of the later protobuf-release-assets review stack
- protobuf package pages and docs nav were intentionally left unchanged on this branch; the UI change here is limited to the published overview page plus the Wallet Gateway overview/spec pages