### PR TITLE
[codex] Rename Reference dropdown to API Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ By default this writes:
 - `docs-main/reference/json-api-reference.mdx`
 - `docs-main/docs.json`
 
-The generated page is placed directly under the top-level `Reference` dropdown in `docs-main/docs.json`, outside the `MainNet`/`TestNet`/`DevNet` versioned navigation branches.
+The generated page is placed directly under the top-level `API Reference` dropdown in `docs-main/docs.json`, outside the `MainNet`/`TestNet`/`DevNet` versioned navigation branches.
 
 ### Generate the JSON API AsyncAPI reference
 
@@ -118,7 +118,7 @@ By default this writes:
 - `docs-main/reference/json-api-asyncapi-reference.mdx`
 - `docs-main/docs.json`
 
-The generated page is placed directly under the top-level `Reference` dropdown in `docs-main/docs.json`.
+The generated page is placed directly under the top-level `API Reference` dropdown in `docs-main/docs.json`.
 
 ### Generate the Ledger bindings API reference
 
@@ -144,7 +144,7 @@ By default this writes:
 - `docs-main/reference/scala/`
 - `docs-main/docs.json`
 
-The generated nav is added under the top-level `Reference` dropdown as `Ledger API JVM Bindings -> Scaladocs/Javadocs`, with each nested group populated directly from the generated JVM package pages.
+The generated nav is added under the top-level `API Reference` dropdown as `Ledger API JVM Bindings -> Scaladocs/Javadocs`, with each nested group populated directly from the generated JVM package pages.
 
 ### Generate the Daml Standard Library reference
 
@@ -168,7 +168,7 @@ By default this writes:
 - `docs-main/appdev/reference/daml-standard-library/`
 - `docs-main/docs.json`
 
-The generated nav is added under the top-level `Reference` dropdown as `Daml Standard Library`, with the overview page listed first and the generated module pages grouped under a nested `Modules` foldout.
+The generated nav is added under the top-level `API Reference` dropdown as `Daml Standard Library`, with the overview page listed first and the generated module pages grouped under a nested `Modules` foldout.
 
 ### Generate the Canton protobuf history reference
 
@@ -192,7 +192,7 @@ By default this writes:
 - `docs-main/appdev/reference/protobuf-history/`
 - `docs-main/docs.json`
 
-The generated nav is added under the top-level `Reference` dropdown as `Canton Protobuf History`, with only the overview page listed in nav. The per-endpoint pages are generated and linked from the overview page but left unlisted.
+The generated nav is added under the top-level `API Reference` dropdown as `Canton Protobuf History`, with only the overview page listed in nav. The per-endpoint pages are generated and linked from the overview page but left unlisted.
 
 ### Generate the TypeScript bindings reference
 
@@ -216,7 +216,7 @@ By default this writes:
 - `docs-main/reference/typescript.mdx`
 - `docs-main/docs.json`
 
-The generator also adds that page under the top-level `Reference` dropdown as `Daml TypeScript Bindings -> TypeScript`.
+The generator also adds that page under the top-level `API Reference` dropdown as `Daml TypeScript Bindings -> TypeScript`.
 
 ### Generate the Wallet Gateway JSON-RPC reference
 
@@ -240,4 +240,4 @@ By default this writes:
 - `docs-main/reference/wallet-gateway-json-rpc/`
 - `docs-main/docs.json`
 
