### PR TITLE
Import Splice Scan OpenAPI references

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,28 @@ or:
 npm run generate:wallet-gateway-openrpc-reference
 ```
 
+### Generate the Splice Scan OpenAPI reference
+
+This repo also includes a checked-in source config for the published decentralized-canton-sync OpenAPI bundle at `config/x2mdx/splice-scan-openapi/source-artifacts.json`.
+The generator script discovers matching stable releases through the GitHub releases API, downloads `*_openapi.tar.gz` bundle assets into `.internal/cache/x2mdx/splice-openapi/`, materializes all bundled YAML files into local versioned fixtures for `$ref` resolution, writes a local x2mdx manifest into `.internal/generated/x2mdx/splice-scan-openapi/manifest.json`, and then renders the checked-in Mintlify pages with the GitHub-pinned `x2mdx`.
+
+Run:
+
+```bash
+python3 scripts/generate_splice_scan_openapi_reference.py
+```
+
+or:
+
+```bash
+npm run generate:splice-scan-openapi-reference
+```
+
 By default this writes:
 
-- `docs-main/reference/wallet-gateway-json-rpc/`
+- `docs-main/reference/splice-scan-openapi/`
 - `docs-main/docs.json`
+
+The generated nav is added under the top-level `API Reference` dropdown as `Splice APIs -> Scan APIs`, with one generated page per OpenAPI spec in the published bundle family.
 
 The generated nav is added under the top-level `API Reference` dropdown as `Wallet Gateway JSON-RPC`, with the overview page plus one page per published OpenRPC surface.

--- a/config/x2mdx/splice-scan-openapi/source-artifacts.json
+++ b/config/x2mdx/splice-scan-openapi/source-artifacts.json
@@ -1,0 +1,23 @@
+{
+  "source": "Splice Scan OpenAPI specs from published decentralized-canton-sync release bundles",
+  "release_repo": "digital-asset/decentralized-canton-sync",
+  "tag_regex": "^v(?P<version>0\\.[0-9]+\\.[0-9]+)$",
+  "min_version": "0.5.10",
+  "asset_template": "{version}_openapi.tar.gz",
+  "source_path_prefix": "openapi",
+  "nav_parent_groups": [
+    "Splice APIs"
+  ],
+  "nav_group_label": "Scan APIs",
+  "top_level_insert_after_group": "Wallet Kernel",
+  "spec_pages": [
+    {
+      "filename": "scan.yaml",
+      "output_filename": "scan-yaml.mdx"
+    },
+    {
+      "filename": "scan-stream-server.yaml",
+      "output_filename": "scan-stream-server-yaml.mdx"
+    }
+  ]
+}

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1261,8 +1261,16 @@
             ]
           },
           {
-            "group": "Wallet Kernel",
-            "pages": []
+            "group": "Splice APIs",
+            "pages": [
+              {
+                "group": "Scan APIs",
+                "pages": [
+                  "reference/splice-scan-openapi/scan-yaml",
+                  "reference/splice-scan-openapi/scan-stream-server-yaml"
+                ]
+              }
+            ]
           },
           {
             "group": "Daml Standard Library",

--- a/docs-main/reference/splice-scan-openapi/scan-stream-server-yaml.mdx
+++ b/docs-main/reference/splice-scan-openapi/scan-stream-server-yaml.mdx
@@ -1,0 +1,89 @@
+---
+title: "Scan Streaming API"
+description: "Generated API reference from versioned OpenAPI artifacts"
+---
+
+Generated from supplied versioned OpenAPI artifacts.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`/v0/history/bulk/download/{object_key}`](#endpoint-path-v0-history-bulk-download-object-key) | - | Download a bulk storage object | `0.5.16` | 0.5.17: tag `pre-alpha` added; tag `external` removed | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.16` | `8` | `0` | `0` |
+| `0.5.17` | `1` | `2` | `0` |
+| `0.5.18` | `0` | `0` | `0` |
+
+## Reference
+
+
+<a id="endpoint-path-v0-history-bulk-download-object-key"></a>
+
+### `/v0/history/bulk/download/{object_key}`
+
+<a id="endpoint-get-v0-history-bulk-download-object-key"></a>
+
+- Method: `GET`
+
+- Operation ID: `bulkStorageDownload`
+- Description: Download a bulk storage object
+- Tags: `pre-alpha, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `object_key` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/octet-stream` | `application/octet-stream:string` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+## Changed Entities
+
+| Entity | Type | Introduced | Changed In | Removed |
+| --- | --- | --- | --- | --- |
+| `GET /v0/history/bulk/download/{object_key}` | `operation` | `0.5.16` | `0.5.17` | - |
+| `/v0/history/bulk/download/{object_key}` | `path` | `0.5.16` | `0.5.17` | - |
+| `pre-alpha` | `tag` | `0.5.17` | - | - |
+
+## Latest Operations
+
+| Operation | Introduced | Changed In | Removed |
+| --- | --- | --- | --- |
+| `GET /v0/history/bulk/download/{object_key}` | `0.5.16` | `0.5.17` | - |
+
+## Latest Components
+
+| Component | Introduced | Changed In | Removed |
+| --- | --- | --- | --- |
+| `responses.404` | `0.5.16` | - | - |
+| `schemas.ErrorResponse` | `0.5.16` | - | - |
+
+## Spec Metadata
+
+- Canonical spec id: `scan-stream-server.yaml`
+- Latest source path: `openapi/scan-stream-server.yaml`
+- OpenAPI version (latest): `3.0.0`
+- Introduced: `0.5.16`
+- Changed in versions: `0.5.17`
+- Removed: -
+
+## Entity Summary
+
+- Total entities tracked: `9`
+- Entities introduced after spec introduction: `1`
+- Entities changed at least once: `2`
+- Entities removed: `0`
+- Latest operations: `1`
+- Latest paths: `1`
+- Latest components: `2`
+- Latest tags: `5`

