### PR TITLE
Tighten reference sidebar spacing

### DIFF
--- a/docs-main/styles.css
+++ b/docs-main/styles.css
@@ -56,6 +56,20 @@ nav a:hover {
   background-color: var(--canton-hover-bg);
 }
 
+/* Tighten spacing within sidebar groups without collapsing the
+   larger gaps between separate nav groups. */
+#navigation-items .sidebar-group-header {
+  margin-bottom: 0.25rem;
+  line-height: 1.25;
+}
+
+#navigation-items .sidebar-group > li > a,
+#navigation-items .sidebar-group > li > button {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  line-height: 1.3;
+}
+
 /* Active/selected navigation items - Light mode: subtle bg with visible text */
 :root a[class*="bg-primary"],
 :root a.text-primary {


### PR DESCRIPTION
Tighten the Reference sidebar item spacing to reduce excess whitespace while preserving the larger gaps between nav groups.

new distance:
<img width="1440" height="1900" alt="image" src="https://github.com/user-attachments/assets/3cd05c49-7831-47f1-bd73-dbc1a6383334" />