-The generated nav is added under the top-level `Reference` dropdown as `Wallet Gateway JSON-RPC`, with the overview page plus one page per published OpenRPC surface.
+The generated nav is added under the top-level `API Reference` dropdown as `Wallet Gateway JSON-RPC`, with the overview page plus one page per published OpenRPC surface.

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -818,7 +818,7 @@
         ]
       },
       {
-        "dropdown": "Reference",
+        "dropdown": "API Reference",
         "icon": "book-open",
         "pages": [
           {

--- a/docs.json
+++ b/docs.json
@@ -578,7 +578,7 @@
         ]
       },
       {
-        "dropdown": "Reference",
+        "dropdown": "API Reference",
         "icon": "book-open",
         "pages": [
           {

--- a/scripts/generate_canton_protobuf_history.py
+++ b/scripts/generate_canton_protobuf_history.py
@@ -48,7 +48,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--manifest-out", default=str(DEFAULT_MANIFEST))
     parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR))
     parser.add_argument("--docs-json", default=str(DEFAULT_DOCS_JSON))
-    parser.add_argument("--nav-dropdown", default="Reference")
+    parser.add_argument("--nav-dropdown", default="API Reference")
     parser.add_argument("--nav-group", action="append")
     parser.add_argument("--repo-dir", default=str(DEFAULT_REPO_DIR))
     parser.add_argument("--version", action="append", help="Explicit version to include. Repeat to limit generation.")

--- a/scripts/generate_daml_standard_library_reference.py
+++ b/scripts/generate_daml_standard_library_reference.py
@@ -29,7 +29,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--manifest-out", default=str(DEFAULT_MANIFEST))
     parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR))
     parser.add_argument("--docs-json", default=str(DEFAULT_DOCS_JSON))
-    parser.add_argument("--nav-dropdown", default="Reference")
+    parser.add_argument("--nav-dropdown", default="API Reference")
     parser.add_argument("--nav-group", action="append")
     parser.add_argument("--version", action="append", help="Version to include. Repeat to limit generation.")
     parser.add_argument("--publish-version", help="Version whose docs should be published.")

--- a/scripts/generate_json_api_asyncapi_reference.py
+++ b/scripts/generate_json_api_asyncapi_reference.py
@@ -42,7 +42,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--manifest-out", default=str(DEFAULT_MANIFEST))
     parser.add_argument("--output-file", default=str(DEFAULT_OUTPUT_FILE))
     parser.add_argument("--docs-json", default=str(DEFAULT_DOCS_JSON))
-    parser.add_argument("--nav-dropdown", default="Reference")
+    parser.add_argument("--nav-dropdown", default="API Reference")
     parser.add_argument(
         "--nav-group",
         action="append",

--- a/scripts/generate_json_api_reference.py
+++ b/scripts/generate_json_api_reference.py
@@ -73,7 +73,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--nav-dropdown",
-        default="Reference",
+        default="API Reference",
         help="Top-level Mintlify dropdown to update.",
     )
     parser.add_argument(

--- a/scripts/generate_ledger_bindings_api_reference.py
+++ b/scripts/generate_ledger_bindings_api_reference.py
@@ -81,7 +81,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--nav-dropdown",
-        default="Reference",
+        default="API Reference",
         help="Top-level Mintlify dropdown to update with the generated JVM bindings section.",
     )
     parser.add_argument(

--- a/scripts/generate_typescript_bindings_reference.py
+++ b/scripts/generate_typescript_bindings_reference.py
@@ -33,7 +33,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--manifest-out", default=str(DEFAULT_MANIFEST))
     parser.add_argument("--output-file", default=str(DEFAULT_OUTPUT_FILE))
     parser.add_argument("--docs-json", default=str(DEFAULT_DOCS_JSON))
-    parser.add_argument("--nav-dropdown", default="Reference")
+    parser.add_argument("--nav-dropdown", default="API Reference")
     parser.add_argument("--nav-group", default=DEFAULT_NAV_GROUP)
     parser.add_argument("--version", action="append", help="Version to include. Repeat to limit generation.")
     parser.add_argument("--publish-version", help="Version whose TypeScript surface should be published.")

--- a/scripts/generate_wallet_gateway_openrpc_reference.py
+++ b/scripts/generate_wallet_gateway_openrpc_reference.py
@@ -33,7 +33,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR))
     parser.add_argument("--docs-json", default=str(DEFAULT_DOCS_JSON))
     parser.add_argument("--repo-dir", default=str(DEFAULT_REPO_DIR))
-    parser.add_argument("--nav-dropdown", default="Reference")
+    parser.add_argument("--nav-dropdown", default="API Reference")
     parser.add_argument("--version", action="append", help="Explicit version to include. Repeat to limit generation.")
     parser.add_argument("--publish-version", help="Version whose spec surface should be published.")
     parser.add_argument("--min-version", help="Minimum wallet-gateway-remote release version to include.")


### PR DESCRIPTION
## What changed

This updates the top-level docs navigation label from `Reference` to `API Reference`.