--- a/docs-main/reference/splice-scan-openapi/scan-yaml.mdx
+++ b/docs-main/reference/splice-scan-openapi/scan-yaml.mdx
@@ -1,0 +1,2296 @@
+---
+title: "Scan API"
+description: "Generated API reference from versioned OpenAPI artifacts"
+---
+
+Generated from supplied versioned OpenAPI artifacts.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`/livez`](#endpoint-path-livez) | - | - | `0.5.10` | - | - | - |
+| [`/readyz`](#endpoint-path-readyz) | - | - | `0.5.10` | - | - | - |
+| [`/status`](#endpoint-path-status) | - | - | `0.5.10` | - | - | - |
+| [`/v0/acs/{party}`](#endpoint-path-v0-acs-party) | - | **Deprecated**. Fetch the current SV participant ACS snapshot for the DSO and `party`. | `0.5.10` | - | - | - |
+| [`/v0/activities`](#endpoint-path-v0-activities) | - | **Deprecated**. Lists activities in descending order, paged, optionally starting after a provided event id. | `0.5.10` | - | - | - |
+| [`/v0/admin/sv/voterequests`](#endpoint-path-v0-admin-sv-voterequests) | - | List all active `VoteRequest`\ s. | `0.5.10` | - | - | - |
+| [`/v0/admin/sv/voteresults`](#endpoint-path-v0-admin-sv-voteresults) | - | - | `0.5.10` | - | - | - |
+| [`/v0/admin/validator/licenses`](#endpoint-path-v0-admin-validator-licenses) | - | List all validators currently approved by members of the DSO, paginated, sorted newest-first. | `0.5.10` | - | - | - |
+| [`/v0/aggregated-rounds`](#endpoint-path-v0-aggregated-rounds) | - | **Deprecated**. Retrieve the current earliest and latest rounds aggregated for this Scan. | `0.5.10` | - | - | - |
+| [`/v0/amulet-config-for-round`](#endpoint-path-v0-amulet-config-for-round) | - | **Deprecated**. Retrieve some information from the `AmuletRules` selected for the given round | `0.5.10` | - | - | - |
+| [`/v0/amulet-price/votes`](#endpoint-path-v0-amulet-price-votes) | - | Retrieve a list of the latest amulet price votes | `0.5.10` | - | - | - |
+| [`/v0/amulet-rules`](#endpoint-path-v0-amulet-rules) | - | - | `0.5.10` | - | - | - |
+| [`/v0/ans-entries`](#endpoint-path-v0-ans-entries) | - | Lists all non-expired ANS entries whose names are prefixed with the `name_prefix`, up to `page_size` entries. | `0.5.10` | - | - | - |
+| [`/v0/ans-entries/by-name/{name}`](#endpoint-path-v0-ans-entries-by-name-name) | - | If present, the ANS entry named exactly `name`. | `0.5.10` | - | - | - |
+| [`/v0/ans-entries/by-party/{party}`](#endpoint-path-v0-ans-entries-by-party-party) | - | If present, the first ANS entry for user `party` according to `name` lexicographic order. | `0.5.10` | - | - | - |
+| [`/v0/ans-rules`](#endpoint-path-v0-ans-rules) | - | - | `0.5.10` | - | - | - |
+| [`/v0/backfilling/import-updates`](#endpoint-path-v0-backfilling-import-updates) | - | - | `0.5.10` | - | - | - |
+| [`/v0/backfilling/migration-info`](#endpoint-path-v0-backfilling-migration-info) | - | List all previous synchronizer migrations in this Splice network's history. | `0.5.10` | - | - | - |
+| [`/v0/backfilling/status`](#endpoint-path-v0-backfilling-status) | - | Retrieve the status of the backfilling process. | `0.5.10` | - | - | - |
+| [`/v0/backfilling/updates-before`](#endpoint-path-v0-backfilling-updates-before) | - | Retrieve transactions and synchronizer reassignments prior to the request's specification. | `0.5.10` | - | - | - |
+| [`/v0/closed-rounds`](#endpoint-path-v0-closed-rounds) | - | Every closed mining round on the ledger still in post-close process for the connected Splice network, in round number order, earliest-first. | `0.5.10` | - | - | - |
+| [`/v0/domains/{domain_id}/members/{member_id}/traffic-status`](#endpoint-path-v0-domains-domain-id-members-member-id-traffic-status) | - | Get a member's traffic status as reported by the sequencer, according to ledger state at the time of the request. | `0.5.10` | - | - | - |
+| [`/v0/domains/{domain_id}/parties/{party_id}/participant-id`](#endpoint-path-v0-domains-domain-id-parties-party-id-participant-id) | - | Get the ID of the participant hosting a given party.  This will fail if there are multiple party-to-participant mappings for the given synchronizer and party, which is not currently supported. | `0.5.10` | - | - | - |
+| [`/v0/dso`](#endpoint-path-v0-dso) | - | - | `0.5.10` | - | - | - |
+| [`/v0/dso-party-id`](#endpoint-path-v0-dso-party-id) | - | The party ID of the DSO for the Splice network connected by this Scan app. | `0.5.10` | - | - | - |
+| [`/v0/dso-sequencers`](#endpoint-path-v0-dso-sequencers) | - | Retrieve Canton sequencer configuration for all SVs, grouped by connected synchronizer ID | `0.5.10` | - | - | - |
+| [`/v0/events`](#endpoint-path-v0-events) | - | Returns the event history in ascending order, paged, from ledger begin or optionally starting after a record time. An event bears some combination of a transaction, a contract reassignment, and a verdict. Events are ordered lexicographically by `(migration id, record time)`. For a given migration id, each event has a unique record time. The record time ranges of different migrations may overlap, i.e., it is not guaranteed that the maximum record time of one migration is smaller than the minimum record time of the next migration, and there may be two updates with the same record time but different migration ids. | `0.5.10` | - | - | - |
+| [`/v0/events/{update_id}`](#endpoint-path-v0-events-update-id) | - | Returns the event with the given update_id. An event bears some combination of a transaction, a contract reassignment, and a verdict. | `0.5.10` | - | - | - |
+| [`/v0/external-party-amulet-rules`](#endpoint-path-v0-external-party-amulet-rules) | - | - | `0.5.10` | - | - | - |
+| [`/v0/feature-support`](#endpoint-path-v0-feature-support) | - | - | `0.5.10` | - | - | - |
+| [`/v0/featured-apps`](#endpoint-path-v0-featured-apps) | - | List every `FeaturedAppRight` registered with the DSO on the ledger. | `0.5.10` | - | - | - |
+| [`/v0/featured-apps/{provider_party_id}`](#endpoint-path-v0-featured-apps-provider-party-id) | - | If `provider_party_id` has a `FeaturedAppRight` registered with the DSO, return it; `featured_app_right` will be empty otherwise. | `0.5.10` | - | - | - |
+| [`/v0/history/bulk/acs`](#endpoint-path-v0-history-bulk-acs) | - | **Under Development, do not use in production yet** Get download URLs and metadata for an ACS snapshot available for bulk download, at or before a certain record time. | `0.5.17` | - | - | - |
+| [`/v0/history/bulk/updates`](#endpoint-path-v0-history-bulk-updates) | - | **Under Development, do not use in production yet** Get download URLs and metadata for update history objects available for bulk download, between two record times. Note that the returned objects may include also updates outside of the requested record time range (since only full objects are served from storage), but guaranteed to include all updates in the requested range. | `0.5.18` | - | - | - |
+| [`/v0/holdings/state`](#endpoint-path-v0-holdings-state) | - | Returns the active amulet contracts for a given migration id and record time, in creation date ascending order, paged. | `0.5.10` | - | - | - |
+| [`/v0/holdings/summary`](#endpoint-path-v0-holdings-summary) | - | Returns the summary of active amulet contracts for a given migration id and record time, for the given parties. This is an aggregate of `/v0/holdings/state` by owner party ID with better performance than client-side computation. | `0.5.10` | - | - | - |
+| [`/v0/migrations/schedule`](#endpoint-path-v0-migrations-schedule) | - | If the DSO has scheduled a synchronizer upgrade, return its planned time and the new migration ID. | `0.5.10` | - | - | - |
+| [`/v0/open-and-issuing-mining-rounds`](#endpoint-path-v0-open-and-issuing-mining-rounds) | - | All current open and issuing mining rounds, if the request is empty; passing contract IDs in the request can reduce the response data for polling/client-cache-update efficiency. | `0.5.10` | - | - | - |
+| [`/v0/rewards-collected`](#endpoint-path-v0-rewards-collected) | - | **Deprecated**. Get the total rewards collected ever | `0.5.10` | - | - | - |
+| [`/v0/round-of-latest-data`](#endpoint-path-v0-round-of-latest-data) | - | **Deprecated**. Get the latest round number for which aggregated data is available and the ledger effective time at which the round was closed. | `0.5.10` | - | - | - |
+| [`/v0/round-party-totals`](#endpoint-path-v0-round-party-totals) | - | **Deprecated**. Retrieve per-party Amulet statistics for up to 50 closed rounds. | `0.5.10` | - | - | - |
+| [`/v0/round-totals`](#endpoint-path-v0-round-totals) | - | **Deprecated**. List Amulet statistics for up to 200 closed rounds. | `0.5.10` | - | - | - |
+| [`/v0/scans`](#endpoint-path-v0-scans) | - | Retrieve Canton scan configuration for all SVs, grouped by connected synchronizer ID | `0.5.10` | - | - | - |
+| [`/v0/splice-instance-names`](#endpoint-path-v0-splice-instance-names) | - | Retrieve the UI names of various elements of this Splice network. | `0.5.10` | - | - | - |
+| [`/v0/state/acs`](#endpoint-path-v0-state-acs) | - | Returns the ACS in creation date ascending order, paged, for a given migration id and record time. | `0.5.10` | - | - | - |
+| [`/v0/state/acs/force`](#endpoint-path-v0-state-acs-force) | - | Takes a snapshot of the ACS at the current time. The responses can be used as parameters to `/v0/state/acs` to retrieve the snapshot. Disabled in production environments due to its persistent alteration of the behavior of future invocations of `/v0/state/acs`, as it causes an immediate internal snapshot and delay in the next automatic snapshot. | `0.5.10` | - | - | - |
+| [`/v0/state/acs/snapshot-timestamp`](#endpoint-path-v0-state-acs-snapshot-timestamp) | - | Returns the timestamp of the most recent snapshot before the given date, for the given migration_id. This corresponds to the record time of the last transaction in the snapshot. | `0.5.10` | - | - | - |
+| [`/v0/state/acs/snapshot-timestamp-after`](#endpoint-path-v0-state-acs-snapshot-timestamp-after) | - | Returns the timestamp of the first snapshot after the given date, for the given migration_id or larger. | `0.5.10` | - | - | - |
+| [`/v0/sv-bft-sequencers`](#endpoint-path-v0-sv-bft-sequencers) | - | Retrieve Canton BFT sequencer configuration for this SV, for each configured Synchronizer | `0.5.10` | - | - | - |
+| [`/v0/synchronizer-bootstrapping-transactions/{domain_id_prefix}`](#endpoint-path-v0-synchronizer-bootstrapping-transactions-domain-id-prefix) | - | - | `0.5.10` | - | - | - |
+| [`/v0/synchronizer-identities/{domain_id_prefix}`](#endpoint-path-v0-synchronizer-identities-domain-id-prefix) | - | - | `0.5.10` | - | - | - |
+| [`/v0/top-providers-by-app-rewards`](#endpoint-path-v0-top-providers-by-app-rewards) | - | **Deprecated**. Get a list of top-earning app providers, and the total earned app rewards for each | `0.5.10` | - | - | - |
+| [`/v0/top-validators-by-purchased-traffic`](#endpoint-path-v0-top-validators-by-purchased-traffic) | - | **Deprecated**. Get a list of validators and their domain fees spends, sorted by the amount of extra traffic purchased | `0.5.10` | - | - | - |
+| [`/v0/top-validators-by-validator-faucets`](#endpoint-path-v0-top-validators-by-validator-faucets) | - | Get a list of top validators by number of rounds in which they collected faucets, and basis statistics on their round collection history | `0.5.10` | - | - | - |
+| [`/v0/top-validators-by-validator-rewards`](#endpoint-path-v0-top-validators-by-validator-rewards) | - | **Deprecated**. Get a list of top-earning validators, and the total earned validator rewards for each | `0.5.10` | - | - | - |
+| [`/v0/transactions`](#endpoint-path-v0-transactions) | - | **Deprecated with known bugs that will not be fixed, use /v2/updates instead**.  Lists transactions, by default in ascending order, paged, from ledger begin or optionally starting after a provided event id. | `0.5.10` | - | - | - |
+| [`/v0/transfer-command-counter/{party}`](#endpoint-path-v0-transfer-command-counter-party) | - | Lookup a TransferCommandCounter by the receiver party. | `0.5.10` | - | - | - |
+| [`/v0/transfer-command/status`](#endpoint-path-v0-transfer-command-status) | - | Retrieve the status of all transfer commands (up to a limit of 100) of the given sender for the specified nonce. | `0.5.10` | - | - | - |
+| [`/v0/transfer-preapprovals/by-party/{party}`](#endpoint-path-v0-transfer-preapprovals-by-party-party) | - | Lookup a TransferPreapproval by the receiver party. | `0.5.10` | - | - | - |
+| [`/v0/unclaimed-development-fund-coupons`](#endpoint-path-v0-unclaimed-development-fund-coupons) | - | List all unclaimed development fund coupons. | `0.5.10` | - | - | - |
+| [`/v0/updates`](#endpoint-path-v0-updates) | - | **Deprecated**, use /v2/updates instead. Returns the update history in ascending order, paged, from ledger begin or optionally starting after a record time. | `0.5.10` | - | - | - |
+| [`/v0/updates/{update_id}`](#endpoint-path-v0-updates-update-id) | - | **Deprecated**, use /v2/updates/\{update_id\} instead. | `0.5.10` | - | - | - |
+| [`/v0/validators/validator-faucets`](#endpoint-path-v0-validators-validator-faucets) | - | For every argument that is a valid onboarded validator, return statistics on its liveness activity, according to on-ledger state at the time of the request. | `0.5.10` | - | - | - |
+| [`/v0/voterequest`](#endpoint-path-v0-voterequest) | - | Look up several `VoteRequest`\ s at once by their contract IDs. | `0.5.10` | - | - | - |
+| [`/v0/voterequests/{vote_request_contract_id}`](#endpoint-path-v0-voterequests-vote-request-contract-id) | - | Look up a `VoteRequest` by contract ID. | `0.5.10` | - | - | - |
+| [`/v1/domains/{domain_id}/parties/{party_id}/participant-id`](#endpoint-path-v1-domains-domain-id-parties-party-id-participant-id) | - | Get the IDs of the participants hosting a given party. Unlike /v0, this endpoint supports parties hosted on multiple participants. | `0.5.17` | - | - | - |
+| [`/v1/updates`](#endpoint-path-v1-updates) | - | Returns the update history in ascending order, paged, from ledger begin or optionally starting after a record time. Unlike /v0/updates, this endpoint returns responses that are consistent across different scan instances. Event ids returned by this endpoint are not comparable to event ids returned by /v0/updates.  Updates are ordered lexicographically by `(migration id, record time)`. For a given migration id, each update has a unique record time. The record time ranges of different migrations may overlap, i.e., it is not guaranteed that the maximum record time of one migration is smaller than the minimum record time of the next migration, and there may be two updates with the same record time but different migration ids. The order of items in events_by_id is not defined. | `0.5.10` | - | - | - |
+| [`/v1/updates/{update_id}`](#endpoint-path-v1-updates-update-id) | - | Returns the update with the given update_id. Unlike /v0/updates/\{update_id\}, this endpoint returns responses that are consistent across different scan instances. Event ids returned by this endpoint are not comparable to event ids returned by /v0/updates. The order of items in events_by_id is not defined. | `0.5.10` | - | - | - |
+| [`/v2/updates`](#endpoint-path-v2-updates) | - | Returns the update history in ascending order, paged, from ledger begin or optionally starting after a record time. Compared to `/v1/updates`, the `/v2/updates` removes the `offset` field in responses, which was hardcoded to 1 in `/v1/updates` for compatibility, and is now removed. `/v2/updates` sorts events lexicographically in `events_by_id` by `ID` for convenience, which should not be confused with the order of events in the transaction, for this you should rely on the order of `root_event_ids` and `child_event_ids`. Updates are ordered lexicographically by `(migration id, record time)`. For a given migration id, each update has a unique record time. The record time ranges of different migrations may overlap, i.e., it is not guaranteed that the maximum record time of one migration is smaller than the minimum record time of the next migration, and there may be two updates with the same record time but different migration ids. | `0.5.10` | - | - | - |
+| [`/v2/updates/{update_id}`](#endpoint-path-v2-updates-update-id) | - | Returns the update with the given update_id. Compared to `/v1/updates/\{update_id\}`, the `/v2/updates/\{update_id\}` removes the `offset` field in responses, which was hardcoded to 1 in `/v1/updates/\{update_id\}` for compatibility, and is now removed. `/v2/updates/\{update_id\}` sorts events lexicographically in `events_by_id` by `ID` for convenience, which should not be confused with the order of events in the transaction, for this you should rely on the order of `root_event_ids` and `child_event_ids`. | `0.5.10` | - | - | - |
+| [`/version`](#endpoint-path-version) | - | - | `0.5.10` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.10` | `286` | `0` | `0` |
+| `0.5.11` | `0` | `0` | `0` |
+| `0.5.12` | `0` | `2` | `0` |
+| `0.5.13` | `0` | `0` | `0` |
+| `0.5.14` | `0` | `0` | `0` |
+| `0.5.15` | `2` | `1` | `0` |
+| `0.5.16` | `0` | `1` | `0` |
+| `0.5.17` | `11` | `3` | `0` |
+| `0.5.18` | `4` | `0` | `0` |
+
+## Reference
+
+
+<a id="endpoint-path-livez"></a>
+
+### `/livez`
+
+<a id="endpoint-get-livez"></a>
+
+- Method: `GET`
+
+- Operation ID: `isLive`
+- Tags: `common`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `-` | `-` |
+| `503` | service_unavailable | `-` | `-` |
+
+<a id="endpoint-path-readyz"></a>
+
+### `/readyz`
+
+<a id="endpoint-get-readyz"></a>
+
+- Method: `GET`
+
+- Operation ID: `isReady`
+- Tags: `common`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `-` | `-` |
+| `503` | service_unavailable | `-` | `-` |
+
+<a id="endpoint-path-status"></a>
+
+### `/status`
+
+<a id="endpoint-get-status"></a>
+
+- Method: `GET`
+
+- Operation ID: `getHealthStatus`
+- Tags: `common`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:oneOf` |
+
+<a id="endpoint-path-v0-acs-party"></a>
+
+### `/v0/acs/{party}`
+
+<a id="endpoint-get-v0-acs-party"></a>
+
+- Method: `GET`
+
+- Operation ID: `getAcsSnapshot`
+- Description: **Deprecated**. Fetch the current SV participant ACS snapshot for the DSO and `party`.
+- Tags: `deprecated`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `party` | `path` | `yes` | `string` | - |
+| `record_time` | `query` | `no` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-activities"></a>
+
+### `/v0/activities`
+
+<a id="endpoint-post-v0-activities"></a>
+
+- Method: `POST`
+
+- Operation ID: `listActivity`
+- Description: **Deprecated**. Lists activities in descending order, paged, optionally starting after a provided event id.
+- Tags: `deprecated, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `page_size` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "page_size": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-admin-sv-voterequests"></a>
+
+### `/v0/admin/sv/voterequests`
+
+<a id="endpoint-get-v0-admin-sv-voterequests"></a>
+
+- Method: `GET`
+
+- Operation ID: `listDsoRulesVoteRequests`
+- Description: List all active `VoteRequest`\ s.
+- Tags: `internal, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-admin-sv-voteresults"></a>
+
+### `/v0/admin/sv/voteresults`
+
+<a id="endpoint-post-v0-admin-sv-voteresults"></a>
+
+- Method: `POST`
+
+- Operation ID: `listVoteRequestResults`
+- Tags: `internal, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `limit` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "limit": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-admin-validator-licenses"></a>
+
+### `/v0/admin/validator/licenses`
+
+<a id="endpoint-get-v0-admin-validator-licenses"></a>
+
+- Method: `GET`
+
+- Operation ID: `listValidatorLicenses`
+- Description: List all validators currently approved by members of the DSO, paginated, sorted newest-first.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `after` | `query` | `no` | `integer` | A `next_page_token` from a prior response; if absent, return the first page. |
+| `limit` | `query` | `no` | `integer` | Maximum number of elements to return, 1000 by default. |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-aggregated-rounds"></a>
+
+### `/v0/aggregated-rounds`
+
+<a id="endpoint-get-v0-aggregated-rounds"></a>
+
+- Method: `GET`
+
+- Operation ID: `getAggregatedRounds`
+- Description: **Deprecated**. Retrieve the current earliest and latest rounds aggregated for this Scan.
+- Tags: `deprecated`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-amulet-config-for-round"></a>
+
+### `/v0/amulet-config-for-round`
+
+<a id="endpoint-get-v0-amulet-config-for-round"></a>
+
+- Method: `GET`
+
+- Operation ID: `getAmuletConfigForRound`
+- Description: **Deprecated**. Retrieve some information from the `AmuletRules` selected for the given round
+- Tags: `deprecated`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `round` | `query` | `yes` | `integer` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-amulet-price-votes"></a>
+
+### `/v0/amulet-price/votes`
+
+<a id="endpoint-get-v0-amulet-price-votes"></a>
+
+- Method: `GET`
+
+- Operation ID: `listAmuletPriceVotes`
+- Description: Retrieve a list of the latest amulet price votes
+- Tags: `scan, internal`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-amulet-rules"></a>
+
+### `/v0/amulet-rules`
+
+<a id="endpoint-post-v0-amulet-rules"></a>
+
+- Method: `POST`
+
+- Operation ID: `getAmuletRules`
+- Tags: `internal, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | - |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "cached_amulet_rules_contract_id": "<string>",
+  "cached_amulet_rules_domain_id": "<string>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-ans-entries"></a>
+
+### `/v0/ans-entries`
+
+<a id="endpoint-get-v0-ans-entries"></a>
+
+- Method: `GET`
+
+- Operation ID: `listAnsEntries`
+- Description: Lists all non-expired ANS entries whose names are prefixed with the `name_prefix`, up to `page_size` entries.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `name_prefix` | `query` | `no` | `string` | Every result's name will start with this substring; if empty or absent, all entries will be listed. Does not have to be a whole word or segment; any substring will be accepted. |
+| `page_size` | `query` | `yes` | `integer` | The maximum number of results returned. Older (but still non-expired) results are listed first. |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-ans-entries-by-name-name"></a>
+
+### `/v0/ans-entries/by-name/{name}`
+
+<a id="endpoint-get-v0-ans-entries-by-name-name"></a>
+
+- Method: `GET`
+
+- Operation ID: `lookupAnsEntryByName`
+- Description: If present, the ANS entry named exactly `name`.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `name` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-ans-entries-by-party-party"></a>
+
+### `/v0/ans-entries/by-party/{party}`
+
+<a id="endpoint-get-v0-ans-entries-by-party-party"></a>
+
+- Method: `GET`
+
+- Operation ID: `lookupAnsEntryByParty`
+- Description: If present, the first ANS entry for user `party` according to `name` lexicographic order.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `party` | `path` | `yes` | `string` | The user party ID that holds the ANS entry. |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-ans-rules"></a>
+
+### `/v0/ans-rules`
+
+<a id="endpoint-post-v0-ans-rules"></a>
+
+- Method: `POST`
+
+- Operation ID: `getAnsRules`
+- Tags: `internal, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | - |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "cached_ans_rules_contract_id": "<string>",
+  "cached_ans_rules_domain_id": "<string>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-backfilling-import-updates"></a>
+
+### `/v0/backfilling/import-updates`
+
+<a id="endpoint-post-v0-backfilling-import-updates"></a>
+
+- Method: `POST`
+
+- Operation ID: `getImportUpdates`
+- Tags: `scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `after_update_id`, `limit`, `migration_id` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "migration_id": "<integer>",
+  "after_update_id": "<string>",
+  "limit": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-backfilling-migration-info"></a>
+
+### `/v0/backfilling/migration-info`
+
+<a id="endpoint-post-v0-backfilling-migration-info"></a>
+
+- Method: `POST`
+
+- Operation ID: `getMigrationInfo`
+- Description: List all previous synchronizer migrations in this Splice network's history.
+- Tags: `internal, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `migration_id` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "migration_id": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-backfilling-status"></a>
+
+### `/v0/backfilling/status`
+
+<a id="endpoint-get-v0-backfilling-status"></a>
+
+- Method: `GET`
+
+- Operation ID: `getBackfillingStatus`
+- Description: Retrieve the status of the backfilling process.
+- Tags: `internal, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-backfilling-updates-before"></a>
+
+### `/v0/backfilling/updates-before`
+
+<a id="endpoint-post-v0-backfilling-updates-before"></a>
+
+- Method: `POST`
+
+- Operation ID: `getUpdatesBefore`
+- Description: Retrieve transactions and synchronizer reassignments prior to the request's specification.
+- Tags: `internal, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `before`, `count`, `migration_id`, `synchronizer_id` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "migration_id": "<integer>",
+  "synchronizer_id": "<string>",
+  "before": "<string>",
+  "count": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-closed-rounds"></a>
+
+### `/v0/closed-rounds`
+
+<a id="endpoint-get-v0-closed-rounds"></a>
+
+- Method: `GET`
+
+- Operation ID: `getClosedRounds`
+- Description: Every closed mining round on the ledger still in post-close process for the connected Splice network, in round number order, earliest-first.
+- Tags: `external, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-domains-domain-id-members-member-id-traffic-status"></a>
+
+### `/v0/domains/{domain_id}/members/{member_id}/traffic-status`
+
+<a id="endpoint-get-v0-domains-domain-id-members-member-id-traffic-status"></a>
+
+- Method: `GET`
+
+- Operation ID: `getMemberTrafficStatus`
+- Description: Get a member's traffic status as reported by the sequencer, according to ledger state at the time of the request.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `domain_id` | `path` | `yes` | `string` | The synchronizer ID to look up traffic for. |
+| `member_id` | `path` | `yes` | `string` | The participant or mediator whose traffic to look up, in the format `code::id::fingerprint` where `code` is `PAR` or `MED`. |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-domains-domain-id-parties-party-id-participant-id"></a>
+
+### `/v0/domains/{domain_id}/parties/{party_id}/participant-id`
+
+<a id="endpoint-get-v0-domains-domain-id-parties-party-id-participant-id"></a>
+
+- Method: `GET`
+
+- Operation ID: `getPartyToParticipant`
+- Description: Get the ID of the participant hosting a given party.  This will fail if there are multiple party-to-participant mappings for the given synchronizer and party, which is not currently supported.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `domain_id` | `path` | `yes` | `string` | The synchronizer ID to look up a mapping for. |
+| `party_id` | `path` | `yes` | `string` | The party ID to lookup a participant ID for. |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-dso"></a>
+
+### `/v0/dso`
+
+<a id="endpoint-get-v0-dso"></a>
+
+- Method: `GET`
+
+- Operation ID: `getDsoInfo`
+- Tags: `external, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-dso-party-id"></a>
+
+### `/v0/dso-party-id`
+
+<a id="endpoint-get-v0-dso-party-id"></a>
+
+- Method: `GET`
+
+- Operation ID: `getDsoPartyId`
+- Description: The party ID of the DSO for the Splice network connected by this Scan app.
+- Tags: `external, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-dso-sequencers"></a>
+
+### `/v0/dso-sequencers`
+
+<a id="endpoint-get-v0-dso-sequencers"></a>
+
+- Method: `GET`
+
+- Operation ID: `listDsoSequencers`
+- Description: Retrieve Canton sequencer configuration for all SVs, grouped by connected synchronizer ID
+- Tags: `external, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-events"></a>
+
+### `/v0/events`
+
+<a id="endpoint-post-v0-events"></a>
+
+- Method: `POST`
+
+- Operation ID: `getEventHistory`
+- Description: Returns the event history in ascending order, paged, from ledger begin or optionally starting after a record time. An event bears some combination of a transaction, a contract reassignment, and a verdict. Events are ordered lexicographically by `(migration id, record time)`. For a given migration id, each event has a unique record time. The record time ranges of different migrations may overlap, i.e., it is not guaranteed that the maximum record time of one migration is smaller than the minimum record time of the next migration, and there may be two updates with the same record time but different migration ids.
+- Tags: `external, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `page_size` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "page_size": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-events-update-id"></a>
+
+### `/v0/events/{update_id}`
+
+<a id="endpoint-get-v0-events-update-id"></a>
+
+- Method: `GET`
+
+- Operation ID: `getEventById`
+- Description: Returns the event with the given update_id. An event bears some combination of a transaction, a contract reassignment, and a verdict.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `update_id` | `path` | `yes` | `string` | - |
+| `daml_value_encoding` | `query` | `no` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-external-party-amulet-rules"></a>
+
+### `/v0/external-party-amulet-rules`
+
+<a id="endpoint-post-v0-external-party-amulet-rules"></a>
+
+- Method: `POST`
+
+- Operation ID: `getExternalPartyAmuletRules`
+- Tags: `internal, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | - |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "cached_external_party_amulet_rules_contract_id": "<string>",
+  "cached_external_party_amulet_rules_domain_id": "<string>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-feature-support"></a>
+
+### `/v0/feature-support`
+
+<a id="endpoint-get-v0-feature-support"></a>
+
+- Method: `GET`
+
+- Operation ID: `featureSupport`
+- Tags: `internal, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-featured-apps"></a>
+
+### `/v0/featured-apps`
+
+<a id="endpoint-get-v0-featured-apps"></a>
+
+- Method: `GET`
+
+- Operation ID: `listFeaturedAppRights`
+- Description: List every `FeaturedAppRight` registered with the DSO on the ledger.
+- Tags: `internal, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-featured-apps-provider-party-id"></a>
+
+### `/v0/featured-apps/{provider_party_id}`
+
+<a id="endpoint-get-v0-featured-apps-provider-party-id"></a>
+
+- Method: `GET`
+
+- Operation ID: `lookupFeaturedAppRight`
+- Description: If `provider_party_id` has a `FeaturedAppRight` registered with the DSO, return it; `featured_app_right` will be empty otherwise.
+- Tags: `internal, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `provider_party_id` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-history-bulk-acs"></a>
+
+### `/v0/history/bulk/acs`
+
+<a id="endpoint-get-v0-history-bulk-acs"></a>
+
+- Method: `GET`
+
+- Operation ID: `listBulkAcsSnapshotObjects`
+- Description: **Under Development, do not use in production yet** Get download URLs and metadata for an ACS snapshot available for bulk download, at or before a certain record time.
+- Tags: `pre-alpha, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `at_or_before_record_time` | `query` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `501` | not implemented | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-history-bulk-updates"></a>
+
+### `/v0/history/bulk/updates`
+
+<a id="endpoint-post-v0-history-bulk-updates"></a>
+
+- Method: `POST`
+
+- Operation ID: `listBulkUpdateHistoryObjects`
+- Description: **Under Development, do not use in production yet** Get download URLs and metadata for update history objects available for bulk download, between two record times. Note that the returned objects may include also updates outside of the requested record time range (since only full objects are served from storage), but guaranteed to include all updates in the requested range.
+- Tags: `pre-alpha, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `end_record_time`, `page_size`, `start_record_time` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "start_record_time": "<string>",
+  "end_record_time": "<string>",
+  "page_size": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | not found | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `501` | not implemented | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-holdings-state"></a>
+
+### `/v0/holdings/state`
+
+<a id="endpoint-post-v0-holdings-state"></a>
+
+- Method: `POST`
+
+- Operation ID: `getHoldingsStateAt`
+- Description: Returns the active amulet contracts for a given migration id and record time, in creation date ascending order, paged.
+- Tags: `external, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `migration_id`, `owner_party_ids`, `page_size`, `record_time` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "migration_id": "<integer>",
+  "record_time": "<string>",
+  "page_size": "<integer>",
+  "owner_party_ids": [
+    "<string>"
+  ]
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-holdings-summary"></a>
+
+### `/v0/holdings/summary`
+
+<a id="endpoint-post-v0-holdings-summary"></a>
+
+- Method: `POST`
+
+- Operation ID: `getHoldingsSummaryAt`
+- Description: Returns the summary of active amulet contracts for a given migration id and record time, for the given parties. This is an aggregate of `/v0/holdings/state` by owner party ID with better performance than client-side computation.
+- Tags: `external, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `migration_id`, `owner_party_ids`, `record_time` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "migration_id": "<integer>",
+  "record_time": "<string>",
+  "owner_party_ids": [
+    "<string>"
+  ]
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-migrations-schedule"></a>
+
+### `/v0/migrations/schedule`
+
+<a id="endpoint-get-v0-migrations-schedule"></a>
+
+- Method: `GET`
+
+- Operation ID: `getMigrationSchedule`
+- Description: If the DSO has scheduled a synchronizer upgrade, return its planned time and the new migration ID.
+- Tags: `internal, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | No migration scheduled | `-` | `-` |
+
+<a id="endpoint-path-v0-open-and-issuing-mining-rounds"></a>
+
+### `/v0/open-and-issuing-mining-rounds`
+
+<a id="endpoint-post-v0-open-and-issuing-mining-rounds"></a>
+
+- Method: `POST`
+
+- Operation ID: `getOpenAndIssuingMiningRounds`
+- Description: All current open and issuing mining rounds, if the request is empty; passing contract IDs in the request can reduce the response data for polling/client-cache-update efficiency.
+- Tags: `external, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `cached_issuing_round_contract_ids`, `cached_open_mining_round_contract_ids` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "cached_open_mining_round_contract_ids": [
+    "<string>"
+  ],
+  "cached_issuing_round_contract_ids": [
+    "<string>"
+  ]
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-rewards-collected"></a>
+
+### `/v0/rewards-collected`
+
+<a id="endpoint-get-v0-rewards-collected"></a>
+
+- Method: `GET`
+
+- Operation ID: `getRewardsCollected`
+- Description: **Deprecated**. Get the total rewards collected ever
+- Tags: `deprecated, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `round` | `query` | `no` | `integer` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-round-of-latest-data"></a>
+
+### `/v0/round-of-latest-data`
+
+<a id="endpoint-get-v0-round-of-latest-data"></a>
+
+- Method: `GET`
+
+- Operation ID: `getRoundOfLatestData`
+- Description: **Deprecated**. Get the latest round number for which aggregated data is available and the ledger effective time at which the round was closed.
+- Tags: `deprecated, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-round-party-totals"></a>
+
+### `/v0/round-party-totals`
+
+<a id="endpoint-post-v0-round-party-totals"></a>
+
+- Method: `POST`
+
+- Operation ID: `listRoundPartyTotals`
+- Description: **Deprecated**. Retrieve per-party Amulet statistics for up to 50 closed rounds.
+- Tags: `deprecated`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `end_round`, `start_round` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "start_round": "<integer>",
+  "end_round": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-round-totals"></a>
+
+### `/v0/round-totals`
+
+<a id="endpoint-post-v0-round-totals"></a>
+
+- Method: `POST`
+
+- Operation ID: `listRoundTotals`
+- Description: **Deprecated**. List Amulet statistics for up to 200 closed rounds.
+- Tags: `deprecated`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `end_round`, `start_round` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "start_round": "<integer>",
+  "end_round": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-scans"></a>
+
+### `/v0/scans`
+
+<a id="endpoint-get-v0-scans"></a>
+
+- Method: `GET`
+
+- Operation ID: `listDsoScans`
+- Description: Retrieve Canton scan configuration for all SVs, grouped by connected synchronizer ID
+- Tags: `external, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-splice-instance-names"></a>
+
+### `/v0/splice-instance-names`
+
+<a id="endpoint-get-v0-splice-instance-names"></a>
+
+- Method: `GET`
+
+- Operation ID: `getSpliceInstanceNames`
+- Description: Retrieve the UI names of various elements of this Splice network.
+- Tags: `internal, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-state-acs"></a>
+
+### `/v0/state/acs`
+
+<a id="endpoint-post-v0-state-acs"></a>
+
+- Method: `POST`
+
+- Operation ID: `getAcsSnapshotAt`
+- Description: Returns the ACS in creation date ascending order, paged, for a given migration id and record time.
+- Tags: `external, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `migration_id`, `page_size`, `record_time` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "migration_id": "<integer>",
+  "record_time": "<string>",
+  "page_size": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-state-acs-force"></a>
+
+### `/v0/state/acs/force`
+
+<a id="endpoint-post-v0-state-acs-force"></a>
+
+- Method: `POST`
+
+- Operation ID: `forceAcsSnapshotNow`
+- Description: Takes a snapshot of the ACS at the current time. The responses can be used as parameters to `/v0/state/acs` to retrieve the snapshot. Disabled in production environments due to its persistent alteration of the behavior of future invocations of `/v0/state/acs`, as it causes an immediate internal snapshot and delay in the next automatic snapshot.
+- Tags: `external, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-state-acs-snapshot-timestamp"></a>
+
+### `/v0/state/acs/snapshot-timestamp`
+
+<a id="endpoint-get-v0-state-acs-snapshot-timestamp"></a>
+
+- Method: `GET`
+
+- Operation ID: `getDateOfMostRecentSnapshotBefore`
+- Description: Returns the timestamp of the most recent snapshot before the given date, for the given migration_id. This corresponds to the record time of the last transaction in the snapshot.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `before` | `query` | `yes` | `string` | - |
+| `migration_id` | `query` | `yes` | `integer` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-state-acs-snapshot-timestamp-after"></a>
+
+### `/v0/state/acs/snapshot-timestamp-after`
+
+<a id="endpoint-get-v0-state-acs-snapshot-timestamp-after"></a>
+
+- Method: `GET`
+
+- Operation ID: `getDateOfFirstSnapshotAfter`
+- Description: Returns the timestamp of the first snapshot after the given date, for the given migration_id or larger.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `after` | `query` | `yes` | `string` | - |
+| `migration_id` | `query` | `yes` | `integer` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-sv-bft-sequencers"></a>
+
+### `/v0/sv-bft-sequencers`
+
+<a id="endpoint-get-v0-sv-bft-sequencers"></a>
+
+- Method: `GET`
+
+- Operation ID: `listSvBftSequencers`
+- Description: Retrieve Canton BFT sequencer configuration for this SV, for each configured Synchronizer
+- Tags: `internal, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-synchronizer-bootstrapping-transactions-domain-id-prefix"></a>
+
+### `/v0/synchronizer-bootstrapping-transactions/{domain_id_prefix}`
+
+<a id="endpoint-get-v0-synchronizer-bootstrapping-transactions-domain-id-prefix"></a>
+
+- Method: `GET`
+
+- Operation ID: `getSynchronizerBootstrappingTransactions`
+- Tags: `internal, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `domain_id_prefix` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-synchronizer-identities-domain-id-prefix"></a>
+
+### `/v0/synchronizer-identities/{domain_id_prefix}`
+
+<a id="endpoint-get-v0-synchronizer-identities-domain-id-prefix"></a>
+
+- Method: `GET`
+
+- Operation ID: `getSynchronizerIdentities`
+- Tags: `internal, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `domain_id_prefix` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-top-providers-by-app-rewards"></a>
+
+### `/v0/top-providers-by-app-rewards`
+
+<a id="endpoint-get-v0-top-providers-by-app-rewards"></a>
+
+- Method: `GET`
+
+- Operation ID: `getTopProvidersByAppRewards`
+- Description: **Deprecated**. Get a list of top-earning app providers, and the total earned app rewards for each
+- Tags: `deprecated, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `round` | `query` | `yes` | `integer` | - |
+| `limit` | `query` | `yes` | `integer` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-top-validators-by-purchased-traffic"></a>
+
+### `/v0/top-validators-by-purchased-traffic`
+
+<a id="endpoint-get-v0-top-validators-by-purchased-traffic"></a>
+
+- Method: `GET`
+
+- Operation ID: `getTopValidatorsByPurchasedTraffic`
+- Description: **Deprecated**. Get a list of validators and their domain fees spends, sorted by the amount of extra traffic purchased
+- Tags: `deprecated, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `round` | `query` | `yes` | `integer` | - |
+| `limit` | `query` | `yes` | `integer` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-top-validators-by-validator-faucets"></a>
+
+### `/v0/top-validators-by-validator-faucets`
+
+<a id="endpoint-get-v0-top-validators-by-validator-faucets"></a>
+
+- Method: `GET`
+
+- Operation ID: `getTopValidatorsByValidatorFaucets`
+- Description: Get a list of top validators by number of rounds in which they collected faucets, and basis statistics on their round collection history
+- Tags: `internal, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `limit` | `query` | `yes` | `integer` | Maximum number of validator records that may be returned in the response |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-top-validators-by-validator-rewards"></a>
+
+### `/v0/top-validators-by-validator-rewards`
+
+<a id="endpoint-get-v0-top-validators-by-validator-rewards"></a>
+
+- Method: `GET`
+
+- Operation ID: `getTopValidatorsByValidatorRewards`
+- Description: **Deprecated**. Get a list of top-earning validators, and the total earned validator rewards for each
+- Tags: `deprecated, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `round` | `query` | `yes` | `integer` | - |
+| `limit` | `query` | `yes` | `integer` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-transactions"></a>
+
+### `/v0/transactions`
+
+<a id="endpoint-post-v0-transactions"></a>
+
+- Method: `POST`
+
+- Operation ID: `listTransactionHistory`
+- Description: **Deprecated with known bugs that will not be fixed, use /v2/updates instead**.  Lists transactions, by default in ascending order, paged, from ledger begin or optionally starting after a provided event id.
+- Tags: `deprecated`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `page_size` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "page_size": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-transfer-command-counter-party"></a>
+
+### `/v0/transfer-command-counter/{party}`
+
+<a id="endpoint-get-v0-transfer-command-counter-party"></a>
+
+- Method: `GET`
+
+- Operation ID: `lookupTransferCommandCounterByParty`
+- Description: Lookup a TransferCommandCounter by the receiver party.
+- Tags: `internal, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `party` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-transfer-command-status"></a>
+
+### `/v0/transfer-command/status`
+
+<a id="endpoint-get-v0-transfer-command-status"></a>
+
+- Method: `GET`
+
+- Operation ID: `lookupTransferCommandStatus`
+- Description: Retrieve the status of all transfer commands (up to a limit of 100) of the given sender for the specified nonce.
+- Tags: `internal, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `sender` | `query` | `yes` | `string` | - |
+| `nonce` | `query` | `yes` | `integer` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-transfer-preapprovals-by-party-party"></a>
+
+### `/v0/transfer-preapprovals/by-party/{party}`
+
+<a id="endpoint-get-v0-transfer-preapprovals-by-party-party"></a>
+
+- Method: `GET`
+
+- Operation ID: `lookupTransferPreapprovalByParty`
+- Description: Lookup a TransferPreapproval by the receiver party.
+- Tags: `internal, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `party` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-unclaimed-development-fund-coupons"></a>
+
+### `/v0/unclaimed-development-fund-coupons`
+
+<a id="endpoint-get-v0-unclaimed-development-fund-coupons"></a>
+
+- Method: `GET`
+
+- Operation ID: `listUnclaimedDevelopmentFundCoupons`
+- Description: List all unclaimed development fund coupons.
+- Tags: `external, scan`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-updates"></a>
+
+### `/v0/updates`
+
+<a id="endpoint-post-v0-updates"></a>
+
+- Method: `POST`
+
+- Operation ID: `getUpdateHistory`
+- Description: **Deprecated**, use /v2/updates instead. Returns the update history in ascending order, paged, from ledger begin or optionally starting after a record time.
+- Tags: `deprecated`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `page_size` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "page_size": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-updates-update-id"></a>
+
+### `/v0/updates/{update_id}`
+
+<a id="endpoint-get-v0-updates-update-id"></a>
+
+- Method: `GET`
+
+- Operation ID: `getUpdateById`
+- Description: **Deprecated**, use /v2/updates/\{update_id\} instead.
+- Tags: `deprecated`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `update_id` | `path` | `yes` | `string` | - |
+| `lossless` | `query` | `no` | `boolean` | Whether contract payload should be encoded into json using a lossless, but much harder to process, encoding. This is mostly used for backend calls, and is not recommended for external users. Optional and defaults to false. |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-validators-validator-faucets"></a>
+
+### `/v0/validators/validator-faucets`
+
+<a id="endpoint-get-v0-validators-validator-faucets"></a>
+
+- Method: `GET`
+
+- Operation ID: `getValidatorFaucetsByValidator`
+- Description: For every argument that is a valid onboarded validator, return statistics on its liveness activity, according to on-ledger state at the time of the request.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `validator_ids` | `query` | `yes` | `array[string]` | A list of validator party IDs, one per specification of the parameter. Any party IDs not matching onboarded validators will be ignored |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-voterequest"></a>
+
+### `/v0/voterequest`
+
+<a id="endpoint-post-v0-voterequest"></a>
+
+- Method: `POST`
+
+- Operation ID: `listVoteRequestsByTrackingCid`
+- Description: Look up several `VoteRequest`\ s at once by their contract IDs.
+- Tags: `internal, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `vote_request_contract_ids` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "vote_request_contract_ids": [
+    "<string>"
+  ]
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v0-voterequests-vote-request-contract-id"></a>
+
+### `/v0/voterequests/{vote_request_contract_id}`
+
+<a id="endpoint-get-v0-voterequests-vote-request-contract-id"></a>
+
+- Method: `GET`
+
+- Operation ID: `lookupDsoRulesVoteRequest`
+- Description: Look up a `VoteRequest` by contract ID.
+- Tags: `internal, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `vote_request_contract_id` | `path` | `yes` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | VoteRequest contract not found. | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v1-domains-domain-id-parties-party-id-participant-id"></a>
+
+### `/v1/domains/{domain_id}/parties/{party_id}/participant-id`
+
+<a id="endpoint-get-v1-domains-domain-id-parties-party-id-participant-id"></a>
+
+- Method: `GET`
+
+- Operation ID: `getPartyToParticipantV1`
+- Description: Get the IDs of the participants hosting a given party. Unlike /v0, this endpoint supports parties hosted on multiple participants.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `domain_id` | `path` | `yes` | `string` | The synchronizer ID to look up a mapping for. |
+| `party_id` | `path` | `yes` | `string` | The party ID to lookup a participant ID for. |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v1-updates"></a>
+
+### `/v1/updates`
+
+<a id="endpoint-post-v1-updates"></a>
+
+- Method: `POST`
+
+- Operation ID: `getUpdateHistoryV1`
+- Description: Returns the update history in ascending order, paged, from ledger begin or optionally starting after a record time. Unlike /v0/updates, this endpoint returns responses that are consistent across different scan instances. Event ids returned by this endpoint are not comparable to event ids returned by /v0/updates.  Updates are ordered lexicographically by `(migration id, record time)`. For a given migration id, each update has a unique record time. The record time ranges of different migrations may overlap, i.e., it is not guaranteed that the maximum record time of one migration is smaller than the minimum record time of the next migration, and there may be two updates with the same record time but different migration ids. The order of items in events_by_id is not defined.
+- Tags: `deprecated`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `page_size` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "page_size": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v1-updates-update-id"></a>
+
+### `/v1/updates/{update_id}`
+
+<a id="endpoint-get-v1-updates-update-id"></a>
+
+- Method: `GET`
+
+- Operation ID: `getUpdateByIdV1`
+- Description: Returns the update with the given update_id. Unlike /v0/updates/\{update_id\}, this endpoint returns responses that are consistent across different scan instances. Event ids returned by this endpoint are not comparable to event ids returned by /v0/updates. The order of items in events_by_id is not defined.
+- Tags: `deprecated`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `update_id` | `path` | `yes` | `string` | - |
+| `daml_value_encoding` | `query` | `no` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v2-updates"></a>
+
+### `/v2/updates`
+
+<a id="endpoint-post-v2-updates"></a>
+
+- Method: `POST`
+
+- Operation ID: `getUpdateHistoryV2`
+- Description: Returns the update history in ascending order, paged, from ledger begin or optionally starting after a record time. Compared to `/v1/updates`, the `/v2/updates` removes the `offset` field in responses, which was hardcoded to 1 in `/v1/updates` for compatibility, and is now removed. `/v2/updates` sorts events lexicographically in `events_by_id` by `ID` for convenience, which should not be confused with the order of events in the transaction, for this you should rely on the order of `root_event_ids` and `child_event_ids`. Updates are ordered lexicographically by `(migration id, record time)`. For a given migration id, each update has a unique record time. The record time ranges of different migrations may overlap, i.e., it is not guaranteed that the maximum record time of one migration is smaller than the minimum record time of the next migration, and there may be two updates with the same record time but different migration ids.
+- Tags: `external, scan`
+
+**Request Body**
+
+- Required: `yes`
+
+| Content Type | Schema | Required Fields |
+| --- | --- | --- |
+| `application/json` | `object` | `page_size` |
+
+**Request Example: `application/json`**
+
+```json
+{
+  "page_size": "<integer>"
+}
+```
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-v2-updates-update-id"></a>
+
+### `/v2/updates/{update_id}`
+
+<a id="endpoint-get-v2-updates-update-id"></a>
+
+- Method: `GET`
+
+- Operation ID: `getUpdateByIdV2`
+- Description: Returns the update with the given update_id. Compared to `/v1/updates/\{update_id\}`, the `/v2/updates/\{update_id\}` removes the `offset` field in responses, which was hardcoded to 1 in `/v1/updates/\{update_id\}` for compatibility, and is now removed. `/v2/updates/\{update_id\}` sorts events lexicographically in `events_by_id` by `ID` for convenience, which should not be confused with the order of events in the transaction, for this you should rely on the order of `root_event_ids` and `child_event_ids`.
+- Tags: `external, scan`
+
+**Parameters**
+
+| Name | In | Required | Schema | Description |
+| --- | --- | --- | --- | --- |
+| `update_id` | `path` | `yes` | `string` | - |
+| `daml_value_encoding` | `query` | `no` | `string` | - |
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+| `400` | bad request | `application/json` | `application/json:object` |
+| `404` | not found | `application/json` | `application/json:object` |
+| `500` | internal server error | `application/json` | `application/json:object` |
+
+<a id="endpoint-path-version"></a>
+
+### `/version`
+
+<a id="endpoint-get-version"></a>
+
+- Method: `GET`
+
+- Operation ID: `getVersion`
+- Tags: `common`
+
+**Responses**
+
+| Code | Description | Content Types | Schemas |
+| --- | --- | --- | --- |
+| `200` | ok | `application/json` | `application/json:object` |
+
+## Changed Entities
+
+| Entity | Type | Introduced | Changed In | Removed |
+| --- | --- | --- | --- | --- |
+| `responses.501` | `component` | `0.5.17` | - | - |
+| `schemas.AppActivityRecord` | `component` | `0.5.17` | - | - |
+| `schemas.BulkStorageObjectRef` | `component` | `0.5.17` | - | - |
+| `schemas.EnvelopeTrafficSummary` | `component` | `0.5.15` | - | - |
+| `schemas.EventHistoryAppActivityRecords` | `component` | `0.5.17` | - | - |
+| `schemas.EventHistoryItem` | `component` | `0.5.10` | `0.5.15, 0.5.17` | - |
+| `schemas.EventHistoryTrafficSummary` | `component` | `0.5.15` | - | - |
+| `schemas.FeatureSupportResponse` | `component` | `0.5.10` | `0.5.16` | - |
+| `schemas.GetPartyToParticipantResponseV1` | `component` | `0.5.17` | - | - |
+| `schemas.ListActivityResponseItem` | `component` | `0.5.10` | `0.5.12` | - |
+| `schemas.ListBulkAcsSnapshotObjectsResponse` | `component` | `0.5.17` | - | - |
+| `schemas.ListBulkUpdateHistoryObjectsRequest` | `component` | `0.5.18` | - | - |
+| `schemas.ListBulkUpdateHistoryObjectsResponse` | `component` | `0.5.18` | - | - |
+| `schemas.TransactionHistoryResponseItem` | `component` | `0.5.10` | `0.5.12` | - |
+| `schemas.UpdateHistoryTransaction` | `component` | `0.5.10` | `0.5.17` | - |
+| `schemas.UpdateHistoryTransactionV2` | `component` | `0.5.10` | `0.5.17` | - |
+| `GET /v0/history/bulk/acs` | `operation` | `0.5.17` | - | - |
+| `GET /v1/domains/{domain_id}/parties/{party_id}/participant-id` | `operation` | `0.5.17` | - | - |
+| `POST /v0/history/bulk/updates` | `operation` | `0.5.18` | - | - |
+| `/v0/history/bulk/acs` | `path` | `0.5.17` | - | - |
+| `/v0/history/bulk/updates` | `path` | `0.5.18` | - | - |
+| `/v1/domains/{domain_id}/parties/{party_id}/participant-id` | `path` | `0.5.17` | - | - |
+| `pre-alpha` | `tag` | `0.5.17` | - | - |
+
+## Latest Operations
+
+| Operation | Introduced | Changed In | Removed |
+| --- | --- | --- | --- |
+| `GET /livez` | `0.5.10` | - | - |
+| `GET /readyz` | `0.5.10` | - | - |
+| `GET /status` | `0.5.10` | - | - |
+| `GET /v0/acs/{party}` | `0.5.10` | - | - |
+| `GET /v0/admin/sv/voterequests` | `0.5.10` | - | - |
+| `GET /v0/admin/validator/licenses` | `0.5.10` | - | - |
+| `GET /v0/aggregated-rounds` | `0.5.10` | - | - |
+| `GET /v0/amulet-config-for-round` | `0.5.10` | - | - |
+| `GET /v0/amulet-price/votes` | `0.5.10` | - | - |
+| `GET /v0/ans-entries` | `0.5.10` | - | - |
+| `GET /v0/ans-entries/by-name/{name}` | `0.5.10` | - | - |
+| `GET /v0/ans-entries/by-party/{party}` | `0.5.10` | - | - |
+| `GET /v0/backfilling/status` | `0.5.10` | - | - |
+| `GET /v0/closed-rounds` | `0.5.10` | - | - |
+| `GET /v0/domains/{domain_id}/members/{member_id}/traffic-status` | `0.5.10` | - | - |
+| `GET /v0/domains/{domain_id}/parties/{party_id}/participant-id` | `0.5.10` | - | - |
+| `GET /v0/dso` | `0.5.10` | - | - |
+| `GET /v0/dso-party-id` | `0.5.10` | - | - |
+| `GET /v0/dso-sequencers` | `0.5.10` | - | - |
+| `GET /v0/events/{update_id}` | `0.5.10` | - | - |
+| `GET /v0/feature-support` | `0.5.10` | - | - |
+| `GET /v0/featured-apps` | `0.5.10` | - | - |
+| `GET /v0/featured-apps/{provider_party_id}` | `0.5.10` | - | - |
+| `GET /v0/history/bulk/acs` | `0.5.17` | - | - |
+| `GET /v0/migrations/schedule` | `0.5.10` | - | - |
+| `GET /v0/rewards-collected` | `0.5.10` | - | - |
+| `GET /v0/round-of-latest-data` | `0.5.10` | - | - |
+| `GET /v0/scans` | `0.5.10` | - | - |
+| `GET /v0/splice-instance-names` | `0.5.10` | - | - |
+| `GET /v0/state/acs/snapshot-timestamp` | `0.5.10` | - | - |
+| `GET /v0/state/acs/snapshot-timestamp-after` | `0.5.10` | - | - |
+| `GET /v0/sv-bft-sequencers` | `0.5.10` | - | - |
+| `GET /v0/synchronizer-bootstrapping-transactions/{domain_id_prefix}` | `0.5.10` | - | - |
+| `GET /v0/synchronizer-identities/{domain_id_prefix}` | `0.5.10` | - | - |
+| `GET /v0/top-providers-by-app-rewards` | `0.5.10` | - | - |
+| `GET /v0/top-validators-by-purchased-traffic` | `0.5.10` | - | - |
+| `GET /v0/top-validators-by-validator-faucets` | `0.5.10` | - | - |
+| `GET /v0/top-validators-by-validator-rewards` | `0.5.10` | - | - |
+| `GET /v0/transfer-command-counter/{party}` | `0.5.10` | - | - |
+| `GET /v0/transfer-command/status` | `0.5.10` | - | - |
+| `GET /v0/transfer-preapprovals/by-party/{party}` | `0.5.10` | - | - |
+| `GET /v0/unclaimed-development-fund-coupons` | `0.5.10` | - | - |
+| `GET /v0/updates/{update_id}` | `0.5.10` | - | - |
+| `GET /v0/validators/validator-faucets` | `0.5.10` | - | - |
+| `GET /v0/voterequests/{vote_request_contract_id}` | `0.5.10` | - | - |
+| `GET /v1/domains/{domain_id}/parties/{party_id}/participant-id` | `0.5.17` | - | - |
+| `GET /v1/updates/{update_id}` | `0.5.10` | - | - |
+| `GET /v2/updates/{update_id}` | `0.5.10` | - | - |
+| `GET /version` | `0.5.10` | - | - |
+| `POST /v0/activities` | `0.5.10` | - | - |
+| `POST /v0/admin/sv/voteresults` | `0.5.10` | - | - |
+| `POST /v0/amulet-rules` | `0.5.10` | - | - |
+| `POST /v0/ans-rules` | `0.5.10` | - | - |
+| `POST /v0/backfilling/import-updates` | `0.5.10` | - | - |
+| `POST /v0/backfilling/migration-info` | `0.5.10` | - | - |
+| `POST /v0/backfilling/updates-before` | `0.5.10` | - | - |
+| `POST /v0/events` | `0.5.10` | - | - |
+| `POST /v0/external-party-amulet-rules` | `0.5.10` | - | - |
+| `POST /v0/history/bulk/updates` | `0.5.18` | - | - |
+| `POST /v0/holdings/state` | `0.5.10` | - | - |
+| `POST /v0/holdings/summary` | `0.5.10` | - | - |
+| `POST /v0/open-and-issuing-mining-rounds` | `0.5.10` | - | - |
+| `POST /v0/round-party-totals` | `0.5.10` | - | - |
+| `POST /v0/round-totals` | `0.5.10` | - | - |
+| `POST /v0/state/acs` | `0.5.10` | - | - |
+| `POST /v0/state/acs/force` | `0.5.10` | - | - |
+| `POST /v0/transactions` | `0.5.10` | - | - |
+| `POST /v0/updates` | `0.5.10` | - | - |
+| `POST /v0/voterequest` | `0.5.10` | - | - |
+| `POST /v1/updates` | `0.5.10` | - | - |
+| `POST /v2/updates` | `0.5.10` | - | - |
+
+## Latest Components
+
+| Component | Introduced | Changed In | Removed |
+| --- | --- | --- | --- |
+| `responses.400` | `0.5.10` | - | - |
+| `responses.404` | `0.5.10` | - | - |
+| `responses.500` | `0.5.10` | - | - |
+| `responses.501` | `0.5.17` | - | - |
+| `schemas.AbortTransferInstruction` | `0.5.10` | - | - |
+| `schemas.AcsRequest` | `0.5.10` | - | - |
+| `schemas.AcsResponse` | `0.5.10` | - | - |
+| `schemas.AcsSnapshotTimestampResponse` | `0.5.10` | - | - |
+| `schemas.ActualMemberTrafficState` | `0.5.10` | - | - |
+| `schemas.AmuletAmount` | `0.5.10` | - | - |
+| `schemas.AnsEntry` | `0.5.10` | - | - |
+| `schemas.AppActivityRecord` | `0.5.17` | - | - |
+| `schemas.BalanceChange` | `0.5.10` | - | - |
+| `schemas.BaseLookupTransferCommandStatusResponse` | `0.5.10` | - | - |
+| `schemas.BatchListVotesByVoteRequestsRequest` | `0.5.10` | - | - |
+| `schemas.BulkStorageObjectRef` | `0.5.17` | - | - |
+| `schemas.CheckAndUpdateValidatorTrafficBalanceResponse` | `0.5.10` | - | - |
+| `schemas.Contract` | `0.5.10` | - | - |
+| `schemas.ContractId` | `0.5.10` | - | - |
+| `schemas.ContractWithState` | `0.5.10` | - | - |
+| `schemas.CreatedEvent` | `0.5.10` | - | - |
+| `schemas.DamlValueEncoding` | `0.5.10` | - | - |
+| `schemas.DomainScans` | `0.5.10` | - | - |
+| `schemas.DomainSequencers` | `0.5.10` | - | - |
+| `schemas.DsoSequencer` | `0.5.10` | - | - |
+| `schemas.EnvelopeTrafficSummary` | `0.5.15` | - | - |
+| `schemas.ErrorResponse` | `0.5.10` | - | - |
+| `schemas.EventHistoryAppActivityRecords` | `0.5.17` | - | - |
+| `schemas.EventHistoryItem` | `0.5.10` | `0.5.15, 0.5.17` | - |
+| `schemas.EventHistoryRequest` | `0.5.10` | - | - |
+| `schemas.EventHistoryResponse` | `0.5.10` | - | - |
+| `schemas.EventHistoryTrafficSummary` | `0.5.15` | - | - |
+| `schemas.EventHistoryVerdict` | `0.5.10` | - | - |
+| `schemas.ExercisedEvent` | `0.5.10` | - | - |
+| `schemas.FailureStatusResponse` | `0.5.10` | - | - |
+| `schemas.FeatureSupportResponse` | `0.5.10` | `0.5.16` | - |
+| `schemas.ForceAcsSnapshotResponse` | `0.5.10` | - | - |
+| `schemas.GetAcsSnapshotResponse` | `0.5.10` | - | - |
+| `schemas.GetAggregatedRoundsResponse` | `0.5.10` | - | - |
+| `schemas.GetAmuletConfigForRoundResponse` | `0.5.10` | - | - |
+| `schemas.GetAmuletRulesRequest` | `0.5.10` | - | - |
+| `schemas.GetAmuletRulesResponse` | `0.5.10` | - | - |
+| `schemas.GetAnsRulesRequest` | `0.5.10` | - | - |
+| `schemas.GetAnsRulesResponse` | `0.5.10` | - | - |
+| `schemas.GetBackfillingStatusResponse` | `0.5.10` | - | - |
+| `schemas.GetClosedRoundsResponse` | `0.5.10` | - | - |
+| `schemas.GetDsoInfoResponse` | `0.5.10` | - | - |
+| `schemas.GetDsoPartyIdResponse` | `0.5.10` | - | - |
+| `schemas.GetExternalPartyAmuletRulesRequest` | `0.5.10` | - | - |
+| `schemas.GetExternalPartyAmuletRulesResponse` | `0.5.10` | - | - |
+| `schemas.GetImportUpdatesRequest` | `0.5.10` | - | - |
+| `schemas.GetImportUpdatesResponse` | `0.5.10` | - | - |
+| `schemas.GetMemberTrafficStatusResponse` | `0.5.10` | - | - |
+| `schemas.GetMigrationInfoRequest` | `0.5.10` | - | - |
+| `schemas.GetMigrationInfoResponse` | `0.5.10` | - | - |
+| `schemas.GetOpenAndIssuingMiningRoundsRequest` | `0.5.10` | - | - |
+| `schemas.GetOpenAndIssuingMiningRoundsResponse` | `0.5.10` | - | - |
+| `schemas.GetPartyToParticipantResponse` | `0.5.10` | - | - |
+| `schemas.GetPartyToParticipantResponseV1` | `0.5.17` | - | - |
+| `schemas.GetRewardsCollectedResponse` | `0.5.10` | - | - |
+| `schemas.GetRoundOfLatestDataResponse` | `0.5.10` | - | - |
+| `schemas.GetSpliceInstanceNamesResponse` | `0.5.10` | - | - |
+| `schemas.GetTopProvidersByAppRewardsResponse` | `0.5.10` | - | - |
+| `schemas.GetTopValidatorsByPurchasedTrafficResponse` | `0.5.10` | - | - |
+| `schemas.GetTopValidatorsByValidatorFaucetsResponse` | `0.5.10` | - | - |
+| `schemas.GetTopValidatorsByValidatorRewardsResponse` | `0.5.10` | - | - |
+| `schemas.GetUpdatesBeforeRequest` | `0.5.10` | - | - |
+| `schemas.GetUpdatesBeforeResponse` | `0.5.10` | - | - |
+| `schemas.GetValidatorFaucetsByValidatorResponse` | `0.5.10` | - | - |
+| `schemas.GetValidatorTrafficBalanceResponse` | `0.5.10` | - | - |
+| `schemas.HoldingsStateRequest` | `0.5.10` | - | - |
+| `schemas.HoldingsSummary` | `0.5.10` | - | - |
+| `schemas.HoldingsSummaryRequest` | `0.5.10` | - | - |
+| `schemas.HoldingsSummaryResponse` | `0.5.10` | - | - |
+| `schemas.ListActivityRequest` | `0.5.10` | - | - |
+| `schemas.ListActivityResponse` | `0.5.10` | - | - |
+| `schemas.ListActivityResponseItem` | `0.5.10` | `0.5.12` | - |
+| `schemas.ListAmuletPriceVotesResponse` | `0.5.10` | - | - |
+| `schemas.ListBulkAcsSnapshotObjectsResponse` | `0.5.17` | - | - |
+| `schemas.ListBulkUpdateHistoryObjectsRequest` | `0.5.18` | - | - |
+| `schemas.ListBulkUpdateHistoryObjectsResponse` | `0.5.18` | - | - |
+| `schemas.ListDsoRulesVoteRequestsResponse` | `0.5.10` | - | - |
+| `schemas.ListDsoRulesVoteResultsResponse` | `0.5.10` | - | - |
+| `schemas.ListDsoScansResponse` | `0.5.10` | - | - |
+| `schemas.ListDsoSequencersResponse` | `0.5.10` | - | - |
+| `schemas.ListEntriesResponse` | `0.5.10` | - | - |
+| `schemas.ListFeaturedAppRightsResponse` | `0.5.10` | - | - |
+| `schemas.ListRoundPartyTotalsRequest` | `0.5.10` | - | - |
+| `schemas.ListRoundPartyTotalsResponse` | `0.5.10` | - | - |
+| `schemas.ListRoundTotalsRequest` | `0.5.10` | - | - |
+| `schemas.ListRoundTotalsResponse` | `0.5.10` | - | - |
+| `schemas.ListSvBftSequencersResponse` | `0.5.10` | - | - |
+| `schemas.ListUnclaimedDevelopmentFundCouponsResponse` | `0.5.10` | - | - |
+| `schemas.ListValidatorLicensesResponse` | `0.5.10` | - | - |
+| `schemas.ListVoteRequestByTrackingCidResponse` | `0.5.10` | - | - |
+| `schemas.ListVoteResultsRequest` | `0.5.10` | - | - |
+| `schemas.LookupDsoRulesVoteRequestResponse` | `0.5.10` | - | - |
+| `schemas.LookupEntryByNameResponse` | `0.5.10` | - | - |
+| `schemas.LookupEntryByPartyResponse` | `0.5.10` | - | - |
+| `schemas.LookupFeaturedAppRightResponse` | `0.5.10` | - | - |
+| `schemas.LookupTransferCommandCounterByPartyResponse` | `0.5.10` | - | - |
+| `schemas.LookupTransferCommandStatusResponse` | `0.5.10` | - | - |
+| `schemas.LookupTransferPreapprovalByPartyResponse` | `0.5.10` | - | - |
+| `schemas.MaybeCachedContractWithState` | `0.5.10` | - | - |
+| `schemas.MaybeCachedContractWithStateMap` | `0.5.10` | - | - |
+| `schemas.MemberTrafficStatus` | `0.5.10` | - | - |
+| `schemas.MigrationSchedule` | `0.5.10` | - | - |
+| `schemas.NodeStatus` | `0.5.10` | - | - |
+| `schemas.NotInitialized` | `0.5.10` | - | - |
+| `schemas.NotInitializedStatusResponse` | `0.5.10` | - | - |
+| `schemas.PartyAndRewards` | `0.5.10` | - | - |
+| `schemas.Quorum` | `0.5.10` | - | - |
+| `schemas.RateStep` | `0.5.10` | - | - |
+| `schemas.ReceiverAmount` | `0.5.10` | - | - |
+| `schemas.RecordTimeRange` | `0.5.10` | - | - |
+| `schemas.RoundPartyTotals` | `0.5.10` | - | - |
+| `schemas.RoundTotals` | `0.5.10` | - | - |
+| `schemas.ScanInfo` | `0.5.10` | - | - |
+| `schemas.SenderAmount` | `0.5.10` | - | - |
+| `schemas.Status` | `0.5.10` | - | - |
+| `schemas.SteppedRate` | `0.5.10` | - | - |
+| `schemas.SuccessStatusResponse` | `0.5.10` | - | - |
+| `schemas.SynchronizerBftSequencer` | `0.5.10` | - | - |
+| `schemas.SynchronizerBootstrappingTransactions` | `0.5.10` | - | - |
+| `schemas.SynchronizerIdentities` | `0.5.10` | - | - |
+| `schemas.TargetMemberTrafficState` | `0.5.10` | - | - |
+| `schemas.TransactionHistoryRequest` | `0.5.10` | - | - |
+| `schemas.TransactionHistoryResponse` | `0.5.10` | - | - |
+| `schemas.TransactionHistoryResponseItem` | `0.5.10` | `0.5.12` | - |
+| `schemas.TransactionView` | `0.5.10` | - | - |
+| `schemas.TransactionViews` | `0.5.10` | - | - |
+| `schemas.Transfer` | `0.5.10` | - | - |
+| `schemas.TransferCommandContractStatus` | `0.5.10` | - | - |
+| `schemas.TransferCommandContractWithStatus` | `0.5.10` | - | - |
+| `schemas.TransferCommandCreatedResponse` | `0.5.10` | - | - |
+| `schemas.TransferCommandFailedResponse` | `0.5.10` | - | - |
+| `schemas.TransferCommandMap` | `0.5.10` | - | - |
+| `schemas.TransferCommandSentResponse` | `0.5.10` | - | - |
+| `schemas.TreeEvent` | `0.5.10` | - | - |
+| `schemas.UpdateHistoryAssignment` | `0.5.10` | - | - |
+| `schemas.UpdateHistoryItem` | `0.5.10` | - | - |
+| `schemas.UpdateHistoryItemV2` | `0.5.10` | - | - |
+| `schemas.UpdateHistoryReassignment` | `0.5.10` | - | - |
+| `schemas.UpdateHistoryRequest` | `0.5.10` | - | - |
+| `schemas.UpdateHistoryRequestAfter` | `0.5.10` | - | - |
+| `schemas.UpdateHistoryRequestV1` | `0.5.10` | - | - |
+| `schemas.UpdateHistoryRequestV2` | `0.5.10` | - | - |
+| `schemas.UpdateHistoryResponse` | `0.5.10` | - | - |
+| `schemas.UpdateHistoryResponseV2` | `0.5.10` | - | - |
+| `schemas.UpdateHistoryTransaction` | `0.5.10` | `0.5.17` | - |
+| `schemas.UpdateHistoryTransactionV2` | `0.5.10` | `0.5.17` | - |
+| `schemas.UpdateHistoryUnassignment` | `0.5.10` | - | - |
+| `schemas.ValidatorPurchasedTraffic` | `0.5.10` | - | - |
+| `schemas.ValidatorReceivedFaucets` | `0.5.10` | - | - |
+| `schemas.VerdictResult` | `0.5.10` | - | - |
+| `schemas.Version` | `0.5.10` | - | - |
+
+## Spec Metadata
+
+- Canonical spec id: `scan.yaml`
+- Latest source path: `openapi/scan.yaml`
+- OpenAPI version (latest): `3.0.0`
+- Introduced: `0.5.10`
+- Changed in versions: `0.5.12, 0.5.15, 0.5.16, 0.5.17, 0.5.18`
+- Removed: -
+
+## Entity Summary
+
+- Total entities tracked: `303`
+- Entities introduced after spec introduction: `17`
+- Entities changed at least once: `6`
+- Entities removed: `0`
+- Latest operations: `71`
+- Latest paths: `71`
+- Latest components: `156`
+- Latest tags: `5`

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "generate:daml-standard-library-reference": "python3 scripts/generate_daml_standard_library_reference.py",
     "generate:canton-protobuf-history": "python3 scripts/generate_canton_protobuf_history.py",
     "generate:wallet-gateway-openrpc-reference": "python3 scripts/generate_wallet_gateway_openrpc_reference.py",
+    "generate:splice-scan-openapi-reference": "python3 scripts/generate_splice_scan_openapi_reference.py",
     "generate:typescript-bindings-reference": "python3 scripts/generate_typescript_bindings_reference.py"
   },
   "dependencies": {

--- a/scripts/generate_all_reference_docs.py
+++ b/scripts/generate_all_reference_docs.py
@@ -18,6 +18,7 @@ SCRIPT_PATHS = [
     REPO_ROOT / "scripts" / "generate_daml_standard_library_reference.py",
     REPO_ROOT / "scripts" / "generate_canton_protobuf_history.py",
     REPO_ROOT / "scripts" / "generate_wallet_gateway_openrpc_reference.py",
+    REPO_ROOT / "scripts" / "generate_splice_scan_openapi_reference.py",
     REPO_ROOT / "scripts" / "generate_typescript_bindings_reference.py",
 ]
 

--- a/scripts/generate_splice_scan_openapi_reference.py
+++ b/scripts/generate_splice_scan_openapi_reference.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from splice_openapi_release_bundles import render_reference
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SOURCE_CONFIG = REPO_ROOT / "config" / "x2mdx" / "splice-scan-openapi" / "source-artifacts.json"
+DEFAULT_CACHE_DIR = REPO_ROOT / ".internal" / "cache" / "x2mdx" / "splice-openapi"
+DEFAULT_MANIFEST = REPO_ROOT / ".internal" / "generated" / "x2mdx" / "splice-scan-openapi" / "manifest.json"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "docs-main" / "reference" / "splice-scan-openapi"
+DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
+DEFAULT_SOURCE_NAME = "Splice Scan OpenAPI specs from published decentralized-canton-sync release bundles"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download published decentralized-canton-sync OpenAPI bundles, materialize the Scan API specs, and render Mintlify pages."
+    )
+    parser.add_argument("--source-config", default=str(DEFAULT_SOURCE_CONFIG))
+    parser.add_argument("--cache-dir", default=str(DEFAULT_CACHE_DIR))
+    parser.add_argument("--manifest-out", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR))
+    parser.add_argument("--docs-json", default=str(DEFAULT_DOCS_JSON))
+    parser.add_argument("--nav-dropdown", default="API Reference")
+    parser.add_argument("--version", action="append", help="Explicit release version to include. Repeat to limit generation.")
+    parser.add_argument("--min-version", help="Minimum release version to include.")
+    parser.add_argument("--force-refresh", action="store_true", help="Refresh cached release bundles and extracted YAML fixtures.")
+    parser.add_argument(
+        "--source-name",
+        default=DEFAULT_SOURCE_NAME,
+        help="Source label embedded in generated content.",
+    )
+    parser.add_argument(
+        "--version-filter",
+        help="Version-filter label embedded in generated content.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    include_versions = set(args.version) if args.version else None
+    version_filter = args.version_filter
+    if not version_filter:
+        if include_versions:
+            version_filter = "selected decentralized-canton-sync OpenAPI releases"
+        else:
+            version_filter = f"stable decentralized-canton-sync OpenAPI releases >= {args.min_version or '0.5.10'}"
+
+    render_reference(
+        source_config_path=Path(args.source_config).resolve(),
+        cache_dir=Path(args.cache_dir).resolve(),
+        manifest_path=Path(args.manifest_out).resolve(),
+        output_dir=Path(args.output_dir).resolve(),
+        docs_json_path=Path(args.docs_json).resolve(),
+        dropdown_label=args.nav_dropdown,
+        include_versions=include_versions,
+        min_version_override=args.min_version,
+        source_name=args.source_name,
+        version_filter=version_filter,
+        force_refresh=args.force_refresh,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/splice_openapi_release_bundles.py
+++ b/scripts/splice_openapi_release_bundles.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import generate_canton_protobuf_history as canton_protobuf_history
+
+
+USER_AGENT = "digital-asset-docs-x2mdx/1.0"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def version_key(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+def github_json(url: str) -> Any:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    with urllib.request.urlopen(request, timeout=180) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def selected_releases(
+    *,
+    source_config: dict[str, Any],
+    include_versions: set[str] | None,
+) -> list[dict[str, str]]:
+    release_repo = source_config.get("release_repo")
+    if not isinstance(release_repo, str) or not release_repo:
+        raise ValueError("Source config must define release_repo")
+    tag_regex = source_config.get("tag_regex")
+    if not isinstance(tag_regex, str) or not tag_regex:
+        raise ValueError("Source config must define tag_regex")
+    asset_template = source_config.get("asset_template")
+    if not isinstance(asset_template, str) or not asset_template:
+        raise ValueError("Source config must define asset_template")
+    min_version = source_config.get("min_version") or "0.0.0"
+    if not isinstance(min_version, str):
+        raise ValueError("min_version must be a string")
+
+    matcher = re.compile(tag_regex)
+    minimum_key = version_key(min_version)
+    releases: list[dict[str, str]] = []
+    page = 1
+    while True:
+        payload = github_json(
+            f"https://api.github.com/repos/{release_repo}/releases?per_page=100&page={page}"
+        )
+        if not isinstance(payload, list):
+            raise ValueError(f"Expected list payload from GitHub releases API for {release_repo}")
+        if not payload:
+            break
+        for release in payload:
+            if not isinstance(release, dict):
+                continue
+            if release.get("draft") or release.get("prerelease"):
+                continue
+            tag_name = release.get("tag_name")
+            if not isinstance(tag_name, str):
+                continue
+            match = matcher.fullmatch(tag_name)
+            if not match:
+                continue
+            version = match.groupdict().get("version") or tag_name.removeprefix("v")
+            if version_key(version) < minimum_key:
+                continue
+            if include_versions is not None and version not in include_versions:
+                continue
+            asset_name = asset_template.format(version=version)
+            assets = release.get("assets")
+            if not isinstance(assets, list):
+                continue
+            asset = next(
+                (
+                    item
+                    for item in assets
+                    if isinstance(item, dict) and item.get("name") == asset_name
+                ),
+                None,
+            )
+            if asset is None:
+                continue
+            download_url = asset.get("browser_download_url")
+            if not isinstance(download_url, str) or not download_url:
+                continue
+            releases.append(
+                {
+                    "version": version,
+                    "tag": tag_name,
+                    "asset_name": asset_name,
+                    "download_url": download_url,
+                }
+            )
+        if len(payload) < 100:
+            break
+        page += 1
+
+    releases.sort(key=lambda entry: version_key(entry["version"]))
+    if not releases:
+        raise ValueError(f"No published releases matched the configured Splice OpenAPI bundle selection for {release_repo}")
+    return releases
+
+
+def archive_path(cache_dir: Path, *, release: dict[str, str]) -> Path:
+    return cache_dir / "archives" / release["version"] / release["asset_name"]
+
+
+def ensure_archive(
+    *,
+    cache_dir: Path,
+    release: dict[str, str],
+    force_refresh: bool,
+) -> Path:
+    output_path = archive_path(cache_dir, release=release)
+    if output_path.exists() and not force_refresh:
+        return output_path
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = output_path.with_name(f"{output_path.name}.{os.getpid()}.tmp")
+    request = urllib.request.Request(
+        release["download_url"],
+        headers={"User-Agent": USER_AGENT},
+    )
+    with urllib.request.urlopen(request, timeout=180) as response, temp_path.open("wb") as handle:
+        shutil.copyfileobj(response, handle)
+    temp_path.replace(output_path)
+    return output_path
+
+
+def materialize_release_fixtures(
+    *,
+    cache_dir: Path,
+    release: dict[str, str],
+    force_refresh: bool,
+) -> list[str]:
+    fixture_dir = cache_dir / "fixtures" / release["version"]
+    if fixture_dir.exists() and force_refresh:
+        shutil.rmtree(fixture_dir)
+    if fixture_dir.exists():
+        existing = sorted(
+            path.name
+            for path in fixture_dir.iterdir()
+            if path.is_file() and path.suffix.lower() in {".yaml", ".yml"}
+        )
+        if existing:
+            return existing
+
+    archive = ensure_archive(cache_dir=cache_dir, release=release, force_refresh=force_refresh)
+    fixture_dir.mkdir(parents=True, exist_ok=True)
+
+    filenames: list[str] = []
+    seen: set[str] = set()
+    with tarfile.open(archive, "r:gz") as handle:
+        for member in handle.getmembers():
+            if not member.isfile():
+                continue
+            filename = Path(member.name).name
+            if Path(filename).suffix.lower() not in {".yaml", ".yml"}:
+                continue
+            if filename in seen:
+                raise ValueError(f"Duplicate YAML filename '{filename}' found in {archive}")
+            extracted = handle.extractfile(member)
+            if extracted is None:
+                raise FileNotFoundError(f"Failed to extract '{member.name}' from {archive}")
+            (fixture_dir / filename).write_bytes(extracted.read())
+            seen.add(filename)
+            filenames.append(filename)
+
+    filenames.sort()
+    if not filenames:
+        raise FileNotFoundError(f"No YAML files found in {archive}")
+    return filenames
+
+
+def write_manifest(
+    *,
+    source_config: dict[str, Any],
+    cache_dir: Path,
+    manifest_path: Path,
+    releases: list[dict[str, str]],
+    source_name: str,
+) -> Path:
+    source_path_prefix = source_config.get("source_path_prefix") or "openapi"
+    if not isinstance(source_path_prefix, str):
+        raise ValueError("source_path_prefix must be a string")
+    entries: list[dict[str, str]] = []
+    for release in releases:
+        for filename in release["fixture_filenames"]:
+            entries.append(
+                {
+                    "version": release["version"],
+                    "url": release["download_url"],
+                    "source_path": f"{source_path_prefix.rstrip('/')}/{filename}",
+                    "fixture_path": str((cache_dir / "fixtures" / release["version"] / filename).resolve()),
+                }
+            )
+
+    manifest = {
+        "source": source_name,
+        "versions": entries,
+    }
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote manifest: {manifest_path}")
+    return manifest_path
+
+
+def slugify(value: str) -> str:
+    output = value.lower()
+    output = re.sub(r"[^a-z0-9]+", "-", output)
+    output = re.sub(r"-{2,}", "-", output).strip("-")
+    return output
+
+
+def normalized_spec_pages(source_config: dict[str, Any]) -> list[dict[str, str]]:
+    spec_pages = source_config.get("spec_pages")
+    if spec_pages is None:
+        legacy_filenames = source_config.get("spec_filenames")
+        if not isinstance(legacy_filenames, list) or not all(
+            isinstance(item, str) and item for item in legacy_filenames
+        ):
+            raise ValueError("Source config must define spec_pages or spec_filenames")
+        return [
+            {
+                "filename": spec_filename,
+                "output_filename": f"{slugify(spec_filename)}.mdx",
+            }
+            for spec_filename in legacy_filenames
+        ]
+
+    if not isinstance(spec_pages, list) or not spec_pages:
+        raise ValueError("spec_pages must be a non-empty list")
+
+    normalized: list[dict[str, str]] = []
+    for entry in spec_pages:
+        if not isinstance(entry, dict):
+            raise ValueError("Each spec_pages entry must be an object")
+        filename = entry.get("filename")
+        if not isinstance(filename, str) or not filename:
+            raise ValueError("Each spec_pages entry must define a non-empty filename")
+        output_filename = entry.get("output_filename")
+        if output_filename is None:
+            output_filename = f"{slugify(filename)}.mdx"
+        if not isinstance(output_filename, str) or not output_filename.endswith(".mdx"):
+            raise ValueError("Each spec_pages entry must define an output_filename ending in .mdx")
+        normalized.append(
+            {
+                "filename": filename,
+                "output_filename": output_filename,
+            }
+        )
+    return normalized
+
+
+def page_output_path(output_dir: Path, spec_page: dict[str, str]) -> Path:
+    return output_dir / spec_page["output_filename"]
+
+
+def page_ref(output_dir: Path, docs_json_path: Path, spec_page: dict[str, str]) -> str:
+    return canton_protobuf_history.docs_json_page_ref(page_output_path(output_dir, spec_page), docs_json_path)
+
+
+def build_nav_group(
+    *,
+    docs_json_path: Path,
+    output_dir: Path,
+    nav_group_label: str,
+    spec_pages: list[dict[str, str]],
+) -> tuple[dict[str, Any], set[str]]:
+    refs = [page_ref(output_dir, docs_json_path, spec_page) for spec_page in spec_pages]
+    return {"group": nav_group_label, "pages": refs}, set(refs)
+
+
+def legacy_nav_refs(
+    *,
+    docs_json_path: Path,
+    output_dir: Path,
+    spec_pages: list[dict[str, str]],
+) -> set[str]:
+    refs = {
+        canton_protobuf_history.docs_json_page_ref(output_dir / "index.mdx", docs_json_path),
+    }
+    for spec_page in spec_pages:
+        refs.add(
+            canton_protobuf_history.docs_json_page_ref(
+                output_dir / "specs" / f"{slugify(spec_page['filename'])}.mdx",
+                docs_json_path,
+            )
+        )
+    return refs
+
+
+def insert_group(items: list[Any], *, group: dict[str, Any], after_group: str | None) -> None:
+    if after_group:
+        for index, item in enumerate(items):
+            if isinstance(item, dict) and item.get("group") == after_group:
+                items.insert(index + 1, group)
+                return
+    items.append(group)
+
+
+def ensure_group_path(
+    items: list[Any],
+    group_path: list[str],
+    *,
+    top_level_insert_after_group: str | None,
+) -> list[Any]:
+    current_pages = items
+    top_level_items = items
+    for depth, label in enumerate(group_path):
+        group = next(
+            (item for item in current_pages if isinstance(item, dict) and item.get("group") == label),
+            None,
+        )
+        if group is None:
+            group = {"group": label, "pages": []}
+            if depth == 0:
+                insert_group(top_level_items, group=group, after_group=top_level_insert_after_group)
+            else:
+                current_pages.append(group)
+        pages = group.get("pages")
+        if not isinstance(pages, list):
+            pages = []
+            group["pages"] = pages
+        current_pages = pages
+    return current_pages
+
+
+def update_docs_navigation(
+    *,
+    docs_json_path: Path,
+    dropdown_label: str,
+    parent_groups: list[str],
+    top_level_insert_after_group: str | None,
+    output_dir: Path,
+    nav_group_label: str,
+    spec_pages: list[dict[str, str]],
+) -> None:
+    docs = load_json(docs_json_path)
+    navigation = docs.get("navigation")
+    if not isinstance(navigation, dict):
+        raise ValueError(f"docs.json navigation must be an object: {docs_json_path}")
+    dropdowns = navigation.get("dropdowns")
+    if not isinstance(dropdowns, list):
+        raise ValueError(f"docs.json navigation.dropdowns must be a list: {docs_json_path}")
+    dropdown = next(
+        (item for item in dropdowns if isinstance(item, dict) and item.get("dropdown") == dropdown_label),
+        None,
+    )
+    if dropdown is None:
+        raise ValueError(f"Dropdown not found in docs.json: {dropdown_label}")
+    pages = dropdown.get("pages")
+    if not isinstance(pages, list):
+        raise ValueError(f"Dropdown does not expose a pages list: {dropdown_label}")
+
+    nav_group, generated_refs = build_nav_group(
+        docs_json_path=docs_json_path,
+        output_dir=output_dir,
+        nav_group_label=nav_group_label,
+        spec_pages=spec_pages,
+    )
+    generated_refs |= legacy_nav_refs(
+        docs_json_path=docs_json_path,
+        output_dir=output_dir,
+        spec_pages=spec_pages,
+    )
+    dropdown["pages"] = canton_protobuf_history.prune_nav_items(
+        pages,
+        page_refs=generated_refs,
+        group_labels={nav_group_label},
+    )
+    target_pages = ensure_group_path(
+        dropdown["pages"],
+        parent_groups,
+        top_level_insert_after_group=top_level_insert_after_group,
+    )
+    insert_group(target_pages, group=nav_group, after_group=None)
+    docs_json_path.write_text(json.dumps(docs, indent=2) + "\n", encoding="utf-8")
+    print(f"Updated docs navigation: {docs_json_path}")
+
+
+def build_command(
+    *,
+    source_config: dict[str, Any],
+    manifest_path: Path,
+    output_file: Path,
+    spec_page: dict[str, str],
+    versions: list[str],
+    source_name: str,
+    version_filter: str,
+) -> list[str]:
+    source_path_prefix = source_config.get("source_path_prefix") or "openapi"
+    if not isinstance(source_path_prefix, str) or not source_path_prefix:
+        raise ValueError("source_path_prefix must be a non-empty string")
+    spec_filename = spec_page["filename"]
+
+    command = [
+        "x2mdx",
+        "openapi",
+        "build-api-pages-from-manifest",
+        "--manifest",
+        str(manifest_path),
+        "--root",
+        source_path_prefix,
+        "--output-file",
+        str(output_file),
+        "--source-name",
+        source_name,
+        "--version-filter",
+        version_filter,
+    ]
+    command.extend(["--include-spec-pattern", rf"^{re.escape(spec_filename)}$"])
+    for mapping in source_config.get("canonical_paths", []):
+        command.extend(["--canonical-path", mapping])
+    for prefix in source_config.get("priority_prefixes", []):
+        command.extend(["--priority-prefix", prefix])
+    for version in versions:
+        command.extend(["--version", version])
+    return command
+
+
+def render_reference(
+    *,
+    source_config_path: Path,
+    cache_dir: Path,
+    manifest_path: Path,
+    output_dir: Path,
+    docs_json_path: Path,
+    dropdown_label: str,
+    include_versions: set[str] | None,
+    min_version_override: str | None,
+    source_name: str,
+    version_filter: str,
+    force_refresh: bool,
+) -> None:
+    source_config = load_json(source_config_path)
+    spec_pages = normalized_spec_pages(source_config)
+    nav_parent_groups = source_config.get("nav_parent_groups")
+    if not isinstance(nav_parent_groups, list) or not all(isinstance(item, str) and item for item in nav_parent_groups):
+        raise ValueError("nav_parent_groups must be a list of non-empty strings")
+    nav_group_label = source_config.get("nav_group_label")
+    if not isinstance(nav_group_label, str) or not nav_group_label:
+        raise ValueError("nav_group_label must be a non-empty string")
+    top_level_insert_after_group = source_config.get("top_level_insert_after_group")
+    if top_level_insert_after_group is not None and not isinstance(top_level_insert_after_group, str):
+        raise ValueError("top_level_insert_after_group must be a string if present")
+
+    if min_version_override:
+        source_config = dict(source_config)
+        source_config["min_version"] = min_version_override
+
+    releases = selected_releases(source_config=source_config, include_versions=include_versions)
+    for release in releases:
+        release["fixture_filenames"] = materialize_release_fixtures(
+            cache_dir=cache_dir,
+            release=release,
+            force_refresh=force_refresh,
+        )
+
+    write_manifest(
+        source_config=source_config,
+        cache_dir=cache_dir,
+        manifest_path=manifest_path,
+        releases=releases,
+        source_name=source_name,
+    )
+
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    versions = [release["version"] for release in releases]
+    for spec_page in spec_pages:
+        output_file = page_output_path(output_dir, spec_page)
+        command = build_command(
+            source_config=source_config,
+            manifest_path=manifest_path,
+            output_file=output_file,
+            spec_page=spec_page,
+            versions=versions,
+            source_name=source_name,
+            version_filter=version_filter,
+        )
+        print("Running:", " ".join(command))
+        subprocess.run(command, check=True)
+        if not output_file.exists():
+            raise FileNotFoundError(f"Expected generated spec page not found: {output_file}")
+
+    update_docs_navigation(
+        docs_json_path=docs_json_path,
+        dropdown_label=dropdown_label,
+        parent_groups=nav_parent_groups,
+        top_level_insert_after_group=top_level_insert_after_group,
+        output_dir=output_dir,
+        nav_group_label=nav_group_label,
+        spec_pages=spec_pages,
+    )


### PR DESCRIPTION
## Summary

Adds partial splice. [Preview here](https://cantonfoundation-splice-scan-openapi-reference.mintlify.io/reference/splice-scan-openapi/scan-yaml).
<img width="237" height="128" alt="image" src="https://github.com/user-attachments/assets/879b0ce8-8985-43a2-9137-b1dc6fbd272e" />

## Changes
- add a docs-side generator for Splice Scan OpenAPI release bundles from published decentralized-canton-sync assets
- generate and check in the Scan API and Scan Streaming API Mintlify pages under `API Reference -> Splice APIs -> Scan APIs`
- add the new wrapper to the repo-level reference regeneration commands and document it in the README
