### PR TITLE
[codex] Rename reference doc titles

### DIFF
--- a/docs-main/appdev/reference/protobuf-history/index.mdx
+++ b/docs-main/appdev/reference/protobuf-history/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Canton Protobuf History"
+title: "Ledger API Protobuf"
 description: "Descriptor-backed protobuf API history grouped by package."
 ---
 
-# Canton Protobuf History
+# Ledger API Protobuf
 
 This page is generated from local descriptor-image snapshots with source info.
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-admin.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-admin.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.daml.ledger
 
 # Package `com.daml.ledger.api.v2.admin`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.daml.ledger
 
 # Package `com.daml.ledger.api.v2.interactive.transaction.v1`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2-interactive.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.daml.ledger
 
 # Package `com.daml.ledger.api.v2.interactive`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-daml-ledger-api-v2.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.daml.ledger
 
 # Package `com.daml.ledger.api.v2`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-crypto-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-crypto-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.crypto.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-health-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-health-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.health.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-mediator-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-mediator-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.mediator.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-participant-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-participant-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.participant.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-pruning-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-pruning-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.pruning.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-sequencer-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-sequencer-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.sequencer.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-time-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-admin-time-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.admin.time.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-connection-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-connection-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.connection.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-crypto-admin-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-crypto-admin-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.crypto.admin.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-crypto-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-crypto-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.crypto.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-mediator-admin-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-mediator-admin-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.mediator.admin.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-participant-protocol-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-participant-protocol-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.participant.protocol.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-protocol-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-protocol-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.protocol.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-protocol-v31.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-protocol-v31.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.protocol.v31`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-sequencer-admin-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-sequencer-admin-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.sequencer.admin.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-sequencer-api-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-sequencer-api-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.sequencer.api.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-protocol-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-protocol-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.synchronizer.protocol.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-standalone-v1.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-standalone-v1.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.standalone.v1`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-sequencing-sequencer-bftordering-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.synchronizer.sequencing.sequencer.bftordering.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-synchronizer-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.synchronizer.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-time-admin-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-time-admin-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.time.admin.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-topology-admin-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-topology-admin-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.topology.admin.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-v30.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-v30.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.v30`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-version-v1.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/com-digitalasset-canton-version-v1.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package com.digitalasse
 
 # Package `com.digitalasset.canton.version.v1`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/appdev/reference/protobuf-history/packages/daml-platform-v1.mdx
+++ b/docs-main/appdev/reference/protobuf-history/packages/daml-platform-v1.mdx
@@ -5,7 +5,7 @@ description: "Descriptor-backed protobuf API history for package daml.platform.v
 
 # Package `daml.platform.v1`
 
-[Back to Canton Protobuf History](../index)
+[Back to Ledger API Protobuf](../index)
 
 ## Snapshot
 

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -888,7 +888,7 @@
             ]
           },
           {
-            "group": "Wallet Gateway JSON-RPC",
+            "group": "Wallet Kernel",
             "pages": [
               "reference/wallet-gateway-json-rpc/index",
               "reference/wallet-gateway-json-rpc/specs/dapp-api",
@@ -898,7 +898,7 @@
             ]
           },
           {
-            "group": "Ledger API JVM Bindings",
+            "group": "Ledger API Java Bindings",
             "pages": [
               "reference/ledger-api-jvm-bindings",
               {

--- a/docs-main/reference/ledger-api-jvm-bindings.mdx
+++ b/docs-main/reference/ledger-api-jvm-bindings.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Ledger API JVM Bindings"
+title: "Ledger API Java Bindings"
 description: "Generated lifecycle timeline and reference pages for Javadoc/Scaladoc artifacts"
 ---
 

--- a/docs-main/reference/wallet-gateway-json-rpc/index.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Wallet Gateway JSON-RPC"
+title: "Wallet Kernel"
 description: "Versioned OpenRPC reference docs."
 ---
 
-# Wallet Gateway JSON-RPC
+# Wallet Kernel
 
 Generated from versioned OpenRPC snapshots.
 


### PR DESCRIPTION
## What changed
- renamed the wallet OpenRPC overview from `Wallet Gateway JSON-RPC` to `Wallet Kernel`
- renamed the protobuf overview from `Canton Protobuf History` to `Ledger API Protobuf`
- renamed the JVM overview from `Ledger API JVM Bindings` to `Ledger API Java Bindings`
- updated the protobuf package backlinks and the existing docs nav labels to match

## Why
This PR is the docs-only rename pass against `main`.

## Validation
- reviewed the generated docs diff locally

## Notes
- supersedes #199, which was stacked on `x2mdx/openrpc-wallet-gateway`
- this branch intentionally excludes the docs-generator and manifest plumbing work
