### PR TITLE
Add gRPC Ledger API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,30 @@ By default this writes:
 
 The generated nav is added under the top-level `API Reference` dropdown as `Canton Protobuf History`, with only the overview page listed in nav. The per-endpoint pages are generated and linked from the overview page but left unlisted.
 
+### Generate the gRPC Ledger API reference
+
+This repo also includes a checked-in source config for the Ledger API gRPC protobuf surface at `config/x2mdx/grpc-ledger-api-reference/source-artifacts.json`.
+The generator script reuses the published Canton release-bundle protobuf acquisition flow, filters the resulting protobuf report to `com.daml.ledger.api.v2*`, and writes a dedicated Ledger API-only MDX surface without modifying `x2mdx`.
+
+Run:
+
+```bash
+python3 scripts/generate_grpc_ledger_api_reference.py
+```
+
+or:
+
+```bash
+npm run generate:grpc-ledger-api-reference
+```
+
+By default this writes:
+
+- `docs-main/reference/grpc-ledger-api-reference/`
+- `docs-main/docs.json`
+
+The generated nav is added under the top-level `Reference` dropdown as `gRPC Ledger API Reference`, with the overview page first and the generated package pages grouped under a nested `Packages` foldout.
+
 ### Generate the TypeScript bindings reference
 
 This repo also includes a checked-in source config for published `@daml/types` npm artifacts at `config/x2mdx/typescript-bindings/source-artifacts.json`.

--- a/config/x2mdx/grpc-ledger-api-reference/source-artifacts.json
+++ b/config/x2mdx/grpc-ledger-api-reference/source-artifacts.json
@@ -1,0 +1,14 @@
+{
+  "source": "Canton protobuf trees from published release bundles",
+  "release_url_template": "https://www.canton.io/releases/canton-open-source-{version}.tar.gz",
+  "bundle_proto_dir": "protobuf",
+  "repo": {
+    "remote": "https://github.com/DACH-NY/canton.git",
+    "web_url": "https://github.com/DACH-NY/canton"
+  },
+  "min_version": "3.4.4",
+  "metadata_path": "config/x2mdx/protobuf-history/metadata.json",
+  "package_prefixes": [
+    "com.daml.ledger.api.v2"
+  ]
+}

--- a/docs-main/appdev/reference/ledger-api-reference.mdx
+++ b/docs-main/appdev/reference/ledger-api-reference.mdx
@@ -7,3 +7,4 @@ Content coming soon.
 
 For Ledger API endpoint references, see the [JSON API](/reference/json-api-reference) and the [JSON API AsyncAPI Reference](/reference/json-api-asyncapi-reference).
 For generated interface references, see the [Canton Protobuf Reference](/reference/protobuf) and the [Ledger API JVM Bindings](/reference/ledger-api-jvm-bindings).
+Generated package references live under API Reference so the endpoint and interface docs stay in one place.

--- a/docs-main/appdev/reference/ledger-api-reference.mdx
+++ b/docs-main/appdev/reference/ledger-api-reference.mdx
@@ -6,5 +6,5 @@ description: "Reference documentation for the Ledger API"
 Content coming soon.
 
 For Ledger API endpoint references, see the [JSON API](/reference/json-api-reference) and the [JSON API AsyncAPI Reference](/reference/json-api-asyncapi-reference).
