### PR TITLE
[codex] Rename manifest-owned reference titles

### DIFF
--- a/config/x2mdx/ledger-bindings/source-artifacts.json
+++ b/config/x2mdx/ledger-bindings/source-artifacts.json
@@ -1,4 +1,5 @@
 {
+  "overview_title": "Ledger API Java Bindings",
   "repo_base": "https://repo1.maven.org/maven2",
   "artifacts": [
     {

--- a/config/x2mdx/protobuf-history/source-artifacts.json
+++ b/config/x2mdx/protobuf-history/source-artifacts.json
@@ -1,5 +1,6 @@
 {
   "source": "Canton protobuf descriptor snapshots from release tags",
+  "overview_title": "Ledger API Protobuf",
   "repo": {
     "remote": "https://github.com/DACH-NY/canton.git",
     "web_url": "https://github.com/DACH-NY/canton"

--- a/config/x2mdx/wallet-gateway-openrpc/source-artifacts.json
+++ b/config/x2mdx/wallet-gateway-openrpc/source-artifacts.json
@@ -1,5 +1,6 @@
 {
   "source": "splice-wallet-kernel Wallet Gateway OpenRPC specs from release tags",
+  "overview_title": "Wallet Kernel",
   "remote": "https://github.com/hyperledger-labs/splice-wallet-kernel.git",
   "tag_prefix": "@canton-network/wallet-gateway-remote@",
   "publish_version": "0.24.0",

--- a/docs-main/appdev/reference/protobuf-history/index.mdx
+++ b/docs-main/appdev/reference/protobuf-history/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Canton Protobuf History"
+title: "Ledger API Protobuf"
 description: "Descriptor-backed protobuf API history grouped by package."
 ---
 
-# Canton Protobuf History
+# Ledger API Protobuf
 
 This page is generated from local descriptor-image snapshots with source info.
 
@@ -13,7 +13,7 @@ This page is generated from local descriptor-image snapshots with source info.
 - Version filter: `stable Canton release tags >= 3.2.0`
 - Latest release: `v3.4.11`
 - Source repo: `https://github.com/DACH-NY/canton.git`
-- Generated at: `2026-03-31T23:10:57.160271+00:00`
+- Generated at: `2026-04-17T17:11:00.027424+00:00`
 
 ## Latest Snapshot
 
@@ -23,7 +23,60 @@ This page is generated from local descriptor-image snapshots with source info.
 - Messages: `932`
 - Enums: `48`
 
-## Package Reference
+## Table of Contents
+
+🟢 Active Since  🔵 Changed  🔴 Removed
+
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`com.daml.ledger.api.v2`](protobuf-history/packages/com-daml-ledger-api-v2) | 🟢 `v3.4` | 9 services, 20 endpoints, 103 messages, 8 enums |
+| [`com.daml.ledger.api.v2.admin`](protobuf-history/packages/com-daml-ledger-api-v2-admin) | 🟢 `v3.4` | 6 services, 28 endpoints, 78 messages, 3 enums |
+| [`com.daml.ledger.api.v2.interactive`](protobuf-history/packages/com-daml-ledger-api-v2-interactive) | 🟢 `v3.4` | 1 services, 6 endpoints, 28 messages, 1 enums |
+| [`com.digitalasset.canton.admin.participant.v30`](protobuf-history/packages/com-digitalasset-canton-admin-participant-v30) | 🟢 `v3.4` | 11 services, 69 endpoints, 169 messages, 7 enums |
+| [`com.digitalasset.canton.admin.sequencer.v30`](protobuf-history/packages/com-digitalasset-canton-admin-sequencer-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 12 messages, 1 enums |
+| [`com.digitalasset.canton.sequencer.admin.v30`](protobuf-history/packages/com-digitalasset-canton-sequencer-admin-v30) | 🟢 `v3.4` | 5 services, 37 endpoints, 81 messages, 1 enums |
+| [`com.digitalasset.canton.sequencer.api.v30`](protobuf-history/packages/com-digitalasset-canton-sequencer-api-v30) | 🟢 `v3.4` | 4 services, 17 endpoints, 48 messages |
+| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.standalone.v1`](protobuf-history/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-standalone-v1) | 🟢 `v3.4` | 1 services, 2 endpoints, 5 messages |
+| [`com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.v30`](protobuf-history/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 37 messages |
+| [`com.digitalasset.canton.admin.mediator.v30`](protobuf-history/packages/com-digitalasset-canton-admin-mediator-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 3 messages |
+| [`com.digitalasset.canton.mediator.admin.v30`](protobuf-history/packages/com-digitalasset-canton-mediator-admin-v30) | 🟢 `v3.4` | 4 services, 13 endpoints, 17 messages, 1 enums |
+| [`com.digitalasset.canton.admin.health.v30`](protobuf-history/packages/com-digitalasset-canton-admin-health-v30) | 🟢 `v3.4` | 1 services, 4 endpoints, 14 messages, 1 enums |
+| [`com.digitalasset.canton.connection.v30`](protobuf-history/packages/com-digitalasset-canton-connection-v30) | 🟢 `v3.4` | 1 services, 1 endpoints, 2 messages |
+| [`com.digitalasset.canton.crypto.admin.v30`](protobuf-history/packages/com-digitalasset-canton-crypto-admin-v30) | 🟢 `v3.4` | 1 services, 12 endpoints, 33 messages |
+| [`com.digitalasset.canton.time.admin.v30`](protobuf-history/packages/com-digitalasset-canton-time-admin-v30) | 🟢 `v3.4` | 1 services, 2 endpoints, 4 messages |
+| [`com.digitalasset.canton.topology.admin.v30`](protobuf-history/packages/com-digitalasset-canton-topology-admin-v30) | 🟢 `v3.4` | 4 services, 34 endpoints, 100 messages, 1 enums |
+| [`com.daml.ledger.api.v2.interactive.transaction.v1`](protobuf-history/packages/com-daml-ledger-api-v2-interactive-transaction-v1) | - | 0 services, 0 endpoints, 5 messages |
+| [`com.digitalasset.canton.admin.crypto.v30`](protobuf-history/packages/com-digitalasset-canton-admin-crypto-v30) | - | 0 services, 0 endpoints, 1 messages, 1 enums |
+| [`com.digitalasset.canton.admin.pruning.v30`](protobuf-history/packages/com-digitalasset-canton-admin-pruning-v30) | - | 0 services, 0 endpoints, 28 messages |
+| [`com.digitalasset.canton.admin.time.v30`](protobuf-history/packages/com-digitalasset-canton-admin-time-v30) | - | 0 services, 0 endpoints, 2 messages |
+| [`com.digitalasset.canton.crypto.v30`](protobuf-history/packages/com-digitalasset-canton-crypto-v30) | - | 0 services, 0 endpoints, 20 messages, 14 enums |
+| [`com.digitalasset.canton.participant.protocol.v30`](protobuf-history/packages/com-digitalasset-canton-participant-protocol-v30) | - | 0 services, 0 endpoints, 12 messages |
+| [`com.digitalasset.canton.protocol.v30`](protobuf-history/packages/com-digitalasset-canton-protocol-v30) | - | 0 services, 0 endpoints, 120 messages, 9 enums |
+| [`com.digitalasset.canton.protocol.v31`](protobuf-history/packages/com-digitalasset-canton-protocol-v31) | - | 0 services, 0 endpoints, 1 messages |
+| [`com.digitalasset.canton.synchronizer.protocol.v30`](protobuf-history/packages/com-digitalasset-canton-synchronizer-protocol-v30) | - | 0 services, 0 endpoints, 2 messages |
+| [`com.digitalasset.canton.synchronizer.v30`](protobuf-history/packages/com-digitalasset-canton-synchronizer-v30) | - | 0 services, 0 endpoints, 1 messages |
+| [`com.digitalasset.canton.v30`](protobuf-history/packages/com-digitalasset-canton-v30) | - | 0 services, 0 endpoints, 1 messages |
+| [`com.digitalasset.canton.version.v1`](protobuf-history/packages/com-digitalasset-canton-version-v1) | - | 0 services, 0 endpoints, 1 messages |
+| [`daml.platform.v1`](protobuf-history/packages/daml-platform-v1) | - | 0 services, 0 endpoints, 4 messages |
+
+## Release Summary
+
+| Version | Endpoints +/~/- | Messages +/~/- | Enums +/~/- | Files +/~/- |
+| --- | --- | --- | --- | --- |
+| `3.4.0` | `246/0/0` | `928/0/0` | `47/0/0` | `107/0/0` |
+| `3.4.1` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.2` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.3` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.4` | `0/0/0` | `0/5/0` | `0/1/0` | `0/5/0` |
+| `3.4.5` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.6` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.7` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.8` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.9` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.10` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.11` | `2/0/0` | `4/9/0` | `1/0/0` | `1/5/0` |
+
+## Reference
 
 Packages are grouped by API area. Each package page contains its services, endpoint history, and shared type reference.
 
@@ -85,20 +138,3 @@ Packages are grouped by API area. Each package page contains its services, endpo
 | [`com.digitalasset.canton.v30`](protobuf-history/packages/com-digitalasset-canton-v30) | `0` | `0` | `1` | `0` |
 | [`com.digitalasset.canton.version.v1`](protobuf-history/packages/com-digitalasset-canton-version-v1) | `0` | `0` | `1` | `0` |
 | [`daml.platform.v1`](protobuf-history/packages/daml-platform-v1) | `0` | `0` | `4` | `0` |
-
-## Release Summary
-
-| Version | Endpoints +/~/- | Messages +/~/- | Enums +/~/- | Files +/~/- |
-| --- | --- | --- | --- | --- |
-| `3.4.0` | `246/0/0` | `928/0/0` | `47/0/0` | `107/0/0` |
-| `3.4.1` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.2` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.3` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.4` | `0/0/0` | `0/5/0` | `0/1/0` | `0/5/0` |
-| `3.4.5` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.6` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.7` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.8` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.9` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.10` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.11` | `2/0/0` | `4/9/0` | `1/0/0` | `1/5/0` |

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-admin.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-admin.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.daml.ledger
 
 # Package `com.daml.ledger.api.v2.admin`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.daml.ledger
 
 # Package `com.daml.ledger.api.v2.interactive.transaction.v1`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.daml.ledger
 
 # Package `com.daml.ledger.api.v2.interactive`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.daml.ledger
 
 # Package `com.daml.ledger.api.v2`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-crypto-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-crypto-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.crypto.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-health-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-health-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.health.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-mediator-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-mediator-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.mediator.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-participant-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-participant-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.participant.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-pruning-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-pruning-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.pruning.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-sequencer-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-sequencer-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.sequencer.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-time-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-time-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.time.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-connection-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-connection-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.connection.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-crypto-admin-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-crypto-admin-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.crypto.admin.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-crypto-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-crypto-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.crypto.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-mediator-admin-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-mediator-admin-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.mediator.admin.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-participant-protocol-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-participant-protocol-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.participant.protocol.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-protocol-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-protocol-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.protocol.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-protocol-v31.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-protocol-v31.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.protocol.v31`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-sequencer-admin-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-sequencer-admin-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.sequencer.admin.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-sequencer-api-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-sequencer-api-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.sequencer.api.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-protocol-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-protocol-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.synchronizer.protocol.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-standalone-v1.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-standalone-v1.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.standalone.v1`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.synchronizer.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-time-admin-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-time-admin-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.time.admin.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-topology-admin-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-topology-admin-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.topology.admin.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-version-v1.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-version-v1.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.version.v1`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/daml-platform-v1.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/daml-platform-v1.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package daml.platform.v
 
 # Package `daml.platform.v1`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -445,7 +445,7 @@
         "pages": [
           "appdev/reference/json-api-reference",
           {
-            "group": "Ledger API JVM Bindings",
+            "group": "Ledger API Java Bindings",
             "pages": [
               {
                 "group": "Scaladocs",
@@ -467,13 +467,13 @@
             ]
           },
           {
-            "group": "Canton Protobuf History",
+            "group": "Ledger API Protobuf",
             "pages": [
               "appdev/reference/protobuf-history/index"
             ]
           },
           {
-            "group": "Wallet Gateway JSON-RPC",
+            "group": "Wallet Kernel",
             "pages": [
               "reference/wallet-gateway-json-rpc/index",
               "reference/wallet-gateway-json-rpc/specs/dapp-api",

--- a/docs-main/reference/java/index.mdx
+++ b/docs-main/reference/java/index.mdx
@@ -5,7 +5,17 @@ description: "Generated lifecycle timeline and type index from local Javadoc/Sca
 
 Back to [overview](../ledger-api-jvm-bindings).
 
-## Artifact
+## Table of Contents
+
+🟢 Active Since  🔵 Changed  🔴 Removed
+
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`com.daml.ledger.javaapi.data`](com-daml-ledger-javaapi-data) | 🟢 `3.4.8` 🔵 `3.4.11` | 142 types. Changes in range: 1 deprecated, 1 removed. |
+| [`com.daml.ledger.javaapi.data.codegen`](com-daml-ledger-javaapi-data-codegen) | 🟢 `3.4.8` | 31 types. No lifecycle changes in selected range. |
+| [`com.daml.ledger.javaapi.data.codegen.json`](com-daml-ledger-javaapi-data-codegen-json) | 🟢 `3.4.8` | 12 types. No lifecycle changes in selected range. |
+
+## Version Change Summary
 
 - Group: `com.daml`
 - Artifact: `bindings-java`
@@ -14,22 +24,13 @@ Back to [overview](../ledger-api-jvm-bindings).
 - Total symbols tracked: `1453`
 - Types: `185`
 - Members: `1268`
-
-## Lifecycle Summary
-
 - Introduced in range: `2`
 - Deprecated in range: `2`
 - Removed in range: `1`
 
-## Package Reference
+## Reference
 
-| Local Page | Package | Types | Introduced | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- |
-| [Open](com-daml-ledger-javaapi-data) | `com.daml.ledger.javaapi.data` | `142` | `0` | `1` | `1` |
-| [Open](com-daml-ledger-javaapi-data-codegen) | `com.daml.ledger.javaapi.data.codegen` | `31` | `0` | `0` | `0` |
-| [Open](com-daml-ledger-javaapi-data-codegen-json) | `com.daml.ledger.javaapi.data.codegen.json` | `12` | `0` | `0` | `0` |
-
-## Changed Symbols
+### Changed Symbols
 
 | Docs | Symbol | Kind | Introduced | Deprecated | Removed |
 | --- | --- | --- | --- | --- | --- |
@@ -39,7 +40,7 @@ Back to [overview](../ledger-api-jvm-bindings).
 | [Open](https://javadoc.io/doc/com.daml/bindings-java/3.4.11/com/daml/ledger/javaapi/data/Transaction.html#%3Cinit%3E(java.lang.String,java.lang.String,java.lang.String,java.time.Instant,java.util.List,java.lang.Long,java.lang.String,com.daml.ledger.api.v2.TraceContextOuterClass.TraceContext,java.time.Instant,com.google.protobuf.ByteString)) | `com.daml.ledger.javaapi.data.Transaction#Transaction(String, String, String, Instant, List<Event>, Long, String, TraceContextOuterClass.TraceContext, Instant, ByteString)` | `member` | `3.4.11` | - | - |
 | [Open](https://javadoc.io/doc/com.daml/bindings-java/3.4.11/com/daml/ledger/javaapi/data/Transaction.html#getExternalTransactionHash%28%29) | `com.daml.ledger.javaapi.data.Transaction#getExternalTransactionHash()` | `member` | `3.4.11` | - | - |
 
-## Deprecation Notes
+### Deprecation Notes
 
 | Symbol | Deprecated | Note |
 | --- | --- | --- |

--- a/docs-main/reference/ledger-api-jvm-bindings.mdx
+++ b/docs-main/reference/ledger-api-jvm-bindings.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Ledger API JVM Bindings"
+title: "Ledger API Java Bindings"
 description: "Generated lifecycle timeline and reference pages for local Javadoc/Scaladoc artifacts"
 ---
 
@@ -7,7 +7,7 @@ This page is generated from supplied local Javadoc/Scaladoc jars.
 
 ## Source
 
-- Generated at (UTC): `2026-03-31T19:41:35.142605+00:00`
+- Generated at (UTC): `2026-04-17T17:10:41.384880+00:00`
 - Source name: `Published DAML Java/Scala bindings Javadoc/Scaladoc jars`
 - Version filter: `configured bindings artifact versions`
 - Artifacts: `2`

--- a/docs-main/reference/scala/index.mdx
+++ b/docs-main/reference/scala/index.mdx
@@ -5,7 +5,18 @@ description: "Generated lifecycle timeline and type index from local Javadoc/Sca
 
 Back to [overview](../ledger-api-jvm-bindings).
 
-## Artifact
+## Table of Contents
+
+🟢 Active Since  🔵 Changed  🔴 Removed
+
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`com.daml.api.util`](com-daml-api-util) | 🟢 `2.10.0` | 5 types. No lifecycle changes in selected range. |
+| [`com.daml.ledger.api.refinements`](com-daml-ledger-api-refinements) | 🟢 `2.10.0` | 4 types. No lifecycle changes in selected range. |
+| [`com.daml.ledger.client.binding`](com-daml-ledger-client-binding) | 🟢 `2.10.0` | 23 types. No lifecycle changes in selected range. |
+| [`com.daml.ledger.client.binding.encoding`](com-daml-ledger-client-binding-encoding) | 🟢 `2.10.0` | 6 types. No lifecycle changes in selected range. |
+
+## Version Change Summary
 
 - Group: `com.daml`
 - Artifact: `bindings-scala_2.13`
@@ -14,22 +25,12 @@ Back to [overview](../ledger-api-jvm-bindings).
 - Total symbols tracked: `321`
 - Types: `38`
 - Members: `283`
-
-## Lifecycle Summary
-
 - Introduced in range: `0`
 - Deprecated in range: `0`
 - Removed in range: `0`
 
-## Package Reference
+## Reference
 
-| Local Page | Package | Types | Introduced | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- |
-| [Open](com-daml-api-util) | `com.daml.api.util` | `5` | `0` | `0` | `0` |
-| [Open](com-daml-ledger-api-refinements) | `com.daml.ledger.api.refinements` | `4` | `0` | `0` | `0` |
-| [Open](com-daml-ledger-client-binding) | `com.daml.ledger.client.binding` | `23` | `0` | `0` | `0` |
-| [Open](com-daml-ledger-client-binding-encoding) | `com.daml.ledger.client.binding.encoding` | `6` | `0` | `0` | `0` |
-
-## Changed Symbols
+### Changed Symbols
 
 No lifecycle changes were detected in the configured version range.

--- a/docs-main/reference/wallet-gateway-json-rpc/index.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Wallet Gateway JSON-RPC"
+title: "Wallet Kernel"
 description: "Versioned OpenRPC reference docs."
 ---
 
-# Wallet Gateway JSON-RPC
+# Wallet Kernel
 
 Generated from versioned OpenRPC snapshots.
 
@@ -11,13 +11,15 @@ Generated from versioned OpenRPC snapshots.
 - Versions compared: `0.20.0`, `0.21.0`, `0.22.0`, `0.23.0`, `0.23.1`, `0.24.0`
 - Source: `splice-wallet-kernel Wallet Gateway OpenRPC release-tag snapshots`
 - Version filter: `@canton-network/wallet-gateway-remote@ release tags`
-- Generated at: `2026-04-02T18:56:54Z`
+- Generated at: `2026-04-17T17:11:16Z`
 
-## Spec Reference
+## Table of Contents
 
-| Spec | Title | Methods | Changed In |
-| --- | --- | --- | --- |
-| [`dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-api) | Splice Wallet JSON-RPC dApp API | `12` | `0.23.0` |
-| [`Remote dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-remote-api) | Splice Wallet JSON-RPC Remote dApp API | `13` | `0.23.0` |
-| [`Signing API`](/reference/wallet-gateway-json-rpc/specs/signing-api) | Wallet JSON-RPC Signing API | `8` | - |
-| [`User API`](/reference/wallet-gateway-json-rpc/specs/user-api) | Splice Wallet JSON-RPC User API | `22` | `0.21.0`, `0.22.0`, `0.23.0` |
+🟢 Active Since  🔵 Changed  🔴 Removed
+
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-api) | 🟢 `v0.20` 🔵 `v0.23` | Splice Wallet JSON-RPC dApp API. 12 methods |
+| [`Remote dApp API`](/reference/wallet-gateway-json-rpc/specs/dapp-remote-api) | 🟢 `v0.20` 🔵 `v0.23` | Splice Wallet JSON-RPC Remote dApp API. 13 methods |
+| [`Signing API`](/reference/wallet-gateway-json-rpc/specs/signing-api) | 🟢 `v0.20` | Wallet JSON-RPC Signing API. 8 methods |
+| [`User API`](/reference/wallet-gateway-json-rpc/specs/user-api) | 🟢 `v0.20` 🔵 `v0.23 +2` | Splice Wallet JSON-RPC User API. 22 methods |

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-api.mdx
@@ -25,22 +25,24 @@ An OpenRPC specification for the dapp to interact with a Wallet Provider.
 | `0.23.1` | 12 | 0 | 0 | 0 |
 | `0.24.0` | 12 | 0 | 0 | 0 |
 
-## Method Diff Summary
+## Table of Contents
 
-| Method | Introduced | Changes | Removed |
-| --- | --- | --- | --- |
-| [`accountsChanged`](#method-accountschanged) | `0.20.0` | - | - |
-| [`connect`](#method-connect) | `0.20.0` | - | - |
-| [`disconnect`](#method-disconnect) | `0.20.0` | - | - |
-| [`getActiveNetwork`](#method-getactivenetwork) | `0.20.0` | - | - |
-| [`getPrimaryAccount`](#method-getprimaryaccount) | `0.20.0` | - | - |
-| [`ledgerApi`](#method-ledgerapi) | `0.20.0` | `0.23.0`: result updated (required fields) | - |
-| [`listAccounts`](#method-listaccounts) | `0.20.0` | - | - |
-| [`prepareExecute`](#method-prepareexecute) | `0.20.0` | - | - |
-| [`prepareExecuteAndWait`](#method-prepareexecuteandwait) | `0.20.0` | - | - |
-| [`signMessage`](#method-signmessage) | `0.20.0` | - | - |
-| [`status`](#method-status) | `0.20.0` | - | - |
-| [`txChanged`](#method-txchanged) | `0.20.0` | - | - |
+🟢 Active Since  🔵 Changed  🔴 Removed
+
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`accountsChanged`](#method-accountschanged) | 🟢 `v0.20` | - |
+| [`connect`](#method-connect) | 🟢 `v0.20` | Ensures ledger connectivity and returns the connected network information along with the session information. |
+| [`disconnect`](#method-disconnect) | 🟢 `v0.20` | Invoke a disconnect of the wallet provider session. |
+| [`getActiveNetwork`](#method-getactivenetwork) | 🟢 `v0.20` | Returns the active network. |
+| [`getPrimaryAccount`](#method-getprimaryaccount) | 🟢 `v0.20` | Returns the primary account. |
+| [`ledgerApi`](#method-ledgerapi) | 🟢 `v0.20` 🔵 `v0.23` | Proxy for the JSON-API endpoints. Injects authorization headers automatically. |
+| [`listAccounts`](#method-listaccounts) | 🟢 `v0.20` | Lists the addresses (wallets) with their properties; including which network they are associated to and with signing provider is used. |
+| [`prepareExecute`](#method-prepareexecute) | 🟢 `v0.20` | Prepares a transaction for subsequent signing & execution. |
+| [`prepareExecuteAndWait`](#method-prepareexecuteandwait) | 🟢 `v0.20` | Like prepareExecute, but waits for the transaction to be executed on the ledger. |
+| [`signMessage`](#method-signmessage) | 🟢 `v0.20` | Signs a message. |
+| [`status`](#method-status) | 🟢 `v0.20` | Returns the current status of the wallet provider session. |
+| [`txChanged`](#method-txchanged) | 🟢 `v0.20` | - |
 
 ## Methods
 

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-remote-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-remote-api.mdx
@@ -25,23 +25,25 @@ An OpenRPC specification for remotely hosted Wallet Providers. Due to the remote
 | `0.23.1` | 13 | 0 | 0 | 0 |
 | `0.24.0` | 13 | 0 | 0 | 0 |
 
-## Method Diff Summary
+## Table of Contents
 
-| Method | Introduced | Changes | Removed |
-| --- | --- | --- | --- |
-| [`accountsChanged`](#method-accountschanged) | `0.20.0` | - | - |
-| [`connect`](#method-connect) | `0.20.0` | - | - |
-| [`connected`](#method-connected) | `0.20.0` | - | - |
-| [`disconnect`](#method-disconnect) | `0.20.0` | - | - |
-| [`getActiveNetwork`](#method-getactivenetwork) | `0.20.0` | - | - |
-| [`getPrimaryAccount`](#method-getprimaryaccount) | `0.20.0` | `0.23.0`: result updated (required fields) | - |
-| [`ledgerApi`](#method-ledgerapi) | `0.20.0` | `0.23.0`: result updated (required fields) | - |
-| [`listAccounts`](#method-listaccounts) | `0.20.0` | - | - |
-| [`onStatusChanged`](#method-onstatuschanged) | `0.20.0` | - | - |
-| [`prepareExecute`](#method-prepareexecute) | `0.20.0` | - | - |
-| [`signMessage`](#method-signmessage) | `0.20.0` | - | - |
-| [`status`](#method-status) | `0.20.0` | - | - |
-| [`txChanged`](#method-txchanged) | `0.20.0` | - | - |
+🟢 Active Since  🔵 Changed  🔴 Removed
+
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`accountsChanged`](#method-accountschanged) | 🟢 `v0.20` | - |
+| [`connect`](#method-connect) | 🟢 `v0.20` | Ensures ledger connectivity and returns the connected network information. |
+| [`connected`](#method-connected) | 🟢 `v0.20` | Informs when the user connects to a network. |
+| [`disconnect`](#method-disconnect) | 🟢 `v0.20` | Invoke a disconnect of the wallet gateway session. |
+| [`getActiveNetwork`](#method-getactivenetwork) | 🟢 `v0.20` | Returns the active network. |
+| [`getPrimaryAccount`](#method-getprimaryaccount) | 🟢 `v0.20` 🔵 `v0.23` | Returns the primary account. |
+| [`ledgerApi`](#method-ledgerapi) | 🟢 `v0.20` 🔵 `v0.23` | Proxy for the JSON-API endpoints. Injects authorization headers automatically. |
+| [`listAccounts`](#method-listaccounts) | 🟢 `v0.20` | - |
+| [`onStatusChanged`](#method-onstatuschanged) | 🟢 `v0.20` | - |
+| [`prepareExecute`](#method-prepareexecute) | 🟢 `v0.20` | Prepares, signs, and executes a transaction. |
+| [`signMessage`](#method-signmessage) | 🟢 `v0.20` | Signs a message. |
+| [`status`](#method-status) | 🟢 `v0.20` | Returns the current status of the wallet provider session. |
+| [`txChanged`](#method-txchanged) | 🟢 `v0.20` | - |
 
 ## Methods
 

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/signing-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/signing-api.mdx
@@ -25,18 +25,20 @@ An OpenRPC specification for the Signing API which allows the Wallet Gateway to 
 | `0.23.1` | 8 | 0 | 0 | 0 |
 | `0.24.0` | 8 | 0 | 0 | 0 |
 
-## Method Diff Summary
+## Table of Contents
 
-| Method | Introduced | Changes | Removed |
-| --- | --- | --- | --- |
-| [`createKey`](#method-createkey) | `0.20.0` | - | - |
-| [`getConfiguration`](#method-getconfiguration) | `0.20.0` | - | - |
-| [`getKeys`](#method-getkeys) | `0.20.0` | - | - |
-| [`getTransaction`](#method-gettransaction) | `0.20.0` | - | - |
-| [`getTransactions`](#method-gettransactions) | `0.20.0` | - | - |
-| [`setConfiguration`](#method-setconfiguration) | `0.20.0` | - | - |
-| [`signTransaction`](#method-signtransaction) | `0.20.0` | - | - |
-| [`subscribeTransactions`](#method-subscribetransactions) | `0.20.0` | - | - |
+🟢 Active Since  🔵 Changed  🔴 Removed
+
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`createKey`](#method-createkey) | 🟢 `v0.20` | Create a new key at the Wallet Provider. |
+| [`getConfiguration`](#method-getconfiguration) | 🟢 `v0.20` | - |
+| [`getKeys`](#method-getkeys) | 🟢 `v0.20` | Get a list of public keys availabile for signing. |
+| [`getTransaction`](#method-gettransaction) | 🟢 `v0.20` | Get the status of a single transaction by its ID. |
+| [`getTransactions`](#method-gettransactions) | 🟢 `v0.20` | Get the status of multiple transactions, filtering by txIds or publicKeys. Either publicKeys or txIds must be provided. |
+| [`setConfiguration`](#method-setconfiguration) | 🟢 `v0.20` | Set configuration parameters for the Wallet Provider. The paramaters will change depending on the Wallet Provider implementation |
+| [`signTransaction`](#method-signtransaction) | 🟢 `v0.20` | Uses the Wallet Provider to sign a transaction. This will likely be an asynchronous operation. |
+| [`subscribeTransactions`](#method-subscribetransactions) | 🟢 `v0.20` | Subscribe to updates for specific transactions. The server will emit updates when the status of the specified transactions have changed. On initial subscription, the server will emit the current status of all subscribed transactions. |
 
 ## Methods
 

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/user-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/user-api.mdx
@@ -25,32 +25,34 @@ An OpenRPC specification for the user to interact with the Wallet Gateway.
 | `0.23.1` | 22 | 0 | 0 | 0 |
 | `0.24.0` | 22 | 0 | 0 | 0 |
 
-## Method Diff Summary
+## Table of Contents
 
-| Method | Introduced | Changes | Removed |
-| --- | --- | --- | --- |
-| [`addIdp`](#method-addidp) | `0.20.0` | - | - |
-| [`addNetwork`](#method-addnetwork) | `0.20.0` | - | - |
-| [`addSession`](#method-addsession) | `0.20.0` | `0.23.0`: result updated (required fields) | - |
-| [`allocatePartyForWallet`](#method-allocatepartyforwallet) | `0.21.0` | - | - |
-| [`createWallet`](#method-createwallet) | `0.20.0` | `0.21.0`: description updated | - |
-| [`deleteTransaction`](#method-deletetransaction) | `0.20.0` | - | - |
-| [`execute`](#method-execute) | `0.20.0` | - | - |
-| [`getTransaction`](#method-gettransaction) | `0.20.0` | - | - |
-| [`getUser`](#method-getuser) | `0.20.0` | - | - |
-| [`isWalletSyncNeeded`](#method-iswalletsyncneeded) | `0.20.0` | - | - |
-| [`listIdps`](#method-listidps) | `0.20.0` | - | - |
-| [`listNetworks`](#method-listnetworks) | `0.20.0` | - | - |
-| [`listSessions`](#method-listsessions) | `0.20.0` | `0.23.0`: details updated | - |
-| [`listTransactions`](#method-listtransactions) | `0.20.0` | - | - |
-| [`listWallets`](#method-listwallets) | `0.20.0` | - | - |
-| [`removeIdp`](#method-removeidp) | `0.20.0` | - | - |
-| [`removeNetwork`](#method-removenetwork) | `0.20.0` | - | - |
-| [`removeSession`](#method-removesession) | `0.20.0` | - | - |
-| [`removeWallet`](#method-removewallet) | `0.20.0` | - | - |
-| [`setPrimaryWallet`](#method-setprimarywallet) | `0.20.0` | - | - |
-| [`sign`](#method-sign) | `0.20.0` | `0.22.0`: result updated (schema, required fields) | - |
-| [`syncWallets`](#method-syncwallets) | `0.20.0` | `0.21.0`: result updated (required fields) | - |
+🟢 Active Since  🔵 Changed  🔴 Removed
+
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`addIdp`](#method-addidp) | 🟢 `v0.20` | Adds a new identity provider. |
+| [`addNetwork`](#method-addnetwork) | 🟢 `v0.20` | Adds a new network configuration (similar to EIP-3085). |
+| [`addSession`](#method-addsession) | 🟢 `v0.20` 🔵 `v0.23` | Adds a network session. |
+| [`allocatePartyForWallet`](#method-allocatepartyforwallet) | 🟢 `v0.21` | Allocates a party for an already initialized wallet if external signing is complete. |
+| [`createWallet`](#method-createwallet) | 🟢 `v0.20` 🔵 `v0.21` | Creates a new wallet and party with the given hint. |
+| [`deleteTransaction`](#method-deletetransaction) | 🟢 `v0.20` | Deletes a pending transaction. Only transactions with status 'pending' can be deleted. |
+| [`execute`](#method-execute) | 🟢 `v0.20` | Executes a signed transaction. |
+| [`getTransaction`](#method-gettransaction) | 🟢 `v0.20` | - |
+| [`getUser`](#method-getuser) | 🟢 `v0.20` | Returns information about the current user, including whether they are an admin. |
+| [`isWalletSyncNeeded`](#method-iswalletsyncneeded) | 🟢 `v0.20` | Checks if wallet sync is needed (disabled wallets or new parties on ledger). |
+| [`listIdps`](#method-listidps) | 🟢 `v0.20` | - |
+| [`listNetworks`](#method-listnetworks) | 🟢 `v0.20` | - |
+| [`listSessions`](#method-listsessions) | 🟢 `v0.20` 🔵 `v0.23` | - |
+| [`listTransactions`](#method-listtransactions) | 🟢 `v0.20` | - |
+| [`listWallets`](#method-listwallets) | 🟢 `v0.20` | Lists wallets. |
+| [`removeIdp`](#method-removeidp) | 🟢 `v0.20` | Removes an identity provider. Fails if an existing network is using the identity provider. |
+| [`removeNetwork`](#method-removenetwork) | 🟢 `v0.20` | Removes a new network configuration (similar to EIP-3085). |
+| [`removeSession`](#method-removesession) | 🟢 `v0.20` | Removes the current network session. |
+| [`removeWallet`](#method-removewallet) | 🟢 `v0.20` | Removes a party with the given hint. |
+| [`setPrimaryWallet`](#method-setprimarywallet) | 🟢 `v0.20` | Sets the specified wallet as the primary wallet for dApp usage. |
+| [`sign`](#method-sign) | 🟢 `v0.20` 🔵 `v0.22` | Signs the provided data with the private key of the specified or active party. |
+| [`syncWallets`](#method-syncwallets) | 🟢 `v0.20` 🔵 `v0.21` | Synchronizes wallets with the connected network. |
 
 ## Methods
 

--- a/scripts/generate_canton_protobuf_history.py
+++ b/scripts/generate_canton_protobuf_history.py
@@ -18,7 +18,8 @@ DEFAULT_MANIFEST = REPO_ROOT / ".internal" / "generated" / "x2mdx" / "protobuf-h
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "docs-main" / "appdev" / "reference" / "protobuf-history"
 DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
 DEFAULT_REPO_DIR = DEFAULT_CACHE_DIR / "repos" / "canton"
-GROUP_LABEL = "Canton Protobuf History"
+X2MDX_REPO = REPO_ROOT.parent / "x2mdx"
+DEFAULT_OVERVIEW_TITLE = "Canton Protobuf History"
 DESCRIPTOR_IMAGE_NAME = ".proto_snapshot_image.bin.gz"
 STABLE_TAG_RE = re.compile(r"^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
 OWNED_PROTO_RE = re.compile(r"^community/.+/src/main/protobuf/.+\.proto$")
@@ -49,6 +50,10 @@ def parse_args() -> argparse.Namespace:
         "--version-filter",
         help="Version-filter label embedded in generated content.",
     )
+    parser.add_argument(
+        "--overview-title",
+        help="Title to use for the generated overview page.",
+    )
     return parser.parse_args()
 
 
@@ -57,6 +62,15 @@ def load_json(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError(f"Expected JSON object in {path}")
     return payload
+
+
+def resolve_overview_title(*, source_config: dict[str, Any], cli_value: str | None) -> str:
+    if cli_value:
+        return cli_value
+    configured = source_config.get("overview_title")
+    if isinstance(configured, str) and configured.strip():
+        return configured.strip()
+    return DEFAULT_OVERVIEW_TITLE
 
 
 def run(args: list[str], *, cwd: Path | None = None, capture: bool = False) -> str:
@@ -233,6 +247,8 @@ def update_docs_navigation(
     dropdown_label: str,
     parent_groups: list[str],
     overview_path: Path,
+    group_label: str,
+    group_labels: set[str],
 ) -> None:
     docs = load_json(docs_json_path)
     navigation = docs.get("navigation")
@@ -249,9 +265,9 @@ def update_docs_navigation(
         raise ValueError(f"Dropdown does not expose a pages list: {dropdown_label}")
 
     page_ref = docs_json_page_ref(overview_path, docs_json_path)
-    dropdown["pages"] = prune_nav_items(pages, page_refs={page_ref}, group_labels={GROUP_LABEL})
+    dropdown["pages"] = prune_nav_items(pages, page_refs={page_ref}, group_labels=group_labels)
     target_pages = ensure_group_path(dropdown["pages"], parent_groups)
-    target_pages.append({"group": GROUP_LABEL, "pages": [page_ref]})
+    target_pages.append({"group": group_label, "pages": [page_ref]})
     docs_json_path.write_text(json.dumps(docs, indent=2) + "\n", encoding="utf-8")
     print(f"Updated docs navigation: {docs_json_path}")
 
@@ -261,6 +277,7 @@ def write_manifest(
     source_config: dict[str, Any],
     releases: list[dict[str, Any]],
     manifest_path: Path,
+    overview_title: str,
 ) -> Path:
     metadata_path = source_config.get("metadata_path")
     metadata_ref: str | None = None
@@ -272,6 +289,7 @@ def write_manifest(
 
     manifest = {
         "source": source_config.get("source") or "Canton protobuf descriptor snapshots from local git tags",
+        "overview_title": overview_title,
         "repo": source_config.get("repo") if isinstance(source_config.get("repo"), dict) else {},
         "metadata_path": metadata_ref,
         "versions": releases,
@@ -285,6 +303,7 @@ def write_manifest(
 def main() -> int:
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
+    overview_title = resolve_overview_title(source_config=source_config, cli_value=args.overview_title)
     repo_config = source_config.get("repo") if isinstance(source_config.get("repo"), dict) else {}
     remote = repo_config.get("remote")
     if not isinstance(remote, str) or not remote:
@@ -336,6 +355,7 @@ def main() -> int:
         source_config=source_config,
         releases=releases,
         manifest_path=Path(args.manifest_out).resolve(),
+        overview_title=overview_title,
     )
 
     version_filter = args.version_filter
@@ -346,6 +366,9 @@ def main() -> int:
             version_filter = f"stable Canton release tags >= {min_version}"
 
     command = [
+        "direnv",
+        "exec",
+        str(X2MDX_REPO),
         "x2mdx",
         "protobuf",
         "build-api-pages-from-manifest",
@@ -368,6 +391,8 @@ def main() -> int:
         dropdown_label=args.nav_dropdown,
         parent_groups=args.nav_group or [],
         overview_path=Path(args.output_dir).resolve() / "index.mdx",
+        group_label=overview_title,
+        group_labels={DEFAULT_OVERVIEW_TITLE, overview_title},
     )
     return 0
 

--- a/scripts/generate_ledger_bindings_api_reference.py
+++ b/scripts/generate_ledger_bindings_api_reference.py
@@ -23,8 +23,10 @@ DEFAULT_RENDER_ROOT = REPO_ROOT / ".internal" / "generated" / "x2mdx" / "ledger-
 DEFAULT_OVERVIEW_FILE = REPO_ROOT / "docs-main" / "reference" / "ledger-api-jvm-bindings.mdx"
 DEFAULT_DETAILS_DIR = REPO_ROOT / "docs-main" / "reference"
 DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
+X2MDX_REPO = REPO_ROOT.parent / "x2mdx"
 LEGACY_OVERVIEW_FILE = REPO_ROOT / "docs-main" / "appdev" / "reference" / "ledger-bindings-api-lifecycle.mdx"
 LEGACY_DETAILS_DIR = REPO_ROOT / "docs-main" / "appdev" / "reference" / "ledger-bindings-api-lifecycle"
+DEFAULT_OVERVIEW_TITLE = "Ledger API JVM Bindings"
 LANGUAGE_LABELS = {
     "scala": "Scaladocs",
     "java": "Javadocs",
@@ -104,7 +106,6 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--overview-title",
-        default="Ledger API JVM Bindings",
         help="Title to use for the generated overview page and parent Mintlify nav group.",
     )
     parser.add_argument(
@@ -120,6 +121,15 @@ def load_json(path: Path) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"Expected JSON object in {path}")
     return data
+
+
+def resolve_overview_title(*, source_config: dict[str, Any], cli_value: str | None) -> str:
+    if cli_value:
+        return cli_value
+    configured = source_config.get("overview_title")
+    if isinstance(configured, str) and configured.strip():
+        return configured.strip()
+    return DEFAULT_OVERVIEW_TITLE
 
 
 def slugify(value: str) -> str:
@@ -244,6 +254,7 @@ def update_docs_navigation(
     dropdown_label: str,
     parent_groups: list[str],
     group_label: str,
+    group_labels: set[str],
     overview_file: Path,
     publish_root: Path,
 ) -> Path:
@@ -275,7 +286,7 @@ def update_docs_navigation(
     dropdown["pages"] = prune_nav_items(
         pages,
         page_refs=generated_refs,
-        group_labels={group_label},
+        group_labels=group_labels,
     )
     target_pages = ensure_group_path(dropdown["pages"], parent_groups)
     target_pages.append(jvm_group)
@@ -316,6 +327,7 @@ def build_manifest(
     include_versions: set[str] | None,
     repo_base_override: str | None,
     force_download: bool,
+    overview_title: str,
 ) -> Path:
     repo_base = repo_base_override or str(source_config.get("repo_base") or "https://repo1.maven.org/maven2")
     artifacts_payload: list[dict[str, Any]] = []
@@ -377,6 +389,7 @@ def build_manifest(
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest = {
         "source": source_config.get("source") or "digital-asset/docs local JVM docs cache",
+        "overview_title": overview_title,
         "repo_base": repo_base,
         "artifacts": artifacts_payload,
     }
@@ -389,6 +402,9 @@ def build_command(args: argparse.Namespace, manifest_path: Path) -> list[str]:
     render_overview_file = DEFAULT_RENDER_ROOT / "ledger-api-jvm-bindings.mdx"
     render_details_dir = DEFAULT_RENDER_ROOT / "details"
     command = [
+        "direnv",
+        "exec",
+        str(X2MDX_REPO),
         "x2mdx",
         "jvm-docs",
         "build-api-pages-from-manifest",
@@ -398,8 +414,6 @@ def build_command(args: argparse.Namespace, manifest_path: Path) -> list[str]:
         str(render_overview_file.resolve()),
         "--details-dir",
         str(render_details_dir.resolve()),
-        "--overview-title",
-        args.overview_title,
         "--source-name",
         args.source_name,
         "--version-filter",
@@ -492,6 +506,7 @@ def publish_rendered_pages(
 def main() -> int:
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
+    overview_title = resolve_overview_title(source_config=source_config, cli_value=args.overview_title)
     include_versions = set(args.version) if args.version else None
     manifest_path = build_manifest(
         source_config=source_config,
@@ -500,6 +515,7 @@ def main() -> int:
         include_versions=include_versions,
         repo_base_override=args.repo_base,
         force_download=args.force_download,
+        overview_title=overview_title,
     )
     command = build_command(args, manifest_path)
     print("Running:", " ".join(command))
@@ -516,7 +532,8 @@ def main() -> int:
         docs_json_path=Path(args.docs_json).resolve(),
         dropdown_label=args.nav_dropdown,
         parent_groups=args.nav_group or [],
-        group_label=args.overview_title,
+        group_label=overview_title,
+        group_labels={DEFAULT_OVERVIEW_TITLE, overview_title},
         overview_file=publish_overview_file.resolve(),
         publish_root=Path(args.details_dir).resolve(),
     )

--- a/scripts/generate_wallet_gateway_openrpc_reference.py
+++ b/scripts/generate_wallet_gateway_openrpc_reference.py
@@ -17,7 +17,8 @@ DEFAULT_MANIFEST = REPO_ROOT / ".internal" / "generated" / "x2mdx" / "wallet-gat
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "docs-main" / "reference" / "wallet-gateway-json-rpc"
 DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
 DEFAULT_REPO_DIR = DEFAULT_CACHE_DIR / "repos" / "splice-wallet-kernel"
-GROUP_LABEL = "Wallet Gateway JSON-RPC"
+X2MDX_REPO = REPO_ROOT.parent / "x2mdx"
+DEFAULT_OVERVIEW_TITLE = "Wallet Gateway JSON-RPC"
 SPEC_DIR_NAME = "specs"
 
 
@@ -46,7 +47,6 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--overview-title",
-        default=GROUP_LABEL,
         help="Title to use for the generated overview page.",
     )
     return parser.parse_args()
@@ -57,6 +57,15 @@ def load_json(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError(f"Expected JSON object in {path}")
     return payload
+
+
+def resolve_overview_title(*, source_config: dict[str, Any], cli_value: str | None) -> str:
+    if cli_value:
+        return cli_value
+    configured = source_config.get("overview_title")
+    if isinstance(configured, str) and configured.strip():
+        return configured.strip()
+    return DEFAULT_OVERVIEW_TITLE
 
 
 def run(args: list[str], *, cwd: Path | None = None, capture: bool = False) -> str:
@@ -160,6 +169,8 @@ def update_docs_navigation(
     dropdown_label: str,
     output_dir: Path,
     spec_entries: list[dict[str, Any]],
+    group_label: str,
+    group_labels: set[str],
 ) -> None:
     docs = load_json(docs_json_path)
     navigation = docs.get("navigation")
@@ -177,10 +188,10 @@ def update_docs_navigation(
 
     refs = {overview_page_ref(output_dir, docs_json_path)}
     refs.update(spec_page_ref(output_dir, docs_json_path, spec["spec_id"]) for spec in spec_entries)
-    dropdown["pages"] = prune_nav_items(pages, page_refs=refs, group_labels={GROUP_LABEL})
+    dropdown["pages"] = prune_nav_items(pages, page_refs=refs, group_labels=group_labels)
     dropdown["pages"].append(
         {
-            "group": GROUP_LABEL,
+            "group": group_label,
             "pages": [
                 overview_page_ref(output_dir, docs_json_path),
                 *[spec_page_ref(output_dir, docs_json_path, spec["spec_id"]) for spec in spec_entries],
@@ -200,6 +211,7 @@ def write_manifest(
     versions: list[str],
     publish_version: str,
     spec_entries: list[dict[str, Any]],
+    overview_title: str,
 ) -> Path:
     specs_payload: list[dict[str, Any]] = []
     for spec in spec_entries:
@@ -227,6 +239,7 @@ def write_manifest(
 
     manifest = {
         "source": source_config.get("source") or "splice-wallet-kernel OpenRPC snapshots",
+        "overview_title": overview_title,
         "publish_version": publish_version,
         "specs": specs_payload,
     }
@@ -239,6 +252,7 @@ def write_manifest(
 def main() -> int:
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
+    overview_title = resolve_overview_title(source_config=source_config, cli_value=args.overview_title)
     configured_versions = source_config.get("versions")
     if not isinstance(configured_versions, list) or not all(isinstance(item, str) for item in configured_versions):
         raise ValueError("Source config must define a string list under `versions`")
@@ -282,10 +296,14 @@ def main() -> int:
         versions=selected_versions,
         publish_version=publish_version,
         spec_entries=spec_entries,
+        overview_title=overview_title,
     )
 
     fixture_root = REPO_ROOT
     command = [
+        "direnv",
+        "exec",
+        str(X2MDX_REPO),
         "x2mdx",
         "openrpc",
         "build-api-pages-from-manifest",
@@ -297,8 +315,6 @@ def main() -> int:
         str(Path(args.output_dir).resolve()),
         "--publish-version",
         publish_version,
-        "--overview-title",
-        args.overview_title,
         "--link-prefix",
         overview_route_prefix(Path(args.output_dir).resolve(), Path(args.docs_json).resolve()),
         "--source-name",
@@ -318,6 +334,8 @@ def main() -> int:
         dropdown_label=args.nav_dropdown,
         output_dir=Path(args.output_dir).resolve(),
         spec_entries=spec_entries,
+        group_label=overview_title,
+        group_labels={DEFAULT_OVERVIEW_TITLE, overview_title},
     )
     return 0
 


### PR DESCRIPTION
## What changed
- moved the three affected collection titles to docs-owned `overview_title` values in the checked-in x2mdx source configs
- updated the docs-side generators to pass `overview_title` through the generated manifests and use the same resolved title for docs navigation labels
- regenerated the wallet OpenRPC, protobuf history, and ledger bindings pages so the visible titles now read `Wallet Kernel`, `Ledger API Protobuf`, and `Ledger API Java Bindings`
