### PR TITLE
Fix dark mode text highlight styling

### DIFF
--- a/docs-main/overview/understand/what-is-canton.mdx
+++ b/docs-main/overview/understand/what-is-canton.mdx
@@ -3,6 +3,8 @@ title: "What is Canton Network?"
 description: "Privacy-enabled blockchain for regulated assets and multi-party workflows"
 ---
 
+<!-- Mintlify preview rebuild marker for stylesheet-only dark-mode highlight fix. -->
+
 Canton Network is a public layer 1 blockchain designed for privacy-preserving transactions. Unlike traditional blockchains where all transactions are visible to all participants, Canton enables selective disclosure - parties see only the data they're entitled to see.
 
 ## The 60-Second Pitch

--- a/docs-main/overview/understand/what-is-canton.mdx
+++ b/docs-main/overview/understand/what-is-canton.mdx
@@ -3,7 +3,7 @@ title: "What is Canton Network?"
 description: "Privacy-enabled blockchain for regulated assets and multi-party workflows"
 ---
 
-<!-- Mintlify preview rebuild marker for stylesheet-only dark-mode highlight fix. -->
+{/* Mintlify preview rebuild marker for stylesheet-only dark-mode highlight fix. */}
 
 Canton Network is a public layer 1 blockchain designed for privacy-preserving transactions. Unlike traditional blockchains where all transactions are visible to all participants, Canton enables selective disclosure - parties see only the data they're entitled to see.
 

--- a/docs-main/styles.css
+++ b/docs-main/styles.css
@@ -18,17 +18,22 @@
   --canton-highlight-rgb: 115, 75, 226;
   --canton-selected-bg: rgba(115, 75, 226, 0.10);
   --canton-hover-bg: rgba(115, 75, 226, 0.05);
+  --canton-inline-highlight-bg: rgba(115, 75, 226, 0.14);
+  --canton-inline-highlight-border: rgba(115, 75, 226, 0.26);
 
   /* Typography */
   --canton-font-family: 'Inter', system-ui, -apple-system, sans-serif;
 }
 
-[data-theme="dark"] {
+[data-theme="dark"],
+:root.dark {
   /* Dark mode colors */
   --canton-highlight: #A985FF;
   --canton-highlight-rgb: 169, 133, 255;
   --canton-selected-bg: rgba(169, 133, 255, 0.10);
   --canton-hover-bg: rgba(169, 133, 255, 0.05);
+  --canton-inline-highlight-bg: rgba(169, 133, 255, 0.22);
+  --canton-inline-highlight-border: rgba(169, 133, 255, 0.34);
 }
 
 /* ============================================
@@ -44,6 +49,15 @@
 ::-moz-selection {
   background-color: var(--canton-selected-bg);
   color: inherit;
+}
+
+/* Inline text highlighting */
+mark {
+  background-color: var(--canton-inline-highlight-bg);
+  color: inherit;
+  border-radius: 0.25rem;
+  box-shadow: inset 0 0 0 1px var(--canton-inline-highlight-border);
+  padding: 0.08em 0.18em;
 }
 
 /* ============================================
@@ -195,7 +209,7 @@ table tbody tr:hover {
 /* Search result highlighting */
 [class*="search"] mark,
 [class*="search"] [class*="highlight"] {
-  background-color: var(--canton-selected-bg);
+  background-color: var(--canton-inline-highlight-bg);
   color: inherit;
 }
 


### PR DESCRIPTION
## What changed
- added explicit inline `<mark>` styling in `docs-main/styles.css`

<img width="770" height="238" alt="image" src="https://github.com/user-attachments/assets/06a8d776-5ee3-4afe-a712-2fe31be1e316" />