-For generated interface references, see the [Canton Protobuf Reference](/reference/protobuf) and the [Ledger API JVM Bindings](/reference/ledger-api-jvm-bindings).
+For generated interface references, see the [gRPC Ledger API Reference](/reference/grpc-ledger-api-reference), the [Canton Protobuf Reference](/reference/protobuf), and the [Ledger API JVM Bindings](/reference/ledger-api-jvm-bindings).
 Generated package references live under API Reference so the endpoint and interface docs stay in one place.

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -829,6 +829,22 @@
             ]
           },
           {
+            "group": "gRPC Ledger API Reference",
+            "pages": [
+              "reference/grpc-ledger-api-reference/index",
+              {
+                "group": "Packages",
+                "pages": [
+                  "reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2",
+                  "reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-admin",
+                  "reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive",
+                  "reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-testing",
+                  "reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive-transaction-v1"
+                ]
+              }
+            ]
+          },
+          {
             "group": "Canton Protobuf",
             "pages": [
               "reference/protobuf/index"

--- a/docs-main/reference/grpc-ledger-api-reference/index.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/index.mdx
@@ -1,0 +1,68 @@
+---
+title: "gRPC Ledger API Reference"
+description: "Generated Ledger API gRPC reference grouped by package."
+---
+
+# gRPC Ledger API Reference
+
+This page is generated from published Canton protobuf release bundles and filtered to the Ledger API gRPC packages.
+
+## Source
+
+- Source name: `Canton Ledger API protobuf release bundles`
+- Version filter: `stable Canton release bundles >= 3.4.4`
+- Latest release: `v3.4.11`
+- Source repo: `https://github.com/DACH-NY/canton.git`
+- Generated at: `2026-04-17T18:38:50.640552+00:00`
+
+## Latest Snapshot
+
+- Packages: `5`
+- Services: `17`
+- Endpoints: `56`
+- Messages: `229`
+- Enums: `12`
+
+## Table of Contents
+
+🟢 Active Since  🔵 Changed  🔴 Removed
+
+| NAME | STATUS | SUMMARY |
+| --- | --- | --- |
+| [`com.daml.ledger.api.v2`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2) | 🟢 `v3.4` | 9 services, 20 endpoints, 115 messages, 8 enums |
+| [`com.daml.ledger.api.v2.admin`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-admin) | 🟢 `v3.4` | 6 services, 28 endpoints, 78 messages, 3 enums |
+| [`com.daml.ledger.api.v2.interactive`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive) | 🟢 `v3.4` | 1 services, 6 endpoints, 28 messages, 1 enums |
+| [`com.daml.ledger.api.v2.testing`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-testing) | 🟢 `v3.4` | 1 services, 2 endpoints, 3 messages |
+| [`com.daml.ledger.api.v2.interactive.transaction.v1`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive-transaction-v1) | - | 0 services, 0 endpoints, 5 messages |
+
+## Release Summary
+
+| Version | Endpoints +/~/- | Messages +/~/- | Enums +/~/- | Files +/~/- |
+| --- | --- | --- | --- | --- |
+| `3.4.4` | `55/0/0` | `227/0/0` | `12/0/0` | `33/0/0` |
+| `3.4.5` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.6` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.7` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.8` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.9` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
+| `3.4.10` | `0/0/0` | `0/1/0` | `0/0/0` | `0/1/0` |
+| `3.4.11` | `1/0/0` | `2/0/0` | `0/0/0` | `1/0/0` |
+
+## Reference
+
+Packages are grouped by API area. Each package page contains its services, endpoint history, and shared type reference.
+
+### Ledger API
+
+| Package | Services | Endpoints | Messages | Enums |
+| --- | --- | --- | --- | --- |
+| [`com.daml.ledger.api.v2`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2) | `9` | `20` | `115` | `8` |
+| [`com.daml.ledger.api.v2.admin`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-admin) | `6` | `28` | `78` | `3` |
+| [`com.daml.ledger.api.v2.interactive`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive) | `1` | `6` | `28` | `1` |
+| [`com.daml.ledger.api.v2.testing`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-testing) | `1` | `2` | `3` | `0` |
+
+### Schema Packages
+
+| Package | Services | Endpoints | Messages | Enums |
+| --- | --- | --- | --- | --- |
+| [`com.daml.ledger.api.v2.interactive.transaction.v1`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive-transaction-v1) | `0` | `0` | `5` | `0` |

--- a/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-admin.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-admin.mdx
@@ -1,0 +1,2019 @@
+---
+title: "com.daml.ledger.api.v2.admin"
+description: "Descriptor-backed protobuf API history for package com.daml.ledger.api.v2.admin."
+---
+
+# Package `com.daml.ledger.api.v2.admin`
+
+[Back to gRPC Ledger API Reference](../index)
+
+## Snapshot
+
+- Current files: `7`
+- Current services: `6`
+- Current endpoints: `28`
+- Current messages: `78`
+- Current enums: `3`
+- Lifecycle endpoints tracked: `28`
+
+## Source Files
+
+| File | Services | Messages | Enums | Source |
+| --- | --- | --- | --- | --- |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto | `1` | `6` | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto | `1` | `11` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto | `0` | `1` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto | `1` | `11` | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto | `1` | `2` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto | `1` | `17` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto | `1` | `20` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
+
+## Services
+
+| Service | Endpoints | Source | Description |
+| --- | --- | --- | --- |
+| [`CommandInspectionService`](#service-com-daml-ledger-api-v2-admin-commandinspectionservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto) |  |
+| [`IdentityProviderConfigService`](#service-com-daml-ledger-api-v2-admin-identityproviderconfigservice) | `5` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |  |
+| [`PackageManagementService`](#service-com-daml-ledger-api-v2-admin-packagemanagementservice) | `4` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |  |
+| [`ParticipantPruningService`](#service-com-daml-ledger-api-v2-admin-participantpruningservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto) |  |
+| [`PartyManagementService`](#service-com-daml-ledger-api-v2-admin-partymanagementservice) | `8` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |  |
+| [`UserManagementService`](#service-com-daml-ledger-api-v2-admin-usermanagementservice) | `9` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |  |
+
+<a id="service-com-daml-ledger-api-v2-admin-commandinspectionservice"></a>
+### Service `CommandInspectionService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
+- Endpoints tracked: `1`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`GetCommandStatus`](#endpoint-com-daml-ledger-api-v2-admin-commandinspectionservice-getcommandstatus) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GetCommandStatusRequest`](#type-com-daml-ledger-api-v2-admin-getcommandstatusrequest) | [`com.daml.ledger.api.v2.admin.GetCommandStatusResponse`](#type-com-daml-ledger-api-v2-admin-getcommandstatusresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-commandinspectionservice-getcommandstatus"></a>
+**Endpoint `CommandInspectionService.GetCommandStatus`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
+
+**Signature**
+
+```protobuf
+rpc CommandInspectionService.GetCommandStatus(com.daml.ledger.api.v2.admin.GetCommandStatusRequest) returns (com.daml.ledger.api.v2.admin.GetCommandStatusResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.GetCommandStatusRequest`](#type-com-daml-ledger-api-v2-admin-getcommandstatusrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.GetCommandStatusResponse`](#type-com-daml-ledger-api-v2-admin-getcommandstatusresponse)
+
+<a id="service-com-daml-ledger-api-v2-admin-identityproviderconfigservice"></a>
+### Service `IdentityProviderConfigService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Endpoints tracked: `5`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`CreateIdentityProviderConfig`](#endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-createidentityproviderconfig) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest) | [`com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
+| [`DeleteIdentityProviderConfig`](#endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-deleteidentityproviderconfig) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest) | [`com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
+| [`GetIdentityProviderConfig`](#endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-getidentityproviderconfig) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest) | [`com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
+| [`ListIdentityProviderConfigs`](#endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-listidentityproviderconfigs) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest`](#type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest) | [`com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse`](#type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
+| [`UpdateIdentityProviderConfig`](#endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-updateidentityproviderconfig) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest) | [`com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-createidentityproviderconfig"></a>
+**Endpoint `IdentityProviderConfigService.CreateIdentityProviderConfig`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+
+**Signature**
+
+```protobuf
+rpc IdentityProviderConfigService.CreateIdentityProviderConfig(com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-deleteidentityproviderconfig"></a>
+**Endpoint `IdentityProviderConfigService.DeleteIdentityProviderConfig`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+
+**Signature**
+
+```protobuf
+rpc IdentityProviderConfigService.DeleteIdentityProviderConfig(com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-getidentityproviderconfig"></a>
+**Endpoint `IdentityProviderConfigService.GetIdentityProviderConfig`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+
+**Signature**
+
+```protobuf
+rpc IdentityProviderConfigService.GetIdentityProviderConfig(com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-listidentityproviderconfigs"></a>
+**Endpoint `IdentityProviderConfigService.ListIdentityProviderConfigs`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+
+**Signature**
+
+```protobuf
+rpc IdentityProviderConfigService.ListIdentityProviderConfigs(com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest) returns (com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest`](#type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse`](#type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-updateidentityproviderconfig"></a>
+**Endpoint `IdentityProviderConfigService.UpdateIdentityProviderConfig`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+
+**Signature**
+
+```protobuf
+rpc IdentityProviderConfigService.UpdateIdentityProviderConfig(com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse)
+
+<a id="service-com-daml-ledger-api-v2-admin-packagemanagementservice"></a>
+### Service `PackageManagementService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Endpoints tracked: `4`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`ListKnownPackages`](#endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-listknownpackages) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ListKnownPackagesRequest`](#type-com-daml-ledger-api-v2-admin-listknownpackagesrequest) | [`com.daml.ledger.api.v2.admin.ListKnownPackagesResponse`](#type-com-daml-ledger-api-v2-admin-listknownpackagesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |
+| [`UpdateVettedPackages`](#endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-updatevettedpackages) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest`](#type-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest) | [`com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse`](#type-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |
+| [`UploadDarFile`](#endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-uploaddarfile) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UploadDarFileRequest`](#type-com-daml-ledger-api-v2-admin-uploaddarfilerequest) | [`com.daml.ledger.api.v2.admin.UploadDarFileResponse`](#type-com-daml-ledger-api-v2-admin-uploaddarfileresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |
+| [`ValidateDarFile`](#endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-validatedarfile) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ValidateDarFileRequest`](#type-com-daml-ledger-api-v2-admin-validatedarfilerequest) | [`com.daml.ledger.api.v2.admin.ValidateDarFileResponse`](#type-com-daml-ledger-api-v2-admin-validatedarfileresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-listknownpackages"></a>
+**Endpoint `PackageManagementService.ListKnownPackages`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PackageManagementService.ListKnownPackages(com.daml.ledger.api.v2.admin.ListKnownPackagesRequest) returns (com.daml.ledger.api.v2.admin.ListKnownPackagesResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.ListKnownPackagesRequest`](#type-com-daml-ledger-api-v2-admin-listknownpackagesrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.ListKnownPackagesResponse`](#type-com-daml-ledger-api-v2-admin-listknownpackagesresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-updatevettedpackages"></a>
+**Endpoint `PackageManagementService.UpdateVettedPackages`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PackageManagementService.UpdateVettedPackages(com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest) returns (com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest`](#type-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse`](#type-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-uploaddarfile"></a>
+**Endpoint `PackageManagementService.UploadDarFile`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PackageManagementService.UploadDarFile(com.daml.ledger.api.v2.admin.UploadDarFileRequest) returns (com.daml.ledger.api.v2.admin.UploadDarFileResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.UploadDarFileRequest`](#type-com-daml-ledger-api-v2-admin-uploaddarfilerequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.UploadDarFileResponse`](#type-com-daml-ledger-api-v2-admin-uploaddarfileresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-validatedarfile"></a>
+**Endpoint `PackageManagementService.ValidateDarFile`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PackageManagementService.ValidateDarFile(com.daml.ledger.api.v2.admin.ValidateDarFileRequest) returns (com.daml.ledger.api.v2.admin.ValidateDarFileResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.ValidateDarFileRequest`](#type-com-daml-ledger-api-v2-admin-validatedarfilerequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.ValidateDarFileResponse`](#type-com-daml-ledger-api-v2-admin-validatedarfileresponse)
+
+<a id="service-com-daml-ledger-api-v2-admin-participantpruningservice"></a>
+### Service `ParticipantPruningService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto)
+- Endpoints tracked: `1`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Prune`](#endpoint-com-daml-ledger-api-v2-admin-participantpruningservice-prune) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.PruneRequest`](#type-com-daml-ledger-api-v2-admin-prunerequest) | [`com.daml.ledger.api.v2.admin.PruneResponse`](#type-com-daml-ledger-api-v2-admin-pruneresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-participantpruningservice-prune"></a>
+**Endpoint `ParticipantPruningService.Prune`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto)
+
+**Signature**
+
+```protobuf
+rpc ParticipantPruningService.Prune(com.daml.ledger.api.v2.admin.PruneRequest) returns (com.daml.ledger.api.v2.admin.PruneResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.PruneRequest`](#type-com-daml-ledger-api-v2-admin-prunerequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.PruneResponse`](#type-com-daml-ledger-api-v2-admin-pruneresponse)
+
+<a id="service-com-daml-ledger-api-v2-admin-partymanagementservice"></a>
+### Service `PartyManagementService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Endpoints tracked: `8`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`AllocateExternalParty`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-allocateexternalparty) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest`](#type-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest) | [`com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse`](#type-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
+| [`AllocateParty`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-allocateparty) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.AllocatePartyRequest`](#type-com-daml-ledger-api-v2-admin-allocatepartyrequest) | [`com.daml.ledger.api.v2.admin.AllocatePartyResponse`](#type-com-daml-ledger-api-v2-admin-allocatepartyresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
+| [`GenerateExternalPartyTopology`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-generateexternalpartytopology) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest`](#type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest) | [`com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse`](#type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
+| [`GetParticipantId`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-getparticipantid) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GetParticipantIdRequest`](#type-com-daml-ledger-api-v2-admin-getparticipantidrequest) | [`com.daml.ledger.api.v2.admin.GetParticipantIdResponse`](#type-com-daml-ledger-api-v2-admin-getparticipantidresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
+| [`GetParties`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-getparties) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GetPartiesRequest`](#type-com-daml-ledger-api-v2-admin-getpartiesrequest) | [`com.daml.ledger.api.v2.admin.GetPartiesResponse`](#type-com-daml-ledger-api-v2-admin-getpartiesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
+| [`ListKnownParties`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-listknownparties) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ListKnownPartiesRequest`](#type-com-daml-ledger-api-v2-admin-listknownpartiesrequest) | [`com.daml.ledger.api.v2.admin.ListKnownPartiesResponse`](#type-com-daml-ledger-api-v2-admin-listknownpartiesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
+| [`UpdatePartyDetails`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-updatepartydetails) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest`](#type-com-daml-ledger-api-v2-admin-updatepartydetailsrequest) | [`com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse`](#type-com-daml-ledger-api-v2-admin-updatepartydetailsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
+| [`UpdatePartyIdentityProviderId`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-updatepartyidentityproviderid) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest`](#type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest) | [`com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse`](#type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-allocateexternalparty"></a>
+**Endpoint `PartyManagementService.AllocateExternalParty`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PartyManagementService.AllocateExternalParty(com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest) returns (com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest`](#type-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse`](#type-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-allocateparty"></a>
+**Endpoint `PartyManagementService.AllocateParty`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PartyManagementService.AllocateParty(com.daml.ledger.api.v2.admin.AllocatePartyRequest) returns (com.daml.ledger.api.v2.admin.AllocatePartyResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.AllocatePartyRequest`](#type-com-daml-ledger-api-v2-admin-allocatepartyrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.AllocatePartyResponse`](#type-com-daml-ledger-api-v2-admin-allocatepartyresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-generateexternalpartytopology"></a>
+**Endpoint `PartyManagementService.GenerateExternalPartyTopology`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PartyManagementService.GenerateExternalPartyTopology(com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest) returns (com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest`](#type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse`](#type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-getparticipantid"></a>
+**Endpoint `PartyManagementService.GetParticipantId`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PartyManagementService.GetParticipantId(com.daml.ledger.api.v2.admin.GetParticipantIdRequest) returns (com.daml.ledger.api.v2.admin.GetParticipantIdResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.GetParticipantIdRequest`](#type-com-daml-ledger-api-v2-admin-getparticipantidrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.GetParticipantIdResponse`](#type-com-daml-ledger-api-v2-admin-getparticipantidresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-getparties"></a>
+**Endpoint `PartyManagementService.GetParties`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PartyManagementService.GetParties(com.daml.ledger.api.v2.admin.GetPartiesRequest) returns (com.daml.ledger.api.v2.admin.GetPartiesResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.GetPartiesRequest`](#type-com-daml-ledger-api-v2-admin-getpartiesrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.GetPartiesResponse`](#type-com-daml-ledger-api-v2-admin-getpartiesresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-listknownparties"></a>
+**Endpoint `PartyManagementService.ListKnownParties`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PartyManagementService.ListKnownParties(com.daml.ledger.api.v2.admin.ListKnownPartiesRequest) returns (com.daml.ledger.api.v2.admin.ListKnownPartiesResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.ListKnownPartiesRequest`](#type-com-daml-ledger-api-v2-admin-listknownpartiesrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.ListKnownPartiesResponse`](#type-com-daml-ledger-api-v2-admin-listknownpartiesresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-updatepartydetails"></a>
+**Endpoint `PartyManagementService.UpdatePartyDetails`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PartyManagementService.UpdatePartyDetails(com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest) returns (com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest`](#type-com-daml-ledger-api-v2-admin-updatepartydetailsrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse`](#type-com-daml-ledger-api-v2-admin-updatepartydetailsresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-updatepartyidentityproviderid"></a>
+**Endpoint `PartyManagementService.UpdatePartyIdentityProviderId`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PartyManagementService.UpdatePartyIdentityProviderId(com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest) returns (com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest`](#type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse`](#type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse)
+
+<a id="service-com-daml-ledger-api-v2-admin-usermanagementservice"></a>
+### Service `UserManagementService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Endpoints tracked: `9`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`CreateUser`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-createuser) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.CreateUserRequest`](#type-com-daml-ledger-api-v2-admin-createuserrequest) | [`com.daml.ledger.api.v2.admin.CreateUserResponse`](#type-com-daml-ledger-api-v2-admin-createuserresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
+| [`DeleteUser`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-deleteuser) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.DeleteUserRequest`](#type-com-daml-ledger-api-v2-admin-deleteuserrequest) | [`com.daml.ledger.api.v2.admin.DeleteUserResponse`](#type-com-daml-ledger-api-v2-admin-deleteuserresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
+| [`GetUser`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-getuser) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GetUserRequest`](#type-com-daml-ledger-api-v2-admin-getuserrequest) | [`com.daml.ledger.api.v2.admin.GetUserResponse`](#type-com-daml-ledger-api-v2-admin-getuserresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
+| [`GrantUserRights`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-grantuserrights) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GrantUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-grantuserrightsrequest) | [`com.daml.ledger.api.v2.admin.GrantUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-grantuserrightsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
+| [`ListUserRights`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-listuserrights) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ListUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-listuserrightsrequest) | [`com.daml.ledger.api.v2.admin.ListUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-listuserrightsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
+| [`ListUsers`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-listusers) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ListUsersRequest`](#type-com-daml-ledger-api-v2-admin-listusersrequest) | [`com.daml.ledger.api.v2.admin.ListUsersResponse`](#type-com-daml-ledger-api-v2-admin-listusersresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
+| [`RevokeUserRights`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-revokeuserrights) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.RevokeUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-revokeuserrightsrequest) | [`com.daml.ledger.api.v2.admin.RevokeUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-revokeuserrightsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
+| [`UpdateUser`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-updateuser) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdateUserRequest`](#type-com-daml-ledger-api-v2-admin-updateuserrequest) | [`com.daml.ledger.api.v2.admin.UpdateUserResponse`](#type-com-daml-ledger-api-v2-admin-updateuserresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
+| [`UpdateUserIdentityProviderId`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-updateuseridentityproviderid) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest`](#type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest) | [`com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse`](#type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-createuser"></a>
+**Endpoint `UserManagementService.CreateUser`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UserManagementService.CreateUser(com.daml.ledger.api.v2.admin.CreateUserRequest) returns (com.daml.ledger.api.v2.admin.CreateUserResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.CreateUserRequest`](#type-com-daml-ledger-api-v2-admin-createuserrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.CreateUserResponse`](#type-com-daml-ledger-api-v2-admin-createuserresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-deleteuser"></a>
+**Endpoint `UserManagementService.DeleteUser`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UserManagementService.DeleteUser(com.daml.ledger.api.v2.admin.DeleteUserRequest) returns (com.daml.ledger.api.v2.admin.DeleteUserResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.DeleteUserRequest`](#type-com-daml-ledger-api-v2-admin-deleteuserrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.DeleteUserResponse`](#type-com-daml-ledger-api-v2-admin-deleteuserresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-getuser"></a>
+**Endpoint `UserManagementService.GetUser`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UserManagementService.GetUser(com.daml.ledger.api.v2.admin.GetUserRequest) returns (com.daml.ledger.api.v2.admin.GetUserResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.GetUserRequest`](#type-com-daml-ledger-api-v2-admin-getuserrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.GetUserResponse`](#type-com-daml-ledger-api-v2-admin-getuserresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-grantuserrights"></a>
+**Endpoint `UserManagementService.GrantUserRights`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UserManagementService.GrantUserRights(com.daml.ledger.api.v2.admin.GrantUserRightsRequest) returns (com.daml.ledger.api.v2.admin.GrantUserRightsResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.GrantUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-grantuserrightsrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.GrantUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-grantuserrightsresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-listuserrights"></a>
+**Endpoint `UserManagementService.ListUserRights`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UserManagementService.ListUserRights(com.daml.ledger.api.v2.admin.ListUserRightsRequest) returns (com.daml.ledger.api.v2.admin.ListUserRightsResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.ListUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-listuserrightsrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.ListUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-listuserrightsresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-listusers"></a>
+**Endpoint `UserManagementService.ListUsers`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UserManagementService.ListUsers(com.daml.ledger.api.v2.admin.ListUsersRequest) returns (com.daml.ledger.api.v2.admin.ListUsersResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.ListUsersRequest`](#type-com-daml-ledger-api-v2-admin-listusersrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.ListUsersResponse`](#type-com-daml-ledger-api-v2-admin-listusersresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-revokeuserrights"></a>
+**Endpoint `UserManagementService.RevokeUserRights`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UserManagementService.RevokeUserRights(com.daml.ledger.api.v2.admin.RevokeUserRightsRequest) returns (com.daml.ledger.api.v2.admin.RevokeUserRightsResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.RevokeUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-revokeuserrightsrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.RevokeUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-revokeuserrightsresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-updateuser"></a>
+**Endpoint `UserManagementService.UpdateUser`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UserManagementService.UpdateUser(com.daml.ledger.api.v2.admin.UpdateUserRequest) returns (com.daml.ledger.api.v2.admin.UpdateUserResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdateUserRequest`](#type-com-daml-ledger-api-v2-admin-updateuserrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdateUserResponse`](#type-com-daml-ledger-api-v2-admin-updateuserresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-updateuseridentityproviderid"></a>
+**Endpoint `UserManagementService.UpdateUserIdentityProviderId`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UserManagementService.UpdateUserIdentityProviderId(com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest) returns (com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest`](#type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse`](#type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse)
+
+## Type Reference
+
+<a id="type-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| synchronizer | `string` | optional |  |
+| onboarding_transactions | [`com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest.SignedTransaction`](#type-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest-signedtransaction) | repeated |  |
+| multi_hash_signatures | [`com.daml.ledger.api.v2.Signature`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-signature) | repeated |  |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest-signedtransaction"></a>
+**Message `com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest.SignedTransaction`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| transaction | `bytes` | optional |  |
+| signatures | [`com.daml.ledger.api.v2.Signature`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-signature) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-allocatepartyrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.AllocatePartyRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 5
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party_id_hint | `string` | optional |  |
+| local_metadata | [`com.daml.ledger.api.v2.admin.ObjectMeta`](#type-com-daml-ledger-api-v2-admin-objectmeta) | optional |  |
+| identity_provider_id | `string` | optional |  |
+| synchronizer_id | `string` | optional |  |
+| user_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-allocatepartyresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.AllocatePartyResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party_details | [`com.daml.ledger.api.v2.admin.PartyDetails`](#type-com-daml-ledger-api-v2-admin-partydetails) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-commandstatus"></a>
+**Message `com.daml.ledger.api.v2.admin.CommandStatus`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
+- Fields: 7
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| started | `google.protobuf.Timestamp` | optional |  |
+| completed | `google.protobuf.Timestamp` | optional |  |
+| completion | [`com.daml.ledger.api.v2.Completion`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-completion) | optional |  |
+| state | [`com.daml.ledger.api.v2.admin.CommandState`](#type-com-daml-ledger-api-v2-admin-commandstate) | optional |  |
+| commands | [`com.daml.ledger.api.v2.Command`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-command) | repeated |  |
+| request_statistics | [`com.daml.ledger.api.v2.admin.RequestStatistics`](#type-com-daml-ledger-api-v2-admin-requeststatistics) | optional |  |
+| updates | [`com.daml.ledger.api.v2.admin.CommandUpdates`](#type-com-daml-ledger-api-v2-admin-commandupdates) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-commandupdates"></a>
+**Message `com.daml.ledger.api.v2.admin.CommandUpdates`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
+- Fields: 5
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| created | [`com.daml.ledger.api.v2.admin.Contract`](#type-com-daml-ledger-api-v2-admin-contract) | repeated |  |
+| archived | [`com.daml.ledger.api.v2.admin.Contract`](#type-com-daml-ledger-api-v2-admin-contract) | repeated |  |
+| exercised | `uint32` | optional |  |
+| fetched | `uint32` | optional |  |
+| looked_up_by_key | `uint32` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-contract"></a>
+**Message `com.daml.ledger.api.v2.admin.Contract`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| contract_id | `string` | optional |  |
+| contract_key | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| identity_provider_config | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| identity_provider_config | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-createuserrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.CreateUserRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | optional |  |
+| rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-createuserresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.CreateUserResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-deleteuserrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.DeleteUserRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user_id | `string` | optional |  |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-deleteuserresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.DeleteUserResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 7
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| synchronizer | `string` | optional |  |
+| party_hint | `string` | optional |  |
+| public_key | [`com.daml.ledger.api.v2.SigningPublicKey`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-signingpublickey) | optional |  |
+| local_participant_observation_only | `bool` | optional |  |
+| other_confirming_participant_uids | `string` | repeated |  |
+| confirmation_threshold | `uint32` | optional |  |
+| observing_participant_uids | `string` | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party_id | `string` | optional |  |
+| public_key_fingerprint | `string` | optional |  |
+| topology_transactions | `bytes` | repeated |  |
+| multi_hash | `bytes` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-getcommandstatusrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.GetCommandStatusRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| command_id_prefix | `string` | optional |  |
+| state | [`com.daml.ledger.api.v2.admin.CommandState`](#type-com-daml-ledger-api-v2-admin-commandstate) | optional |  |
+| limit | `uint32` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-getcommandstatusresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.GetCommandStatusResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| command_status | [`com.daml.ledger.api.v2.admin.CommandStatus`](#type-com-daml-ledger-api-v2-admin-commandstatus) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| identity_provider_config | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-getparticipantidrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.GetParticipantIdRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-getparticipantidresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.GetParticipantIdResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| participant_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-getpartiesrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.GetPartiesRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| parties | `string` | repeated |  |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-getpartiesresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.GetPartiesResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party_details | [`com.daml.ledger.api.v2.admin.PartyDetails`](#type-com-daml-ledger-api-v2-admin-partydetails) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-getuserrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.GetUserRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user_id | `string` | optional |  |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-getuserresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.GetUserResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-grantuserrightsrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.GrantUserRightsRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user_id | `string` | optional |  |
+| rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-grantuserrightsresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.GrantUserRightsResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| newly_granted_rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-identityproviderconfig"></a>
+**Message `com.daml.ledger.api.v2.admin.IdentityProviderConfig`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Fields: 5
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| identity_provider_id | `string` | optional |  |
+| is_deactivated | `bool` | optional |  |
+| issuer | `string` | optional |  |
+| jwks_url | `string` | optional |  |
+| audience | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| identity_provider_configs | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-listknownpackagesrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.ListKnownPackagesRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-listknownpackagesresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.ListKnownPackagesResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_details | [`com.daml.ledger.api.v2.admin.PackageDetails`](#type-com-daml-ledger-api-v2-admin-packagedetails) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-listknownpartiesrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.ListKnownPartiesRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| page_token | `string` | optional |  |
+| page_size | `int32` | optional |  |
+| identity_provider_id | `string` | optional |  |
+| filter_party | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-listknownpartiesresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.ListKnownPartiesResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party_details | [`com.daml.ledger.api.v2.admin.PartyDetails`](#type-com-daml-ledger-api-v2-admin-partydetails) | repeated |  |
+| next_page_token | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-listuserrightsrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.ListUserRightsRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user_id | `string` | optional |  |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-listuserrightsresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.ListUserRightsResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-listusersrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.ListUsersRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| page_token | `string` | optional |  |
+| page_size | `int32` | optional |  |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-listusersresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.ListUsersResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| users | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | repeated |  |
+| next_page_token | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-objectmeta"></a>
+**Message `com.daml.ledger.api.v2.admin.ObjectMeta`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| resource_version | `string` | optional |  |
+| annotations | `map<string, string>` | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-packagedetails"></a>
+**Message `com.daml.ledger.api.v2.admin.PackageDetails`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 5
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_id | `string` | optional |  |
+| package_size | `uint64` | optional |  |
+| known_since | `google.protobuf.Timestamp` | optional |  |
+| name | `string` | optional |  |
+| version | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-partydetails"></a>
+**Message `com.daml.ledger.api.v2.admin.PartyDetails`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party | `string` | optional |  |
+| is_local | `bool` | optional |  |
+| local_metadata | [`com.daml.ledger.api.v2.admin.ObjectMeta`](#type-com-daml-ledger-api-v2-admin-objectmeta) | optional |  |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-prunerequest"></a>
+**Message `com.daml.ledger.api.v2.admin.PruneRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| prune_up_to | `int64` | optional |  |
+| submission_id | `string` | optional |  |
+| prune_all_divulged_contracts | `bool` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-pruneresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.PruneResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-requeststatistics"></a>
+**Message `com.daml.ledger.api.v2.admin.RequestStatistics`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| envelopes | `uint32` | optional |  |
+| request_size | `uint32` | optional |  |
+| recipients | `uint32` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-revokeuserrightsrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.RevokeUserRightsRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user_id | `string` | optional |  |
+| rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-revokeuserrightsresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.RevokeUserRightsResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| newly_revoked_rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-right"></a>
+**Message `com.daml.ledger.api.v2.admin.Right`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 7
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| participant_admin | [`com.daml.ledger.api.v2.admin.Right.ParticipantAdmin`](#type-com-daml-ledger-api-v2-admin-right-participantadmin) | optional |  |
+| can_act_as | [`com.daml.ledger.api.v2.admin.Right.CanActAs`](#type-com-daml-ledger-api-v2-admin-right-canactas) | optional |  |
+| can_read_as | [`com.daml.ledger.api.v2.admin.Right.CanReadAs`](#type-com-daml-ledger-api-v2-admin-right-canreadas) | optional |  |
+| identity_provider_admin | [`com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin`](#type-com-daml-ledger-api-v2-admin-right-identityprovideradmin) | optional |  |
+| can_read_as_any_party | [`com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty`](#type-com-daml-ledger-api-v2-admin-right-canreadasanyparty) | optional |  |
+| can_execute_as | [`com.daml.ledger.api.v2.admin.Right.CanExecuteAs`](#type-com-daml-ledger-api-v2-admin-right-canexecuteas) | optional |  |
+| can_execute_as_any_party | [`com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty`](#type-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-right-participantadmin"></a>
+**Message `com.daml.ledger.api.v2.admin.Right.ParticipantAdmin`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-right-canactas"></a>
+**Message `com.daml.ledger.api.v2.admin.Right.CanActAs`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-right-canreadas"></a>
+**Message `com.daml.ledger.api.v2.admin.Right.CanReadAs`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-right-canexecuteas"></a>
+**Message `com.daml.ledger.api.v2.admin.Right.CanExecuteAs`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-right-identityprovideradmin"></a>
+**Message `com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-right-canreadasanyparty"></a>
+**Message `com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty"></a>
+**Message `com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| identity_provider_config | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | optional |  |
+| update_mask | `google.protobuf.FieldMask` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| identity_provider_config | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-updatepartydetailsrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party_details | [`com.daml.ledger.api.v2.admin.PartyDetails`](#type-com-daml-ledger-api-v2-admin-partydetails) | optional |  |
+| update_mask | `google.protobuf.FieldMask` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-updatepartydetailsresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party_details | [`com.daml.ledger.api.v2.admin.PartyDetails`](#type-com-daml-ledger-api-v2-admin-partydetails) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party | `string` | optional |  |
+| source_identity_provider_id | `string` | optional |  |
+| target_identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user_id | `string` | optional |  |
+| source_identity_provider_id | `string` | optional |  |
+| target_identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-updateuserrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdateUserRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | optional |  |
+| update_mask | `google.protobuf.FieldMask` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-updateuserresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdateUserResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 5
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| changes | [`com.daml.ledger.api.v2.admin.VettedPackagesChange`](#type-com-daml-ledger-api-v2-admin-vettedpackageschange) | repeated |  |
+| dry_run | `bool` | optional |  |
+| synchronizer_id | `string` | optional |  |
+| expected_topology_serial | [`com.daml.ledger.api.v2.PriorTopologySerial`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-priortopologyserial) | optional |  |
+| update_vetted_packages_force_flags | [`com.daml.ledger.api.v2.admin.UpdateVettedPackagesForceFlag`](#type-com-daml-ledger-api-v2-admin-updatevettedpackagesforceflag) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| past_vetted_packages | [`com.daml.ledger.api.v2.VettedPackages`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-vettedpackages) | optional |  |
+| new_vetted_packages | [`com.daml.ledger.api.v2.VettedPackages`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-vettedpackages) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-uploaddarfilerequest"></a>
+**Message `com.daml.ledger.api.v2.admin.UploadDarFileRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| dar_file | `bytes` | optional |  |
+| submission_id | `string` | optional |  |
+| vetting_change | [`com.daml.ledger.api.v2.admin.UploadDarFileRequest.VettingChange`](#type-com-daml-ledger-api-v2-admin-uploaddarfilerequest-vettingchange) | optional |  |
+| synchronizer_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-uploaddarfilerequest-vettingchange"></a>
+**Enum `com.daml.ledger.api.v2.admin.UploadDarFileRequest.VettingChange`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| VETTING_CHANGE_UNSPECIFIED | `0` |
+| VETTING_CHANGE_VET_ALL_PACKAGES | `1` |
+| VETTING_CHANGE_DONT_VET_ANY_PACKAGES | `2` |
+
+<a id="type-com-daml-ledger-api-v2-admin-uploaddarfileresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.UploadDarFileResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-user"></a>
+**Message `com.daml.ledger.api.v2.admin.User`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
+- Fields: 5
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| id | `string` | optional |  |
+| primary_party | `string` | optional |  |
+| is_deactivated | `bool` | optional |  |
+| metadata | [`com.daml.ledger.api.v2.admin.ObjectMeta`](#type-com-daml-ledger-api-v2-admin-objectmeta) | optional |  |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-validatedarfilerequest"></a>
+**Message `com.daml.ledger.api.v2.admin.ValidateDarFileRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| dar_file | `bytes` | optional |  |
+| submission_id | `string` | optional |  |
+| synchronizer_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-validatedarfileresponse"></a>
+**Message `com.daml.ledger.api.v2.admin.ValidateDarFileResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-admin-vettedpackageschange"></a>
+**Message `com.daml.ledger.api.v2.admin.VettedPackagesChange`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| vet | [`com.daml.ledger.api.v2.admin.VettedPackagesChange.Vet`](#type-com-daml-ledger-api-v2-admin-vettedpackageschange-vet) | optional |  |
+| unvet | [`com.daml.ledger.api.v2.admin.VettedPackagesChange.Unvet`](#type-com-daml-ledger-api-v2-admin-vettedpackageschange-unvet) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-vettedpackageschange-unvet"></a>
+**Message `com.daml.ledger.api.v2.admin.VettedPackagesChange.Unvet`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| packages | [`com.daml.ledger.api.v2.admin.VettedPackagesRef`](#type-com-daml-ledger-api-v2-admin-vettedpackagesref) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-vettedpackageschange-vet"></a>
+**Message `com.daml.ledger.api.v2.admin.VettedPackagesChange.Vet`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| packages | [`com.daml.ledger.api.v2.admin.VettedPackagesRef`](#type-com-daml-ledger-api-v2-admin-vettedpackagesref) | repeated |  |
+| new_valid_from_inclusive | `google.protobuf.Timestamp` | optional |  |
+| new_valid_until_exclusive | `google.protobuf.Timestamp` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-vettedpackagesref"></a>
+**Message `com.daml.ledger.api.v2.admin.VettedPackagesRef`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_id | `string` | optional |  |
+| package_name | `string` | optional |  |
+| package_version | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-admin-commandstate"></a>
+**Enum `com.daml.ledger.api.v2.admin.CommandState`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| COMMAND_STATE_UNSPECIFIED | `0` |
+| COMMAND_STATE_PENDING | `1` |
+| COMMAND_STATE_SUCCEEDED | `2` |
+| COMMAND_STATE_FAILED | `3` |
+
+<a id="type-com-daml-ledger-api-v2-admin-updatevettedpackagesforceflag"></a>
+**Enum `com.daml.ledger.api.v2.admin.UpdateVettedPackagesForceFlag`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED | `0` |
+| UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES | `2` |
+| UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES | `3` |

--- a/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
@@ -1,0 +1,114 @@
+---
+title: "com.daml.ledger.api.v2.interactive.transaction.v1"
+description: "Descriptor-backed protobuf API history for package com.daml.ledger.api.v2.interactive.transaction.v1."
+---
+
+# Package `com.daml.ledger.api.v2.interactive.transaction.v1`
+
+[Back to gRPC Ledger API Reference](../index)
+
+## Snapshot
+
+- Current files: `1`
+- Current services: `0`
+- Current endpoints: `0`
+- Current messages: `5`
+- Current enums: `0`
+- Lifecycle endpoints tracked: `0`
+
+## Source Files
+
+| File | Services | Messages | Enums | Source |
+| --- | --- | --- | --- | --- |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto | `0` | `5` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto) |
+
+## Type Reference
+
+<a id="type-com-daml-ledger-api-v2-interactive-transaction-v1-create"></a>
+**Message `com.daml.ledger.api.v2.interactive.transaction.v1.Create`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto)
+- Fields: 7
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| lf_version | `string` | optional |  |
+| contract_id | `string` | optional |  |
+| package_name | `string` | optional |  |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| argument | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
+| signatories | `string` | repeated |  |
+| stakeholders | `string` | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-transaction-v1-exercise"></a>
+**Message `com.daml.ledger.api.v2.interactive.transaction.v1.Exercise`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto)
+- Fields: 14
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| lf_version | `string` | optional |  |
+| contract_id | `string` | optional |  |
+| package_name | `string` | optional |  |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| signatories | `string` | repeated |  |
+| stakeholders | `string` | repeated |  |
+| acting_parties | `string` | repeated |  |
+| interface_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| choice_id | `string` | optional |  |
+| chosen_value | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
+| consuming | `bool` | optional |  |
+| children | `string` | repeated |  |
+| exercise_result | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
+| choice_observers | `string` | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-transaction-v1-fetch"></a>
+**Message `com.daml.ledger.api.v2.interactive.transaction.v1.Fetch`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto)
+- Fields: 8
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| lf_version | `string` | optional |  |
+| contract_id | `string` | optional |  |
+| package_name | `string` | optional |  |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| signatories | `string` | repeated |  |
+| stakeholders | `string` | repeated |  |
+| acting_parties | `string` | repeated |  |
+| interface_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-transaction-v1-node"></a>
+**Message `com.daml.ledger.api.v2.interactive.transaction.v1.Node`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| create | [`com.daml.ledger.api.v2.interactive.transaction.v1.Create`](#type-com-daml-ledger-api-v2-interactive-transaction-v1-create) | optional |  |
+| fetch | [`com.daml.ledger.api.v2.interactive.transaction.v1.Fetch`](#type-com-daml-ledger-api-v2-interactive-transaction-v1-fetch) | optional |  |
+| exercise | [`com.daml.ledger.api.v2.interactive.transaction.v1.Exercise`](#type-com-daml-ledger-api-v2-interactive-transaction-v1-exercise) | optional |  |
+| rollback | [`com.daml.ledger.api.v2.interactive.transaction.v1.Rollback`](#type-com-daml-ledger-api-v2-interactive-transaction-v1-rollback) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-transaction-v1-rollback"></a>
+**Message `com.daml.ledger.api.v2.interactive.transaction.v1.Rollback`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| children | `string` | repeated |  |

--- a/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive.mdx
@@ -1,0 +1,654 @@
+---
+title: "com.daml.ledger.api.v2.interactive"
+description: "Descriptor-backed protobuf API history for package com.daml.ledger.api.v2.interactive."
+---
+
+# Package `com.daml.ledger.api.v2.interactive`
+
+[Back to gRPC Ledger API Reference](../index)
+
+## Snapshot
+
+- Current files: `2`
+- Current services: `1`
+- Current endpoints: `6`
+- Current messages: `28`
+- Current enums: `1`
+- Lifecycle endpoints tracked: `6`
+
+## Source Files
+
+| File | Services | Messages | Enums | Source |
+| --- | --- | --- | --- | --- |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto | `0` | `1` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto | `1` | `22` | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
+
+## Services
+
+| Service | Endpoints | Source | Description |
+| --- | --- | --- | --- |
+| [`InteractiveSubmissionService`](#service-com-daml-ledger-api-v2-interactive-interactivesubmissionservice) | `6` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |  |
+
+<a id="service-com-daml-ledger-api-v2-interactive-interactivesubmissionservice"></a>
+### Service `InteractiveSubmissionService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Endpoints tracked: `6`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`ExecuteSubmission`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmission) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionrequest) | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
+| [`ExecuteSubmissionAndWait`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmissionandwait) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest) | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
+| [`ExecuteSubmissionAndWaitForTransaction`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmissionandwaitfortransaction) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest) | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
+| [`GetPreferredPackageVersion`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-getpreferredpackageversion) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest) | [`com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
+| [`GetPreferredPackages`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-getpreferredpackages) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest) | [`com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
+| [`PrepareSubmission`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-preparesubmission) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest`](#type-com-daml-ledger-api-v2-interactive-preparesubmissionrequest) | [`com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse`](#type-com-daml-ledger-api-v2-interactive-preparesubmissionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmission"></a>
+**Endpoint `InteractiveSubmissionService.ExecuteSubmission`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+
+**Signature**
+
+```protobuf
+rpc InteractiveSubmissionService.ExecuteSubmission(com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest) returns (com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmissionandwait"></a>
+**Endpoint `InteractiveSubmissionService.ExecuteSubmissionAndWait`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+
+**Signature**
+
+```protobuf
+rpc InteractiveSubmissionService.ExecuteSubmissionAndWait(com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest) returns (com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmissionandwaitfortransaction"></a>
+**Endpoint `InteractiveSubmissionService.ExecuteSubmissionAndWaitForTransaction`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+
+**Signature**
+
+```protobuf
+rpc InteractiveSubmissionService.ExecuteSubmissionAndWaitForTransaction(com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest) returns (com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-getpreferredpackageversion"></a>
+**Endpoint `InteractiveSubmissionService.GetPreferredPackageVersion`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+
+**Signature**
+
+```protobuf
+rpc InteractiveSubmissionService.GetPreferredPackageVersion(com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest) returns (com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-getpreferredpackages"></a>
+**Endpoint `InteractiveSubmissionService.GetPreferredPackages`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+
+**Signature**
+
+```protobuf
+rpc InteractiveSubmissionService.GetPreferredPackages(com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest) returns (com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-preparesubmission"></a>
+**Endpoint `InteractiveSubmissionService.PrepareSubmission`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+
+**Signature**
+
+```protobuf
+rpc InteractiveSubmissionService.PrepareSubmission(com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest) returns (com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest`](#type-com-daml-ledger-api-v2-interactive-preparesubmissionrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse`](#type-com-daml-ledger-api-v2-interactive-preparesubmissionresponse)
+
+## Type Reference
+
+<a id="type-com-daml-ledger-api-v2-interactive-costestimation"></a>
+**Message `com.daml.ledger.api.v2.interactive.CostEstimation`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| estimation_timestamp | `google.protobuf.Timestamp` | optional |  |
+| confirmation_request_traffic_cost_estimation | `uint64` | optional |  |
+| confirmation_response_traffic_cost_estimation | `uint64` | optional |  |
+| total_traffic_cost_estimation | `uint64` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-costestimationhints"></a>
+**Message `com.daml.ledger.api.v2.interactive.CostEstimationHints`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| disabled | `bool` | optional |  |
+| expected_signatures | [`com.daml.ledger.api.v2.SigningAlgorithmSpec`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-signingalgorithmspec) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-damltransaction"></a>
+**Message `com.daml.ledger.api.v2.interactive.DamlTransaction`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| version | `string` | optional |  |
+| roots | `string` | repeated |  |
+| nodes | [`com.daml.ledger.api.v2.interactive.DamlTransaction.Node`](#type-com-daml-ledger-api-v2-interactive-damltransaction-node) | repeated |  |
+| node_seeds | [`com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed`](#type-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed"></a>
+**Message `com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| node_id | `int32` | optional |  |
+| seed | `bytes` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-damltransaction-node"></a>
+**Message `com.daml.ledger.api.v2.interactive.DamlTransaction.Node`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| node_id | `string` | optional |  |
+| v1 | [`com.daml.ledger.api.v2.interactive.transaction.v1.Node`](com-daml-ledger-api-v2-interactive-transaction-v1#type-com-daml-ledger-api-v2-interactive-transaction-v1-node) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest"></a>
+**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 9
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| prepared_transaction | [`com.daml.ledger.api.v2.interactive.PreparedTransaction`](#type-com-daml-ledger-api-v2-interactive-preparedtransaction) | optional |  |
+| party_signatures | [`com.daml.ledger.api.v2.interactive.PartySignatures`](#type-com-daml-ledger-api-v2-interactive-partysignatures) | optional |  |
+| deduplication_duration | `google.protobuf.Duration` | optional |  |
+| deduplication_offset | `int64` | optional |  |
+| submission_id | `string` | optional |  |
+| user_id | `string` | optional |  |
+| hashing_scheme_version | [`com.daml.ledger.api.v2.interactive.HashingSchemeVersion`](#type-com-daml-ledger-api-v2-interactive-hashingschemeversion) | optional |  |
+| min_ledger_time | [`com.daml.ledger.api.v2.interactive.MinLedgerTime`](#type-com-daml-ledger-api-v2-interactive-minledgertime) | optional |  |
+| transaction_format | [`com.daml.ledger.api.v2.TransactionFormat`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-transactionformat) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse"></a>
+**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| transaction | [`com.daml.ledger.api.v2.Transaction`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-transaction) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest"></a>
+**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 8
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| prepared_transaction | [`com.daml.ledger.api.v2.interactive.PreparedTransaction`](#type-com-daml-ledger-api-v2-interactive-preparedtransaction) | optional |  |
+| party_signatures | [`com.daml.ledger.api.v2.interactive.PartySignatures`](#type-com-daml-ledger-api-v2-interactive-partysignatures) | optional |  |
+| deduplication_duration | `google.protobuf.Duration` | optional |  |
+| deduplication_offset | `int64` | optional |  |
+| submission_id | `string` | optional |  |
+| user_id | `string` | optional |  |
+| hashing_scheme_version | [`com.daml.ledger.api.v2.interactive.HashingSchemeVersion`](#type-com-daml-ledger-api-v2-interactive-hashingschemeversion) | optional |  |
+| min_ledger_time | [`com.daml.ledger.api.v2.interactive.MinLedgerTime`](#type-com-daml-ledger-api-v2-interactive-minledgertime) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse"></a>
+**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| update_id | `string` | optional |  |
+| completion_offset | `int64` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionrequest"></a>
+**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 8
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| prepared_transaction | [`com.daml.ledger.api.v2.interactive.PreparedTransaction`](#type-com-daml-ledger-api-v2-interactive-preparedtransaction) | optional |  |
+| party_signatures | [`com.daml.ledger.api.v2.interactive.PartySignatures`](#type-com-daml-ledger-api-v2-interactive-partysignatures) | optional |  |
+| deduplication_duration | `google.protobuf.Duration` | optional |  |
+| deduplication_offset | `int64` | optional |  |
+| submission_id | `string` | optional |  |
+| user_id | `string` | optional |  |
+| hashing_scheme_version | [`com.daml.ledger.api.v2.interactive.HashingSchemeVersion`](#type-com-daml-ledger-api-v2-interactive-hashingschemeversion) | optional |  |
+| min_ledger_time | [`com.daml.ledger.api.v2.interactive.MinLedgerTime`](#type-com-daml-ledger-api-v2-interactive-minledgertime) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionresponse"></a>
+**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest"></a>
+**Message `com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| parties | `string` | repeated |  |
+| package_name | `string` | optional |  |
+| synchronizer_id | `string` | optional |  |
+| vetting_valid_at | `google.protobuf.Timestamp` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse"></a>
+**Message `com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_preference | [`com.daml.ledger.api.v2.interactive.PackagePreference`](#type-com-daml-ledger-api-v2-interactive-packagepreference) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest"></a>
+**Message `com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_vetting_requirements | [`com.daml.ledger.api.v2.interactive.PackageVettingRequirement`](#type-com-daml-ledger-api-v2-interactive-packagevettingrequirement) | repeated |  |
+| synchronizer_id | `string` | optional |  |
+| vetting_valid_at | `google.protobuf.Timestamp` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse"></a>
+**Message `com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_references | [`com.daml.ledger.api.v2.PackageReference`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-packagereference) | repeated |  |
+| synchronizer_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-globalkey"></a>
+**Message `com.daml.ledger.api.v2.interactive.GlobalKey`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| package_name | `string` | optional |  |
+| key | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
+| hash | `bytes` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-metadata"></a>
+**Message `com.daml.ledger.api.v2.interactive.Metadata`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 10
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| submitter_info | [`com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo`](#type-com-daml-ledger-api-v2-interactive-metadata-submitterinfo) | optional |  |
+| synchronizer_id | `string` | optional |  |
+| mediator_group | `uint32` | optional |  |
+| transaction_uuid | `string` | optional |  |
+| preparation_time | `uint64` | optional |  |
+| input_contracts | [`com.daml.ledger.api.v2.interactive.Metadata.InputContract`](#type-com-daml-ledger-api-v2-interactive-metadata-inputcontract) | repeated |  |
+| min_ledger_effective_time | `uint64` | optional |  |
+| max_ledger_effective_time | `uint64` | optional |  |
+| global_key_mapping | [`com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry`](#type-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry) | repeated |  |
+| max_record_time | `uint64` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-metadata-submitterinfo"></a>
+**Message `com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| act_as | `string` | repeated |  |
+| command_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry"></a>
+**Message `com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| key | [`com.daml.ledger.api.v2.interactive.GlobalKey`](#type-com-daml-ledger-api-v2-interactive-globalkey) | optional |  |
+| value | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-metadata-inputcontract"></a>
+**Message `com.daml.ledger.api.v2.interactive.Metadata.InputContract`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| v1 | [`com.daml.ledger.api.v2.interactive.transaction.v1.Create`](com-daml-ledger-api-v2-interactive-transaction-v1#type-com-daml-ledger-api-v2-interactive-transaction-v1-create) | optional |  |
+| created_at | `uint64` | optional |  |
+| event_blob | `bytes` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-minledgertime"></a>
+**Message `com.daml.ledger.api.v2.interactive.MinLedgerTime`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| min_ledger_time_abs | `google.protobuf.Timestamp` | optional |  |
+| min_ledger_time_rel | `google.protobuf.Duration` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-packagepreference"></a>
+**Message `com.daml.ledger.api.v2.interactive.PackagePreference`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_reference | [`com.daml.ledger.api.v2.PackageReference`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-packagereference) | optional |  |
+| synchronizer_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-packagevettingrequirement"></a>
+**Message `com.daml.ledger.api.v2.interactive.PackageVettingRequirement`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| parties | `string` | repeated |  |
+| package_name | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-partysignatures"></a>
+**Message `com.daml.ledger.api.v2.interactive.PartySignatures`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| signatures | [`com.daml.ledger.api.v2.interactive.SinglePartySignatures`](#type-com-daml-ledger-api-v2-interactive-singlepartysignatures) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-preparesubmissionrequest"></a>
+**Message `com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 13
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user_id | `string` | optional |  |
+| command_id | `string` | optional |  |
+| commands | [`com.daml.ledger.api.v2.Command`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-command) | repeated |  |
+| min_ledger_time | [`com.daml.ledger.api.v2.interactive.MinLedgerTime`](#type-com-daml-ledger-api-v2-interactive-minledgertime) | optional |  |
+| max_record_time | `google.protobuf.Timestamp` | optional |  |
+| act_as | `string` | repeated |  |
+| read_as | `string` | repeated |  |
+| disclosed_contracts | [`com.daml.ledger.api.v2.DisclosedContract`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-disclosedcontract) | repeated |  |
+| synchronizer_id | `string` | optional |  |
+| package_id_selection_preference | `string` | repeated |  |
+| verbose_hashing | `bool` | optional |  |
+| prefetch_contract_keys | [`com.daml.ledger.api.v2.PrefetchContractKey`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-prefetchcontractkey) | repeated |  |
+| estimate_traffic_cost | [`com.daml.ledger.api.v2.interactive.CostEstimationHints`](#type-com-daml-ledger-api-v2-interactive-costestimationhints) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-preparesubmissionresponse"></a>
+**Message `com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 5
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| prepared_transaction | [`com.daml.ledger.api.v2.interactive.PreparedTransaction`](#type-com-daml-ledger-api-v2-interactive-preparedtransaction) | optional |  |
+| prepared_transaction_hash | `bytes` | optional |  |
+| hashing_scheme_version | [`com.daml.ledger.api.v2.interactive.HashingSchemeVersion`](#type-com-daml-ledger-api-v2-interactive-hashingschemeversion) | optional |  |
+| hashing_details | `string` | optional |  |
+| cost_estimation | [`com.daml.ledger.api.v2.interactive.CostEstimation`](#type-com-daml-ledger-api-v2-interactive-costestimation) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-preparedtransaction"></a>
+**Message `com.daml.ledger.api.v2.interactive.PreparedTransaction`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| transaction | [`com.daml.ledger.api.v2.interactive.DamlTransaction`](#type-com-daml-ledger-api-v2-interactive-damltransaction) | optional |  |
+| metadata | [`com.daml.ledger.api.v2.interactive.Metadata`](#type-com-daml-ledger-api-v2-interactive-metadata) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-singlepartysignatures"></a>
+**Message `com.daml.ledger.api.v2.interactive.SinglePartySignatures`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party | `string` | optional |  |
+| signatures | [`com.daml.ledger.api.v2.Signature`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-signature) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-interactive-hashingschemeversion"></a>
+**Enum `com.daml.ledger.api.v2.interactive.HashingSchemeVersion`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| HASHING_SCHEME_VERSION_UNSPECIFIED | `0` |
+| HASHING_SCHEME_VERSION_V2 | `2` |

--- a/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-testing.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-testing.mdx
@@ -1,0 +1,139 @@
+---
+title: "com.daml.ledger.api.v2.testing"
+description: "Descriptor-backed protobuf API history for package com.daml.ledger.api.v2.testing."
+---
+
+# Package `com.daml.ledger.api.v2.testing`
+
+[Back to gRPC Ledger API Reference](../index)
+
+## Snapshot
+
+- Current files: `1`
+- Current services: `1`
+- Current endpoints: `2`
+- Current messages: `3`
+- Current enums: `0`
+- Lifecycle endpoints tracked: `2`
+
+## Source Files
+
+| File | Services | Messages | Enums | Source |
+| --- | --- | --- | --- | --- |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto | `1` | `3` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto) |
+
+## Services
+
+| Service | Endpoints | Source | Description |
+| --- | --- | --- | --- |
+| [`TimeService`](#service-com-daml-ledger-api-v2-testing-timeservice) | `2` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto) |  |
+
+<a id="service-com-daml-ledger-api-v2-testing-timeservice"></a>
+### Service `TimeService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
+- Endpoints tracked: `2`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`GetTime`](#endpoint-com-daml-ledger-api-v2-testing-timeservice-gettime) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.testing.GetTimeRequest`](#type-com-daml-ledger-api-v2-testing-gettimerequest) | [`com.daml.ledger.api.v2.testing.GetTimeResponse`](#type-com-daml-ledger-api-v2-testing-gettimeresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto) |
+| [`SetTime`](#endpoint-com-daml-ledger-api-v2-testing-timeservice-settime) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.testing.SetTimeRequest`](#type-com-daml-ledger-api-v2-testing-settimerequest) | `google.protobuf.Empty` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-testing-timeservice-gettime"></a>
+**Endpoint `TimeService.GetTime`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
+
+**Signature**
+
+```protobuf
+rpc TimeService.GetTime(com.daml.ledger.api.v2.testing.GetTimeRequest) returns (com.daml.ledger.api.v2.testing.GetTimeResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.testing.GetTimeRequest`](#type-com-daml-ledger-api-v2-testing-gettimerequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.testing.GetTimeResponse`](#type-com-daml-ledger-api-v2-testing-gettimeresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-testing-timeservice-settime"></a>
+**Endpoint `TimeService.SetTime`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
+
+**Signature**
+
+```protobuf
+rpc TimeService.SetTime(com.daml.ledger.api.v2.testing.SetTimeRequest) returns (google.protobuf.Empty);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.testing.SetTimeRequest`](#type-com-daml-ledger-api-v2-testing-settimerequest)
+
+**Response Type**
+
+- `google.protobuf.Empty`
+
+## Type Reference
+
+<a id="type-com-daml-ledger-api-v2-testing-gettimerequest"></a>
+**Message `com.daml.ledger.api.v2.testing.GetTimeRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-testing-gettimeresponse"></a>
+**Message `com.daml.ledger.api.v2.testing.GetTimeResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| current_time | `google.protobuf.Timestamp` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-testing-settimerequest"></a>
+**Message `com.daml.ledger.api.v2.testing.SetTimeRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| current_time | `google.protobuf.Timestamp` | optional |  |
+| new_time | `google.protobuf.Timestamp` | optional |  |

--- a/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2.mdx
@@ -1,0 +1,2498 @@
+---
+title: "com.daml.ledger.api.v2"
+description: "Descriptor-backed protobuf API history for package com.daml.ledger.api.v2."
+---
+
+# Package `com.daml.ledger.api.v2`
+
+[Back to gRPC Ledger API Reference](../index)
+
+## Snapshot
+
+- Current files: `23`
+- Current services: `9`
+- Current endpoints: `20`
+- Current messages: `115`
+- Current enums: `8`
+- Lifecycle endpoints tracked: `20`
+
+## Source Files
+
+| File | Services | Messages | Enums | Source |
+| --- | --- | --- | --- | --- |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto | `1` | `2` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto | `1` | `6` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto | `1` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto | `0` | `8` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto | `0` | `1` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto | `1` | `2` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto | `0` | `2` | `4` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto | `0` | `5` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto | `1` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto | `0` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto | `0` | `2` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto | `0` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto | `1` | `10` | `2` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto | `0` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto | `0` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto | `1` | `11` | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto | `0` | `5` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto | `0` | `1` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto | `0` | `1` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto | `0` | `10` | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto | `1` | `5` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto | `0` | `10` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto) |
+| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto | `1` | `7` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto) |
+
+## Services
+
+| Service | Endpoints | Source | Description |
+| --- | --- | --- | --- |
+| [`CommandCompletionService`](#service-com-daml-ledger-api-v2-commandcompletionservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto) |  |
+| [`CommandService`](#service-com-daml-ledger-api-v2-commandservice) | `3` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto) |  |
+| [`CommandSubmissionService`](#service-com-daml-ledger-api-v2-commandsubmissionservice) | `2` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto) |  |
+| [`ContractService`](#service-com-daml-ledger-api-v2-contractservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto) |  |
+| [`EventQueryService`](#service-com-daml-ledger-api-v2-eventqueryservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto) |  |
+| [`PackageService`](#service-com-daml-ledger-api-v2-packageservice) | `4` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |  |
+| [`StateService`](#service-com-daml-ledger-api-v2-stateservice) | `4` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |  |
+| [`UpdateService`](#service-com-daml-ledger-api-v2-updateservice) | `3` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto) |  |
+| [`VersionService`](#service-com-daml-ledger-api-v2-versionservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto) |  |
+
+<a id="service-com-daml-ledger-api-v2-commandcompletionservice"></a>
+### Service `CommandCompletionService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto)
+- Endpoints tracked: `1`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`CompletionStream`](#endpoint-com-daml-ledger-api-v2-commandcompletionservice-completionstream) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.CompletionStreamRequest`](#type-com-daml-ledger-api-v2-completionstreamrequest) | [`com.daml.ledger.api.v2.CompletionStreamResponse`](#type-com-daml-ledger-api-v2-completionstreamresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-commandcompletionservice-completionstream"></a>
+**Endpoint `CommandCompletionService.CompletionStream`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto)
+
+**Signature**
+
+```protobuf
+rpc CommandCompletionService.CompletionStream(com.daml.ledger.api.v2.CompletionStreamRequest) returns (stream com.daml.ledger.api.v2.CompletionStreamResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.CompletionStreamRequest`](#type-com-daml-ledger-api-v2-completionstreamrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.CompletionStreamResponse`](#type-com-daml-ledger-api-v2-completionstreamresponse)
+
+<a id="service-com-daml-ledger-api-v2-commandservice"></a>
+### Service `CommandService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
+- Endpoints tracked: `3`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`SubmitAndWait`](#endpoint-com-daml-ledger-api-v2-commandservice-submitandwait) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.SubmitAndWaitRequest`](#type-com-daml-ledger-api-v2-submitandwaitrequest) | [`com.daml.ledger.api.v2.SubmitAndWaitResponse`](#type-com-daml-ledger-api-v2-submitandwaitresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto) |
+| [`SubmitAndWaitForReassignment`](#endpoint-com-daml-ledger-api-v2-commandservice-submitandwaitforreassignment) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest`](#type-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest) | [`com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse`](#type-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto) |
+| [`SubmitAndWaitForTransaction`](#endpoint-com-daml-ledger-api-v2-commandservice-submitandwaitfortransaction) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest`](#type-com-daml-ledger-api-v2-submitandwaitfortransactionrequest) | [`com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse`](#type-com-daml-ledger-api-v2-submitandwaitfortransactionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-commandservice-submitandwait"></a>
+**Endpoint `CommandService.SubmitAndWait`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
+
+**Signature**
+
+```protobuf
+rpc CommandService.SubmitAndWait(com.daml.ledger.api.v2.SubmitAndWaitRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.SubmitAndWaitRequest`](#type-com-daml-ledger-api-v2-submitandwaitrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.SubmitAndWaitResponse`](#type-com-daml-ledger-api-v2-submitandwaitresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-commandservice-submitandwaitforreassignment"></a>
+**Endpoint `CommandService.SubmitAndWaitForReassignment`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
+
+**Signature**
+
+```protobuf
+rpc CommandService.SubmitAndWaitForReassignment(com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest`](#type-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse`](#type-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-commandservice-submitandwaitfortransaction"></a>
+**Endpoint `CommandService.SubmitAndWaitForTransaction`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
+
+**Signature**
+
+```protobuf
+rpc CommandService.SubmitAndWaitForTransaction(com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest`](#type-com-daml-ledger-api-v2-submitandwaitfortransactionrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse`](#type-com-daml-ledger-api-v2-submitandwaitfortransactionresponse)
+
+<a id="service-com-daml-ledger-api-v2-commandsubmissionservice"></a>
+### Service `CommandSubmissionService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
+- Endpoints tracked: `2`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Submit`](#endpoint-com-daml-ledger-api-v2-commandsubmissionservice-submit) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.SubmitRequest`](#type-com-daml-ledger-api-v2-submitrequest) | [`com.daml.ledger.api.v2.SubmitResponse`](#type-com-daml-ledger-api-v2-submitresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto) |
+| [`SubmitReassignment`](#endpoint-com-daml-ledger-api-v2-commandsubmissionservice-submitreassignment) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.SubmitReassignmentRequest`](#type-com-daml-ledger-api-v2-submitreassignmentrequest) | [`com.daml.ledger.api.v2.SubmitReassignmentResponse`](#type-com-daml-ledger-api-v2-submitreassignmentresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-commandsubmissionservice-submit"></a>
+**Endpoint `CommandSubmissionService.Submit`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
+
+**Signature**
+
+```protobuf
+rpc CommandSubmissionService.Submit(com.daml.ledger.api.v2.SubmitRequest) returns (com.daml.ledger.api.v2.SubmitResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.SubmitRequest`](#type-com-daml-ledger-api-v2-submitrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.SubmitResponse`](#type-com-daml-ledger-api-v2-submitresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-commandsubmissionservice-submitreassignment"></a>
+**Endpoint `CommandSubmissionService.SubmitReassignment`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
+
+**Signature**
+
+```protobuf
+rpc CommandSubmissionService.SubmitReassignment(com.daml.ledger.api.v2.SubmitReassignmentRequest) returns (com.daml.ledger.api.v2.SubmitReassignmentResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.SubmitReassignmentRequest`](#type-com-daml-ledger-api-v2-submitreassignmentrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.SubmitReassignmentResponse`](#type-com-daml-ledger-api-v2-submitreassignmentresponse)
+
+<a id="service-com-daml-ledger-api-v2-contractservice"></a>
+### Service `ContractService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto)
+- Endpoints tracked: `1`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`GetContract`](#endpoint-com-daml-ledger-api-v2-contractservice-getcontract) | `3.4.11` | `3.4.11` | `` | [`com.daml.ledger.api.v2.GetContractRequest`](#type-com-daml-ledger-api-v2-getcontractrequest) | [`com.daml.ledger.api.v2.GetContractResponse`](#type-com-daml-ledger-api-v2-getcontractresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-contractservice-getcontract"></a>
+**Endpoint `ContractService.GetContract`**
+
+- Introduced in: `3.4.11`
+- Last changed in: `3.4.11`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto)
+
+**Signature**
+
+```protobuf
+rpc ContractService.GetContract(com.daml.ledger.api.v2.GetContractRequest) returns (com.daml.ledger.api.v2.GetContractResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.11` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetContractRequest`](#type-com-daml-ledger-api-v2-getcontractrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetContractResponse`](#type-com-daml-ledger-api-v2-getcontractresponse)
+
+<a id="service-com-daml-ledger-api-v2-eventqueryservice"></a>
+### Service `EventQueryService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
+- Endpoints tracked: `1`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`GetEventsByContractId`](#endpoint-com-daml-ledger-api-v2-eventqueryservice-geteventsbycontractid) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetEventsByContractIdRequest`](#type-com-daml-ledger-api-v2-geteventsbycontractidrequest) | [`com.daml.ledger.api.v2.GetEventsByContractIdResponse`](#type-com-daml-ledger-api-v2-geteventsbycontractidresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-eventqueryservice-geteventsbycontractid"></a>
+**Endpoint `EventQueryService.GetEventsByContractId`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
+
+**Signature**
+
+```protobuf
+rpc EventQueryService.GetEventsByContractId(com.daml.ledger.api.v2.GetEventsByContractIdRequest) returns (com.daml.ledger.api.v2.GetEventsByContractIdResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetEventsByContractIdRequest`](#type-com-daml-ledger-api-v2-geteventsbycontractidrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetEventsByContractIdResponse`](#type-com-daml-ledger-api-v2-geteventsbycontractidresponse)
+
+<a id="service-com-daml-ledger-api-v2-packageservice"></a>
+### Service `PackageService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+- Endpoints tracked: `4`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`GetPackage`](#endpoint-com-daml-ledger-api-v2-packageservice-getpackage) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetPackageRequest`](#type-com-daml-ledger-api-v2-getpackagerequest) | [`com.daml.ledger.api.v2.GetPackageResponse`](#type-com-daml-ledger-api-v2-getpackageresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |
+| [`GetPackageStatus`](#endpoint-com-daml-ledger-api-v2-packageservice-getpackagestatus) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetPackageStatusRequest`](#type-com-daml-ledger-api-v2-getpackagestatusrequest) | [`com.daml.ledger.api.v2.GetPackageStatusResponse`](#type-com-daml-ledger-api-v2-getpackagestatusresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |
+| [`ListPackages`](#endpoint-com-daml-ledger-api-v2-packageservice-listpackages) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.ListPackagesRequest`](#type-com-daml-ledger-api-v2-listpackagesrequest) | [`com.daml.ledger.api.v2.ListPackagesResponse`](#type-com-daml-ledger-api-v2-listpackagesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |
+| [`ListVettedPackages`](#endpoint-com-daml-ledger-api-v2-packageservice-listvettedpackages) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.ListVettedPackagesRequest`](#type-com-daml-ledger-api-v2-listvettedpackagesrequest) | [`com.daml.ledger.api.v2.ListVettedPackagesResponse`](#type-com-daml-ledger-api-v2-listvettedpackagesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-packageservice-getpackage"></a>
+**Endpoint `PackageService.GetPackage`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PackageService.GetPackage(com.daml.ledger.api.v2.GetPackageRequest) returns (com.daml.ledger.api.v2.GetPackageResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetPackageRequest`](#type-com-daml-ledger-api-v2-getpackagerequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetPackageResponse`](#type-com-daml-ledger-api-v2-getpackageresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-packageservice-getpackagestatus"></a>
+**Endpoint `PackageService.GetPackageStatus`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PackageService.GetPackageStatus(com.daml.ledger.api.v2.GetPackageStatusRequest) returns (com.daml.ledger.api.v2.GetPackageStatusResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetPackageStatusRequest`](#type-com-daml-ledger-api-v2-getpackagestatusrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetPackageStatusResponse`](#type-com-daml-ledger-api-v2-getpackagestatusresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-packageservice-listpackages"></a>
+**Endpoint `PackageService.ListPackages`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PackageService.ListPackages(com.daml.ledger.api.v2.ListPackagesRequest) returns (com.daml.ledger.api.v2.ListPackagesResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.ListPackagesRequest`](#type-com-daml-ledger-api-v2-listpackagesrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.ListPackagesResponse`](#type-com-daml-ledger-api-v2-listpackagesresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-packageservice-listvettedpackages"></a>
+**Endpoint `PackageService.ListVettedPackages`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+
+**Signature**
+
+```protobuf
+rpc PackageService.ListVettedPackages(com.daml.ledger.api.v2.ListVettedPackagesRequest) returns (com.daml.ledger.api.v2.ListVettedPackagesResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.ListVettedPackagesRequest`](#type-com-daml-ledger-api-v2-listvettedpackagesrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.ListVettedPackagesResponse`](#type-com-daml-ledger-api-v2-listvettedpackagesresponse)
+
+<a id="service-com-daml-ledger-api-v2-stateservice"></a>
+### Service `StateService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Endpoints tracked: `4`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`GetActiveContracts`](#endpoint-com-daml-ledger-api-v2-stateservice-getactivecontracts) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetActiveContractsRequest`](#type-com-daml-ledger-api-v2-getactivecontractsrequest) | [`com.daml.ledger.api.v2.GetActiveContractsResponse`](#type-com-daml-ledger-api-v2-getactivecontractsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |
+| [`GetConnectedSynchronizers`](#endpoint-com-daml-ledger-api-v2-stateservice-getconnectedsynchronizers) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetConnectedSynchronizersRequest`](#type-com-daml-ledger-api-v2-getconnectedsynchronizersrequest) | [`com.daml.ledger.api.v2.GetConnectedSynchronizersResponse`](#type-com-daml-ledger-api-v2-getconnectedsynchronizersresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |
+| [`GetLatestPrunedOffsets`](#endpoint-com-daml-ledger-api-v2-stateservice-getlatestprunedoffsets) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest`](#type-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest) | [`com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse`](#type-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |
+| [`GetLedgerEnd`](#endpoint-com-daml-ledger-api-v2-stateservice-getledgerend) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetLedgerEndRequest`](#type-com-daml-ledger-api-v2-getledgerendrequest) | [`com.daml.ledger.api.v2.GetLedgerEndResponse`](#type-com-daml-ledger-api-v2-getledgerendresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-stateservice-getactivecontracts"></a>
+**Endpoint `StateService.GetActiveContracts`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+
+**Signature**
+
+```protobuf
+rpc StateService.GetActiveContracts(com.daml.ledger.api.v2.GetActiveContractsRequest) returns (stream com.daml.ledger.api.v2.GetActiveContractsResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetActiveContractsRequest`](#type-com-daml-ledger-api-v2-getactivecontractsrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetActiveContractsResponse`](#type-com-daml-ledger-api-v2-getactivecontractsresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-stateservice-getconnectedsynchronizers"></a>
+**Endpoint `StateService.GetConnectedSynchronizers`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+
+**Signature**
+
+```protobuf
+rpc StateService.GetConnectedSynchronizers(com.daml.ledger.api.v2.GetConnectedSynchronizersRequest) returns (com.daml.ledger.api.v2.GetConnectedSynchronizersResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetConnectedSynchronizersRequest`](#type-com-daml-ledger-api-v2-getconnectedsynchronizersrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetConnectedSynchronizersResponse`](#type-com-daml-ledger-api-v2-getconnectedsynchronizersresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-stateservice-getlatestprunedoffsets"></a>
+**Endpoint `StateService.GetLatestPrunedOffsets`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+
+**Signature**
+
+```protobuf
+rpc StateService.GetLatestPrunedOffsets(com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest) returns (com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest`](#type-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse`](#type-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-stateservice-getledgerend"></a>
+**Endpoint `StateService.GetLedgerEnd`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+
+**Signature**
+
+```protobuf
+rpc StateService.GetLedgerEnd(com.daml.ledger.api.v2.GetLedgerEndRequest) returns (com.daml.ledger.api.v2.GetLedgerEndResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetLedgerEndRequest`](#type-com-daml-ledger-api-v2-getledgerendrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetLedgerEndResponse`](#type-com-daml-ledger-api-v2-getledgerendresponse)
+
+<a id="service-com-daml-ledger-api-v2-updateservice"></a>
+### Service `UpdateService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
+- Endpoints tracked: `3`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`GetUpdateById`](#endpoint-com-daml-ledger-api-v2-updateservice-getupdatebyid) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetUpdateByIdRequest`](#type-com-daml-ledger-api-v2-getupdatebyidrequest) | [`com.daml.ledger.api.v2.GetUpdateResponse`](#type-com-daml-ledger-api-v2-getupdateresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto) |
+| [`GetUpdateByOffset`](#endpoint-com-daml-ledger-api-v2-updateservice-getupdatebyoffset) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetUpdateByOffsetRequest`](#type-com-daml-ledger-api-v2-getupdatebyoffsetrequest) | [`com.daml.ledger.api.v2.GetUpdateResponse`](#type-com-daml-ledger-api-v2-getupdateresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto) |
+| [`GetUpdates`](#endpoint-com-daml-ledger-api-v2-updateservice-getupdates) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetUpdatesRequest`](#type-com-daml-ledger-api-v2-getupdatesrequest) | [`com.daml.ledger.api.v2.GetUpdatesResponse`](#type-com-daml-ledger-api-v2-getupdatesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-updateservice-getupdatebyid"></a>
+**Endpoint `UpdateService.GetUpdateById`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UpdateService.GetUpdateById(com.daml.ledger.api.v2.GetUpdateByIdRequest) returns (com.daml.ledger.api.v2.GetUpdateResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetUpdateByIdRequest`](#type-com-daml-ledger-api-v2-getupdatebyidrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetUpdateResponse`](#type-com-daml-ledger-api-v2-getupdateresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-updateservice-getupdatebyoffset"></a>
+**Endpoint `UpdateService.GetUpdateByOffset`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UpdateService.GetUpdateByOffset(com.daml.ledger.api.v2.GetUpdateByOffsetRequest) returns (com.daml.ledger.api.v2.GetUpdateResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetUpdateByOffsetRequest`](#type-com-daml-ledger-api-v2-getupdatebyoffsetrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetUpdateResponse`](#type-com-daml-ledger-api-v2-getupdateresponse)
+
+<a id="endpoint-com-daml-ledger-api-v2-updateservice-getupdates"></a>
+**Endpoint `UpdateService.GetUpdates`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
+
+**Signature**
+
+```protobuf
+rpc UpdateService.GetUpdates(com.daml.ledger.api.v2.GetUpdatesRequest) returns (stream com.daml.ledger.api.v2.GetUpdatesResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetUpdatesRequest`](#type-com-daml-ledger-api-v2-getupdatesrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetUpdatesResponse`](#type-com-daml-ledger-api-v2-getupdatesresponse)
+
+<a id="service-com-daml-ledger-api-v2-versionservice"></a>
+### Service `VersionService`
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
+- Endpoints tracked: `1`
+
+_No description._
+
+| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`GetLedgerApiVersion`](#endpoint-com-daml-ledger-api-v2-versionservice-getledgerapiversion) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetLedgerApiVersionRequest`](#type-com-daml-ledger-api-v2-getledgerapiversionrequest) | [`com.daml.ledger.api.v2.GetLedgerApiVersionResponse`](#type-com-daml-ledger-api-v2-getledgerapiversionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto) |
+
+<a id="endpoint-com-daml-ledger-api-v2-versionservice-getledgerapiversion"></a>
+**Endpoint `VersionService.GetLedgerApiVersion`**
+
+- Introduced in: `3.4.4`
+- Last changed in: `3.4.4`
+- Removed in: `-`
+- Status: `current`
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
+
+**Signature**
+
+```protobuf
+rpc VersionService.GetLedgerApiVersion(com.daml.ledger.api.v2.GetLedgerApiVersionRequest) returns (com.daml.ledger.api.v2.GetLedgerApiVersionResponse);
+```
+
+_No description._
+
+**History**
+
+| Version | Kind | Details |
+| --- | --- | --- |
+| `3.4.4` | `introduced` |  |
+
+**Request Type**
+
+- [`com.daml.ledger.api.v2.GetLedgerApiVersionRequest`](#type-com-daml-ledger-api-v2-getledgerapiversionrequest)
+
+**Response Type**
+
+- [`com.daml.ledger.api.v2.GetLedgerApiVersionResponse`](#type-com-daml-ledger-api-v2-getledgerapiversionresponse)
+
+## Type Reference
+
+<a id="type-com-daml-ledger-api-v2-activecontract"></a>
+**Message `com.daml.ledger.api.v2.ActiveContract`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| created_event | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
+| synchronizer_id | `string` | optional |  |
+| reassignment_counter | `uint64` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-archived"></a>
+**Message `com.daml.ledger.api.v2.Archived`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| archived_event | [`com.daml.ledger.api.v2.ArchivedEvent`](#type-com-daml-ledger-api-v2-archivedevent) | optional |  |
+| synchronizer_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-archivedevent"></a>
+**Message `com.daml.ledger.api.v2.ArchivedEvent`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto)
+- Fields: 7
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| offset | `int64` | optional |  |
+| node_id | `int32` | optional |  |
+| contract_id | `string` | optional |  |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| witness_parties | `string` | repeated |  |
+| package_name | `string` | optional |  |
+| implemented_interfaces | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-assigncommand"></a>
+**Message `com.daml.ledger.api.v2.AssignCommand`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| reassignment_id | `string` | optional |  |
+| source | `string` | optional |  |
+| target | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-assignedevent"></a>
+**Message `com.daml.ledger.api.v2.AssignedEvent`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto)
+- Fields: 6
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| source | `string` | optional |  |
+| target | `string` | optional |  |
+| reassignment_id | `string` | optional |  |
+| submitter | `string` | optional |  |
+| reassignment_counter | `uint64` | optional |  |
+| created_event | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-command"></a>
+**Message `com.daml.ledger.api.v2.Command`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| create | [`com.daml.ledger.api.v2.CreateCommand`](#type-com-daml-ledger-api-v2-createcommand) | optional |  |
+| exercise | [`com.daml.ledger.api.v2.ExerciseCommand`](#type-com-daml-ledger-api-v2-exercisecommand) | optional |  |
+| exercise_by_key | [`com.daml.ledger.api.v2.ExerciseByKeyCommand`](#type-com-daml-ledger-api-v2-exercisebykeycommand) | optional |  |
+| create_and_exercise | [`com.daml.ledger.api.v2.CreateAndExerciseCommand`](#type-com-daml-ledger-api-v2-createandexercisecommand) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-commands"></a>
+**Message `com.daml.ledger.api.v2.Commands`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
+- Fields: 15
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| workflow_id | `string` | optional |  |
+| user_id | `string` | optional |  |
+| command_id | `string` | optional |  |
+| commands | [`com.daml.ledger.api.v2.Command`](#type-com-daml-ledger-api-v2-command) | repeated |  |
+| deduplication_duration | `google.protobuf.Duration` | optional |  |
+| deduplication_offset | `int64` | optional |  |
+| min_ledger_time_abs | `google.protobuf.Timestamp` | optional |  |
+| min_ledger_time_rel | `google.protobuf.Duration` | optional |  |
+| act_as | `string` | repeated |  |
+| read_as | `string` | repeated |  |
+| submission_id | `string` | optional |  |
+| disclosed_contracts | [`com.daml.ledger.api.v2.DisclosedContract`](#type-com-daml-ledger-api-v2-disclosedcontract) | repeated |  |
+| synchronizer_id | `string` | optional |  |
+| package_id_selection_preference | `string` | repeated |  |
+| prefetch_contract_keys | [`com.daml.ledger.api.v2.PrefetchContractKey`](#type-com-daml-ledger-api-v2-prefetchcontractkey) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-completion"></a>
+**Message `com.daml.ledger.api.v2.Completion`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto)
+- Fields: 11
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| command_id | `string` | optional |  |
+| status | `google.rpc.Status` | optional |  |
+| update_id | `string` | optional |  |
+| user_id | `string` | optional |  |
+| act_as | `string` | repeated |  |
+| submission_id | `string` | optional |  |
+| deduplication_offset | `int64` | optional |  |
+| deduplication_duration | `google.protobuf.Duration` | optional |  |
+| trace_context | [`com.daml.ledger.api.v2.TraceContext`](#type-com-daml-ledger-api-v2-tracecontext) | optional |  |
+| offset | `int64` | optional |  |
+| synchronizer_time | [`com.daml.ledger.api.v2.SynchronizerTime`](#type-com-daml-ledger-api-v2-synchronizertime) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-completionstreamrequest"></a>
+**Message `com.daml.ledger.api.v2.CompletionStreamRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| user_id | `string` | optional |  |
+| parties | `string` | repeated |  |
+| begin_exclusive | `int64` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-completionstreamresponse"></a>
+**Message `com.daml.ledger.api.v2.CompletionStreamResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| completion | [`com.daml.ledger.api.v2.Completion`](#type-com-daml-ledger-api-v2-completion) | optional |  |
+| offset_checkpoint | [`com.daml.ledger.api.v2.OffsetCheckpoint`](#type-com-daml-ledger-api-v2-offsetcheckpoint) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-createandexercisecommand"></a>
+**Message `com.daml.ledger.api.v2.CreateAndExerciseCommand`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| create_arguments | [`com.daml.ledger.api.v2.Record`](#type-com-daml-ledger-api-v2-record) | optional |  |
+| choice | `string` | optional |  |
+| choice_argument | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-createcommand"></a>
+**Message `com.daml.ledger.api.v2.CreateCommand`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| create_arguments | [`com.daml.ledger.api.v2.Record`](#type-com-daml-ledger-api-v2-record) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-created"></a>
+**Message `com.daml.ledger.api.v2.Created`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| created_event | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
+| synchronizer_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-createdevent"></a>
+**Message `com.daml.ledger.api.v2.CreatedEvent`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto)
+- Fields: 15
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| offset | `int64` | optional |  |
+| node_id | `int32` | optional |  |
+| contract_id | `string` | optional |  |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| contract_key | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+| create_arguments | [`com.daml.ledger.api.v2.Record`](#type-com-daml-ledger-api-v2-record) | optional |  |
+| created_event_blob | `bytes` | optional |  |
+| interface_views | [`com.daml.ledger.api.v2.InterfaceView`](#type-com-daml-ledger-api-v2-interfaceview) | repeated |  |
+| witness_parties | `string` | repeated |  |
+| signatories | `string` | repeated |  |
+| observers | `string` | repeated |  |
+| created_at | `google.protobuf.Timestamp` | optional |  |
+| package_name | `string` | optional |  |
+| acs_delta | `bool` | optional |  |
+| representative_package_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-cumulativefilter"></a>
+**Message `com.daml.ledger.api.v2.CumulativeFilter`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| wildcard_filter | [`com.daml.ledger.api.v2.WildcardFilter`](#type-com-daml-ledger-api-v2-wildcardfilter) | optional |  |
+| interface_filter | [`com.daml.ledger.api.v2.InterfaceFilter`](#type-com-daml-ledger-api-v2-interfacefilter) | optional |  |
+| template_filter | [`com.daml.ledger.api.v2.TemplateFilter`](#type-com-daml-ledger-api-v2-templatefilter) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-disclosedcontract"></a>
+**Message `com.daml.ledger.api.v2.DisclosedContract`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| contract_id | `string` | optional |  |
+| created_event_blob | `bytes` | optional |  |
+| synchronizer_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-enum"></a>
+**Message `com.daml.ledger.api.v2.Enum`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| enum_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| constructor | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-event"></a>
+**Message `com.daml.ledger.api.v2.Event`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| created | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
+| archived | [`com.daml.ledger.api.v2.ArchivedEvent`](#type-com-daml-ledger-api-v2-archivedevent) | optional |  |
+| exercised | [`com.daml.ledger.api.v2.ExercisedEvent`](#type-com-daml-ledger-api-v2-exercisedevent) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-eventformat"></a>
+**Message `com.daml.ledger.api.v2.EventFormat`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| filters_by_party | `map<string, com.daml.ledger.api.v2.Filters>` | repeated |  |
+| filters_for_any_party | [`com.daml.ledger.api.v2.Filters`](#type-com-daml-ledger-api-v2-filters) | optional |  |
+| verbose | `bool` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-exercisebykeycommand"></a>
+**Message `com.daml.ledger.api.v2.ExerciseByKeyCommand`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| contract_key | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+| choice | `string` | optional |  |
+| choice_argument | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-exercisecommand"></a>
+**Message `com.daml.ledger.api.v2.ExerciseCommand`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| contract_id | `string` | optional |  |
+| choice | `string` | optional |  |
+| choice_argument | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-exercisedevent"></a>
+**Message `com.daml.ledger.api.v2.ExercisedEvent`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto)
+- Fields: 15
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| offset | `int64` | optional |  |
+| node_id | `int32` | optional |  |
+| contract_id | `string` | optional |  |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| interface_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| choice | `string` | optional |  |
+| choice_argument | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+| acting_parties | `string` | repeated |  |
+| consuming | `bool` | optional |  |
+| witness_parties | `string` | repeated |  |
+| last_descendant_node_id | `int32` | optional |  |
+| exercise_result | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+| package_name | `string` | optional |  |
+| implemented_interfaces | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | repeated |  |
+| acs_delta | `bool` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-experimentalcommandinspectionservice"></a>
+**Message `com.daml.ledger.api.v2.ExperimentalCommandInspectionService`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| supported | `bool` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-experimentalfeatures"></a>
+**Message `com.daml.ledger.api.v2.ExperimentalFeatures`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| static_time | [`com.daml.ledger.api.v2.ExperimentalStaticTime`](#type-com-daml-ledger-api-v2-experimentalstatictime) | optional |  |
+| command_inspection_service | [`com.daml.ledger.api.v2.ExperimentalCommandInspectionService`](#type-com-daml-ledger-api-v2-experimentalcommandinspectionservice) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-experimentalpartytopologyevents"></a>
+**Message `com.daml.ledger.api.v2.ExperimentalPartyTopologyEvents`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| supported | `bool` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-experimentalstatictime"></a>
+**Message `com.daml.ledger.api.v2.ExperimentalStaticTime`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| supported | `bool` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-featuresdescriptor"></a>
+**Message `com.daml.ledger.api.v2.FeaturesDescriptor`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
+- Fields: 5
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| experimental | [`com.daml.ledger.api.v2.ExperimentalFeatures`](#type-com-daml-ledger-api-v2-experimentalfeatures) | optional |  |
+| user_management | [`com.daml.ledger.api.v2.UserManagementFeature`](#type-com-daml-ledger-api-v2-usermanagementfeature) | optional |  |
+| party_management | [`com.daml.ledger.api.v2.PartyManagementFeature`](#type-com-daml-ledger-api-v2-partymanagementfeature) | optional |  |
+| offset_checkpoint | [`com.daml.ledger.api.v2.OffsetCheckpointFeature`](#type-com-daml-ledger-api-v2-offsetcheckpointfeature) | optional |  |
+| package_feature | [`com.daml.ledger.api.v2.PackageFeature`](#type-com-daml-ledger-api-v2-packagefeature) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-filters"></a>
+**Message `com.daml.ledger.api.v2.Filters`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| cumulative | [`com.daml.ledger.api.v2.CumulativeFilter`](#type-com-daml-ledger-api-v2-cumulativefilter) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-genmap"></a>
+**Message `com.daml.ledger.api.v2.GenMap`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| entries | [`com.daml.ledger.api.v2.GenMap.Entry`](#type-com-daml-ledger-api-v2-genmap-entry) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-genmap-entry"></a>
+**Message `com.daml.ledger.api.v2.GenMap.Entry`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| key | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+| value | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getactivecontractsrequest"></a>
+**Message `com.daml.ledger.api.v2.GetActiveContractsRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| active_at_offset | `int64` | optional |  |
+| event_format | [`com.daml.ledger.api.v2.EventFormat`](#type-com-daml-ledger-api-v2-eventformat) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getactivecontractsresponse"></a>
+**Message `com.daml.ledger.api.v2.GetActiveContractsResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| workflow_id | `string` | optional |  |
+| active_contract | [`com.daml.ledger.api.v2.ActiveContract`](#type-com-daml-ledger-api-v2-activecontract) | optional |  |
+| incomplete_unassigned | [`com.daml.ledger.api.v2.IncompleteUnassigned`](#type-com-daml-ledger-api-v2-incompleteunassigned) | optional |  |
+| incomplete_assigned | [`com.daml.ledger.api.v2.IncompleteAssigned`](#type-com-daml-ledger-api-v2-incompleteassigned) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getconnectedsynchronizersrequest"></a>
+**Message `com.daml.ledger.api.v2.GetConnectedSynchronizersRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party | `string` | optional |  |
+| participant_id | `string` | optional |  |
+| identity_provider_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getconnectedsynchronizersresponse"></a>
+**Message `com.daml.ledger.api.v2.GetConnectedSynchronizersResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| connected_synchronizers | [`com.daml.ledger.api.v2.GetConnectedSynchronizersResponse.ConnectedSynchronizer`](#type-com-daml-ledger-api-v2-getconnectedsynchronizersresponse-connectedsynchronizer) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-getconnectedsynchronizersresponse-connectedsynchronizer"></a>
+**Message `com.daml.ledger.api.v2.GetConnectedSynchronizersResponse.ConnectedSynchronizer`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| synchronizer_alias | `string` | optional |  |
+| synchronizer_id | `string` | optional |  |
+| permission | [`com.daml.ledger.api.v2.ParticipantPermission`](#type-com-daml-ledger-api-v2-participantpermission) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getcontractrequest"></a>
+**Message `com.daml.ledger.api.v2.GetContractRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| contract_id | `string` | optional |  |
+| querying_parties | `string` | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-getcontractresponse"></a>
+**Message `com.daml.ledger.api.v2.GetContractResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| created_event | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-geteventsbycontractidrequest"></a>
+**Message `com.daml.ledger.api.v2.GetEventsByContractIdRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| contract_id | `string` | optional |  |
+| event_format | [`com.daml.ledger.api.v2.EventFormat`](#type-com-daml-ledger-api-v2-eventformat) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-geteventsbycontractidresponse"></a>
+**Message `com.daml.ledger.api.v2.GetEventsByContractIdResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| created | [`com.daml.ledger.api.v2.Created`](#type-com-daml-ledger-api-v2-created) | optional |  |
+| archived | [`com.daml.ledger.api.v2.Archived`](#type-com-daml-ledger-api-v2-archived) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest"></a>
+**Message `com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse"></a>
+**Message `com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| participant_pruned_up_to_inclusive | `int64` | optional |  |
+| all_divulged_contracts_pruned_up_to_inclusive | `int64` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getledgerapiversionrequest"></a>
+**Message `com.daml.ledger.api.v2.GetLedgerApiVersionRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-getledgerapiversionresponse"></a>
+**Message `com.daml.ledger.api.v2.GetLedgerApiVersionResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| version | `string` | optional |  |
+| features | [`com.daml.ledger.api.v2.FeaturesDescriptor`](#type-com-daml-ledger-api-v2-featuresdescriptor) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getledgerendrequest"></a>
+**Message `com.daml.ledger.api.v2.GetLedgerEndRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-getledgerendresponse"></a>
+**Message `com.daml.ledger.api.v2.GetLedgerEndResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| offset | `int64` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getpackagerequest"></a>
+**Message `com.daml.ledger.api.v2.GetPackageRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getpackageresponse"></a>
+**Message `com.daml.ledger.api.v2.GetPackageResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| hash_function | [`com.daml.ledger.api.v2.HashFunction`](#type-com-daml-ledger-api-v2-hashfunction) | optional |  |
+| archive_payload | `bytes` | optional |  |
+| hash | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getpackagestatusrequest"></a>
+**Message `com.daml.ledger.api.v2.GetPackageStatusRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getpackagestatusresponse"></a>
+**Message `com.daml.ledger.api.v2.GetPackageStatusResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_status | [`com.daml.ledger.api.v2.PackageStatus`](#type-com-daml-ledger-api-v2-packagestatus) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getupdatebyidrequest"></a>
+**Message `com.daml.ledger.api.v2.GetUpdateByIdRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| update_id | `string` | optional |  |
+| update_format | [`com.daml.ledger.api.v2.UpdateFormat`](#type-com-daml-ledger-api-v2-updateformat) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getupdatebyoffsetrequest"></a>
+**Message `com.daml.ledger.api.v2.GetUpdateByOffsetRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| offset | `int64` | optional |  |
+| update_format | [`com.daml.ledger.api.v2.UpdateFormat`](#type-com-daml-ledger-api-v2-updateformat) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getupdateresponse"></a>
+**Message `com.daml.ledger.api.v2.GetUpdateResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| transaction | [`com.daml.ledger.api.v2.Transaction`](#type-com-daml-ledger-api-v2-transaction) | optional |  |
+| reassignment | [`com.daml.ledger.api.v2.Reassignment`](#type-com-daml-ledger-api-v2-reassignment) | optional |  |
+| topology_transaction | [`com.daml.ledger.api.v2.TopologyTransaction`](#type-com-daml-ledger-api-v2-topologytransaction) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getupdatesrequest"></a>
+**Message `com.daml.ledger.api.v2.GetUpdatesRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| begin_exclusive | `int64` | optional |  |
+| end_inclusive | `int64` | optional |  |
+| update_format | [`com.daml.ledger.api.v2.UpdateFormat`](#type-com-daml-ledger-api-v2-updateformat) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-getupdatesresponse"></a>
+**Message `com.daml.ledger.api.v2.GetUpdatesResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| transaction | [`com.daml.ledger.api.v2.Transaction`](#type-com-daml-ledger-api-v2-transaction) | optional |  |
+| reassignment | [`com.daml.ledger.api.v2.Reassignment`](#type-com-daml-ledger-api-v2-reassignment) | optional |  |
+| offset_checkpoint | [`com.daml.ledger.api.v2.OffsetCheckpoint`](#type-com-daml-ledger-api-v2-offsetcheckpoint) | optional |  |
+| topology_transaction | [`com.daml.ledger.api.v2.TopologyTransaction`](#type-com-daml-ledger-api-v2-topologytransaction) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-identifier"></a>
+**Message `com.daml.ledger.api.v2.Identifier`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_id | `string` | optional |  |
+| module_name | `string` | optional |  |
+| entity_name | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-incompleteassigned"></a>
+**Message `com.daml.ledger.api.v2.IncompleteAssigned`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| assigned_event | [`com.daml.ledger.api.v2.AssignedEvent`](#type-com-daml-ledger-api-v2-assignedevent) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-incompleteunassigned"></a>
+**Message `com.daml.ledger.api.v2.IncompleteUnassigned`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| created_event | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
+| unassigned_event | [`com.daml.ledger.api.v2.UnassignedEvent`](#type-com-daml-ledger-api-v2-unassignedevent) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interfacefilter"></a>
+**Message `com.daml.ledger.api.v2.InterfaceFilter`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| interface_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| include_interface_view | `bool` | optional |  |
+| include_created_event_blob | `bool` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-interfaceview"></a>
+**Message `com.daml.ledger.api.v2.InterfaceView`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| interface_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| view_status | `google.rpc.Status` | optional |  |
+| view_value | [`com.daml.ledger.api.v2.Record`](#type-com-daml-ledger-api-v2-record) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-list"></a>
+**Message `com.daml.ledger.api.v2.List`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| elements | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-listpackagesrequest"></a>
+**Message `com.daml.ledger.api.v2.ListPackagesRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-listpackagesresponse"></a>
+**Message `com.daml.ledger.api.v2.ListPackagesResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_ids | `string` | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-listvettedpackagesrequest"></a>
+**Message `com.daml.ledger.api.v2.ListVettedPackagesRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_metadata_filter | [`com.daml.ledger.api.v2.PackageMetadataFilter`](#type-com-daml-ledger-api-v2-packagemetadatafilter) | optional |  |
+| topology_state_filter | [`com.daml.ledger.api.v2.TopologyStateFilter`](#type-com-daml-ledger-api-v2-topologystatefilter) | optional |  |
+| page_token | `string` | optional |  |
+| page_size | `uint32` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-listvettedpackagesresponse"></a>
+**Message `com.daml.ledger.api.v2.ListVettedPackagesResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| vetted_packages | [`com.daml.ledger.api.v2.VettedPackages`](#type-com-daml-ledger-api-v2-vettedpackages) | repeated |  |
+| next_page_token | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-offsetcheckpoint"></a>
+**Message `com.daml.ledger.api.v2.OffsetCheckpoint`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| offset | `int64` | optional |  |
+| synchronizer_times | [`com.daml.ledger.api.v2.SynchronizerTime`](#type-com-daml-ledger-api-v2-synchronizertime) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-offsetcheckpointfeature"></a>
+**Message `com.daml.ledger.api.v2.OffsetCheckpointFeature`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| max_offset_checkpoint_emission_delay | `google.protobuf.Duration` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-optional"></a>
+**Message `com.daml.ledger.api.v2.Optional`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| value | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-packagefeature"></a>
+**Message `com.daml.ledger.api.v2.PackageFeature`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| max_vetted_packages_page_size | `int32` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-packagemetadatafilter"></a>
+**Message `com.daml.ledger.api.v2.PackageMetadataFilter`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_ids | `string` | repeated |  |
+| package_name_prefixes | `string` | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-packagereference"></a>
+**Message `com.daml.ledger.api.v2.PackageReference`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_id | `string` | optional |  |
+| package_name | `string` | optional |  |
+| package_version | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-participantauthorizationadded"></a>
+**Message `com.daml.ledger.api.v2.ParticipantAuthorizationAdded`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party_id | `string` | optional |  |
+| participant_id | `string` | optional |  |
+| participant_permission | [`com.daml.ledger.api.v2.ParticipantPermission`](#type-com-daml-ledger-api-v2-participantpermission) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-participantauthorizationchanged"></a>
+**Message `com.daml.ledger.api.v2.ParticipantAuthorizationChanged`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party_id | `string` | optional |  |
+| participant_id | `string` | optional |  |
+| participant_permission | [`com.daml.ledger.api.v2.ParticipantPermission`](#type-com-daml-ledger-api-v2-participantpermission) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-participantauthorizationrevoked"></a>
+**Message `com.daml.ledger.api.v2.ParticipantAuthorizationRevoked`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| party_id | `string` | optional |  |
+| participant_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-participantauthorizationtopologyformat"></a>
+**Message `com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| parties | `string` | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-partymanagementfeature"></a>
+**Message `com.daml.ledger.api.v2.PartyManagementFeature`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| max_parties_page_size | `int32` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-prefetchcontractkey"></a>
+**Message `com.daml.ledger.api.v2.PrefetchContractKey`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| contract_key | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-priortopologyserial"></a>
+**Message `com.daml.ledger.api.v2.PriorTopologySerial`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| prior | `uint32` | optional |  |
+| no_prior | `google.protobuf.Empty` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-reassignment"></a>
+**Message `com.daml.ledger.api.v2.Reassignment`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto)
+- Fields: 8
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| update_id | `string` | optional |  |
+| command_id | `string` | optional |  |
+| workflow_id | `string` | optional |  |
+| offset | `int64` | optional |  |
+| events | [`com.daml.ledger.api.v2.ReassignmentEvent`](#type-com-daml-ledger-api-v2-reassignmentevent) | repeated |  |
+| trace_context | [`com.daml.ledger.api.v2.TraceContext`](#type-com-daml-ledger-api-v2-tracecontext) | optional |  |
+| record_time | `google.protobuf.Timestamp` | optional |  |
+| synchronizer_id | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-reassignmentcommand"></a>
+**Message `com.daml.ledger.api.v2.ReassignmentCommand`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| unassign_command | [`com.daml.ledger.api.v2.UnassignCommand`](#type-com-daml-ledger-api-v2-unassigncommand) | optional |  |
+| assign_command | [`com.daml.ledger.api.v2.AssignCommand`](#type-com-daml-ledger-api-v2-assigncommand) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-reassignmentcommands"></a>
+**Message `com.daml.ledger.api.v2.ReassignmentCommands`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto)
+- Fields: 6
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| workflow_id | `string` | optional |  |
+| user_id | `string` | optional |  |
+| command_id | `string` | optional |  |
+| submitter | `string` | optional |  |
+| submission_id | `string` | optional |  |
+| commands | [`com.daml.ledger.api.v2.ReassignmentCommand`](#type-com-daml-ledger-api-v2-reassignmentcommand) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-reassignmentevent"></a>
+**Message `com.daml.ledger.api.v2.ReassignmentEvent`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| unassigned | [`com.daml.ledger.api.v2.UnassignedEvent`](#type-com-daml-ledger-api-v2-unassignedevent) | optional |  |
+| assigned | [`com.daml.ledger.api.v2.AssignedEvent`](#type-com-daml-ledger-api-v2-assignedevent) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-record"></a>
+**Message `com.daml.ledger.api.v2.Record`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| record_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| fields | [`com.daml.ledger.api.v2.RecordField`](#type-com-daml-ledger-api-v2-recordfield) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-recordfield"></a>
+**Message `com.daml.ledger.api.v2.RecordField`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| label | `string` | optional |  |
+| value | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-signature"></a>
+**Message `com.daml.ledger.api.v2.Signature`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| format | [`com.daml.ledger.api.v2.SignatureFormat`](#type-com-daml-ledger-api-v2-signatureformat) | optional |  |
+| signature | `bytes` | optional |  |
+| signed_by | `string` | optional |  |
+| signing_algorithm_spec | [`com.daml.ledger.api.v2.SigningAlgorithmSpec`](#type-com-daml-ledger-api-v2-signingalgorithmspec) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-signingpublickey"></a>
+**Message `com.daml.ledger.api.v2.SigningPublicKey`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| format | [`com.daml.ledger.api.v2.CryptoKeyFormat`](#type-com-daml-ledger-api-v2-cryptokeyformat) | optional |  |
+| key_data | `bytes` | optional |  |
+| key_spec | [`com.daml.ledger.api.v2.SigningKeySpec`](#type-com-daml-ledger-api-v2-signingkeyspec) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest"></a>
+**Message `com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| reassignment_commands | [`com.daml.ledger.api.v2.ReassignmentCommands`](#type-com-daml-ledger-api-v2-reassignmentcommands) | optional |  |
+| event_format | [`com.daml.ledger.api.v2.EventFormat`](#type-com-daml-ledger-api-v2-eventformat) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse"></a>
+**Message `com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| reassignment | [`com.daml.ledger.api.v2.Reassignment`](#type-com-daml-ledger-api-v2-reassignment) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-submitandwaitfortransactionrequest"></a>
+**Message `com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| commands | [`com.daml.ledger.api.v2.Commands`](#type-com-daml-ledger-api-v2-commands) | optional |  |
+| transaction_format | [`com.daml.ledger.api.v2.TransactionFormat`](#type-com-daml-ledger-api-v2-transactionformat) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-submitandwaitfortransactionresponse"></a>
+**Message `com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| transaction | [`com.daml.ledger.api.v2.Transaction`](#type-com-daml-ledger-api-v2-transaction) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-submitandwaitrequest"></a>
+**Message `com.daml.ledger.api.v2.SubmitAndWaitRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| commands | [`com.daml.ledger.api.v2.Commands`](#type-com-daml-ledger-api-v2-commands) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-submitandwaitresponse"></a>
+**Message `com.daml.ledger.api.v2.SubmitAndWaitResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| update_id | `string` | optional |  |
+| completion_offset | `int64` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-submitreassignmentrequest"></a>
+**Message `com.daml.ledger.api.v2.SubmitReassignmentRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| reassignment_commands | [`com.daml.ledger.api.v2.ReassignmentCommands`](#type-com-daml-ledger-api-v2-reassignmentcommands) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-submitreassignmentresponse"></a>
+**Message `com.daml.ledger.api.v2.SubmitReassignmentResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-submitrequest"></a>
+**Message `com.daml.ledger.api.v2.SubmitRequest`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| commands | [`com.daml.ledger.api.v2.Commands`](#type-com-daml-ledger-api-v2-commands) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-submitresponse"></a>
+**Message `com.daml.ledger.api.v2.SubmitResponse`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
+- Fields: 0
+
+_No description._
+
+<a id="type-com-daml-ledger-api-v2-synchronizertime"></a>
+**Message `com.daml.ledger.api.v2.SynchronizerTime`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| synchronizer_id | `string` | optional |  |
+| record_time | `google.protobuf.Timestamp` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-templatefilter"></a>
+**Message `com.daml.ledger.api.v2.TemplateFilter`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| include_created_event_blob | `bool` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-textmap"></a>
+**Message `com.daml.ledger.api.v2.TextMap`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| entries | [`com.daml.ledger.api.v2.TextMap.Entry`](#type-com-daml-ledger-api-v2-textmap-entry) | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-textmap-entry"></a>
+**Message `com.daml.ledger.api.v2.TextMap.Entry`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| key | `string` | optional |  |
+| value | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-topologyevent"></a>
+**Message `com.daml.ledger.api.v2.TopologyEvent`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| participant_authorization_changed | [`com.daml.ledger.api.v2.ParticipantAuthorizationChanged`](#type-com-daml-ledger-api-v2-participantauthorizationchanged) | optional |  |
+| participant_authorization_revoked | [`com.daml.ledger.api.v2.ParticipantAuthorizationRevoked`](#type-com-daml-ledger-api-v2-participantauthorizationrevoked) | optional |  |
+| participant_authorization_added | [`com.daml.ledger.api.v2.ParticipantAuthorizationAdded`](#type-com-daml-ledger-api-v2-participantauthorizationadded) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-topologyformat"></a>
+**Message `com.daml.ledger.api.v2.TopologyFormat`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| include_participant_authorization_events | [`com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat`](#type-com-daml-ledger-api-v2-participantauthorizationtopologyformat) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-topologystatefilter"></a>
+**Message `com.daml.ledger.api.v2.TopologyStateFilter`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| participant_ids | `string` | repeated |  |
+| synchronizer_ids | `string` | repeated |  |
+
+<a id="type-com-daml-ledger-api-v2-topologytransaction"></a>
+**Message `com.daml.ledger.api.v2.TopologyTransaction`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto)
+- Fields: 6
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| update_id | `string` | optional |  |
+| offset | `int64` | optional |  |
+| synchronizer_id | `string` | optional |  |
+| record_time | `google.protobuf.Timestamp` | optional |  |
+| events | [`com.daml.ledger.api.v2.TopologyEvent`](#type-com-daml-ledger-api-v2-topologyevent) | repeated |  |
+| trace_context | [`com.daml.ledger.api.v2.TraceContext`](#type-com-daml-ledger-api-v2-tracecontext) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-tracecontext"></a>
+**Message `com.daml.ledger.api.v2.TraceContext`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| traceparent | `string` | optional |  |
+| tracestate | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-transaction"></a>
+**Message `com.daml.ledger.api.v2.Transaction`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto)
+- Fields: 10
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| update_id | `string` | optional |  |
+| command_id | `string` | optional |  |
+| workflow_id | `string` | optional |  |
+| effective_at | `google.protobuf.Timestamp` | optional |  |
+| events | [`com.daml.ledger.api.v2.Event`](#type-com-daml-ledger-api-v2-event) | repeated |  |
+| offset | `int64` | optional |  |
+| synchronizer_id | `string` | optional |  |
+| trace_context | [`com.daml.ledger.api.v2.TraceContext`](#type-com-daml-ledger-api-v2-tracecontext) | optional |  |
+| record_time | `google.protobuf.Timestamp` | optional |  |
+| external_transaction_hash | `bytes` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-transactionformat"></a>
+**Message `com.daml.ledger.api.v2.TransactionFormat`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
+- Fields: 2
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| event_format | [`com.daml.ledger.api.v2.EventFormat`](#type-com-daml-ledger-api-v2-eventformat) | optional |  |
+| transaction_shape | [`com.daml.ledger.api.v2.TransactionShape`](#type-com-daml-ledger-api-v2-transactionshape) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-unassigncommand"></a>
+**Message `com.daml.ledger.api.v2.UnassignCommand`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| contract_id | `string` | optional |  |
+| source | `string` | optional |  |
+| target | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-unassignedevent"></a>
+**Message `com.daml.ledger.api.v2.UnassignedEvent`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto)
+- Fields: 12
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| reassignment_id | `string` | optional |  |
+| contract_id | `string` | optional |  |
+| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| source | `string` | optional |  |
+| target | `string` | optional |  |
+| submitter | `string` | optional |  |
+| reassignment_counter | `uint64` | optional |  |
+| assignment_exclusivity | `google.protobuf.Timestamp` | optional |  |
+| witness_parties | `string` | repeated |  |
+| package_name | `string` | optional |  |
+| offset | `int64` | optional |  |
+| node_id | `int32` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-updateformat"></a>
+**Message `com.daml.ledger.api.v2.UpdateFormat`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| include_transactions | [`com.daml.ledger.api.v2.TransactionFormat`](#type-com-daml-ledger-api-v2-transactionformat) | optional |  |
+| include_reassignments | [`com.daml.ledger.api.v2.EventFormat`](#type-com-daml-ledger-api-v2-eventformat) | optional |  |
+| include_topology_events | [`com.daml.ledger.api.v2.TopologyFormat`](#type-com-daml-ledger-api-v2-topologyformat) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-usermanagementfeature"></a>
+**Message `com.daml.ledger.api.v2.UserManagementFeature`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| supported | `bool` | optional |  |
+| max_rights_per_user | `int32` | optional |  |
+| max_users_page_size | `int32` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-value"></a>
+**Message `com.daml.ledger.api.v2.Value`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 16
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| unit | `google.protobuf.Empty` | optional |  |
+| bool | `bool` | optional |  |
+| int64 | `sint64` | optional |  |
+| date | `int32` | optional |  |
+| timestamp | `sfixed64` | optional |  |
+| numeric | `string` | optional |  |
+| party | `string` | optional |  |
+| text | `string` | optional |  |
+| contract_id | `string` | optional |  |
+| optional | [`com.daml.ledger.api.v2.Optional`](#type-com-daml-ledger-api-v2-optional) | optional |  |
+| list | [`com.daml.ledger.api.v2.List`](#type-com-daml-ledger-api-v2-list) | optional |  |
+| text_map | [`com.daml.ledger.api.v2.TextMap`](#type-com-daml-ledger-api-v2-textmap) | optional |  |
+| gen_map | [`com.daml.ledger.api.v2.GenMap`](#type-com-daml-ledger-api-v2-genmap) | optional |  |
+| record | [`com.daml.ledger.api.v2.Record`](#type-com-daml-ledger-api-v2-record) | optional |  |
+| variant | [`com.daml.ledger.api.v2.Variant`](#type-com-daml-ledger-api-v2-variant) | optional |  |
+| enum | [`com.daml.ledger.api.v2.Enum`](#type-com-daml-ledger-api-v2-enum) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-variant"></a>
+**Message `com.daml.ledger.api.v2.Variant`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
+- Fields: 3
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| variant_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
+| constructor | `string` | optional |  |
+| value | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-vettedpackage"></a>
+**Message `com.daml.ledger.api.v2.VettedPackage`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto)
+- Fields: 5
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| package_id | `string` | optional |  |
+| valid_from_inclusive | `google.protobuf.Timestamp` | optional |  |
+| valid_until_exclusive | `google.protobuf.Timestamp` | optional |  |
+| package_name | `string` | optional |  |
+| package_version | `string` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-vettedpackages"></a>
+**Message `com.daml.ledger.api.v2.VettedPackages`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto)
+- Fields: 4
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| packages | [`com.daml.ledger.api.v2.VettedPackage`](#type-com-daml-ledger-api-v2-vettedpackage) | repeated |  |
+| participant_id | `string` | optional |  |
+| synchronizer_id | `string` | optional |  |
+| topology_serial | `uint32` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-wildcardfilter"></a>
+**Message `com.daml.ledger.api.v2.WildcardFilter`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
+- Fields: 1
+
+_No description._
+
+| Field | Type | Label | Description |
+| --- | --- | --- | --- |
+| include_created_event_blob | `bool` | optional |  |
+
+<a id="type-com-daml-ledger-api-v2-cryptokeyformat"></a>
+**Enum `com.daml.ledger.api.v2.CryptoKeyFormat`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| CRYPTO_KEY_FORMAT_UNSPECIFIED | `0` |
+| CRYPTO_KEY_FORMAT_DER | `1` |
+| CRYPTO_KEY_FORMAT_RAW | `2` |
+| CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO | `3` |
+
+<a id="type-com-daml-ledger-api-v2-hashfunction"></a>
+**Enum `com.daml.ledger.api.v2.HashFunction`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| HASH_FUNCTION_SHA256 | `0` |
+
+<a id="type-com-daml-ledger-api-v2-packagestatus"></a>
+**Enum `com.daml.ledger.api.v2.PackageStatus`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| PACKAGE_STATUS_UNSPECIFIED | `0` |
+| PACKAGE_STATUS_REGISTERED | `1` |
+
+<a id="type-com-daml-ledger-api-v2-participantpermission"></a>
+**Enum `com.daml.ledger.api.v2.ParticipantPermission`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| PARTICIPANT_PERMISSION_UNSPECIFIED | `0` |
+| PARTICIPANT_PERMISSION_SUBMISSION | `1` |
+| PARTICIPANT_PERMISSION_CONFIRMATION | `2` |
+| PARTICIPANT_PERMISSION_OBSERVATION | `3` |
+
+<a id="type-com-daml-ledger-api-v2-signatureformat"></a>
+**Enum `com.daml.ledger.api.v2.SignatureFormat`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| SIGNATURE_FORMAT_UNSPECIFIED | `0` |
+| SIGNATURE_FORMAT_RAW | `1` |
+| SIGNATURE_FORMAT_DER | `2` |
+| SIGNATURE_FORMAT_CONCAT | `3` |
+| SIGNATURE_FORMAT_SYMBOLIC | `10000` |
+
+<a id="type-com-daml-ledger-api-v2-signingalgorithmspec"></a>
+**Enum `com.daml.ledger.api.v2.SigningAlgorithmSpec`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| SIGNING_ALGORITHM_SPEC_UNSPECIFIED | `0` |
+| SIGNING_ALGORITHM_SPEC_ED25519 | `1` |
+| SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256 | `2` |
+| SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384 | `3` |
+
+<a id="type-com-daml-ledger-api-v2-signingkeyspec"></a>
+**Enum `com.daml.ledger.api.v2.SigningKeySpec`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| SIGNING_KEY_SPEC_UNSPECIFIED | `0` |
+| SIGNING_KEY_SPEC_EC_CURVE25519 | `1` |
+| SIGNING_KEY_SPEC_EC_P256 | `2` |
+| SIGNING_KEY_SPEC_EC_P384 | `3` |
+| SIGNING_KEY_SPEC_EC_SECP256K1 | `4` |
+
+<a id="type-com-daml-ledger-api-v2-transactionshape"></a>
+**Enum `com.daml.ledger.api.v2.TransactionShape`**
+
+- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
+
+_No description._
+
+| Name | Number |
+| --- | --- |
+| TRANSACTION_SHAPE_UNSPECIFIED | `0` |
+| TRANSACTION_SHAPE_ACS_DELTA | `1` |
+| TRANSACTION_SHAPE_LEDGER_EFFECTS | `2` |

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "generate:all-reference-docs": "python3 scripts/generate_all_reference_docs.py",
     "generate:json-api-reference": "python3 scripts/generate_json_api_reference.py",
     "generate:json-api-asyncapi-reference": "python3 scripts/generate_json_api_asyncapi_reference.py",
     "generate:grpc-ledger-api-reference": "python3 scripts/generate_grpc_ledger_api_reference.py",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "generate:json-api-reference": "python3 scripts/generate_json_api_reference.py",
     "generate:json-api-asyncapi-reference": "python3 scripts/generate_json_api_asyncapi_reference.py",
+    "generate:grpc-ledger-api-reference": "python3 scripts/generate_grpc_ledger_api_reference.py",
     "generate:ledger-bindings-api-reference": "python3 scripts/generate_ledger_bindings_api_reference.py",
     "generate:daml-standard-library-reference": "python3 scripts/generate_daml_standard_library_reference.py",
     "generate:canton-protobuf-history": "python3 scripts/generate_canton_protobuf_history.py",

--- a/scripts/generate_all_reference_docs.py
+++ b/scripts/generate_all_reference_docs.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATHS = [
     REPO_ROOT / "scripts" / "generate_json_api_reference.py",
     REPO_ROOT / "scripts" / "generate_json_api_asyncapi_reference.py",
+    REPO_ROOT / "scripts" / "generate_grpc_ledger_api_reference.py",
     REPO_ROOT / "scripts" / "generate_ledger_bindings_api_reference.py",
     REPO_ROOT / "scripts" / "generate_daml_standard_library_reference.py",
     REPO_ROOT / "scripts" / "generate_canton_protobuf_history.py",

--- a/scripts/generate_grpc_ledger_api_reference.py
+++ b/scripts/generate_grpc_ledger_api_reference.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import generate_canton_protobuf_history as canton_protobuf_history
+from x2mdx.protobuf.lifecycle import (
+    build_endpoint_lifecycle,
+    build_protobuf_history_report_from_sources,
+    build_release_diffs,
+)
+from x2mdx.protobuf.render import build_pages
+from x2mdx.protobuf.snapshots import load_protobuf_sources
+from x2mdx.render import write_pages
+
+
+DEFAULT_SOURCE_CONFIG = REPO_ROOT / "config" / "x2mdx" / "grpc-ledger-api-reference" / "source-artifacts.json"
+DEFAULT_CACHE_DIR = REPO_ROOT / ".internal" / "cache" / "x2mdx" / "protobuf-history"
+DEFAULT_MANIFEST = REPO_ROOT / ".internal" / "generated" / "x2mdx" / "grpc-ledger-api-reference" / "manifest.json"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "docs-main" / "reference" / "grpc-ledger-api-reference"
+DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
+DEFAULT_REPO_DIR = DEFAULT_CACHE_DIR / "repos" / "canton"
+GROUP_LABEL = "gRPC Ledger API Reference"
+PACKAGE_GROUP_LABEL = "Packages"
+DEFAULT_INSERT_AFTER_GROUP = "Ledger API Endpoints"
+DEFAULT_SOURCE_NAME = "Canton Ledger API protobuf release bundles"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fetch Canton release-bundle protobuf inputs, filter them to Ledger API packages, and render a gRPC Ledger API reference."
+    )
+    parser.add_argument("--source-config", default=str(DEFAULT_SOURCE_CONFIG))
+    parser.add_argument("--cache-dir", default=str(DEFAULT_CACHE_DIR))
+    parser.add_argument("--manifest-out", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR))
+    parser.add_argument("--docs-json", default=str(DEFAULT_DOCS_JSON))
+    parser.add_argument("--nav-dropdown", default="Reference")
+    parser.add_argument("--nav-group", action="append")
+    parser.add_argument("--insert-after-group", default=DEFAULT_INSERT_AFTER_GROUP)
+    parser.add_argument("--repo-dir", default=str(DEFAULT_REPO_DIR))
+    parser.add_argument("--version", action="append", help="Explicit version to include. Repeat to limit generation.")
+    parser.add_argument("--min-version", help="Minimum stable version to include when auto-discovering tags.")
+    parser.add_argument("--skip-fetch", action="store_true", help="Skip fetching tags from origin before generation.")
+    parser.add_argument("--force-refresh", action="store_true", help="Refresh cached protobuf bundles and descriptor images.")
+    parser.add_argument(
+        "--source-name",
+        default=DEFAULT_SOURCE_NAME,
+        help="Source label embedded in generated content.",
+    )
+    parser.add_argument(
+        "--version-filter",
+        help="Version-filter label embedded in generated content.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def package_prefixes(source_config: dict[str, Any]) -> tuple[str, ...]:
+    configured = source_config.get("package_prefixes")
+    if configured is None:
+        return ("com.daml.ledger.api.v2",)
+    if not isinstance(configured, list) or not all(isinstance(item, str) and item for item in configured):
+        raise ValueError("Source config package_prefixes must be a list of non-empty strings")
+    return tuple(configured)
+
+
+def package_matches(package_name: str, *, prefixes: tuple[str, ...]) -> bool:
+    return any(package_name.startswith(prefix) for prefix in prefixes)
+
+
+def filter_snapshot(snapshot: dict[str, Any], *, prefixes: tuple[str, ...]) -> dict[str, Any]:
+    packages = [
+        copy.deepcopy(package)
+        for package in snapshot["packages"]
+        if package_matches(str(package["package"]), prefixes=prefixes)
+    ]
+    files = {
+        key: copy.deepcopy(value)
+        for key, value in snapshot["files"].items()
+        if package_matches(str(value["package"]), prefixes=prefixes)
+    }
+    services = {
+        key: copy.deepcopy(value)
+        for key, value in snapshot["services"].items()
+        if package_matches(str(value["package"]), prefixes=prefixes)
+    }
+    endpoints = {
+        key: copy.deepcopy(value)
+        for key, value in snapshot["endpoints"].items()
+        if package_matches(str(value["package"]), prefixes=prefixes)
+    }
+    messages = {
+        key: copy.deepcopy(value)
+        for key, value in snapshot["messages"].items()
+        if package_matches(str(value["package"]), prefixes=prefixes)
+    }
+    fields = {
+        key: copy.deepcopy(value)
+        for key, value in snapshot["fields"].items()
+        if package_matches(str(value["package"]), prefixes=prefixes)
+    }
+    enums = {
+        key: copy.deepcopy(value)
+        for key, value in snapshot["enums"].items()
+        if package_matches(str(value["package"]), prefixes=prefixes)
+    }
+    enum_values = {
+        key: copy.deepcopy(value)
+        for key, value in snapshot["enumValues"].items()
+        if package_matches(str(value["package"]), prefixes=prefixes)
+    }
+    return {
+        **snapshot,
+        "packages": packages,
+        "files": files,
+        "services": services,
+        "endpoints": endpoints,
+        "messages": messages,
+        "fields": fields,
+        "enums": enums,
+        "enumValues": enum_values,
+        "stats": {
+            "protoFiles": len(files),
+            "packages": len(packages),
+            "services": len(services),
+            "endpoints": len(endpoints),
+            "messages": len(messages),
+            "fields": len(fields),
+            "enums": len(enums),
+            "enumValues": len(enum_values),
+        },
+    }
+
+
+def build_filtered_report(
+    manifest_path: Path,
+    *,
+    prefixes: tuple[str, ...],
+    source_name: str,
+    version_filter: str,
+) -> dict[str, Any]:
+    sources = load_protobuf_sources(manifest_path)
+    report = build_protobuf_history_report_from_sources(
+        sources,
+        source_name=source_name,
+        version_filter=version_filter,
+    )
+    releases = [
+        {
+            **copy.deepcopy(release),
+            "snapshot": filter_snapshot(release["snapshot"], prefixes=prefixes),
+        }
+        for release in report["releases"]
+    ]
+    if not any(release["snapshot"]["packages"] for release in releases):
+        selected = ", ".join(prefixes)
+        raise ValueError(f"No protobuf packages matched the configured prefixes: {selected}")
+
+    build_release_diffs(releases)
+    endpoint_lifecycle = [
+        copy.deepcopy(entry)
+        for entry in build_endpoint_lifecycle(releases)
+        if package_matches(str(entry["package"]), prefixes=prefixes)
+    ]
+    latest_snapshot = releases[-1]["snapshot"]
+    return {
+        "generatedAt": report["generatedAt"],
+        "sourceName": source_name,
+        "versionFilter": version_filter,
+        "repo": copy.deepcopy(report["repo"]),
+        "latestRelease": releases[-1]["tag"],
+        "latestSnapshot": latest_snapshot,
+        "releases": releases,
+        "endpointLifecycle": endpoint_lifecycle,
+    }
+
+
+def replace_text(path: Path, replacements: list[tuple[str, str]]) -> None:
+    text = path.read_text(encoding="utf-8")
+    updated = text
+    for old, new in replacements:
+        updated = updated.replace(old, new)
+    if updated != text:
+        path.write_text(updated, encoding="utf-8")
+
+
+def retitle_generated_pages(*, output_dir: Path) -> None:
+    overview_path = output_dir / "index.mdx"
+    if overview_path.exists():
+        replace_text(
+            overview_path,
+            [
+                ("Canton Protobuf History", GROUP_LABEL),
+                (
+                    'description: "Descriptor-backed protobuf API history grouped by package."',
+                    'description: "Generated Ledger API gRPC reference grouped by package."',
+                ),
+                (
+                    "This page is generated from local descriptor-image snapshots with source info.",
+                    "This page is generated from published Canton protobuf release bundles and filtered to the Ledger API gRPC packages.",
+                ),
+            ],
+        )
+    packages_dir = output_dir / "packages"
+    for package_page in sorted(packages_dir.glob("*.mdx")):
+        replace_text(package_page, [("Canton Protobuf History", GROUP_LABEL)])
+
+
+def build_nav_group(
+    *,
+    docs_json_path: Path,
+    overview_path: Path,
+    package_paths: list[Path],
+) -> tuple[dict[str, Any], set[str]]:
+    overview_ref = canton_protobuf_history.docs_json_page_ref(overview_path, docs_json_path)
+    package_refs = [
+        canton_protobuf_history.docs_json_page_ref(package_path, docs_json_path)
+        for package_path in package_paths
+    ]
+    refs = {overview_ref, *package_refs}
+    pages: list[Any] = [overview_ref]
+    if package_refs:
+        pages.append({"group": PACKAGE_GROUP_LABEL, "pages": package_refs})
+    return {"group": GROUP_LABEL, "pages": pages}, refs
+
+
+def insert_group(items: list[Any], *, group: dict[str, Any], after_group: str | None) -> None:
+    if after_group:
+        for index, item in enumerate(items):
+            if isinstance(item, dict) and item.get("group") == after_group:
+                items.insert(index + 1, group)
+                return
+    items.append(group)
+
+
+def update_docs_navigation(
+    *,
+    docs_json_path: Path,
+    dropdown_label: str,
+    parent_groups: list[str],
+    insert_after_group: str | None,
+    overview_path: Path,
+    package_paths: list[Path],
+) -> None:
+    docs = load_json(docs_json_path)
+    navigation = docs.get("navigation")
+    if not isinstance(navigation, dict):
+        raise ValueError(f"docs.json navigation must be an object: {docs_json_path}")
+    dropdowns = navigation.get("dropdowns")
+    if not isinstance(dropdowns, list):
+        raise ValueError(f"docs.json navigation.dropdowns must be a list: {docs_json_path}")
+    dropdown = next((item for item in dropdowns if isinstance(item, dict) and item.get("dropdown") == dropdown_label), None)
+    if dropdown is None:
+        raise ValueError(f"Dropdown not found in docs.json: {dropdown_label}")
+    pages = dropdown.get("pages")
+    if not isinstance(pages, list):
+        raise ValueError(f"Dropdown does not expose a pages list: {dropdown_label}")
+
+    nav_group, generated_refs = build_nav_group(
+        docs_json_path=docs_json_path,
+        overview_path=overview_path,
+        package_paths=package_paths,
+    )
+    dropdown["pages"] = canton_protobuf_history.prune_nav_items(
+        pages,
+        page_refs=generated_refs,
+        group_labels={GROUP_LABEL},
+    )
+    target_pages = canton_protobuf_history.ensure_group_path(dropdown["pages"], parent_groups)
+    insert_group(target_pages, group=nav_group, after_group=insert_after_group)
+    docs_json_path.write_text(json.dumps(docs, indent=2) + "\n", encoding="utf-8")
+    print(f"Updated docs navigation: {docs_json_path}")
+
+
+def write_manifest(
+    *,
+    source_config: dict[str, Any],
+    cache_dir: Path,
+    manifest_path: Path,
+    repo_dir: Path,
+    include_versions: set[str] | None,
+    min_version: str,
+    skip_fetch: bool,
+    force_refresh: bool,
+) -> Path:
+    repo_config = source_config.get("repo") if isinstance(source_config.get("repo"), dict) else {}
+    remote = repo_config.get("remote")
+    if not isinstance(remote, str) or not remote:
+        raise ValueError("Source config must define repo.remote")
+    bundle_proto_dir = source_config.get("bundle_proto_dir") or "protobuf"
+    if not isinstance(bundle_proto_dir, str) or not bundle_proto_dir:
+        raise ValueError("Source config must define bundle_proto_dir")
+
+    repo_dir = canton_protobuf_history.ensure_repo(repo_dir, remote=remote, fetch=not skip_fetch)
+    selected_tags = canton_protobuf_history.stable_tags(
+        repo_dir,
+        min_version=min_version,
+        include_versions=include_versions,
+    )
+    if not selected_tags:
+        raise ValueError("No stable Canton tags selected")
+
+    releases: list[dict[str, Any]] = []
+    for version, tag in selected_tags:
+        archive_path = canton_protobuf_history.ensure_bundle_archive(
+            source_config=source_config,
+            version=version,
+            output_path=canton_protobuf_history.bundle_archive_path(cache_dir, version),
+            force_refresh=force_refresh,
+        )
+        protobuf_root = canton_protobuf_history.extract_archive(
+            archive_path,
+            extract_root=canton_protobuf_history.bundle_extract_root(cache_dir, version),
+            bundle_proto_dir=bundle_proto_dir,
+            force_refresh=force_refresh,
+        )
+        import_to_repo_path = canton_protobuf_history.import_to_repo_path_from_bundle(protobuf_root)
+        if not import_to_repo_path:
+            print(f"Skipping {tag}: no published owned protobuf files found")
+            continue
+        image_path = canton_protobuf_history.descriptor_image_path(cache_dir, version)
+        if not image_path.exists() or force_refresh:
+            canton_protobuf_history.compile_descriptor_image(protobuf_root, output_path=image_path)
+        releases.append(
+            {
+                "version": version,
+                "tag": tag,
+                "date": canton_protobuf_history.release_date(repo_dir, tag),
+                "descriptor_image_path": str(image_path.resolve()),
+                "import_to_repo_path": import_to_repo_path,
+            }
+        )
+    if not releases:
+        raise ValueError("No protobuf releases were materialized")
+    return canton_protobuf_history.write_manifest(
+        source_config=source_config,
+        releases=releases,
+        manifest_path=manifest_path,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    source_config = load_json(Path(args.source_config).resolve())
+    prefixes = package_prefixes(source_config)
+    include_versions = set(args.version) if args.version else None
+    min_version = args.min_version or source_config.get("min_version") or "0.0.0"
+    if not isinstance(min_version, str):
+        raise ValueError("min_version must be a string")
+
+    manifest_path = write_manifest(
+        source_config=source_config,
+        cache_dir=Path(args.cache_dir).resolve(),
+        manifest_path=Path(args.manifest_out).resolve(),
+        repo_dir=Path(args.repo_dir).resolve(),
+        include_versions=include_versions,
+        min_version=min_version,
+        skip_fetch=args.skip_fetch,
+        force_refresh=args.force_refresh,
+    )
+
+    version_filter = args.version_filter
+    if not version_filter:
+        if include_versions:
+            version_filter = "selected Canton release bundles"
+        else:
+            version_filter = f"stable Canton release bundles >= {min_version}"
+
+    report = build_filtered_report(
+        manifest_path,
+        prefixes=prefixes,
+        source_name=args.source_name,
+        version_filter=version_filter,
+    )
+    output_dir = Path(args.output_dir).resolve()
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    root, pages = build_pages(report, output_dir=output_dir)
+    written_paths = write_pages(pages, root)
+    retitle_generated_pages(output_dir=output_dir)
+
+    overview_path = output_dir / "index.mdx"
+    package_paths = [root / page.path for page in pages[1:]]
+    update_docs_navigation(
+        docs_json_path=Path(args.docs_json).resolve(),
+        dropdown_label=args.nav_dropdown,
+        parent_groups=args.nav_group or [],
+        insert_after_group=args.insert_after_group,
+        overview_path=overview_path,
+        package_paths=package_paths,
+    )
+    print(f"Wrote {len(written_paths)} generated pages under {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a docs-side gRPC Ledger API reference generator backed by published Canton release bundles
- check in the generated gRPC Ledger API pages under API Reference

Preview here: https://cantonfoundation-grpc-ledger-api-preview-base.mintlify.io/reference/grpc-ledger-api-reference