### PR TITLE
Import Splice Daml API references

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,30 @@ By default this writes:
 
 The generated nav is added under the top-level `API Reference` dropdown as `Splice APIs -> Token Standard APIs`, with the overview page listed first followed by the generated token-standard spec pages.
 
+### Generate the Splice Daml API reference
+
+This repo also includes a checked-in source config for the published decentralized-canton-sync Splice Daml API surface at `config/x2mdx/splice-daml-api/source-artifacts.json`.
+The generator script discovers matching stable releases through the GitHub releases API, downloads the `*_splice-node.tar.gz` bundle assets into `.internal/cache/x2mdx/splice-daml-api/`, validates that the configured family list still matches the live `docs.sync.global/app_dev/api/` surface embedded in the published bundle docs, extracts the corresponding DARs, runs `daml damlc docs --format json` on the extracted `.daml` sources, writes per-family x2mdx manifests into `.internal/generated/x2mdx/splice-daml-api/`, and then renders the checked-in Mintlify pages with the GitHub-pinned `x2mdx`.
+
+Run:
+
+```bash
+python3 scripts/generate_splice_daml_api_reference.py
+```
+
+or:
+
+```bash
+npm run generate:splice-daml-api-reference
+```
+
+By default this writes:
+
+- `docs-main/reference/splice-daml-api/`
+- `docs-main/docs.json`
+
+The generated nav is added under the top-level `API Reference` dropdown as `Splice APIs -> Daml APIs`. The overview page records the one currently-blocked live family, `splice-token-standard-test`, whose live docs exist but whose release bundle does not currently ship a matching DAR.
+
 By default this writes:
 
 - `docs-main/reference/wallet-gateway-json-rpc/`

--- a/config/x2mdx/splice-daml-api/source-artifacts.json
+++ b/config/x2mdx/splice-daml-api/source-artifacts.json
@@ -1,0 +1,63 @@
+{
+  "release_repo": "digital-asset/decentralized-canton-sync",
+  "tag_regex": "^v(?P<version>\\d+\\.\\d+\\.\\d+)$",
+  "min_version": "0.5.18",
+  "publish_version": "0.5.18",
+  "asset_template": "{version}_splice-node.tar.gz",
+  "overview_title": "Splice Daml APIs",
+  "nav_parent_groups": ["Splice APIs"],
+  "nav_group_label": "Daml APIs",
+  "top_level_insert_after_group": "Wallet Kernel",
+  "sections": [
+    {
+      "group": "Token Standard APIs (CIP-0056)",
+      "description": "Stable Daml interfaces for token metadata, holdings, transfer instructions, allocations, and allocation requests.",
+      "families": [
+        "splice-api-token-metadata-v1",
+        "splice-api-token-holding-v1",
+        "splice-api-token-transfer-instruction-v1",
+        "splice-api-token-allocation-v1",
+        "splice-api-token-allocation-instruction-v1",
+        "splice-api-token-allocation-request-v1"
+      ]
+    },
+    {
+      "group": "Featured App Activity Markers API (CIP-0047)",
+      "description": "Published Daml interfaces for featured app rights plus the utility package that delegates featured-app usage on token-standard operations.",
+      "families": [
+        "splice-api-featured-app-v2",
+        "splice-api-featured-app-v1",
+        "splice-util-featured-app-proxies"
+      ]
+    },
+    {
+      "group": "Additional Splice Daml APIs",
+      "description": "Additional stable Daml APIs published by Splice outside the core token-standard and featured-app families.",
+      "families": [
+        "splice-api-token-burn-mint-v1"
+      ]
+    },
+    {
+      "group": "Splice Daml Models",
+      "description": "Published Splice model and utility packages that are exposed on the live Daml API surface and backed by release-bundle DARs.",
+      "families": [
+        "splice-amulet",
+        "splice-amulet-name-service",
+        "splice-dso-governance",
+        "splice-token-test-trading-app",
+        "splice-util",
+        "splice-util-batched-markers",
+        "splice-util-token-standard-wallet",
+        "splice-validator-lifecycle",
+        "splice-wallet",
+        "splice-wallet-payments"
+      ]
+    }
+  ],
+  "blocked_live_families": [
+    {
+      "name": "splice-token-standard-test",
+      "reason": "The published splice-node release bundle does not include a corresponding DAR. The live page itself instructs readers to copy the code from the source repository because Daml Script code cannot be shared across SDKs in compiled form."
+    }
+  ]
+}

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1353,6 +1353,203 @@
                   "reference/splice-token-standard-openapi/specs/allocation-v1-yaml",
                   "reference/splice-token-standard-openapi/specs/allocation-instruction-v1-yaml"
                 ]
+              },
+              {
+                "group": "Daml APIs",
+                "pages": [
+                  "reference/splice-daml-api/index",
+                  {
+                    "group": "Token Standard APIs (CIP-0056)",
+                    "pages": [
+                      {
+                        "group": "splice-api-token-metadata-v1 docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-api-token-metadata-v1/index",
+                          "reference/splice-daml-api/splice-api-token-metadata-v1/splice-api-token-metadatav1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-holding-v1 docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-api-token-holding-v1/index",
+                          "reference/splice-daml-api/splice-api-token-holding-v1/splice-api-token-holdingv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-transfer-instruction-v1 docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-api-token-transfer-instruction-v1/index",
+                          "reference/splice-daml-api/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-allocation-v1 docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-api-token-allocation-v1/index",
+                          "reference/splice-daml-api/splice-api-token-allocation-v1/splice-api-token-allocationv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-allocation-instruction-v1 docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-api-token-allocation-instruction-v1/index",
+                          "reference/splice-daml-api/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-allocation-request-v1 docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-api-token-allocation-request-v1/index",
+                          "reference/splice-daml-api/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Featured App Activity Markers API (CIP-0047)",
+                    "pages": [
+                      {
+                        "group": "splice-api-featured-app-v2 docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-api-featured-app-v2/index",
+                          "reference/splice-daml-api/splice-api-featured-app-v2/splice-api-featuredapprightv2"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-featured-app-v1 docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-api-featured-app-v1/index",
+                          "reference/splice-daml-api/splice-api-featured-app-v1/splice-api-featuredapprightv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-util-featured-app-proxies docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-util-featured-app-proxies/index",
+                          "reference/splice-daml-api/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy",
+                          "reference/splice-daml-api/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Additional Splice Daml APIs",
+                    "pages": [
+                      {
+                        "group": "splice-api-token-burn-mint-v1 docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-api-token-burn-mint-v1/index",
+                          "reference/splice-daml-api/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1"
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "group": "Splice Daml Models",
+                    "pages": [
+                      {
+                        "group": "splice-amulet docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-amulet/index",
+                          "reference/splice-daml-api/splice-amulet/splice-amulet",
+                          "reference/splice-daml-api/splice-amulet/splice-amulet-tokenapiutils",
+                          "reference/splice-daml-api/splice-amulet/splice-amulet-twosteptransfer",
+                          "reference/splice-daml-api/splice-amulet/splice-amuletallocation",
+                          "reference/splice-daml-api/splice-amulet/splice-amuletconfig",
+                          "reference/splice-daml-api/splice-amulet/splice-amuletrules",
+                          "reference/splice-daml-api/splice-amulet/splice-amulettransferinstruction",
+                          "reference/splice-daml-api/splice-amulet/splice-decentralizedsynchronizer",
+                          "reference/splice-daml-api/splice-amulet/splice-expiry",
+                          "reference/splice-daml-api/splice-amulet/splice-externalpartyamuletrules",
+                          "reference/splice-daml-api/splice-amulet/splice-externalpartyconfigstate",
+                          "reference/splice-daml-api/splice-amulet/splice-fees",
+                          "reference/splice-daml-api/splice-amulet/splice-issuance",
+                          "reference/splice-daml-api/splice-amulet/splice-relround",
+                          "reference/splice-daml-api/splice-amulet/splice-round",
+                          "reference/splice-daml-api/splice-amulet/splice-schedule",
+                          "reference/splice-daml-api/splice-amulet/splice-types",
+                          "reference/splice-daml-api/splice-amulet/splice-validatorlicense"
+                        ]
+                      },
+                      {
+                        "group": "splice-amulet-name-service docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-amulet-name-service/index",
+                          "reference/splice-daml-api/splice-amulet-name-service/splice-ans",
+                          "reference/splice-daml-api/splice-amulet-name-service/splice-ans-amuletconversionratefeed"
+                        ]
+                      },
+                      {
+                        "group": "splice-dso-governance docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-dso-governance/index",
+                          "reference/splice-daml-api/splice-dso-governance/splice-cometbft",
+                          "reference/splice-daml-api/splice-dso-governance/splice-dso-amuletprice",
+                          "reference/splice-daml-api/splice-dso-governance/splice-dso-decentralizedsynchronizer",
+                          "reference/splice-daml-api/splice-dso-governance/splice-dso-svstate",
+                          "reference/splice-daml-api/splice-dso-governance/splice-dsobootstrap",
+                          "reference/splice-daml-api/splice-dso-governance/splice-dsorules",
+                          "reference/splice-daml-api/splice-dso-governance/splice-svonboarding"
+                        ]
+                      },
+                      {
+                        "group": "splice-token-test-trading-app docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-token-test-trading-app/index",
+                          "reference/splice-daml-api/splice-token-test-trading-app/splice-testing-apps-tradingapp"
+                        ]
+                      },
+                      {
+                        "group": "splice-util docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-util/index",
+                          "reference/splice-daml-api/splice-util/splice-util"
+                        ]
+                      },
+                      {
+                        "group": "splice-util-batched-markers docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-util-batched-markers/index",
+                          "reference/splice-daml-api/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy"
+                        ]
+                      },
+                      {
+                        "group": "splice-util-token-standard-wallet docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-util-token-standard-wallet/index",
+                          "reference/splice-daml-api/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation"
+                        ]
+                      },
+                      {
+                        "group": "splice-validator-lifecycle docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-validator-lifecycle/index",
+                          "reference/splice-daml-api/splice-validator-lifecycle/splice-validatoronboarding"
+                        ]
+                      },
+                      {
+                        "group": "splice-wallet docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-wallet/index",
+                          "reference/splice-daml-api/splice-wallet/splice-wallet-buytrafficrequest",
+                          "reference/splice-daml-api/splice-wallet/splice-wallet-install",
+                          "reference/splice-daml-api/splice-wallet/splice-wallet-mintingdelegation",
+                          "reference/splice-daml-api/splice-wallet/splice-wallet-topupstate",
+                          "reference/splice-daml-api/splice-wallet/splice-wallet-transferoffer",
+                          "reference/splice-daml-api/splice-wallet/splice-wallet-transferpreapproval"
+                        ]
+                      },
+                      {
+                        "group": "splice-wallet-payments docs",
+                        "pages": [
+                          "reference/splice-daml-api/splice-wallet-payments/index",
+                          "reference/splice-daml-api/splice-wallet-payments/splice-wallet-payment",
+                          "reference/splice-daml-api/splice-wallet-payments/splice-wallet-subscriptions"
+                        ]
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }

--- a/docs-main/reference/splice-daml-api/index.mdx
+++ b/docs-main/reference/splice-daml-api/index.mdx
@@ -1,0 +1,51 @@
+---
+title: "Splice Daml APIs"
+description: "Generated package reference pages for the published Splice Daml API DAR artifacts"
+---
+
+These pages mirror the live `docs.sync.global/app_dev/api/` Daml surface wherever the published `0.5.18_splice-node.tar.gz` bundle provides a corresponding DAR artifact.
+
+## Coverage
+- Generated family pages from published DARs: 20
+- Live families blocked by missing release DARs: 1
+
+## Reference
+### Token Standard APIs (CIP-0056)
+Stable Daml interfaces for token metadata, holdings, transfer instructions, allocations, and allocation requests.
+
+- [splice-api-token-metadata-v1 docs](/reference/splice-daml-api/splice-api-token-metadata-v1)
+- [splice-api-token-holding-v1 docs](/reference/splice-daml-api/splice-api-token-holding-v1)
+- [splice-api-token-transfer-instruction-v1 docs](/reference/splice-daml-api/splice-api-token-transfer-instruction-v1)
+- [splice-api-token-allocation-v1 docs](/reference/splice-daml-api/splice-api-token-allocation-v1)
+- [splice-api-token-allocation-instruction-v1 docs](/reference/splice-daml-api/splice-api-token-allocation-instruction-v1)
+- [splice-api-token-allocation-request-v1 docs](/reference/splice-daml-api/splice-api-token-allocation-request-v1)
+
+### Featured App Activity Markers API (CIP-0047)
+Published Daml interfaces for featured app rights plus the utility package that delegates featured-app usage on token-standard operations.
+
+- [splice-api-featured-app-v2 docs](/reference/splice-daml-api/splice-api-featured-app-v2)
+- [splice-api-featured-app-v1 docs](/reference/splice-daml-api/splice-api-featured-app-v1)
+- [splice-util-featured-app-proxies docs](/reference/splice-daml-api/splice-util-featured-app-proxies)
+
+### Additional Splice Daml APIs
+Additional stable Daml APIs published by Splice outside the core token-standard and featured-app families.
+
+- [splice-api-token-burn-mint-v1 docs](/reference/splice-daml-api/splice-api-token-burn-mint-v1)
+
+### Splice Daml Models
+Published Splice model and utility packages that are exposed on the live Daml API surface and backed by release-bundle DARs.
+
+- [splice-amulet docs](/reference/splice-daml-api/splice-amulet)
+- [splice-amulet-name-service docs](/reference/splice-daml-api/splice-amulet-name-service)
+- [splice-dso-governance docs](/reference/splice-daml-api/splice-dso-governance)
+- [splice-token-test-trading-app docs](/reference/splice-daml-api/splice-token-test-trading-app)
+- [splice-util docs](/reference/splice-daml-api/splice-util)
+- [splice-util-batched-markers docs](/reference/splice-daml-api/splice-util-batched-markers)
+- [splice-util-token-standard-wallet docs](/reference/splice-daml-api/splice-util-token-standard-wallet)
+- [splice-validator-lifecycle docs](/reference/splice-daml-api/splice-validator-lifecycle)
+- [splice-wallet docs](/reference/splice-daml-api/splice-wallet)
+- [splice-wallet-payments docs](/reference/splice-daml-api/splice-wallet-payments)
+
+## Artifact gaps
+
+- `splice-token-standard-test`: The published splice-node release bundle does not include a corresponding DAR. The live page itself instructs readers to copy the code from the source repository because Daml Script code cannot be shared across SDKs in compiled form. Live page: https://docs.sync.global/app_dev/api/splice-token-standard-test/index.html

--- a/docs-main/reference/splice-daml-api/splice-amulet-name-service/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet-name-service/index.mdx
@@ -1,0 +1,26 @@
+---
+title: "splice-amulet-name-service docs"
+description: "Reference documentation for splice-amulet-name-service docs modules."
+---
+
+# splice-amulet-name-service docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Ans`](/reference/splice-daml-api/splice-amulet-name-service/splice-ans) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.Ans.AmuletConversionRateFeed`](/reference/splice-daml-api/splice-amulet-name-service/splice-ans-amuletconversionratefeed) | `Module` | Templates to communicate amulet conversion rates. | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 2 | 0 | 0 |
+
+## Reference
+
+- [Splice.Ans](/reference/splice-daml-api/splice-amulet-name-service/splice-ans)
+- [Splice.Ans.AmuletConversionRateFeed](/reference/splice-daml-api/splice-amulet-name-service/splice-ans-amuletconversionratefeed)

--- a/docs-main/reference/splice-daml-api/splice-amulet-name-service/splice-ans-amuletconversionratefeed.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet-name-service/splice-ans-amuletconversionratefeed.mdx
@@ -1,0 +1,160 @@
+---
+title: "Splice.Ans.AmuletConversionRateFeed"
+description: "Reference documentation for Daml module Splice.Ans.AmuletConversionRateFeed."
+---
+
+<a id="module-splice-ans-amuletconversionratefeed-3650"></a>
+
+# Splice.Ans.AmuletConversionRateFeed
+
+Templates to communicate amulet conversion rates.
+
+This does not fit a narrow interpretation of "Amulet Name Service", but it fits
+
+very well if we widen the role of the ANS to serve as a store for
+
+public data of high-value to network participants. Evolving ANS in this direction
+
+is a long-standing plan.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdsoresult-71133"></a>
+
+### `data AmuletConversionRateFeed_ArchiveAsDsoResult`
+
+Constructors:
+
+<a id="constr-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdsoresult-72702"></a>
+- `AmuletConversionRateFeed_ArchiveAsDsoResult`
+
+Instances:
+
+- `instance HasExercise AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult`
+- `instance HasFromAnyChoice AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult`
+- `instance HasToAnyChoice AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult`
+
+<a id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdateresult-36312"></a>
+
+### `data AmuletConversionRateFeed_UpdateResult`
+
+Constructors:
+
+<a id="constr-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdateresult-68907"></a>
+- `AmuletConversionRateFeed_UpdateResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId AmuletConversionRateFeed |  |
+
+Instances:
+
+- `instance GetField cid AmuletConversionRateFeed_UpdateResult (ContractId AmuletConversionRateFeed)`
+- `instance SetField cid AmuletConversionRateFeed_UpdateResult (ContractId AmuletConversionRateFeed)`
+- `instance HasExercise AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult`
+- `instance HasFromAnyChoice AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult`
+- `instance HasToAnyChoice AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult`
+
+<a id="type-splice-ans-amuletconversionratefeed-markercontext-2172"></a>
+
+### `data MarkerContext`
+
+Constructors:
+
+<a id="constr-splice-ans-amuletconversionratefeed-markercontext-1187"></a>
+- `MarkerContext`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppRightCid | ContractId FeaturedAppRight |  |
+| beneficiaries | [AppRewardBeneficiary] |  |
+
+Instances:
+
+- `instance Eq MarkerContext`
+- `instance Show MarkerContext`
+- `instance GetField beneficiaries MarkerContext [AppRewardBeneficiary]`
+- `instance GetField featuredAppRightCid MarkerContext (ContractId FeaturedAppRight)`
+- `instance GetField markerContextO AmuletConversionRateFeed_Update (Optional MarkerContext)`
+- `instance SetField beneficiaries MarkerContext [AppRewardBeneficiary]`
+- `instance SetField featuredAppRightCid MarkerContext (ContractId FeaturedAppRight)`
+- `instance SetField markerContextO AmuletConversionRateFeed_Update (Optional MarkerContext)`
+
+## Templates
+
+<a id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeed-90528"></a>
+
+### Template `AmuletConversionRateFeed`
+
+Amulet conversion rate feed published by a given 'publisher'.
+Publisher must only create one feed per publisher.
+The feed can only be updated every 0.5 tickDuration as the SVs also only change the price on round boundaries
+and this avoids unnecessary load.
+
+Signatories: `publisher`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| publisher | Party |  |
+| dso | Party |  |
+| nextUpdateAfter | Optional Time | The earliest time after which the publisher is  allowed to update this feed. |
+| amuletConversionRate | Decimal | conversion rate in USD/Amulet |
+
+Choices:
+
+<a id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdso-84096"></a>
+
+#### Choice `AmuletConversionRateFeed_ArchiveAsDso`
+
+Controllers: `dso`
+
+Returns: `AmuletConversionRateFeed_ArchiveAsDsoResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<a id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdate-913"></a>
+
+#### Choice `AmuletConversionRateFeed_Update`
+
+Controllers: `publisher`
+
+Returns: `AmuletConversionRateFeed_UpdateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletConversionRate | Decimal |  |
+| amuletRulesCid | ContractId AmuletRules |  |
+| markerContextO | Optional MarkerContext |  |
+| newNextUpdateAfter | Time | Must be set to at least now + 0.5 tickDuration |
+
+#### Choice `Archive`
+
+Controllers: `publisher`
+
+Returns: `()`
+
+## Orphan Typeclass Instances
+
+- `instance HasCheckedFetch FeaturedAppRightView ForOwner`

--- a/docs-main/reference/splice-daml-api/splice-amulet-name-service/splice-ans.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet-name-service/splice-ans.mdx
@@ -1,0 +1,581 @@
+---
+title: "Splice.Ans"
+description: "Reference documentation for Daml module Splice.Ans."
+---
+
+<a id="module-splice-ans-61283"></a>
+
+# Splice.Ans
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-ans-ansentrycontextcollectentryrenewalpaymentresult-69826"></a>
+
+### `data AnsEntryContext_CollectEntryRenewalPaymentResult`
+
+Constructors:
+
+<a id="constr-splice-ans-ansentrycontextcollectentryrenewalpaymentresult-18109"></a>
+- `AnsEntryContext_CollectEntryRenewalPaymentResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntry |  |
+| subscriptionStateCid | ContractId SubscriptionIdleState |  |
+
+Instances:
+
+- `instance GetField entryCid AnsEntryContext_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance GetField subscriptionStateCid AnsEntryContext_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance SetField entryCid AnsEntryContext_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance SetField subscriptionStateCid AnsEntryContext_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult`
+- `instance HasFromAnyChoice AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult`
+- `instance HasToAnyChoice AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult`
+
+<a id="type-splice-ans-ansentrycontextcollectinitialentrypaymentresult-28518"></a>
+
+### `data AnsEntryContext_CollectInitialEntryPaymentResult`
+
+Constructors:
+
+<a id="constr-splice-ans-ansentrycontextcollectinitialentrypaymentresult-16577"></a>
+- `AnsEntryContext_CollectInitialEntryPaymentResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntry |  |
+| subscriptionStateCid | ContractId SubscriptionIdleState |  |
+
+Instances:
+
+- `instance GetField entryCid AnsEntryContext_CollectInitialEntryPaymentResult (ContractId AnsEntry)`
+- `instance GetField subscriptionStateCid AnsEntryContext_CollectInitialEntryPaymentResult (ContractId SubscriptionIdleState)`
+- `instance SetField entryCid AnsEntryContext_CollectInitialEntryPaymentResult (ContractId AnsEntry)`
+- `instance SetField subscriptionStateCid AnsEntryContext_CollectInitialEntryPaymentResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult`
+- `instance HasFromAnyChoice AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult`
+- `instance HasToAnyChoice AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult`
+
+<a id="type-splice-ans-ansentrycontextrejectentryinitialpaymentresult-4316"></a>
+
+### `data AnsEntryContext_RejectEntryInitialPaymentResult`
+
+Constructors:
+
+<a id="constr-splice-ans-ansentrycontextrejectentryinitialpaymentresult-49933"></a>
+- `AnsEntryContext_RejectEntryInitialPaymentResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amuletSum AnsEntryContext_RejectEntryInitialPaymentResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum AnsEntryContext_RejectEntryInitialPaymentResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult`
+- `instance HasFromAnyChoice AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult`
+- `instance HasToAnyChoice AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult`
+
+<a id="type-splice-ans-ansentrycontextterminateresult-94524"></a>
+
+### `data AnsEntryContext_TerminateResult`
+
+Constructors:
+
+<a id="constr-splice-ans-ansentrycontextterminateresult-84145"></a>
+- `AnsEntryContext_TerminateResult`
+(no fields)
+
+Instances:
+
+- `instance HasExercise AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult`
+- `instance HasFromAnyChoice AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult`
+- `instance HasToAnyChoice AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult`
+
+<a id="type-splice-ans-ansentryexpireresult-89925"></a>
+
+### `data AnsEntry_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-ans-ansentryexpireresult-16032"></a>
+- `AnsEntry_ExpireResult`
+(no fields)
+
+Instances:
+
+- `instance HasExercise AnsEntry AnsEntry_Expire AnsEntry_ExpireResult`
+- `instance HasFromAnyChoice AnsEntry AnsEntry_Expire AnsEntry_ExpireResult`
+- `instance HasToAnyChoice AnsEntry AnsEntry_Expire AnsEntry_ExpireResult`
+
+<a id="type-splice-ans-ansentryrenewresult-81012"></a>
+
+### `data AnsEntry_RenewResult`
+
+Constructors:
+
+<a id="constr-splice-ans-ansentryrenewresult-69331"></a>
+- `AnsEntry_RenewResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntry |  |
+
+Instances:
+
+- `instance GetField entryCid AnsEntry_RenewResult (ContractId AnsEntry)`
+- `instance SetField entryCid AnsEntry_RenewResult (ContractId AnsEntry)`
+- `instance HasExercise AnsEntry AnsEntry_Renew AnsEntry_RenewResult`
+- `instance HasFromAnyChoice AnsEntry AnsEntry_Renew AnsEntry_RenewResult`
+- `instance HasToAnyChoice AnsEntry AnsEntry_Renew AnsEntry_RenewResult`
+
+<a id="type-splice-ans-ansrulesconfig-16984"></a>
+
+### `data AnsRulesConfig`
+
+Constructors:
+
+<a id="constr-splice-ans-ansrulesconfig-70959"></a>
+- `AnsRulesConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| renewalDuration | RelTime |  |
+| entryLifetime | RelTime |  |
+| entryFee | Decimal |  |
+| descriptionPrefix | Text |  |
+
+Instances:
+
+- `instance Eq AnsRulesConfig`
+- `instance Show AnsRulesConfig`
+- `instance GetField config AnsRules AnsRulesConfig`
+- `instance GetField descriptionPrefix AnsRulesConfig Text`
+- `instance GetField entryFee AnsRulesConfig Decimal`
+- `instance GetField entryLifetime AnsRulesConfig RelTime`
+- `instance GetField renewalDuration AnsRulesConfig RelTime`
+- `instance SetField config AnsRules AnsRulesConfig`
+- `instance SetField descriptionPrefix AnsRulesConfig Text`
+- `instance SetField entryFee AnsRulesConfig Decimal`
+- `instance SetField entryLifetime AnsRulesConfig RelTime`
+- `instance SetField renewalDuration AnsRulesConfig RelTime`
+
+<a id="type-splice-ans-ansrulescollectentryrenewalpaymentresult-39091"></a>
+
+### `data AnsRules_CollectEntryRenewalPaymentResult`
+
+Constructors:
+
+<a id="constr-splice-ans-ansrulescollectentryrenewalpaymentresult-73922"></a>
+- `AnsRules_CollectEntryRenewalPaymentResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntry |  |
+| subscriptionStateCid | ContractId SubscriptionIdleState |  |
+
+Instances:
+
+- `instance GetField entryCid AnsRules_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance GetField subscriptionStateCid AnsRules_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance SetField entryCid AnsRules_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance SetField subscriptionStateCid AnsRules_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult`
+- `instance HasFromAnyChoice AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult`
+- `instance HasToAnyChoice AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult`
+
+<a id="type-splice-ans-ansrulescollectinitialentrypaymentresult-64239"></a>
+
+### `data AnsRules_CollectInitialEntryPaymentResult`
+
+Constructors:
+
+<a id="constr-splice-ans-ansrulescollectinitialentrypaymentresult-27238"></a>
+- `AnsRules_CollectInitialEntryPaymentResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntry |  |
+| subscriptionStateCid | ContractId SubscriptionIdleState |  |
+
+Instances:
+
+- `instance GetField entryCid AnsRules_CollectInitialEntryPaymentResult (ContractId AnsEntry)`
+- `instance GetField subscriptionStateCid AnsRules_CollectInitialEntryPaymentResult (ContractId SubscriptionIdleState)`
+- `instance SetField entryCid AnsRules_CollectInitialEntryPaymentResult (ContractId AnsEntry)`
+- `instance SetField subscriptionStateCid AnsRules_CollectInitialEntryPaymentResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult`
+- `instance HasFromAnyChoice AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult`
+- `instance HasToAnyChoice AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult`
+
+<a id="type-splice-ans-ansrulesrejectentryinitialpaymentresult-67395"></a>
+
+### `data AnsRules_RejectEntryInitialPaymentResult`
+
+Constructors:
+
+<a id="constr-splice-ans-ansrulesrejectentryinitialpaymentresult-46056"></a>
+- `AnsRules_RejectEntryInitialPaymentResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amuletSum AnsRules_RejectEntryInitialPaymentResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum AnsRules_RejectEntryInitialPaymentResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult`
+- `instance HasFromAnyChoice AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult`
+- `instance HasToAnyChoice AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult`
+
+<a id="type-splice-ans-ansrulesrequestentryresult-71096"></a>
+
+### `data AnsRules_RequestEntryResult`
+
+Constructors:
+
+<a id="constr-splice-ans-ansrulesrequestentryresult-91097"></a>
+- `AnsRules_RequestEntryResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| entryCid | ContractId AnsEntryContext |  |
+| requestCid | ContractId SubscriptionRequest |  |
+
+Instances:
+
+- `instance GetField entryCid AnsRules_RequestEntryResult (ContractId AnsEntryContext)`
+- `instance GetField requestCid AnsRules_RequestEntryResult (ContractId SubscriptionRequest)`
+- `instance SetField entryCid AnsRules_RequestEntryResult (ContractId AnsEntryContext)`
+- `instance SetField requestCid AnsRules_RequestEntryResult (ContractId SubscriptionRequest)`
+- `instance HasExercise AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult`
+- `instance HasFromAnyChoice AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult`
+- `instance HasToAnyChoice AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult`
+
+<a id="type-splice-ans-expectedentrycontext-86972"></a>
+
+### `data ExpectedEntryContext`
+
+Constructors:
+
+<a id="constr-splice-ans-expectedentrycontext-22467"></a>
+- `ExpectedEntryContext`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| user | Party |  |
+| reference | ContractId SubscriptionRequest |  |
+
+Instances:
+
+- `instance Eq ExpectedEntryContext`
+- `instance Show ExpectedEntryContext`
+- `instance GetField dso ExpectedEntryContext Party`
+- `instance GetField reference ExpectedEntryContext (ContractId SubscriptionRequest)`
+- `instance GetField user ExpectedEntryContext Party`
+- `instance SetField dso ExpectedEntryContext Party`
+- `instance SetField reference ExpectedEntryContext (ContractId SubscriptionRequest)`
+- `instance SetField user ExpectedEntryContext Party`
+
+<a id="type-splice-ans-expectedpayment-99084"></a>
+
+### `data ExpectedPayment`
+
+Constructors:
+
+<a id="constr-splice-ans-expectedpayment-84341"></a>
+- `ExpectedPayment`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sender | Party |  |
+
+Instances:
+
+- `instance Eq ExpectedPayment`
+- `instance Show ExpectedPayment`
+- `instance GetField dso ExpectedPayment Party`
+- `instance GetField sender ExpectedPayment Party`
+- `instance SetField dso ExpectedPayment Party`
+- `instance SetField sender ExpectedPayment Party`
+
+## Functions
+
+<a id="function-splice-ans-fetchandvalidateinitialpayment-51068"></a>
+
+### `fetchAndValidateInitialPayment`
+
+```daml
+fetchAndValidateInitialPayment : ContractId SubscriptionInitialPayment -> ExpectedPayment -> Update SubscriptionInitialPayment
+```
+
+<a id="function-splice-ans-fetchandvalidatepayment-2827"></a>
+
+### `fetchAndValidatePayment`
+
+```daml
+fetchAndValidatePayment : ContractId SubscriptionPayment -> ExpectedPayment -> Update SubscriptionPayment
+```
+
+<a id="function-splice-ans-fetchandvalidateentrycontext-91041"></a>
+
+### `fetchAndValidateEntryContext`
+
+```daml
+fetchAndValidateEntryContext : ContractId AnsEntryContext -> ExpectedEntryContext -> Update AnsEntryContext
+```
+
+<a id="function-splice-ans-validansconfig-37443"></a>
+
+### `validAnsConfig`
+
+```daml
+validAnsConfig : AnsRulesConfig -> Bool
+```
+
+## Templates
+
+<a id="type-splice-ans-ansentry-10233"></a>
+
+### Template `AnsEntry`
+
+A ans entry that needs to be renewed continuously.
+Renewal recreates this contract with an updated `expiresAt` field.
+
+Signatories: `user`, `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| user | Party |  |
+| dso | Party |  |
+| name | Text |  |
+| url | Text |  |
+| description | Text |  |
+| expiresAt | Time |  |
+
+Choices:
+
+<a id="type-splice-ans-ansentryexpire-47228"></a>
+
+#### Choice `AnsEntry_Expire`
+
+Controllers: `actor`
+
+Returns: `AnsEntry_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+
+<a id="type-splice-ans-ansentryrenew-67717"></a>
+
+#### Choice `AnsEntry_Renew`
+
+Controllers: `user`, `dso`
+
+Returns: `AnsEntry_RenewResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extension | RelTime |  |
+
+#### Choice `Archive`
+
+Controllers: `user`, `dso`
+
+Returns: `()`
+
+<a id="type-splice-ans-ansentrycontext-23879"></a>
+
+### Template `AnsEntryContext`
+
+Signatories: `dso`, `user`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| user | Party |  |
+| name | Text |  |
+| url | Text |  |
+| description | Text |  |
+| reference | ContractId SubscriptionRequest | Reference to the corresponding subscription, note that the contract may already be archived. This is just a tracking id. |
+
+Choices:
+
+<a id="type-splice-ans-ansentrycontextcollectentryrenewalpayment-76943"></a>
+
+#### Choice `AnsEntryContext_CollectEntryRenewalPayment`
+
+Controllers: `dso`
+
+Returns: `AnsEntryContext_CollectEntryRenewalPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| paymentCid | ContractId SubscriptionPayment |  |
+| entryCid | ContractId AnsEntry | The currently active entry. |
+| transferContext | AppTransferContext |  |
+| ansRulesCid | ContractId AnsRules |  |
+
+<a id="type-splice-ans-ansentrycontextcollectinitialentrypayment-71811"></a>
+
+#### Choice `AnsEntryContext_CollectInitialEntryPayment`
+
+Controllers: `dso`
+
+Returns: `AnsEntryContext_CollectInitialEntryPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| paymentCid | ContractId SubscriptionInitialPayment |  |
+| transferContext | AppTransferContext |  |
+| ansRulesCid | ContractId AnsRules |  |
+
+<a id="type-splice-ans-ansentrycontextrejectentryinitialpayment-22257"></a>
+
+#### Choice `AnsEntryContext_RejectEntryInitialPayment`
+
+Controllers: `dso`
+
+Returns: `AnsEntryContext_RejectEntryInitialPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| paymentCid | ContractId SubscriptionInitialPayment |  |
+| transferContext | AppTransferContext |  |
+| ansRulesCid | ContractId AnsRules |  |
+
+<a id="type-splice-ans-ansentrycontextterminate-64657"></a>
+
+#### Choice `AnsEntryContext_Terminate`
+
+Controllers: `actor`
+
+Returns: `AnsEntryContext_TerminateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+| terminatedSubscriptionCid | ContractId TerminatedSubscription |  |
+
+#### Choice `Archive`
+
+Controllers: `dso`, `user`
+
+Returns: `()`
+
+<a id="type-splice-ans-ansrules-7552"></a>
+
+### Template `AnsRules`
+
+The rules governing how users can pay to use the Amulet Name service.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| config | AnsRulesConfig |  |
+
+Choices:
+
+<a id="type-splice-ans-ansrulescollectentryrenewalpayment-11710"></a>
+
+#### Choice `AnsRules_CollectEntryRenewalPayment`
+
+Controllers: `dso`, `user`
+
+Returns: `AnsRules_CollectEntryRenewalPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| user | Party |  |
+| entryContext | ContractId AnsEntryContext |  |
+| paymentCid | ContractId SubscriptionPayment |  |
+| entryCid | ContractId AnsEntry | The currently active entry. |
+| transferContext | AppTransferContext |  |
+
+<a id="type-splice-ans-ansrulescollectinitialentrypayment-44970"></a>
+
+#### Choice `AnsRules_CollectInitialEntryPayment`
+
+Controllers: `dso`, `user`
+
+Returns: `AnsRules_CollectInitialEntryPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| user | Party |  |
+| entryContext | ContractId AnsEntryContext |  |
+| paymentCid | ContractId SubscriptionInitialPayment |  |
+| transferContext | AppTransferContext |  |
+
+<a id="type-splice-ans-ansrulesrejectentryinitialpayment-30886"></a>
+
+#### Choice `AnsRules_RejectEntryInitialPayment`
+
+Controllers: `dso`
+
+Returns: `AnsRules_RejectEntryInitialPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| paymentCid | ContractId SubscriptionInitialPayment |  |
+| transferContext | AppTransferContext |  |
+
+<a id="type-splice-ans-ansrulesrequestentry-90125"></a>
+
+#### Choice `AnsRules_RequestEntry`
+
+Controllers: `user`
+
+Returns: `AnsRules_RequestEntryResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| name | Text |  |
+| url | Text |  |
+| description | Text |  |
+| user | Party |  |
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-amulet/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/index.mdx
@@ -1,0 +1,58 @@
+---
+title: "splice-amulet docs"
+description: "Reference documentation for splice-amulet docs modules."
+---
+
+# splice-amulet docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Amulet`](/reference/splice-daml-api/splice-amulet/splice-amulet) | `Module` | The contracts representing the long-term state of Splice. | `0.5.18` | - | - | - |
+| [`Splice.Amulet.TokenApiUtils`](/reference/splice-daml-api/splice-amulet/splice-amulet-tokenapiutils) | `Module` | Common utilities for implementing the token APIs for Amulet. | `0.5.18` | - | - | - |
+| [`Splice.Amulet.TwoStepTransfer`](/reference/splice-daml-api/splice-amulet/splice-amulet-twosteptransfer) | `Module` | Generic code for a two-step transfer of amulet. The first step is to lock | `0.5.18` | - | - | - |
+| [`Splice.AmuletAllocation`](/reference/splice-daml-api/splice-amulet/splice-amuletallocation) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.AmuletConfig`](/reference/splice-daml-api/splice-amulet/splice-amuletconfig) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.AmuletRules`](/reference/splice-daml-api/splice-amulet/splice-amuletrules) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.AmuletTransferInstruction`](/reference/splice-daml-api/splice-amulet/splice-amulettransferinstruction) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.DecentralizedSynchronizer`](/reference/splice-daml-api/splice-amulet/splice-decentralizedsynchronizer) | `Module` | Types and contracts for managing synchronizer fees | `0.5.18` | - | - | - |
+| [`Splice.Expiry`](/reference/splice-daml-api/splice-amulet/splice-expiry) | `Module` | Functions for computing amulet and lock expiry times and conditions. | `0.5.18` | - | - | - |
+| [`Splice.ExternalPartyAmuletRules`](/reference/splice-daml-api/splice-amulet/splice-externalpartyamuletrules) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.ExternalPartyConfigState`](/reference/splice-daml-api/splice-amulet/splice-externalpartyconfigstate) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.Fees`](/reference/splice-daml-api/splice-amulet/splice-fees) | `Module` | Utility functions for different kinds of fees. | `0.5.18` | - | - | - |
+| [`Splice.Issuance`](/reference/splice-daml-api/splice-amulet/splice-issuance) | `Module` | Amulet rewards issuance configuration and computation. | `0.5.18` | - | - | - |
+| [`Splice.RelRound`](/reference/splice-daml-api/splice-amulet/splice-relround) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.Round`](/reference/splice-daml-api/splice-amulet/splice-round) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.Schedule`](/reference/splice-daml-api/splice-amulet/splice-schedule) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.Types`](/reference/splice-daml-api/splice-amulet/splice-types) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.ValidatorLicense`](/reference/splice-daml-api/splice-amulet/splice-validatorlicense) | `Module` | - | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 18 | 0 | 0 |
+
+## Reference
+
+- [Splice.Amulet](/reference/splice-daml-api/splice-amulet/splice-amulet)
+- [Splice.Amulet.TokenApiUtils](/reference/splice-daml-api/splice-amulet/splice-amulet-tokenapiutils)
+- [Splice.Amulet.TwoStepTransfer](/reference/splice-daml-api/splice-amulet/splice-amulet-twosteptransfer)
+- [Splice.AmuletAllocation](/reference/splice-daml-api/splice-amulet/splice-amuletallocation)
+- [Splice.AmuletConfig](/reference/splice-daml-api/splice-amulet/splice-amuletconfig)
+- [Splice.AmuletRules](/reference/splice-daml-api/splice-amulet/splice-amuletrules)
+- [Splice.AmuletTransferInstruction](/reference/splice-daml-api/splice-amulet/splice-amulettransferinstruction)
+- [Splice.DecentralizedSynchronizer](/reference/splice-daml-api/splice-amulet/splice-decentralizedsynchronizer)
+- [Splice.Expiry](/reference/splice-daml-api/splice-amulet/splice-expiry)
+- [Splice.ExternalPartyAmuletRules](/reference/splice-daml-api/splice-amulet/splice-externalpartyamuletrules)
+- [Splice.ExternalPartyConfigState](/reference/splice-daml-api/splice-amulet/splice-externalpartyconfigstate)
+- [Splice.Fees](/reference/splice-daml-api/splice-amulet/splice-fees)
+- [Splice.Issuance](/reference/splice-daml-api/splice-amulet/splice-issuance)
+- [Splice.RelRound](/reference/splice-daml-api/splice-amulet/splice-relround)
+- [Splice.Round](/reference/splice-daml-api/splice-amulet/splice-round)
+- [Splice.Schedule](/reference/splice-daml-api/splice-amulet/splice-schedule)
+- [Splice.Types](/reference/splice-daml-api/splice-amulet/splice-types)
+- [Splice.ValidatorLicense](/reference/splice-daml-api/splice-amulet/splice-validatorlicense)

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-amulet-tokenapiutils.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-amulet-tokenapiutils.mdx
@@ -1,0 +1,452 @@
+---
+title: "Splice.Amulet.TokenApiUtils"
+description: "Reference documentation for Daml module Splice.Amulet.TokenApiUtils."
+---
+
+<a id="module-splice-amulet-tokenapiutils-32536"></a>
+
+# Splice.Amulet.TokenApiUtils
+
+Common utilities for implementing the token APIs for Amulet.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-amulet-tokenapiutils-txkind-33822"></a>
+
+### `data TxKind`
+
+Internal type for the transaction kind.
+
+Constructors:
+
+<a id="constr-splice-amulet-tokenapiutils-txkindtransfer-31504"></a>
+- `TxKind_Transfer`
+<a id="constr-splice-amulet-tokenapiutils-txkindunlock-53359"></a>
+- `TxKind_Unlock`
+<a id="constr-splice-amulet-tokenapiutils-txkindmergesplit-69091"></a>
+- `TxKind_MergeSplit`
+<a id="constr-splice-amulet-tokenapiutils-txkindburn-1830"></a>
+- `TxKind_Burn`
+<a id="constr-splice-amulet-tokenapiutils-txkindmint-40517"></a>
+- `TxKind_Mint`
+<a id="constr-splice-amulet-tokenapiutils-txkindexpiredust-93818"></a>
+- `TxKind_ExpireDust`
+
+Instances:
+
+- `instance Eq TxKind`
+
+## Typeclasses
+
+<a id="class-splice-amulet-tokenapiutils-toanyvalue-45157"></a>
+
+### `class ToAnyValue a`
+
+Values that can be converted to AnyValue
+
+Methods:
+
+- `toAnyValue : a -> AnyValue`
+
+Instances:
+
+- `instance ToAnyValue ChoiceContext`
+- `instance ToAnyValue TimeLock`
+- `instance ToAnyValue Bool`
+- `instance ToAnyValue Decimal`
+- `instance ToAnyValue Int`
+- `instance ToAnyValue Text`
+- `instance ToAnyValue (ContractId t)`
+- `instance ToAnyValue Date`
+- `instance ToAnyValue Party`
+- `instance ToAnyValue Time`
+- `instance ToAnyValue RelTime`
+- `instance ToAnyValue a => ToAnyValue [a]`
+
+<a id="class-splice-amulet-tokenapiutils-fromanyvalue-31164"></a>
+
+### `class FromAnyValue a`
+
+Attempt to parse a value from AnyValue.
+
+If a type implements both `ToAnyValue` and `FromAnyValue` then it must hold that
+`fromAnyValue (toAnyValue x) = Right x` for all `x`.
+
+Methods:
+
+- `fromAnyValue : AnyValue -> Either Text a`
+
+Instances:
+
+- `instance FromAnyValue ChoiceContext`
+- `instance FromAnyValue TimeLock`
+- `instance FromAnyValue Bool`
+- `instance FromAnyValue Decimal`
+- `instance FromAnyValue Int`
+- `instance FromAnyValue Text`
+- `instance Template t => FromAnyValue (ContractId t)`
+- `instance FromAnyValue Date`
+- `instance FromAnyValue Party`
+- `instance FromAnyValue Time`
+- `instance FromAnyValue RelTime`
+- `instance FromAnyValue a => FromAnyValue [a]`
+
+## Functions
+
+<a id="function-splice-amulet-tokenapiutils-spliceprefix-80926"></a>
+
+### `splicePrefix`
+
+```daml
+splicePrefix : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-amuletprefix-59772"></a>
+
+### `amuletPrefix`
+
+```daml
+amuletPrefix : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-amuletinstrumentid-11366"></a>
+
+### `amuletInstrumentId`
+
+```daml
+amuletInstrumentId : Party -> InstrumentId
+```
+
+Shared definition of the instrument-id used for amulets.
+
+<a id="function-splice-amulet-tokenapiutils-optionalmetadata-95597"></a>
+
+### `optionalMetadata`
+
+```daml
+optionalMetadata : Text -> (a -> Text) -> Optional a -> TextMap Text -> TextMap Text
+```
+
+Add an optional metadata entry.
+
+<a id="function-splice-amulet-tokenapiutils-nonzerometadata-67227"></a>
+
+### `nonZeroMetadata`
+
+```daml
+nonZeroMetadata : (Eq a, Additive a, Show a) => Text -> a -> TextMap Text -> TextMap Text
+```
+
+Add an metadata entry if it is non-zero number.
+
+<a id="function-splice-amulet-tokenapiutils-optionalnonzerometadata-8763"></a>
+
+### `optionalNonZeroMetadata`
+
+```daml
+optionalNonZeroMetadata : (Eq a, Additive a, Show a) => Text -> Optional a -> TextMap Text -> TextMap Text
+```
+
+Add an metadata entry for an optional value if it is non-zero number.
+
+<a id="function-splice-amulet-tokenapiutils-createdinroundmetakey-43020"></a>
+
+### `createdInRoundMetaKey`
+
+```daml
+createdInRoundMetaKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-rateperroundmetakey-80476"></a>
+
+### `ratePerRoundMetaKey`
+
+```daml
+ratePerRoundMetaKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-svrewardamountmetakey-76087"></a>
+
+### `svRewardAmountMetaKey`
+
+```daml
+svRewardAmountMetaKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-apprewardamountmetakey-17776"></a>
+
+### `appRewardAmountMetaKey`
+
+```daml
+appRewardAmountMetaKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-unclaimedactivityrecordamountmetakey-33086"></a>
+
+### `unclaimedActivityRecordAmountMetaKey`
+
+```daml
+unclaimedActivityRecordAmountMetaKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-validatorrewardamountmetakey-47315"></a>
+
+### `validatorRewardAmountMetaKey`
+
+```daml
+validatorRewardAmountMetaKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-apprewardbeneficiariesmetakey-63876"></a>
+
+### `appRewardBeneficiariesMetaKey`
+
+```daml
+appRewardBeneficiariesMetaKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-apprewardbeneficiaryweightsmetakey-52370"></a>
+
+### `appRewardBeneficiaryWeightsMetaKey`
+
+```daml
+appRewardBeneficiaryWeightsMetaKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-developmentfundamountmetakey-16464"></a>
+
+### `developmentFundAmountMetaKey`
+
+```daml
+developmentFundAmountMetaKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-reasonmetakey-98413"></a>
+
+### `reasonMetaKey`
+
+```daml
+reasonMetaKey : Text
+```
+
+Short, human-readable reason for the transaction.
+
+<a id="function-splice-amulet-tokenapiutils-txkindmetakey-86963"></a>
+
+### `txKindMetaKey`
+
+```daml
+txKindMetaKey : Text
+```
+
+Kind of the transaction.
+
+<a id="function-splice-amulet-tokenapiutils-sendermetakey-57316"></a>
+
+### `senderMetaKey`
+
+```daml
+senderMetaKey : Text
+```
+
+The sender of a transfer.
+
+<a id="function-splice-amulet-tokenapiutils-burnedmetakey-57705"></a>
+
+### `burnedMetaKey`
+
+```daml
+burnedMetaKey : Text
+```
+
+The amount of token holdings burned as part of a transaction.
+
+<a id="function-splice-amulet-tokenapiutils-holdingtxmeta-93547"></a>
+
+### `holdingTxMeta`
+
+```daml
+holdingTxMeta : TxKind -> Optional Text -> Optional Party -> Optional Decimal -> Metadata
+```
+
+Build the metadata for a transaction affecting the amulet holdings.
+
+<a id="function-splice-amulet-tokenapiutils-txkindtotext-55602"></a>
+
+### `txKindToText`
+
+```daml
+txKindToText : TxKind -> Text
+```
+
+Exported for testing only
+
+<a id="function-splice-amulet-tokenapiutils-simpleholdingtxmeta-84235"></a>
+
+### `simpleHoldingTxMeta`
+
+```daml
+simpleHoldingTxMeta : TxKind -> Optional Text -> Optional Decimal -> Metadata
+```
+
+Simplified version for a few of the common cases.
+
+<a id="function-splice-amulet-tokenapiutils-externalpartyconfigstatecontextkey-59994"></a>
+
+### `externalPartyConfigStateContextKey`
+
+```daml
+externalPartyConfigStateContextKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-featuredapprightcontextkey-84565"></a>
+
+### `featuredAppRightContextKey`
+
+```daml
+featuredAppRightContextKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-transferpreapprovalcontextkey-6006"></a>
+
+### `transferPreapprovalContextKey`
+
+```daml
+transferPreapprovalContextKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-lockcontextkey-29271"></a>
+
+### `lockContextKey`
+
+```daml
+lockContextKey : Text
+```
+
+The key used to embed all the lock specification in the choice context.
+
+<a id="function-splice-amulet-tokenapiutils-lockexpiresatcontextkey-3269"></a>
+
+### `lockExpiresAtContextKey`
+
+```daml
+lockExpiresAtContextKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-lockholderscontextkey-51785"></a>
+
+### `lockHoldersContextKey`
+
+```daml
+lockHoldersContextKey : Text
+```
+
+<a id="function-splice-amulet-tokenapiutils-lockcontextcontextkey-63153"></a>
+
+### `lockContextContextKey`
+
+```daml
+lockContextContextKey : Text
+```
+
+The context description of a lock.
+
+<a id="function-splice-amulet-tokenapiutils-expirelockkey-74460"></a>
+
+### `expireLockKey`
+
+```daml
+expireLockKey : Text
+```
+
+Key used to signal to a choice whether an expired locked amulet should be
+unlocked.
+
+<a id="function-splice-amulet-tokenapiutils-beneficiariesfrommetadata-93977"></a>
+
+### `beneficiariesFromMetadata`
+
+```daml
+beneficiariesFromMetadata : Metadata -> Either Text (Optional [AppRewardBeneficiary])
+```
+
+<a id="function-splice-amulet-tokenapiutils-parsecommaseparated-63776"></a>
+
+### `parseCommaSeparated`
+
+```daml
+parseCommaSeparated : Text -> (Text -> Optional a) -> Text -> Either Text [a]
+```
+
+<a id="function-splice-amulet-tokenapiutils-addoptionalanyvalue-87443"></a>
+
+### `addOptionalAnyValue`
+
+```daml
+addOptionalAnyValue : ToAnyValue a => Text -> Optional a -> TextMap AnyValue -> TextMap AnyValue
+```
+
+Convenience function to create maps that contain an optional value if it is
+set. See its use sites for examples.
+
+<a id="function-splice-amulet-tokenapiutils-lookupfromcontext-26074"></a>
+
+### `lookupFromContext`
+
+```daml
+lookupFromContext : FromAnyValue a => ChoiceContext -> Text -> Either Text (Optional a)
+```
+
+Lookup and decode a value within a choice context.
+
+<a id="function-splice-amulet-tokenapiutils-getfromcontext-35521"></a>
+
+### `getFromContext`
+
+```daml
+getFromContext : FromAnyValue a => ChoiceContext -> Text -> Either Text a
+```
+
+Get a value from a choice context, failing if it is not present or fails to parse.
+
+<a id="function-splice-amulet-tokenapiutils-lookupfromcontextu-72244"></a>
+
+### `lookupFromContextU`
+
+```daml
+lookupFromContextU : FromAnyValue a => ChoiceContext -> Text -> Update (Optional a)
+```
+
+Convenience version of `lookupFromContext` that raises the failure within the `Update`.
+
+<a id="function-splice-amulet-tokenapiutils-getfromcontextu-55645"></a>
+
+### `getFromContextU`
+
+```daml
+getFromContextU : FromAnyValue a => ChoiceContext -> Text -> Update a
+```
+
+Convenience version of `getFromContext` that raises the failure within the `Update`.
+
+## Orphan Typeclass Instances
+
+- `instance Semigroup Metadata`
+
+- `instance Monoid Metadata`

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-amulet-twosteptransfer.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-amulet-twosteptransfer.mdx
@@ -1,0 +1,110 @@
+---
+title: "Splice.Amulet.TwoStepTransfer"
+description: "Reference documentation for Daml module Splice.Amulet.TwoStepTransfer."
+---
+
+<a id="module-splice-amulet-twosteptransfer-66725"></a>
+
+# Splice.Amulet.TwoStepTransfer
+
+Generic code for a two-step transfer of amulet. The first step is to lock
+
+the amulet, the second step is to transfer it.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-amulet-twosteptransfer-twosteptransfer-31697"></a>
+
+### `data TwoStepTransfer`
+
+Constructors:
+
+<a id="constr-splice-amulet-twosteptransfer-twosteptransfer-922"></a>
+- `TwoStepTransfer`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sender | Party |  |
+| receiver | Party |  |
+| amount | Decimal |  |
+| lockContext | Text | Context description of the lock. This is used to display the reason for<br/><br/>the lock in wallets. |
+| transferBefore | Time |  |
+| transferBeforeDeadline | Text | Name of the deadline for the transfer |
+| provider | Party | Provider that should be marked as the app provider on the second step. |
+| allowFeaturing | Bool | Whether the second step can be featured. |
+
+Instances:
+
+- `instance GetField allowFeaturing TwoStepTransfer Bool`
+- `instance GetField amount TwoStepTransfer Decimal`
+- `instance GetField dso TwoStepTransfer Party`
+- `instance GetField lockContext TwoStepTransfer Text`
+- `instance GetField provider TwoStepTransfer Party`
+- `instance GetField receiver TwoStepTransfer Party`
+- `instance GetField sender TwoStepTransfer Party`
+- `instance GetField transferBefore TwoStepTransfer Time`
+- `instance GetField transferBeforeDeadline TwoStepTransfer Text`
+- `instance SetField allowFeaturing TwoStepTransfer Bool`
+- `instance SetField amount TwoStepTransfer Decimal`
+- `instance SetField dso TwoStepTransfer Party`
+- `instance SetField lockContext TwoStepTransfer Text`
+- `instance SetField provider TwoStepTransfer Party`
+- `instance SetField receiver TwoStepTransfer Party`
+- `instance SetField sender TwoStepTransfer Party`
+- `instance SetField transferBefore TwoStepTransfer Time`
+- `instance SetField transferBeforeDeadline TwoStepTransfer Text`
+
+## Functions
+
+<a id="function-splice-amulet-twosteptransfer-holdingtotransferinputs-13824"></a>
+
+### `holdingToTransferInputs`
+
+```daml
+holdingToTransferInputs : ForOwner -> [ContractId Holding] -> Update [TransferInput]
+```
+
+Converting a set of holding inputs to inputs for an amulet transfer,
+unlocking any expired LockedAmulet holdings on the fly.
+
+<a id="function-splice-amulet-twosteptransfer-preparetwosteptransfer-60675"></a>
+
+### `prepareTwoStepTransfer`
+
+```daml
+prepareTwoStepTransfer : TwoStepTransfer -> Time -> [ContractId Holding] -> ExternalPartyTransferContext -> Update (ContractId LockedAmulet, [ContractId Holding], Metadata)
+```
+
+Prepare a two-step transfer of amulet by locking the funds.
+
+<a id="function-splice-amulet-twosteptransfer-executetwosteptransfer-18767"></a>
+
+### `executeTwoStepTransfer`
+
+```daml
+executeTwoStepTransfer : TwoStepTransfer -> ContractId LockedAmulet -> ExtraArgs -> Update ([ContractId Holding], [ContractId Holding], Metadata)
+```
+
+<a id="function-splice-amulet-twosteptransfer-aborttwosteptransfer-11048"></a>
+
+### `abortTwoStepTransfer`
+
+```daml
+abortTwoStepTransfer : TwoStepTransfer -> ContractId LockedAmulet -> ExtraArgs -> Update [ContractId Holding]
+```

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-amulet.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-amulet.mdx
@@ -1,0 +1,1155 @@
+---
+title: "Splice.Amulet"
+description: "Reference documentation for Daml module Splice.Amulet."
+---
+
+<a id="module-splice-amulet-64804"></a>
+
+# Splice.Amulet
+
+The contracts representing the long-term state of Splice.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-amulet-amuletcreatesummary-15609"></a>
+
+### `data AmuletCreateSummary amuletContractId`
+
+Result of an operation that created a new amulet, e.g.,
+by minting a fresh amulet, or by unlocking a locked amulet.
+
+Constructors:
+
+<a id="constr-splice-amulet-amuletcreatesummary-64070"></a>
+- `AmuletCreateSummary`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amulet | amuletContractId | The new amulet that was created |
+| amuletPrice | Decimal | The amulet price at the round the amulet was created |
+| round | Round | Round for which this amulet was created. |
+
+Instances:
+
+- `instance Eq amuletContractId => Eq (AmuletCreateSummary amuletContractId)`
+- `instance Show amuletContractId => Show (AmuletCreateSummary amuletContractId)`
+- `instance GetField amulet (AmuletCreateSummary amuletContractId) amuletContractId`
+- `instance GetField amuletPrice (AmuletCreateSummary amuletContractId) Decimal`
+- `instance GetField amuletSum LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField amuletSum LockedAmulet_UnlockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField amuletSum AmuletRules_DevNet_TapResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField amuletSum AmuletRules_MintResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField round (AmuletCreateSummary amuletContractId) Round`
+- `instance SetField amulet (AmuletCreateSummary amuletContractId) amuletContractId`
+- `instance SetField amuletPrice (AmuletCreateSummary amuletContractId) Decimal`
+- `instance SetField amuletSum LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum LockedAmulet_UnlockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum AmuletRules_DevNet_TapResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum AmuletRules_MintResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField round (AmuletCreateSummary amuletContractId) Round`
+
+<a id="type-splice-amulet-amuletexpiresummary-4706"></a>
+
+### `data AmuletExpireSummary`
+
+Constructors:
+
+<a id="constr-splice-amulet-amuletexpiresummary-31721"></a>
+- `AmuletExpireSummary`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| owner | Party |  |
+| round | Round | Round for which this expiry was registered. |
+| changeToInitialAmountAsOfRoundZero | Decimal |  |
+| changeToHoldingFeesRate | Decimal | The change of total holding fees introduced by a amulet expiry. |
+
+Instances:
+
+- `instance Eq AmuletExpireSummary`
+- `instance Show AmuletExpireSummary`
+- `instance GetField changeToHoldingFeesRate AmuletExpireSummary Decimal`
+- `instance GetField changeToInitialAmountAsOfRoundZero AmuletExpireSummary Decimal`
+- `instance GetField expireSum Amulet_ExpireResult AmuletExpireSummary`
+- `instance GetField expireSum LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance GetField owner AmuletExpireSummary Party`
+- `instance GetField round AmuletExpireSummary Round`
+- `instance SetField changeToHoldingFeesRate AmuletExpireSummary Decimal`
+- `instance SetField changeToInitialAmountAsOfRoundZero AmuletExpireSummary Decimal`
+- `instance SetField expireSum Amulet_ExpireResult AmuletExpireSummary`
+- `instance SetField expireSum LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance SetField owner AmuletExpireSummary Party`
+- `instance SetField round AmuletExpireSummary Round`
+
+<a id="type-splice-amulet-amuletexpirev2summary-45428"></a>
+
+### `data AmuletExpireV2Summary`
+
+Constructors:
+
+<a id="constr-splice-amulet-amuletexpirev2summary-89407"></a>
+- `AmuletExpireV2Summary`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| owner | Party |  |
+
+Instances:
+
+- `instance Eq AmuletExpireV2Summary`
+- `instance Show AmuletExpireV2Summary`
+- `instance GetField expireSum Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance GetField expireSum LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance GetField owner AmuletExpireV2Summary Party`
+- `instance SetField expireSum Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance SetField expireSum LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance SetField owner AmuletExpireV2Summary Party`
+
+<a id="type-splice-amulet-amuletexpireresult-11748"></a>
+
+### `data Amulet_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-amuletexpireresult-71583"></a>
+- `Amulet_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireSummary |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance GetField expireSum Amulet_ExpireResult AmuletExpireSummary`
+- `instance GetField meta Amulet_ExpireResult (Optional Metadata)`
+- `instance SetField expireSum Amulet_ExpireResult AmuletExpireSummary`
+- `instance SetField meta Amulet_ExpireResult (Optional Metadata)`
+- `instance HasExercise Amulet Amulet_Expire Amulet_ExpireResult`
+- `instance HasFromAnyChoice Amulet Amulet_Expire Amulet_ExpireResult`
+- `instance HasToAnyChoice Amulet Amulet_Expire Amulet_ExpireResult`
+
+<a id="type-splice-amulet-amuletexpirev2result-68414"></a>
+
+### `data Amulet_ExpireV2Result`
+
+Constructors:
+
+<a id="constr-splice-amulet-amuletexpirev2result-95029"></a>
+- `Amulet_ExpireV2Result`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireV2Summary |  |
+| meta | Metadata |  |
+
+Instances:
+
+- `instance GetField expireSum Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance GetField meta Amulet_ExpireV2Result Metadata`
+- `instance SetField expireSum Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance SetField meta Amulet_ExpireV2Result Metadata`
+- `instance HasExercise Amulet Amulet_ExpireV2 Amulet_ExpireV2Result`
+- `instance HasFromAnyChoice Amulet Amulet_ExpireV2 Amulet_ExpireV2Result`
+- `instance HasToAnyChoice Amulet Amulet_ExpireV2 Amulet_ExpireV2Result`
+
+<a id="type-splice-amulet-apprewardcoupondsoexpireresult-15772"></a>
+
+### `data AppRewardCoupon_DsoExpireResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-apprewardcoupondsoexpireresult-84547"></a>
+- `AppRewardCoupon_DsoExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featured | Bool |  |
+| amount | Decimal |  |
+
+Instances:
+
+- `instance GetField amount AppRewardCoupon_DsoExpireResult Decimal`
+- `instance GetField featured AppRewardCoupon_DsoExpireResult Bool`
+- `instance SetField amount AppRewardCoupon_DsoExpireResult Decimal`
+- `instance SetField featured AppRewardCoupon_DsoExpireResult Bool`
+- `instance HasExercise AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult`
+- `instance HasFromAnyChoice AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult`
+- `instance HasToAnyChoice AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult`
+
+<a id="type-splice-amulet-developmentfundcoupondsoexpireresult-6252"></a>
+
+### `data DevelopmentFundCoupon_DsoExpireResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-developmentfundcoupondsoexpireresult-48451"></a>
+- `DevelopmentFundCoupon_DsoExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCid | ContractId UnclaimedDevelopmentFundCoupon |  |
+
+Instances:
+
+- `instance GetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_DsoExpireResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance SetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_DsoExpireResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance HasExercise DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult`
+- `instance HasFromAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult`
+- `instance HasToAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult`
+
+<a id="type-splice-amulet-developmentfundcouponrejectresult-16689"></a>
+
+### `data DevelopmentFundCoupon_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-developmentfundcouponrejectresult-31260"></a>
+- `DevelopmentFundCoupon_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCid | ContractId UnclaimedDevelopmentFundCoupon |  |
+
+Instances:
+
+- `instance GetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_RejectResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance SetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_RejectResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance HasExercise DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult`
+- `instance HasFromAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult`
+- `instance HasToAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult`
+
+<a id="type-splice-amulet-developmentfundcouponwithdrawresult-40988"></a>
+
+### `data DevelopmentFundCoupon_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-developmentfundcouponwithdrawresult-40985"></a>
+- `DevelopmentFundCoupon_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCid | ContractId UnclaimedDevelopmentFundCoupon |  |
+
+Instances:
+
+- `instance GetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_WithdrawResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance SetField unclaimedDevelopmentFundCouponCid DevelopmentFundCoupon_WithdrawResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance HasExercise DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult`
+- `instance HasFromAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult`
+- `instance HasToAnyChoice DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult`
+
+<a id="type-splice-amulet-featuredapprightcancelresult-22074"></a>
+
+### `data FeaturedAppRight_CancelResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-featuredapprightcancelresult-30485"></a>
+- `FeaturedAppRight_CancelResult`
+
+Instances:
+
+- `instance HasExercise FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult`
+- `instance HasFromAnyChoice FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult`
+- `instance HasToAnyChoice FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult`
+
+<a id="type-splice-amulet-featuredapprightwithdrawresult-98740"></a>
+
+### `data FeaturedAppRight_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-featuredapprightwithdrawresult-88987"></a>
+- `FeaturedAppRight_WithdrawResult`
+
+Instances:
+
+- `instance HasExercise FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult`
+- `instance HasFromAnyChoice FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult`
+- `instance HasToAnyChoice FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult`
+
+<a id="type-splice-amulet-lockedamuletexpireamuletresult-88432"></a>
+
+### `data LockedAmulet_ExpireAmuletResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-lockedamuletexpireamuletresult-82939"></a>
+- `LockedAmulet_ExpireAmuletResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireSummary |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance GetField expireSum LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance GetField meta LockedAmulet_ExpireAmuletResult (Optional Metadata)`
+- `instance SetField expireSum LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance SetField meta LockedAmulet_ExpireAmuletResult (Optional Metadata)`
+- `instance HasExercise LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult`
+
+<a id="type-splice-amulet-lockedamuletexpireamuletv2result-81066"></a>
+
+### `data LockedAmulet_ExpireAmuletV2Result`
+
+Constructors:
+
+<a id="constr-splice-amulet-lockedamuletexpireamuletv2result-89449"></a>
+- `LockedAmulet_ExpireAmuletV2Result`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireV2Summary |  |
+| meta | Metadata |  |
+
+Instances:
+
+- `instance GetField expireSum LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance GetField meta LockedAmulet_ExpireAmuletV2Result Metadata`
+- `instance SetField expireSum LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance SetField meta LockedAmulet_ExpireAmuletV2Result Metadata`
+- `instance HasExercise LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result`
+
+<a id="type-splice-amulet-lockedamuletownerexpirelockresult-44583"></a>
+
+### `data LockedAmulet_OwnerExpireLockResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-lockedamuletownerexpirelockresult-40926"></a>
+- `LockedAmulet_OwnerExpireLockResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance GetField amuletSum LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField meta LockedAmulet_OwnerExpireLockResult (Optional Metadata)`
+- `instance SetField amuletSum LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField meta LockedAmulet_OwnerExpireLockResult (Optional Metadata)`
+- `instance HasExercise LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult`
+
+<a id="type-splice-amulet-lockedamuletownerexpirelockv2result-70273"></a>
+
+### `data LockedAmulet_OwnerExpireLockV2Result`
+
+Constructors:
+
+<a id="constr-splice-amulet-lockedamuletownerexpirelockv2result-66952"></a>
+- `LockedAmulet_OwnerExpireLockV2Result`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletCid | ContractId Amulet |  |
+| meta | Metadata |  |
+
+Instances:
+
+- `instance GetField amuletCid LockedAmulet_OwnerExpireLockV2Result (ContractId Amulet)`
+- `instance GetField meta LockedAmulet_OwnerExpireLockV2Result Metadata`
+- `instance SetField amuletCid LockedAmulet_OwnerExpireLockV2Result (ContractId Amulet)`
+- `instance SetField meta LockedAmulet_OwnerExpireLockV2Result Metadata`
+- `instance HasExercise LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result`
+
+<a id="type-splice-amulet-lockedamuletunlockresult-29457"></a>
+
+### `data LockedAmulet_UnlockResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-lockedamuletunlockresult-40430"></a>
+- `LockedAmulet_UnlockResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance GetField amuletSum LockedAmulet_UnlockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField meta LockedAmulet_UnlockResult (Optional Metadata)`
+- `instance SetField amuletSum LockedAmulet_UnlockResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField meta LockedAmulet_UnlockResult (Optional Metadata)`
+- `instance HasExercise LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult`
+
+<a id="type-splice-amulet-lockedamuletunlockv2result-80903"></a>
+
+### `data LockedAmulet_UnlockV2Result`
+
+Constructors:
+
+<a id="constr-splice-amulet-lockedamuletunlockv2result-28736"></a>
+- `LockedAmulet_UnlockV2Result`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletCid | ContractId Amulet |  |
+| meta | Metadata |  |
+
+Instances:
+
+- `instance GetField amuletCid LockedAmulet_UnlockV2Result (ContractId Amulet)`
+- `instance GetField meta LockedAmulet_UnlockV2Result Metadata`
+- `instance SetField amuletCid LockedAmulet_UnlockV2Result (ContractId Amulet)`
+- `instance SetField meta LockedAmulet_UnlockV2Result Metadata`
+- `instance HasExercise LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result`
+- `instance HasFromAnyChoice LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result`
+- `instance HasToAnyChoice LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result`
+
+<a id="type-splice-amulet-svrewardcouponarchiveasbeneficiaryresult-20724"></a>
+
+### `data SvRewardCoupon_ArchiveAsBeneficiaryResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-svrewardcouponarchiveasbeneficiaryresult-19239"></a>
+- `SvRewardCoupon_ArchiveAsBeneficiaryResult`
+
+Instances:
+
+- `instance HasExercise SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult`
+- `instance HasFromAnyChoice SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult`
+- `instance HasToAnyChoice SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult`
+
+<a id="type-splice-amulet-svrewardcoupondsoexpireresult-4801"></a>
+
+### `data SvRewardCoupon_DsoExpireResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-svrewardcoupondsoexpireresult-59696"></a>
+- `SvRewardCoupon_DsoExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| weight | Int |  |
+
+Instances:
+
+- `instance GetField weight SvRewardCoupon_DsoExpireResult Int`
+- `instance SetField weight SvRewardCoupon_DsoExpireResult Int`
+- `instance HasExercise SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult`
+- `instance HasFromAnyChoice SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult`
+- `instance HasToAnyChoice SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult`
+
+<a id="type-splice-amulet-unclaimedactivityrecordarchiveasbeneficiaryresult-59553"></a>
+
+### `data UnclaimedActivityRecord_ArchiveAsBeneficiaryResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-unclaimedactivityrecordarchiveasbeneficiaryresult-59904"></a>
+- `UnclaimedActivityRecord_ArchiveAsBeneficiaryResult`
+
+<a id="type-splice-amulet-unclaimedactivityrecorddsoexpireresult-73042"></a>
+
+### `data UnclaimedActivityRecord_DsoExpireResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-unclaimedactivityrecorddsoexpireresult-28805"></a>
+- `UnclaimedActivityRecord_DsoExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedRewardCid | ContractId UnclaimedReward |  |
+
+Instances:
+
+- `instance GetField unclaimedRewardCid UnclaimedActivityRecord_DsoExpireResult (ContractId UnclaimedReward)`
+- `instance SetField unclaimedRewardCid UnclaimedActivityRecord_DsoExpireResult (ContractId UnclaimedReward)`
+- `instance HasExercise UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult`
+- `instance HasFromAnyChoice UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult`
+- `instance HasToAnyChoice UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult`
+
+<a id="type-splice-amulet-validatorrewardcouponarchiveasvalidatorresult-41727"></a>
+
+### `data ValidatorRewardCoupon_ArchiveAsValidatorResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-validatorrewardcouponarchiveasvalidatorresult-51782"></a>
+- `ValidatorRewardCoupon_ArchiveAsValidatorResult`
+(no fields)
+
+Instances:
+
+- `instance HasExercise ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult`
+- `instance HasFromAnyChoice ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult`
+- `instance HasToAnyChoice ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult`
+
+<a id="type-splice-amulet-validatorrewardcoupondsoexpireresult-94761"></a>
+
+### `data ValidatorRewardCoupon_DsoExpireResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-validatorrewardcoupondsoexpireresult-92822"></a>
+- `ValidatorRewardCoupon_DsoExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amount | Decimal |  |
+
+Instances:
+
+- `instance GetField amount ValidatorRewardCoupon_DsoExpireResult Decimal`
+- `instance SetField amount ValidatorRewardCoupon_DsoExpireResult Decimal`
+- `instance HasExercise ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult`
+- `instance HasFromAnyChoice ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult`
+- `instance HasToAnyChoice ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult`
+
+<a id="type-splice-amulet-validatorrightarchiveasuserresult-3193"></a>
+
+### `data ValidatorRight_ArchiveAsUserResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-validatorrightarchiveasuserresult-47620"></a>
+- `ValidatorRight_ArchiveAsUserResult`
+
+Instances:
+
+- `instance HasExercise ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult`
+- `instance HasFromAnyChoice ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult`
+- `instance HasToAnyChoice ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult`
+
+<a id="type-splice-amulet-validatorrightarchiveasvalidatorresult-59299"></a>
+
+### `data ValidatorRight_ArchiveAsValidatorResult`
+
+Constructors:
+
+<a id="constr-splice-amulet-validatorrightarchiveasvalidatorresult-93588"></a>
+- `ValidatorRight_ArchiveAsValidatorResult`
+
+Instances:
+
+- `instance HasExercise ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult`
+- `instance HasFromAnyChoice ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult`
+- `instance HasToAnyChoice ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult`
+
+## Functions
+
+<a id="function-splice-amulet-amuletmetadata-81241"></a>
+
+### `amuletMetadata`
+
+```daml
+amuletMetadata : Amulet -> Metadata
+```
+
+<a id="function-splice-amulet-validateapprewardbeneficiaries-84669"></a>
+
+### `validateAppRewardBeneficiaries`
+
+```daml
+validateAppRewardBeneficiaries : [AppRewardBeneficiary] -> Update ()
+```
+
+<a id="function-splice-amulet-validateapprewardbeneficiariesv2-38479"></a>
+
+### `validateAppRewardBeneficiariesV2`
+
+```daml
+validateAppRewardBeneficiariesV2 : [AppRewardBeneficiary] -> Update ()
+```
+
+<a id="function-splice-amulet-requireamuletexpiredforallrounds-81885"></a>
+
+### `requireAmuletExpiredForAllRounds`
+
+```daml
+requireAmuletExpiredForAllRounds : ContractId ExternalPartyConfigState -> ContractId ExternalPartyConfigState -> Amulet -> Update ()
+```
+
+## Templates
+
+<a id="type-splice-amulet-amulet-63582"></a>
+
+### Template `Amulet`
+
+A amulet, which can be locked and whose amount expires over time.
+
+The expiry serves to charge an inactivity fee, and thereby ensures that the
+SVs can reclaim the corresponding storage space at some point in the future.
+
+Signatories: `dso`, `owner`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| owner | Party |  |
+| amount | ExpiringAmount |  |
+
+Interface Instances:
+- `Holding` for `Amulet`
+
+Choices:
+
+<a id="type-splice-amulet-amuletexpire-87297"></a>
+
+#### Choice `Amulet_Expire`
+
+Controllers: `dso`
+
+Returns: `Amulet_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| roundCid | ContractId OpenMiningRound |  |
+
+<a id="type-splice-amulet-amuletexpirev2-59227"></a>
+
+#### Choice `Amulet_ExpireV2`
+
+Controllers: `dso`
+
+Returns: `Amulet_ExpireV2Result`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| externalPartyConfigState0Cid | ContractId ExternalPartyConfigState |  |
+| externalPartyConfigState1Cid | ContractId ExternalPartyConfigState |  |
+
+#### Choice `Archive`
+
+Controllers: `dso`, `owner`
+
+Returns: `()`
+
+<a id="type-splice-amulet-apprewardcoupon-57229"></a>
+
+### Template `AppRewardCoupon`
+
+A coupon for receiving app rewards proportional to the usage fee paid as part of a
+Amulet transfer coordinated by the app of a provider.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| provider | Party | Application provider |
+| featured | Bool |  |
+| amount | Decimal |  |
+| round | Round |  |
+| beneficiary | Optional Party | The party that can mint this reward.<br/><br/>If not set, this is the provider |
+
+Choices:
+
+<a id="type-splice-amulet-apprewardcoupondsoexpire-84081"></a>
+
+#### Choice `AppRewardCoupon_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `AppRewardCoupon_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-amulet-developmentfundcoupon-75673"></a>
+
+### Template `DevelopmentFundCoupon`
+
+A coupon recording an emission for the Development Fund under CIP-0082,
+which can be collected by the designated beneficiary.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| beneficiary | Party | The owner of the `Amulet` to be minted. |
+| fundManager | Party | The party that executed the assignment of the coupon to the beneficiary<br/><br/>so they can mint from the development fund. |
+| amount | Decimal | The total amount of `Amulet` to mint on collection. |
+| expiresAt | Time | Until when the minting can be completed. |
+| reason | Text | Reason for the emission of the coupon. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-amulet-developmentfundcoupondsoexpire-7301"></a>
+
+#### Choice `DevelopmentFundCoupon_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `DevelopmentFundCoupon_DsoExpireResult`
+
+<a id="type-splice-amulet-developmentfundcouponreject-89668"></a>
+
+#### Choice `DevelopmentFundCoupon_Reject`
+
+Controllers: `beneficiary`
+
+Returns: `DevelopmentFundCoupon_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text | Reason for rejecting the coupon. |
+
+<a id="type-splice-amulet-developmentfundcouponwithdraw-58125"></a>
+
+#### Choice `DevelopmentFundCoupon_Withdraw`
+
+Controllers: `fundManager`
+
+Returns: `DevelopmentFundCoupon_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text | Reason for withdrawing the coupon. |
+
+<a id="type-splice-amulet-featuredappactivitymarker-16451"></a>
+
+### Template `FeaturedAppActivityMarker`
+
+A marker created by a featured application for activity generated from that app. This is used
+to record activity other than amulet transfers where regular AppRewardCoupons are not created directly.
+
+Will be converted to a AppRewardCoupon through automation run by the SVs and can then be
+minted as part of the normal minting process.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| provider | Party | The featured app provider that created the activity marker. |
+| beneficiary | Party | The party that has the right to mint the reward. |
+| weight | Decimal | The weight of the marker. This is used to split the rewards<br/><br/>for a single action, e.g., multiple parties collaborating to enable<br/><br/>a transfer,<br/><br/>by creating several FeaturedAppActivityMarkers with different<br/><br/>beneficiaries such that the weights add up to 1.0. |
+
+Interface Instances:
+- `FeaturedAppActivityMarker` for `FeaturedAppActivityMarker`
+- `FeaturedAppActivityMarker` for `FeaturedAppActivityMarker`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-amulet-featuredappright-765"></a>
+
+### Template `FeaturedAppRight`
+
+The right for an application provider to earn featured app rewards.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| provider | Party |  |
+
+Interface Instances:
+- `FeaturedAppRight` for `FeaturedAppRight`
+- `FeaturedAppRight` for `FeaturedAppRight`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-amulet-featuredapprightcancel-96535"></a>
+
+#### Choice `FeaturedAppRight_Cancel`
+
+Controllers: `provider`
+
+Returns: `FeaturedAppRight_CancelResult`
+
+<a id="type-splice-amulet-featuredapprightwithdraw-8217"></a>
+
+#### Choice `FeaturedAppRight_Withdraw`
+
+Controllers: `dso`
+
+Returns: `FeaturedAppRight_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<a id="type-splice-amulet-lockedamulet-7030"></a>
+
+### Template `LockedAmulet`
+
+Signatories: `(DA.Internal.Record.getField @"holders" lock)`, `signatory amulet`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amulet | Amulet |  |
+| lock | TimeLock |  |
+
+Interface Instances:
+- `Holding` for `LockedAmulet`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `(DA.Internal.Record.getField @"holders" lock)`, `signatory amulet`
+
+Returns: `()`
+
+<a id="type-splice-amulet-lockedamuletexpireamulet-28333"></a>
+
+#### Choice `LockedAmulet_ExpireAmulet`
+
+Controllers: `(DA.Internal.Record.getField @"dso" amulet)`
+
+Returns: `LockedAmulet_ExpireAmuletResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| roundCid | ContractId OpenMiningRound |  |
+
+<a id="type-splice-amulet-lockedamuletexpireamuletv2-51335"></a>
+
+#### Choice `LockedAmulet_ExpireAmuletV2`
+
+Controllers: `(DA.Internal.Record.getField @"dso" amulet)`
+
+Returns: `LockedAmulet_ExpireAmuletV2Result`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| externalPartyConfigState0Cid | ContractId ExternalPartyConfigState |  |
+| externalPartyConfigState1Cid | ContractId ExternalPartyConfigState |  |
+
+<a id="type-splice-amulet-lockedamuletownerexpirelock-79102"></a>
+
+#### Choice `LockedAmulet_OwnerExpireLock`
+
+Controllers: `(DA.Internal.Record.getField @"owner" amulet)`
+
+Returns: `LockedAmulet_OwnerExpireLockResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openRoundCid | ContractId OpenMiningRound |  |
+
+<a id="type-splice-amulet-lockedamuletownerexpirelockv2-20152"></a>
+
+#### Choice `LockedAmulet_OwnerExpireLockV2`
+
+Controllers: `(DA.Internal.Record.getField @"owner" amulet)`
+
+Returns: `LockedAmulet_OwnerExpireLockV2Result`
+
+<a id="type-splice-amulet-lockedamuletunlock-59352"></a>
+
+#### Choice `LockedAmulet_Unlock`
+
+Controllers: `(DA.Internal.Record.getField @"owner" amulet) :: (DA.Internal.Record.getField @"holders" lock)`
+
+Returns: `LockedAmulet_UnlockResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openRoundCid | ContractId OpenMiningRound |  |
+
+<a id="type-splice-amulet-lockedamuletunlockv2-31390"></a>
+
+#### Choice `LockedAmulet_UnlockV2`
+
+Controllers: `(DA.Internal.Record.getField @"owner" amulet) :: (DA.Internal.Record.getField @"holders" lock)`
+
+Returns: `LockedAmulet_UnlockV2Result`
+
+<a id="type-splice-amulet-svrewardcoupon-68580"></a>
+
+### Template `SvRewardCoupon`
+
+A coupon for a beneficiary to receive part of the SV issuance for a specific SV node and round.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv | Party | The party identifying the SV node for which the reward is issued. |
+| beneficiary | Party | The beneficiary allowed to receive the reward. |
+| round | Round |  |
+| weight | Int | Coupons receive a share of the SV issuance proportional to their weight. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-amulet-svrewardcouponarchiveasbeneficiary-26109"></a>
+
+#### Choice `SvRewardCoupon_ArchiveAsBeneficiary`
+
+Controllers: `beneficiary`
+
+Returns: `SvRewardCoupon_ArchiveAsBeneficiaryResult`
+
+<a id="type-splice-amulet-svrewardcoupondsoexpire-92140"></a>
+
+#### Choice `SvRewardCoupon_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `SvRewardCoupon_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+<a id="type-splice-amulet-unclaimedactivityrecord-97331"></a>
+
+### Template `UnclaimedActivityRecord`
+
+A record of activity that can be minted by the beneficiary.
+Note that these do not come out of the per-round issuance but are instead created by burning
+UnclaimedRewardCoupon as defined through a vote by the SVs. That's also why expiry is a separate
+time-based expiry instead of being tied to a round like the other activity records.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| beneficiary | Party | The owner of the `Amulet` to be minted. |
+| amount | Decimal | The amount of `Amulet` to be minted. |
+| reason | Text | A reason to mint the `Amulet`. |
+| expiresAt | Time | Selected timestamp defining the lifetime of the contract. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-amulet-unclaimedactivityrecorddsoexpire-41307"></a>
+
+#### Choice `UnclaimedActivityRecord_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `UnclaimedActivityRecord_DsoExpireResult`
+
+<a id="type-splice-amulet-unclaimeddevelopmentfundcoupon-41000"></a>
+
+### Template `UnclaimedDevelopmentFundCoupon`
+
+A coupon recording an emission for the Development Fund from CIP-0082 that
+was not yet assigned to a specific beneficiary.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| amount | Decimal | The total amount of `Amulet` to mint on collection. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-amulet-unclaimedreward-7814"></a>
+
+### Template `UnclaimedReward`
+
+Rewards that have not been claimed and are thus at the disposal of the foundation.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| amount | Decimal |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-amulet-validatorrewardcoupon-76808"></a>
+
+### Template `ValidatorRewardCoupon`
+
+A coupon for receiving validator rewards proportional to the usage fee paid by a user
+hosted by a validator operator.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| user | Party |  |
+| amount | Decimal |  |
+| round | Round |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-amulet-validatorrewardcouponarchiveasvalidator-99406"></a>
+
+#### Choice `ValidatorRewardCoupon_ArchiveAsValidator`
+
+This choice is used by validators to archive the burn receipt upon claiming its corresponding issuance.
+
+Controllers: `dso`, `validator`
+
+Returns: `ValidatorRewardCoupon_ArchiveAsValidatorResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validator | Party |  |
+| rightCid | ContractId ValidatorRight |  |
+
+<a id="type-splice-amulet-validatorrewardcoupondsoexpire-85552"></a>
+
+#### Choice `ValidatorRewardCoupon_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `ValidatorRewardCoupon_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+<a id="type-splice-amulet-validatorright-15964"></a>
+
+### Template `ValidatorRight`
+
+The right to claim amulet issuances for a user's burns as their validator.
+
+Signatories: `user`, `validator`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| user | Party |  |
+| validator | Party |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `user`, `validator`
+
+Returns: `()`
+
+<a id="type-splice-amulet-validatorrightarchiveasuser-43276"></a>
+
+#### Choice `ValidatorRight_ArchiveAsUser`
+
+Controllers: `user`
+
+Returns: `ValidatorRight_ArchiveAsUserResult`
+
+<a id="type-splice-amulet-validatorrightarchiveasvalidator-83210"></a>
+
+#### Choice `ValidatorRight_ArchiveAsValidator`
+
+Controllers: `validator`
+
+Returns: `ValidatorRight_ArchiveAsValidatorResult`

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-amuletallocation.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-amuletallocation.mdx
@@ -1,0 +1,93 @@
+---
+title: "Splice.AmuletAllocation"
+description: "Reference documentation for Daml module Splice.AmuletAllocation."
+---
+
+<a id="module-splice-amuletallocation-77292"></a>
+
+# Splice.AmuletAllocation
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-amuletallocation-amuletallocationdsoexpireresult-36603"></a>
+
+### `data AmuletAllocation_DsoExpireResult`
+
+Instances:
+
+- `instance Eq AmuletAllocation_DsoExpireResult`
+- `instance Show AmuletAllocation_DsoExpireResult`
+- `instance GetField meta AmuletAllocation_DsoExpireResult Metadata`
+- `instance GetField results ExternalPartyAmuletRules_ExpireAmuletAllocationsResult [AmuletAllocation_DsoExpireResult]`
+- `instance GetField senderHoldingCids AmuletAllocation_DsoExpireResult [ContractId Holding]`
+- `instance SetField meta AmuletAllocation_DsoExpireResult Metadata`
+- `instance SetField results ExternalPartyAmuletRules_ExpireAmuletAllocationsResult [AmuletAllocation_DsoExpireResult]`
+- `instance SetField senderHoldingCids AmuletAllocation_DsoExpireResult [ContractId Holding]`
+- `instance HasExercise AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult`
+- `instance HasFromAnyChoice AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult`
+- `instance HasToAnyChoice AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult`
+
+## Functions
+
+<a id="function-splice-amuletallocation-allocationtotwosteptransfer-63709"></a>
+
+### `allocationToTwoStepTransfer`
+
+```daml
+allocationToTwoStepTransfer : AllocationSpecification -> TwoStepTransfer
+```
+
+## Templates
+
+<a id="type-splice-amuletallocation-amuletallocation-39850"></a>
+
+### Template `AmuletAllocation`
+
+Amulet allocated in locked form to a trade.
+
+Signatories: `allocationInstrumentAdmin allocation`, `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| lockedAmulet | ContractId LockedAmulet | Locked amulet that holds the funds for the allocation |
+| allocation | AllocationSpecification |  |
+
+Choices:
+
+<a id="type-splice-amuletallocation-amuletallocationdsoexpire-72174"></a>
+
+#### Choice `AmuletAllocation_DsoExpire`
+
+Controllers: `allocationInstrumentAdmin allocation`
+
+Returns: `AmuletAllocation_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireLock | Bool |  |
+
+#### Choice `Archive`
+
+Controllers: `allocationInstrumentAdmin allocation`, `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-amuletconfig.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-amuletconfig.mdx
@@ -1,0 +1,311 @@
+---
+title: "Splice.AmuletConfig"
+description: "Reference documentation for Daml module Splice.AmuletConfig."
+---
+
+<a id="module-splice-amuletconfig-30440"></a>
+
+# Splice.AmuletConfig
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-amuletconfig-amulet-69874"></a>
+
+### `data Amulet`
+
+Deprecated type for specifying amounts and fees in units of Amulet. Use Splice.Amulet.Amulet directly instead.
+
+Constructors:
+
+<a id="constr-splice-amuletconfig-amulet-76435"></a>
+- `Amulet`
+
+Instances:
+
+- `instance Eq Amulet`
+- `instance Show Amulet`
+
+<a id="type-splice-amuletconfig-amuletconfig-37414"></a>
+
+### `data AmuletConfig unit`
+
+Configuration includes TransferConfig, issuance curve and tickDuration
+
+See Splice.Scripts.Parameters for concrete values.
+
+Constructors:
+
+<a id="constr-splice-amuletconfig-amuletconfig-91595"></a>
+- `AmuletConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferConfig | TransferConfig unit | Configuration determining the fees and limits for Amulet transfers |
+| issuanceCurve | Schedule RelTime IssuanceConfig | Issuance curve to use. |
+| decentralizedSynchronizer | AmuletDecentralizedSynchronizerConfig | Configuration for the decentralized synchronizer and its fees.<br/><br/>TODO(M4-85): the values in here are likely quite large (several URls and long synchronizerIds) and not required for executing transfers. Split this part of the config out into a separate contract as a performance optimization. |
+| tickDuration | RelTime | Duration of a tick, which is the duration of half a round. |
+| packageConfig | PackageConfig | Configuration determining the version of each package<br/><br/>that should be used for command submissions. |
+| transferPreapprovalFee | Optional Decimal | Fee for keeping a transfer pre-approval around. |
+| featuredAppActivityMarkerAmount | Optional Decimal | $-amount used for the conversion from FeaturedAppActivityMarker -> AppRewardCoupon |
+| optDevelopmentFundManager | Optional Party | Party authorized to manage and allocate minting rights from the Development Fund. |
+| externalPartyConfigStateTickDuration | Optional RelTime | Half the lifetime of an `ExternalPartyConfigState` contract and the overlap between two successive contracts. Default: 24h. |
+
+Instances:
+
+- `instance Patchable (AmuletConfig USD)`
+- `instance Eq (AmuletConfig unit)`
+- `instance Show (AmuletConfig unit)`
+- `instance GetField baseConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance GetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance GetField decentralizedSynchronizer (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig`
+- `instance GetField externalPartyConfigStateTickDuration (AmuletConfig unit) (Optional RelTime)`
+- `instance GetField featuredAppActivityMarkerAmount (AmuletConfig unit) (Optional Decimal)`
+- `instance GetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
+- `instance GetField newConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance GetField newScheduleItem AmuletRules_AddFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance GetField optDevelopmentFundManager (AmuletConfig unit) (Optional Party)`
+- `instance GetField packageConfig (AmuletConfig unit) PackageConfig`
+- `instance GetField scheduleItem AmuletRules_UpdateFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance GetField tickDuration (AmuletConfig unit) RelTime`
+- `instance GetField transferConfig (AmuletConfig unit) (TransferConfig unit)`
+- `instance GetField transferPreapprovalFee (AmuletConfig unit) (Optional Decimal)`
+- `instance SetField baseConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance SetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance SetField decentralizedSynchronizer (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig`
+- `instance SetField externalPartyConfigStateTickDuration (AmuletConfig unit) (Optional RelTime)`
+- `instance SetField featuredAppActivityMarkerAmount (AmuletConfig unit) (Optional Decimal)`
+- `instance SetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
+- `instance SetField newConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance SetField newScheduleItem AmuletRules_AddFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance SetField optDevelopmentFundManager (AmuletConfig unit) (Optional Party)`
+- `instance SetField packageConfig (AmuletConfig unit) PackageConfig`
+- `instance SetField scheduleItem AmuletRules_UpdateFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance SetField tickDuration (AmuletConfig unit) RelTime`
+- `instance SetField transferConfig (AmuletConfig unit) (TransferConfig unit)`
+- `instance SetField transferPreapprovalFee (AmuletConfig unit) (Optional Decimal)`
+
+<a id="type-splice-amuletconfig-packageconfig-59903"></a>
+
+### `data PackageConfig`
+
+The package config defines for each daml package (identified by name)
+the package version that should be used for command submissions
+at that point.
+
+Constructors:
+
+<a id="constr-splice-amuletconfig-packageconfig-69032"></a>
+- `PackageConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amulet | Text |  |
+| amuletNameService | Text |  |
+| dsoGovernance | Text |  |
+| validatorLifecycle | Text |  |
+| wallet | Text |  |
+| walletPayments | Text |  |
+
+Instances:
+
+- `instance Patchable PackageConfig`
+- `instance Eq PackageConfig`
+- `instance Show PackageConfig`
+- `instance GetField amulet PackageConfig Text`
+- `instance GetField amuletNameService PackageConfig Text`
+- `instance GetField dsoGovernance PackageConfig Text`
+- `instance GetField packageConfig (AmuletConfig unit) PackageConfig`
+- `instance GetField validatorLifecycle PackageConfig Text`
+- `instance GetField wallet PackageConfig Text`
+- `instance GetField walletPayments PackageConfig Text`
+- `instance SetField amulet PackageConfig Text`
+- `instance SetField amuletNameService PackageConfig Text`
+- `instance SetField dsoGovernance PackageConfig Text`
+- `instance SetField packageConfig (AmuletConfig unit) PackageConfig`
+- `instance SetField validatorLifecycle PackageConfig Text`
+- `instance SetField wallet PackageConfig Text`
+- `instance SetField walletPayments PackageConfig Text`
+
+<a id="type-splice-amuletconfig-transferconfig-45691"></a>
+
+### `data TransferConfig unit`
+
+Configuration determining the fees and limits for Amulet transfers granted by
+the AmuletRules.
+
+See Splice.Scripts.Parameters for concrete values.
+
+Constructors:
+
+<a id="constr-splice-amuletconfig-transferconfig-20622"></a>
+- `TransferConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| createFee | FixedFee | Fee to create a new amulet. |
+| holdingFee | RatePerRound | Fee for keeping an amulet around. |
+| transferFee | SteppedRate | Fee for transferring some amount of amulet to a new owner. |
+| lockHolderFee | FixedFee | Fee per lock holder of a locked amulet. |
+| extraFeaturedAppRewardAmount | Decimal | Extra $-amount of reward for featured apps. |
+| maxNumInputs | Int | Maximum number of batch inputs for a transfer. |
+| maxNumOutputs | Int | Maximum number of batch outputs for a transfer. |
+| maxNumLockHolders | Int | Maximum number of lock holders allowed for a locked amulet. |
+
+Instances:
+
+- `instance Patchable (TransferConfig USD)`
+- `instance Eq (TransferConfig unit)`
+- `instance Show (TransferConfig unit)`
+- `instance GetField config TransferContextSummary (TransferConfig Amulet)`
+- `instance GetField createFee (TransferConfig unit) FixedFee`
+- `instance GetField extraFeaturedAppRewardAmount (TransferConfig unit) Decimal`
+- `instance GetField holdingFee (TransferConfig unit) RatePerRound`
+- `instance GetField lockHolderFee (TransferConfig unit) FixedFee`
+- `instance GetField maxNumInputs (TransferConfig unit) Int`
+- `instance GetField maxNumLockHolders (TransferConfig unit) Int`
+- `instance GetField maxNumOutputs (TransferConfig unit) Int`
+- `instance GetField transferConfig (AmuletConfig unit) (TransferConfig unit)`
+- `instance GetField transferConfigUsd OpenMiningRound (TransferConfig USD)`
+- `instance GetField transferFee (TransferConfig unit) SteppedRate`
+- `instance SetField config TransferContextSummary (TransferConfig Amulet)`
+- `instance SetField createFee (TransferConfig unit) FixedFee`
+- `instance SetField extraFeaturedAppRewardAmount (TransferConfig unit) Decimal`
+- `instance SetField holdingFee (TransferConfig unit) RatePerRound`
+- `instance SetField lockHolderFee (TransferConfig unit) FixedFee`
+- `instance SetField maxNumInputs (TransferConfig unit) Int`
+- `instance SetField maxNumLockHolders (TransferConfig unit) Int`
+- `instance SetField maxNumOutputs (TransferConfig unit) Int`
+- `instance SetField transferConfig (AmuletConfig unit) (TransferConfig unit)`
+- `instance SetField transferConfigUsd OpenMiningRound (TransferConfig USD)`
+- `instance SetField transferFee (TransferConfig unit) SteppedRate`
+
+<a id="type-splice-amuletconfig-transferconfigv2-59993"></a>
+
+### `data TransferConfigV2 unit`
+
+Stripped down TransferConfig after CIP 78 removed fees.
+
+Constructors:
+
+<a id="constr-splice-amuletconfig-transferconfigv2-42628"></a>
+- `TransferConfigV2`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| holdingFee | RatePerRound |  |
+| maxNumInputs | Int |  |
+| maxNumOutputs | Int |  |
+| maxNumLockHolders | Int |  |
+
+Instances:
+
+- `instance Eq (TransferConfigV2 unit)`
+- `instance Show (TransferConfigV2 unit)`
+- `instance GetField config TransferContextSummaryV2 (TransferConfigV2 Amulet)`
+- `instance GetField holdingFee (TransferConfigV2 unit) RatePerRound`
+- `instance GetField maxNumInputs (TransferConfigV2 unit) Int`
+- `instance GetField maxNumLockHolders (TransferConfigV2 unit) Int`
+- `instance GetField maxNumOutputs (TransferConfigV2 unit) Int`
+- `instance GetField transferConfig ExternalPartyConfigState (TransferConfigV2 USD)`
+- `instance SetField config TransferContextSummaryV2 (TransferConfigV2 Amulet)`
+- `instance SetField holdingFee (TransferConfigV2 unit) RatePerRound`
+- `instance SetField maxNumInputs (TransferConfigV2 unit) Int`
+- `instance SetField maxNumLockHolders (TransferConfigV2 unit) Int`
+- `instance SetField maxNumOutputs (TransferConfigV2 unit) Int`
+- `instance SetField transferConfig ExternalPartyConfigState (TransferConfigV2 USD)`
+
+<a id="type-splice-amuletconfig-usd-42527"></a>
+
+### `data USD`
+
+Constructors:
+
+<a id="constr-splice-amuletconfig-usd-28992"></a>
+- `USD`
+
+Instances:
+
+- `instance Patchable (AmuletConfig USD)`
+- `instance Patchable (TransferConfig USD)`
+- `instance Eq USD`
+- `instance Show USD`
+- `instance GetField baseConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance GetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance GetField newConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance GetField newScheduleItem AmuletRules_AddFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance GetField scheduleItem AmuletRules_UpdateFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance GetField transferConfig ExternalPartyConfigState (TransferConfigV2 USD)`
+- `instance GetField transferConfigUsd OpenMiningRound (TransferConfig USD)`
+- `instance SetField baseConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance SetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance SetField newConfig AmuletRules_SetConfig (AmuletConfig USD)`
+- `instance SetField newScheduleItem AmuletRules_AddFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance SetField scheduleItem AmuletRules_UpdateFutureAmuletConfigSchedule (Time, AmuletConfig USD)`
+- `instance SetField transferConfig ExternalPartyConfigState (TransferConfigV2 USD)`
+- `instance SetField transferConfigUsd OpenMiningRound (TransferConfig USD)`
+
+## Functions
+
+<a id="function-splice-amuletconfig-transferconfigtotransferconfigv2-63497"></a>
+
+### `transferConfigToTransferConfigV2`
+
+```daml
+transferConfigToTransferConfigV2 : TransferConfig unit -> TransferConfigV2 unit
+```
+
+<a id="function-splice-amuletconfig-getexternalpartyconfigstatetickduration-34672"></a>
+
+### `getExternalPartyConfigStateTickDuration`
+
+```daml
+getExternalPartyConfigStateTickDuration : AmuletConfig a -> RelTime
+```
+
+<a id="function-splice-amuletconfig-defaulttransferpreapprovalfee-76073"></a>
+
+### `defaultTransferPreapprovalFee`
+
+```daml
+defaultTransferPreapprovalFee : Decimal
+```
+
+<a id="function-splice-amuletconfig-validamuletconfig-8963"></a>
+
+### `validAmuletConfig`
+
+```daml
+validAmuletConfig : AmuletConfig unit -> Bool
+```
+
+<a id="function-splice-amuletconfig-validtransferconfig-77162"></a>
+
+### `validTransferConfig`
+
+```daml
+validTransferConfig : TransferConfig unit -> Bool
+```
+
+<a id="function-splice-amuletconfig-validpackageconfig-27952"></a>
+
+### `validPackageConfig`
+
+```daml
+validPackageConfig : PackageConfig -> Bool
+```
+
+Package configs are not constrained at the Daml level to maximize flexibility.
+In particular, empty packages versions might be used in the future to indicate that
+no version of that package should be vetted.

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-amuletrules.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-amuletrules.mdx
@@ -1,0 +1,2457 @@
+---
+title: "Splice.AmuletRules"
+description: "Reference documentation for Daml module Splice.AmuletRules."
+---
+
+<a id="module-splice-amuletrules-25638"></a>
+
+# Splice.AmuletRules
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-amuletrules-amuletrulesaddfutureamuletconfigscheduleresult-28167"></a>
+
+### `data AmuletRules_AddFutureAmuletConfigScheduleResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesaddfutureamuletconfigscheduleresult-43322"></a>
+- `AmuletRules_AddFutureAmuletConfigScheduleResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newAmuletRules | ContractId AmuletRules |  |
+
+Instances:
+
+- `instance GetField newAmuletRules AmuletRules_AddFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance SetField newAmuletRules AmuletRules_AddFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance HasExercise AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult`
+
+<a id="type-splice-amuletrules-amuletrulesadvanceopenminingroundsresult-46823"></a>
+
+### `data AmuletRules_AdvanceOpenMiningRoundsResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesadvanceopenminingroundsresult-34806"></a>
+- `AmuletRules_AdvanceOpenMiningRoundsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| summarizingRoundCid | ContractId SummarizingMiningRound |  |
+| openRoundCid | ContractId OpenMiningRound |  |
+
+Instances:
+
+- `instance GetField openRoundCid AmuletRules_AdvanceOpenMiningRoundsResult (ContractId OpenMiningRound)`
+- `instance GetField summarizingRoundCid AmuletRules_AdvanceOpenMiningRoundsResult (ContractId SummarizingMiningRound)`
+- `instance SetField openRoundCid AmuletRules_AdvanceOpenMiningRoundsResult (ContractId OpenMiningRound)`
+- `instance SetField summarizingRoundCid AmuletRules_AdvanceOpenMiningRoundsResult (ContractId SummarizingMiningRound)`
+- `instance HasExercise AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult`
+
+<a id="type-splice-amuletrules-amuletrulesallocatedevelopmentfundcouponresult-49827"></a>
+
+### `data AmuletRules_AllocateDevelopmentFundCouponResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesallocatedevelopmentfundcouponresult-81038"></a>
+- `AmuletRules_AllocateDevelopmentFundCouponResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| developmentFundCouponCid | ContractId DevelopmentFundCoupon |  |
+| optUnclaimedDevelopmentFundCouponCid | Optional (ContractId UnclaimedDevelopmentFundCoupon) |  |
+
+Instances:
+
+- `instance GetField developmentFundCouponCid AmuletRules_AllocateDevelopmentFundCouponResult (ContractId DevelopmentFundCoupon)`
+- `instance GetField optUnclaimedDevelopmentFundCouponCid AmuletRules_AllocateDevelopmentFundCouponResult (Optional (ContractId UnclaimedDevelopmentFundCoupon))`
+- `instance SetField developmentFundCouponCid AmuletRules_AllocateDevelopmentFundCouponResult (ContractId DevelopmentFundCoupon)`
+- `instance SetField optUnclaimedDevelopmentFundCouponCid AmuletRules_AllocateDevelopmentFundCouponResult (Optional (ContractId UnclaimedDevelopmentFundCoupon))`
+- `instance HasExercise AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult`
+
+<a id="type-splice-amuletrules-amuletrulesamuletexpiretransferinstructionsresult-58846"></a>
+
+### `data AmuletRules_Amulet_ExpireTransferInstructionsResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesamuletexpiretransferinstructionsresult-66147"></a>
+- `AmuletRules_Amulet_ExpireTransferInstructionsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| results | [TransferInstructionResult] |  |
+
+Instances:
+
+- `instance Eq AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance Show AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance GetField results AmuletRules_Amulet_ExpireTransferInstructionsResult [TransferInstructionResult]`
+- `instance SetField results AmuletRules_Amulet_ExpireTransferInstructionsResult [TransferInstructionResult]`
+- `instance HasExercise AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult`
+
+<a id="type-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstateresult-72638"></a>
+
+### `data AmuletRules_BootstrapExternalPartyConfigStateResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstateresult-91611"></a>
+- `AmuletRules_BootstrapExternalPartyConfigStateResult`
+
+Instances:
+
+- `instance Eq AmuletRules_BootstrapExternalPartyConfigStateResult`
+- `instance Show AmuletRules_BootstrapExternalPartyConfigStateResult`
+- `instance HasExercise AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult`
+
+<a id="type-splice-amuletrules-amuletrulesbootstraproundsresult-84997"></a>
+
+### `data AmuletRules_Bootstrap_RoundsResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesbootstraproundsresult-21662"></a>
+- `AmuletRules_Bootstrap_RoundsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openMiningRoundCid | ContractId OpenMiningRound |  |
+| initialRound | Optional Round |  |
+
+Instances:
+
+- `instance GetField initialRound AmuletRules_Bootstrap_RoundsResult (Optional Round)`
+- `instance GetField openMiningRoundCid AmuletRules_Bootstrap_RoundsResult (ContractId OpenMiningRound)`
+- `instance SetField initialRound AmuletRules_Bootstrap_RoundsResult (Optional Round)`
+- `instance SetField openMiningRoundCid AmuletRules_Bootstrap_RoundsResult (ContractId OpenMiningRound)`
+- `instance HasExercise AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult`
+
+<a id="type-splice-amuletrules-amuletrulesbuymembertrafficresult-65734"></a>
+
+### `data AmuletRules_BuyMemberTrafficResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesbuymembertrafficresult-62493"></a>
+- `AmuletRules_BuyMemberTrafficResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| round | Round |  |
+| summary | TransferSummary |  |
+| amuletPaid | Decimal |  |
+| purchasedTraffic | ContractId MemberTraffic |  |
+| senderChangeAmulet | Optional (ContractId Amulet) |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq AmuletRules_BuyMemberTrafficResult`
+- `instance Show AmuletRules_BuyMemberTrafficResult`
+- `instance GetField amuletPaid AmuletRules_BuyMemberTrafficResult Decimal`
+- `instance GetField meta AmuletRules_BuyMemberTrafficResult (Optional Metadata)`
+- `instance GetField purchasedTraffic AmuletRules_BuyMemberTrafficResult (ContractId MemberTraffic)`
+- `instance GetField round AmuletRules_BuyMemberTrafficResult Round`
+- `instance GetField senderChangeAmulet AmuletRules_BuyMemberTrafficResult (Optional (ContractId Amulet))`
+- `instance GetField summary AmuletRules_BuyMemberTrafficResult TransferSummary`
+- `instance SetField amuletPaid AmuletRules_BuyMemberTrafficResult Decimal`
+- `instance SetField meta AmuletRules_BuyMemberTrafficResult (Optional Metadata)`
+- `instance SetField purchasedTraffic AmuletRules_BuyMemberTrafficResult (ContractId MemberTraffic)`
+- `instance SetField round AmuletRules_BuyMemberTrafficResult Round`
+- `instance SetField senderChangeAmulet AmuletRules_BuyMemberTrafficResult (Optional (ContractId Amulet))`
+- `instance SetField summary AmuletRules_BuyMemberTrafficResult TransferSummary`
+- `instance HasExercise AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult`
+
+<a id="type-splice-amuletrules-amuletrulesclaimexpiredrewardsresult-1315"></a>
+
+### `data AmuletRules_ClaimExpiredRewardsResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesclaimexpiredrewardsresult-54946"></a>
+- `AmuletRules_ClaimExpiredRewardsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedRewardCid | Optional (ContractId UnclaimedReward) |  |
+
+Instances:
+
+- `instance GetField unclaimedRewardCid AmuletRules_ClaimExpiredRewardsResult (Optional (ContractId UnclaimedReward))`
+- `instance SetField unclaimedRewardCid AmuletRules_ClaimExpiredRewardsResult (Optional (ContractId UnclaimedReward))`
+- `instance HasExercise AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult`
+
+<a id="type-splice-amuletrules-amuletrulescomputefeesresult-44934"></a>
+
+### `data AmuletRules_ComputeFeesResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulescomputefeesresult-49467"></a>
+- `AmuletRules_ComputeFeesResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| fees | [Decimal] |  |
+
+Instances:
+
+- `instance GetField fees AmuletRules_ComputeFeesResult [Decimal]`
+- `instance SetField fees AmuletRules_ComputeFeesResult [Decimal]`
+- `instance HasExercise AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult`
+
+<a id="type-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkersresult-77612"></a>
+
+### `data AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkersresult-46141"></a>
+- `AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| appRewardCouponCids | [ContractId AppRewardCoupon] |  |
+
+Instances:
+
+- `instance GetField appRewardCouponCids AmuletRules_ConvertFeaturedAppActivityMarkersResult [ContractId AppRewardCoupon]`
+- `instance SetField appRewardCouponCids AmuletRules_ConvertFeaturedAppActivityMarkersResult [ContractId AppRewardCoupon]`
+- `instance HasExercise AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+<a id="type-splice-amuletrules-amuletrulescreateexternalpartysetupproposalresult-7515"></a>
+
+### `data AmuletRules_CreateExternalPartySetupProposalResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulescreateexternalpartysetupproposalresult-29120"></a>
+- `AmuletRules_CreateExternalPartySetupProposalResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| proposalCid | ContractId ExternalPartySetupProposal |  |
+| user | Party |  |
+| validator | Party |  |
+| transferResult | TransferResult |  |
+| amuletPaid | Decimal |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq AmuletRules_CreateExternalPartySetupProposalResult`
+- `instance Show AmuletRules_CreateExternalPartySetupProposalResult`
+- `instance GetField amuletPaid AmuletRules_CreateExternalPartySetupProposalResult Decimal`
+- `instance GetField meta AmuletRules_CreateExternalPartySetupProposalResult (Optional Metadata)`
+- `instance GetField proposalCid AmuletRules_CreateExternalPartySetupProposalResult (ContractId ExternalPartySetupProposal)`
+- `instance GetField transferResult AmuletRules_CreateExternalPartySetupProposalResult TransferResult`
+- `instance GetField user AmuletRules_CreateExternalPartySetupProposalResult Party`
+- `instance GetField validator AmuletRules_CreateExternalPartySetupProposalResult Party`
+- `instance SetField amuletPaid AmuletRules_CreateExternalPartySetupProposalResult Decimal`
+- `instance SetField meta AmuletRules_CreateExternalPartySetupProposalResult (Optional Metadata)`
+- `instance SetField proposalCid AmuletRules_CreateExternalPartySetupProposalResult (ContractId ExternalPartySetupProposal)`
+- `instance SetField transferResult AmuletRules_CreateExternalPartySetupProposalResult TransferResult`
+- `instance SetField user AmuletRules_CreateExternalPartySetupProposalResult Party`
+- `instance SetField validator AmuletRules_CreateExternalPartySetupProposalResult Party`
+- `instance HasExercise AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult`
+
+<a id="type-splice-amuletrules-amuletrulescreatetransferpreapprovalresult-96401"></a>
+
+### `data AmuletRules_CreateTransferPreapprovalResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulescreatetransferpreapprovalresult-40608"></a>
+- `AmuletRules_CreateTransferPreapprovalResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferPreapprovalCid | ContractId TransferPreapproval |  |
+| transferResult | TransferResult |  |
+| amuletPaid | Decimal |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq AmuletRules_CreateTransferPreapprovalResult`
+- `instance Show AmuletRules_CreateTransferPreapprovalResult`
+- `instance GetField amuletPaid AmuletRules_CreateTransferPreapprovalResult Decimal`
+- `instance GetField meta AmuletRules_CreateTransferPreapprovalResult (Optional Metadata)`
+- `instance GetField transferPreapprovalCid AmuletRules_CreateTransferPreapprovalResult (ContractId TransferPreapproval)`
+- `instance GetField transferResult AmuletRules_CreateTransferPreapprovalResult TransferResult`
+- `instance SetField amuletPaid AmuletRules_CreateTransferPreapprovalResult Decimal`
+- `instance SetField meta AmuletRules_CreateTransferPreapprovalResult (Optional Metadata)`
+- `instance SetField transferPreapprovalCid AmuletRules_CreateTransferPreapprovalResult (ContractId TransferPreapproval)`
+- `instance SetField transferResult AmuletRules_CreateTransferPreapprovalResult TransferResult`
+- `instance HasExercise AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult`
+
+<a id="type-splice-amuletrules-amuletrulesdevnetfeatureappresult-75066"></a>
+
+### `data AmuletRules_DevNet_FeatureAppResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesdevnetfeatureappresult-18203"></a>
+- `AmuletRules_DevNet_FeatureAppResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppRightCid | ContractId FeaturedAppRight |  |
+
+Instances:
+
+- `instance GetField featuredAppRightCid AmuletRules_DevNet_FeatureAppResult (ContractId FeaturedAppRight)`
+- `instance SetField featuredAppRightCid AmuletRules_DevNet_FeatureAppResult (ContractId FeaturedAppRight)`
+- `instance HasExercise AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult`
+
+<a id="type-splice-amuletrules-amuletrulesdevnettapresult-1845"></a>
+
+### `data AmuletRules_DevNet_TapResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesdevnettapresult-50542"></a>
+- `AmuletRules_DevNet_TapResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance GetField amuletSum AmuletRules_DevNet_TapResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField meta AmuletRules_DevNet_TapResult (Optional Metadata)`
+- `instance SetField amuletSum AmuletRules_DevNet_TapResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField meta AmuletRules_DevNet_TapResult (Optional Metadata)`
+- `instance HasExercise AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult`
+
+<a id="type-splice-amuletrules-amuletrulesexpiretransferinstructioninput-68344"></a>
+
+### `data AmuletRules_ExpireTransferInstructionInput`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesexpiretransferinstructioninput-66803"></a>
+- `AmuletRules_ExpireTransferInstructionInput`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferInstructionCid | ContractId TransferInstruction |  |
+| expireLock | Bool |  |
+
+Instances:
+
+- `instance Eq AmuletRules_ExpireTransferInstructionInput`
+- `instance Show AmuletRules_ExpireTransferInstructionInput`
+- `instance GetField expireLock AmuletRules_ExpireTransferInstructionInput Bool`
+- `instance GetField inputs AmuletRules_Amulet_ExpireTransferInstructions [AmuletRules_ExpireTransferInstructionInput]`
+- `instance GetField transferInstructionCid AmuletRules_ExpireTransferInstructionInput (ContractId TransferInstruction)`
+- `instance SetField expireLock AmuletRules_ExpireTransferInstructionInput Bool`
+- `instance SetField inputs AmuletRules_Amulet_ExpireTransferInstructions [AmuletRules_ExpireTransferInstructionInput]`
+- `instance SetField transferInstructionCid AmuletRules_ExpireTransferInstructionInput (ContractId TransferInstruction)`
+
+<a id="type-splice-amuletrules-amuletrulesmergemembertrafficcontractsresult-2448"></a>
+
+### `data AmuletRules_MergeMemberTrafficContractsResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesmergemembertrafficcontractsresult-32033"></a>
+- `AmuletRules_MergeMemberTrafficContractsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| mergedTrafficCid | ContractId MemberTraffic |  |
+
+Instances:
+
+- `instance GetField mergedTrafficCid AmuletRules_MergeMemberTrafficContractsResult (ContractId MemberTraffic)`
+- `instance SetField mergedTrafficCid AmuletRules_MergeMemberTrafficContractsResult (ContractId MemberTraffic)`
+- `instance HasExercise AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult`
+
+<a id="type-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcouponsresult-42676"></a>
+
+### `data AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcouponsresult-50551"></a>
+- `AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCid | ContractId UnclaimedDevelopmentFundCoupon |  |
+
+Instances:
+
+- `instance GetField unclaimedDevelopmentFundCouponCid AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance SetField unclaimedDevelopmentFundCouponCid AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult (ContractId UnclaimedDevelopmentFundCoupon)`
+- `instance HasExercise AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+<a id="type-splice-amuletrules-amuletrulesmergeunclaimedrewardsresult-41840"></a>
+
+### `data AmuletRules_MergeUnclaimedRewardsResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesmergeunclaimedrewardsresult-46793"></a>
+- `AmuletRules_MergeUnclaimedRewardsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedRewardCid | ContractId UnclaimedReward |  |
+
+Instances:
+
+- `instance GetField unclaimedRewardCid AmuletRules_MergeUnclaimedRewardsResult (ContractId UnclaimedReward)`
+- `instance SetField unclaimedRewardCid AmuletRules_MergeUnclaimedRewardsResult (ContractId UnclaimedReward)`
+- `instance HasExercise AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult`
+
+<a id="type-splice-amuletrules-amuletrulesminingroundarchiveresult-65797"></a>
+
+### `data AmuletRules_MiningRound_ArchiveResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesminingroundarchiveresult-73420"></a>
+- `AmuletRules_MiningRound_ArchiveResult`
+
+Instances:
+
+- `instance HasExercise AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult`
+
+<a id="type-splice-amuletrules-amuletrulesminingroundcloseresult-67441"></a>
+
+### `data AmuletRules_MiningRound_CloseResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesminingroundcloseresult-19004"></a>
+- `AmuletRules_MiningRound_CloseResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+Instances:
+
+- `instance GetField closedRoundCid AmuletRules_MiningRound_CloseResult (ContractId ClosedMiningRound)`
+- `instance SetField closedRoundCid AmuletRules_MiningRound_CloseResult (ContractId ClosedMiningRound)`
+- `instance HasExercise AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult`
+
+<a id="type-splice-amuletrules-amuletrulesminingroundstartissuingresult-26220"></a>
+
+### `data AmuletRules_MiningRound_StartIssuingResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesminingroundstartissuingresult-95691"></a>
+- `AmuletRules_MiningRound_StartIssuingResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| issuingRoundCid | ContractId IssuingMiningRound |  |
+| unclaimedDevelopmentFundCouponCid | Optional (ContractId UnclaimedDevelopmentFundCoupon) |  |
+
+Instances:
+
+- `instance GetField issuingRoundCid AmuletRules_MiningRound_StartIssuingResult (ContractId IssuingMiningRound)`
+- `instance GetField unclaimedDevelopmentFundCouponCid AmuletRules_MiningRound_StartIssuingResult (Optional (ContractId UnclaimedDevelopmentFundCoupon))`
+- `instance SetField issuingRoundCid AmuletRules_MiningRound_StartIssuingResult (ContractId IssuingMiningRound)`
+- `instance SetField unclaimedDevelopmentFundCouponCid AmuletRules_MiningRound_StartIssuingResult (Optional (ContractId UnclaimedDevelopmentFundCoupon))`
+- `instance HasExercise AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult`
+
+<a id="type-splice-amuletrules-amuletrulesmintresult-5311"></a>
+
+### `data AmuletRules_MintResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesmintresult-82812"></a>
+- `AmuletRules_MintResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amuletSum AmuletRules_MintResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum AmuletRules_MintResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise AmuletRules AmuletRules_Mint AmuletRules_MintResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_Mint AmuletRules_MintResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_Mint AmuletRules_MintResult`
+
+<a id="type-splice-amuletrules-amuletrulesremovefutureamuletconfigscheduleresult-69237"></a>
+
+### `data AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesremovefutureamuletconfigscheduleresult-56166"></a>
+- `AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newAmuletRules | ContractId AmuletRules |  |
+
+Instances:
+
+- `instance GetField newAmuletRules AmuletRules_RemoveFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance SetField newAmuletRules AmuletRules_RemoveFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance HasExercise AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+
+<a id="type-splice-amuletrules-amuletrulessetconfigresult-68086"></a>
+
+### `data AmuletRules_SetConfigResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulessetconfigresult-73787"></a>
+- `AmuletRules_SetConfigResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newAmuletRules | ContractId AmuletRules |  |
+
+Instances:
+
+- `instance GetField newAmuletRules AmuletRules_SetConfigResult (ContractId AmuletRules)`
+- `instance SetField newAmuletRules AmuletRules_SetConfigResult (ContractId AmuletRules)`
+- `instance HasExercise AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult`
+
+<a id="type-splice-amuletrules-amuletrulesupdateexternalpartyconfigstatesresult-25160"></a>
+
+### `data AmuletRules_UpdateExternalPartyConfigStatesResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesupdateexternalpartyconfigstatesresult-25761"></a>
+- `AmuletRules_UpdateExternalPartyConfigStatesResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newExternalPartyConfigStateCid | ContractId ExternalPartyConfigState |  |
+
+Instances:
+
+- `instance Eq AmuletRules_UpdateExternalPartyConfigStatesResult`
+- `instance Show AmuletRules_UpdateExternalPartyConfigStatesResult`
+- `instance GetField newExternalPartyConfigStateCid AmuletRules_UpdateExternalPartyConfigStatesResult (ContractId ExternalPartyConfigState)`
+- `instance SetField newExternalPartyConfigStateCid AmuletRules_UpdateExternalPartyConfigStatesResult (ContractId ExternalPartyConfigState)`
+- `instance HasExercise AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult`
+
+<a id="type-splice-amuletrules-amuletrulesupdatefutureamuletconfigscheduleresult-96070"></a>
+
+### `data AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-amuletrulesupdatefutureamuletconfigscheduleresult-12117"></a>
+- `AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newAmuletRules | ContractId AmuletRules |  |
+
+Instances:
+
+- `instance GetField newAmuletRules AmuletRules_UpdateFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance SetField newAmuletRules AmuletRules_UpdateFutureAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance HasExercise AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+
+<a id="type-splice-amuletrules-apptransfercontext-68083"></a>
+
+### `data AppTransferContext`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-apptransfercontext-19128"></a>
+- `AppTransferContext`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRules | ContractId AmuletRules |  |
+| openMiningRound | ContractId OpenMiningRound |  |
+| featuredAppRight | Optional (ContractId FeaturedAppRight) |  |
+
+Instances:
+
+- `instance Eq AppTransferContext`
+- `instance Show AppTransferContext`
+- `instance GetField amuletRules AppTransferContext (ContractId AmuletRules)`
+- `instance GetField featuredAppRight AppTransferContext (Optional (ContractId FeaturedAppRight))`
+- `instance GetField openMiningRound AppTransferContext (ContractId OpenMiningRound)`
+- `instance SetField amuletRules AppTransferContext (ContractId AmuletRules)`
+- `instance SetField featuredAppRight AppTransferContext (Optional (ContractId FeaturedAppRight))`
+- `instance SetField openMiningRound AppTransferContext (ContractId OpenMiningRound)`
+
+<a id="type-splice-amuletrules-balancechange-24411"></a>
+
+### `data BalanceChange`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-balancechange-6762"></a>
+- `BalanceChange`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| changeToInitialAmountAsOfRoundZero | Decimal | The change to the total balance introduced by this balance change, normalized to round zero, i.e.,<br/><br/>a amulet created in round 3 is treated as a amulet created in round 0 with a higher initial amount. |
+| changeToHoldingFeesRate | Decimal | The change of total holding fees introduced by this balance change. |
+
+Instances:
+
+- `instance Eq BalanceChange`
+- `instance Additive BalanceChange`
+- `instance Show BalanceChange`
+- `instance GetField balanceChanges TransferSummary (Map Party BalanceChange)`
+- `instance GetField changeToHoldingFeesRate BalanceChange Decimal`
+- `instance GetField changeToInitialAmountAsOfRoundZero BalanceChange Decimal`
+- `instance SetField balanceChanges TransferSummary (Map Party BalanceChange)`
+- `instance SetField changeToHoldingFeesRate BalanceChange Decimal`
+- `instance SetField changeToInitialAmountAsOfRoundZero BalanceChange Decimal`
+
+<a id="type-splice-amuletrules-createdamulet-4205"></a>
+
+### `data CreatedAmulet`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transferresultamulet-871"></a>
+- `TransferResultAmulet (ContractId Amulet)`
+<a id="constr-splice-amuletrules-transferresultlockedamulet-28147"></a>
+- `TransferResultLockedAmulet (ContractId LockedAmulet)`
+<a id="constr-splice-amuletrules-extcreatedamulet-9390"></a>
+- `ExtCreatedAmulet`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+
+Instances:
+
+- `instance Eq CreatedAmulet`
+- `instance Ord CreatedAmulet`
+- `instance Show CreatedAmulet`
+- `instance GetField createdAmulets TransferResult [CreatedAmulet]`
+- `instance GetField dummyUnitField CreatedAmulet ()`
+- `instance SetField createdAmulets TransferResult [CreatedAmulet]`
+- `instance SetField dummyUnitField CreatedAmulet ()`
+
+<a id="type-splice-amuletrules-externalpartysetupproposalacceptresult-45221"></a>
+
+### `data ExternalPartySetupProposal_AcceptResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-externalpartysetupproposalacceptresult-28452"></a>
+- `ExternalPartySetupProposal_AcceptResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validatorRightCid | ContractId ValidatorRight |  |
+| transferPreapprovalCid | ContractId TransferPreapproval |  |
+
+Instances:
+
+- `instance Eq ExternalPartySetupProposal_AcceptResult`
+- `instance Show ExternalPartySetupProposal_AcceptResult`
+- `instance GetField transferPreapprovalCid ExternalPartySetupProposal_AcceptResult (ContractId TransferPreapproval)`
+- `instance GetField validatorRightCid ExternalPartySetupProposal_AcceptResult (ContractId ValidatorRight)`
+- `instance SetField transferPreapprovalCid ExternalPartySetupProposal_AcceptResult (ContractId TransferPreapproval)`
+- `instance SetField validatorRightCid ExternalPartySetupProposal_AcceptResult (ContractId ValidatorRight)`
+- `instance HasExercise ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult`
+- `instance HasFromAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult`
+- `instance HasToAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult`
+
+<a id="type-splice-amuletrules-externalpartysetupproposalrejectresult-76848"></a>
+
+### `data ExternalPartySetupProposal_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-externalpartysetupproposalrejectresult-73325"></a>
+- `ExternalPartySetupProposal_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyArg | () |  |
+
+Instances:
+
+- `instance Eq ExternalPartySetupProposal_RejectResult`
+- `instance Show ExternalPartySetupProposal_RejectResult`
+- `instance GetField dummyArg ExternalPartySetupProposal_RejectResult ()`
+- `instance SetField dummyArg ExternalPartySetupProposal_RejectResult ()`
+- `instance HasExercise ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult`
+- `instance HasFromAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult`
+- `instance HasToAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult`
+
+<a id="type-splice-amuletrules-externalpartysetupproposalwithdrawresult-88253"></a>
+
+### `data ExternalPartySetupProposal_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-externalpartysetupproposalwithdrawresult-17304"></a>
+- `ExternalPartySetupProposal_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyArg | () |  |
+
+Instances:
+
+- `instance Eq ExternalPartySetupProposal_WithdrawResult`
+- `instance Show ExternalPartySetupProposal_WithdrawResult`
+- `instance GetField dummyArg ExternalPartySetupProposal_WithdrawResult ()`
+- `instance SetField dummyArg ExternalPartySetupProposal_WithdrawResult ()`
+- `instance HasExercise ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult`
+- `instance HasFromAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult`
+- `instance HasToAnyChoice ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult`
+
+<a id="type-splice-amuletrules-externalpartytransfercontext-70523"></a>
+
+### `data ExternalPartyTransferContext`
+
+Contracts that need to be passed in to a Transfer so that
+we can reference them by contract id instead of by key.
+
+Constructors:
+
+<a id="constr-splice-amuletrules-externalpartytransfercontext-43164"></a>
+- `ExternalPartyTransferContext`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| externalPartyConfigState | ContractId ExternalPartyConfigState |  |
+| featuredAppRight | Optional (ContractId FeaturedAppRight) | Optional proof that the provider is a featured app provider. |
+
+Instances:
+
+- `instance Eq ExternalPartyTransferContext`
+- `instance Show ExternalPartyTransferContext`
+- `instance GetField context TransferPreapproval_SendV2 ExternalPartyTransferContext`
+- `instance GetField externalPartyConfigState ExternalPartyTransferContext (ContractId ExternalPartyConfigState)`
+- `instance GetField featuredAppRight ExternalPartyTransferContext (Optional (ContractId FeaturedAppRight))`
+- `instance SetField context TransferPreapproval_SendV2 ExternalPartyTransferContext`
+- `instance SetField externalPartyConfigState ExternalPartyTransferContext (ContractId ExternalPartyConfigState)`
+- `instance SetField featuredAppRight ExternalPartyTransferContext (Optional (ContractId FeaturedAppRight))`
+
+<a id="type-splice-amuletrules-invalidtransfer-45437"></a>
+
+### `data InvalidTransfer`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-invalidtransfer-25400"></a>
+- `InvalidTransfer`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | InvalidTransferReason |  |
+
+Instances:
+
+- `instance Eq InvalidTransfer`
+- `instance Show InvalidTransfer`
+- `instance HasFromAnyException InvalidTransfer`
+- `instance HasMessage InvalidTransfer`
+- `instance HasThrow InvalidTransfer`
+- `instance HasToAnyException InvalidTransfer`
+- `instance GetField reason InvalidTransfer InvalidTransferReason`
+- `instance SetField reason InvalidTransfer InvalidTransferReason`
+
+<a id="type-splice-amuletrules-invalidtransferreason-16587"></a>
+
+### `data InvalidTransferReason`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-itrinsufficientfunds-49975"></a>
+- `ITR_InsufficientFunds`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| missingAmount | Decimal |  |
+<a id="constr-splice-amuletrules-itrunknownsynchronizer-472"></a>
+- `ITR_UnknownSynchronizer`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| synchronizerId | Text |  |
+<a id="constr-splice-amuletrules-itrinsufficienttopupamount-60775"></a>
+- `ITR_InsufficientTopupAmount`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requestedTopupAmount | Int |  |
+| minTopupAmount | Int |  |
+<a id="constr-splice-amuletrules-itrother-36638"></a>
+- `ITR_Other`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| description | Text |  |
+<a id="constr-splice-amuletrules-extinvalidtransferreason-71060"></a>
+- `ExtInvalidTransferReason`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+
+Instances:
+
+- `instance Eq InvalidTransferReason`
+- `instance Show InvalidTransferReason`
+- `instance GetField description InvalidTransferReason Text`
+- `instance GetField dummyUnitField InvalidTransferReason ()`
+- `instance GetField minTopupAmount InvalidTransferReason Int`
+- `instance GetField missingAmount InvalidTransferReason Decimal`
+- `instance GetField reason InvalidTransfer InvalidTransferReason`
+- `instance GetField reason TransferCommandResult InvalidTransferReason`
+- `instance GetField requestedTopupAmount InvalidTransferReason Int`
+- `instance GetField synchronizerId InvalidTransferReason Text`
+- `instance SetField description InvalidTransferReason Text`
+- `instance SetField dummyUnitField InvalidTransferReason ()`
+- `instance SetField minTopupAmount InvalidTransferReason Int`
+- `instance SetField missingAmount InvalidTransferReason Decimal`
+- `instance SetField reason InvalidTransfer InvalidTransferReason`
+- `instance SetField reason TransferCommandResult InvalidTransferReason`
+- `instance SetField requestedTopupAmount InvalidTransferReason Int`
+- `instance SetField synchronizerId InvalidTransferReason Text`
+
+<a id="type-splice-amuletrules-openminingroundtriple-84091"></a>
+
+### `data OpenMiningRoundTriple`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-openminingroundtriple-73258"></a>
+- `OpenMiningRoundTriple`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| round0Cid | ContractId OpenMiningRound |  |
+| round1Cid | ContractId OpenMiningRound |  |
+| round2Cid | ContractId OpenMiningRound |  |
+
+Instances:
+
+- `instance Eq OpenMiningRoundTriple`
+- `instance Show OpenMiningRoundTriple`
+- `instance GetField openMiningRoundTriple AmuletRules_BootstrapExternalPartyConfigState OpenMiningRoundTriple`
+- `instance GetField openMiningRoundTriple AmuletRules_UpdateExternalPartyConfigStates OpenMiningRoundTriple`
+- `instance GetField round0Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+- `instance GetField round1Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+- `instance GetField round2Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+- `instance SetField openMiningRoundTriple AmuletRules_BootstrapExternalPartyConfigState OpenMiningRoundTriple`
+- `instance SetField openMiningRoundTriple AmuletRules_UpdateExternalPartyConfigStates OpenMiningRoundTriple`
+- `instance SetField round0Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+- `instance SetField round1Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+- `instance SetField round2Cid OpenMiningRoundTriple (ContractId OpenMiningRound)`
+
+<a id="type-splice-amuletrules-paymenttransfercontext-72190"></a>
+
+### `data PaymentTransferContext`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-paymenttransfercontext-9413"></a>
+- `PaymentTransferContext`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRules | ContractId AmuletRules |  |
+| context | TransferContext |  |
+
+Instances:
+
+- `instance Eq PaymentTransferContext`
+- `instance Show PaymentTransferContext`
+- `instance GetField amuletRules PaymentTransferContext (ContractId AmuletRules)`
+- `instance GetField context AmuletRules_CreateExternalPartySetupProposal PaymentTransferContext`
+- `instance GetField context AmuletRules_CreateTransferPreapproval PaymentTransferContext`
+- `instance GetField context PaymentTransferContext TransferContext`
+- `instance GetField context TransferPreapproval_Renew PaymentTransferContext`
+- `instance GetField context TransferPreapproval_Send PaymentTransferContext`
+- `instance GetField context TransferCommand_Send PaymentTransferContext`
+- `instance SetField amuletRules PaymentTransferContext (ContractId AmuletRules)`
+- `instance SetField context AmuletRules_CreateExternalPartySetupProposal PaymentTransferContext`
+- `instance SetField context AmuletRules_CreateTransferPreapproval PaymentTransferContext`
+- `instance SetField context PaymentTransferContext TransferContext`
+- `instance SetField context TransferPreapproval_Renew PaymentTransferContext`
+- `instance SetField context TransferPreapproval_Send PaymentTransferContext`
+- `instance SetField context TransferCommand_Send PaymentTransferContext`
+
+<a id="type-splice-amuletrules-preprocessedtransferoutput-12209"></a>
+
+### `data PreprocessedTransferOutput`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-preprocessedtransferoutput-93914"></a>
+- `PreprocessedTransferOutput`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| owner | Party | Owner of the output |
+| outputFee | Decimal | Fee charged to create this output |
+| amount | Decimal | Amount of amulet held by this output (after deducting fees) |
+| lock | Optional TimeLock | Whether to lock the amulet or not |
+
+Instances:
+
+- `instance Eq PreprocessedTransferOutput`
+- `instance Show PreprocessedTransferOutput`
+- `instance GetField amount PreprocessedTransferOutput Decimal`
+- `instance GetField lock PreprocessedTransferOutput (Optional TimeLock)`
+- `instance GetField outputFee PreprocessedTransferOutput Decimal`
+- `instance GetField owner PreprocessedTransferOutput Party`
+- `instance SetField amount PreprocessedTransferOutput Decimal`
+- `instance SetField lock PreprocessedTransferOutput (Optional TimeLock)`
+- `instance SetField outputFee PreprocessedTransferOutput Decimal`
+- `instance SetField owner PreprocessedTransferOutput Party`
+
+<a id="type-splice-amuletrules-rewardsissuanceconfig-37252"></a>
+
+### `data RewardsIssuanceConfig`
+
+An easy way to configure `exucuteTransfer` wrt what rewards to issue.
+We currently only use two configurations: but all of the options in here make sense, so we keep them.
+
+Constructors:
+
+<a id="constr-splice-amuletrules-rewardsissuanceconfig-46673"></a>
+- `RewardsIssuanceConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| issueAppRewards | Bool |  |
+| issueValidatorRewards | Bool |  |
+
+Instances:
+
+- `instance GetField issueAppRewards RewardsIssuanceConfig Bool`
+- `instance GetField issueValidatorRewards RewardsIssuanceConfig Bool`
+- `instance SetField issueAppRewards RewardsIssuanceConfig Bool`
+- `instance SetField issueValidatorRewards RewardsIssuanceConfig Bool`
+
+<a id="type-splice-amuletrules-transfer-72721"></a>
+
+### `data Transfer`
+
+Representation of a batch transfer.
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transfer-1214"></a>
+- `Transfer`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| provider | Party |  |
+| inputs | [TransferInput] |  |
+| outputs | [TransferOutput] |  |
+| beneficiaries | Optional [AppRewardBeneficiary] | Beneficiaries between which the app reward is split. |
+
+Instances:
+
+- `instance Eq Transfer`
+- `instance Ord Transfer`
+- `instance Show Transfer`
+- `instance GetField beneficiaries Transfer (Optional [AppRewardBeneficiary])`
+- `instance GetField inputs Transfer [TransferInput]`
+- `instance GetField outputs Transfer [TransferOutput]`
+- `instance GetField provider Transfer Party`
+- `instance GetField sender Transfer Party`
+- `instance GetField transfer AmuletRules_Transfer Transfer`
+- `instance SetField beneficiaries Transfer (Optional [AppRewardBeneficiary])`
+- `instance SetField inputs Transfer [TransferInput]`
+- `instance SetField outputs Transfer [TransferOutput]`
+- `instance SetField provider Transfer Party`
+- `instance SetField sender Transfer Party`
+- `instance SetField transfer AmuletRules_Transfer Transfer`
+
+<a id="type-splice-amuletrules-transfercontext-68991"></a>
+
+### `data TransferContext`
+
+Contracts that need to be passed in to a Transfer so that
+we can reference them by contract id instead of by key.
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transfercontext-56806"></a>
+- `TransferContext`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openMiningRound | ContractId OpenMiningRound |  |
+| issuingMiningRounds | Map Round (ContractId IssuingMiningRound) |  |
+| validatorRights | Map Party (ContractId ValidatorRight) | Map from user to ValidatorRight contract. |
+| featuredAppRight | Optional (ContractId FeaturedAppRight) | Optional proof that the provider is a featured app provider. |
+
+Instances:
+
+- `instance Eq TransferContext`
+- `instance Show TransferContext`
+- `instance GetField context AmuletRules_BuyMemberTraffic TransferContext`
+- `instance GetField context AmuletRules_ComputeFees TransferContext`
+- `instance GetField context AmuletRules_Transfer TransferContext`
+- `instance GetField context PaymentTransferContext TransferContext`
+- `instance GetField featuredAppRight TransferContext (Optional (ContractId FeaturedAppRight))`
+- `instance GetField issuingMiningRounds TransferContext (Map Round (ContractId IssuingMiningRound))`
+- `instance GetField openMiningRound TransferContext (ContractId OpenMiningRound)`
+- `instance GetField validatorRights TransferContext (Map Party (ContractId ValidatorRight))`
+- `instance SetField context AmuletRules_BuyMemberTraffic TransferContext`
+- `instance SetField context AmuletRules_ComputeFees TransferContext`
+- `instance SetField context AmuletRules_Transfer TransferContext`
+- `instance SetField context PaymentTransferContext TransferContext`
+- `instance SetField featuredAppRight TransferContext (Optional (ContractId FeaturedAppRight))`
+- `instance SetField issuingMiningRounds TransferContext (Map Round (ContractId IssuingMiningRound))`
+- `instance SetField openMiningRound TransferContext (ContractId OpenMiningRound)`
+- `instance SetField validatorRights TransferContext (Map Party (ContractId ValidatorRight))`
+
+<a id="type-splice-amuletrules-transfercontextsummary-99392"></a>
+
+### `data TransferContextSummary`
+
+Deprecated: unused, we just can't remove it yet due to upgrading rules
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transfercontextsummary-98359"></a>
+- `TransferContextSummary`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppProvider | Optional Party |  |
+| config | TransferConfig Amulet |  |
+| openRound | OpenMiningRound |  |
+| issuingMiningRounds | Map Round IssuingMiningRound |  |
+| validatorRights | Map Party (ContractId ValidatorRight) |  |
+
+Instances:
+
+- `instance Eq TransferContextSummary`
+- `instance Show TransferContextSummary`
+- `instance GetField config TransferContextSummary (TransferConfig Amulet)`
+- `instance GetField featuredAppProvider TransferContextSummary (Optional Party)`
+- `instance GetField issuingMiningRounds TransferContextSummary (Map Round IssuingMiningRound)`
+- `instance GetField openRound TransferContextSummary OpenMiningRound`
+- `instance GetField validatorRights TransferContextSummary (Map Party (ContractId ValidatorRight))`
+- `instance SetField config TransferContextSummary (TransferConfig Amulet)`
+- `instance SetField featuredAppProvider TransferContextSummary (Optional Party)`
+- `instance SetField issuingMiningRounds TransferContextSummary (Map Round IssuingMiningRound)`
+- `instance SetField openRound TransferContextSummary OpenMiningRound`
+- `instance SetField validatorRights TransferContextSummary (Map Party (ContractId ValidatorRight))`
+
+<a id="type-splice-amuletrules-transfercontextsummaryv2-75114"></a>
+
+### `data TransferContextSummaryV2`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transfercontextsummaryv2-63237"></a>
+- `TransferContextSummaryV2`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| featuredAppProvider | Optional Party |  |
+| config | TransferConfigV2 Amulet |  |
+| openRoundNumber | Round |  |
+| amuletPrice | Decimal |  |
+| issuingMiningRounds | Map Round IssuingMiningRound |  |
+| validatorRights | Map Party (ContractId ValidatorRight) |  |
+
+Instances:
+
+- `instance Eq TransferContextSummaryV2`
+- `instance Show TransferContextSummaryV2`
+- `instance GetField amuletPrice TransferContextSummaryV2 Decimal`
+- `instance GetField config TransferContextSummaryV2 (TransferConfigV2 Amulet)`
+- `instance GetField dso TransferContextSummaryV2 Party`
+- `instance GetField featuredAppProvider TransferContextSummaryV2 (Optional Party)`
+- `instance GetField issuingMiningRounds TransferContextSummaryV2 (Map Round IssuingMiningRound)`
+- `instance GetField openRoundNumber TransferContextSummaryV2 Round`
+- `instance GetField validatorRights TransferContextSummaryV2 (Map Party (ContractId ValidatorRight))`
+- `instance SetField amuletPrice TransferContextSummaryV2 Decimal`
+- `instance SetField config TransferContextSummaryV2 (TransferConfigV2 Amulet)`
+- `instance SetField dso TransferContextSummaryV2 Party`
+- `instance SetField featuredAppProvider TransferContextSummaryV2 (Optional Party)`
+- `instance SetField issuingMiningRounds TransferContextSummaryV2 (Map Round IssuingMiningRound)`
+- `instance SetField openRoundNumber TransferContextSummaryV2 Round`
+- `instance SetField validatorRights TransferContextSummaryV2 (Map Party (ContractId ValidatorRight))`
+
+<a id="type-splice-amuletrules-transferinput-61796"></a>
+
+### `data TransferInput`
+
+An individual input for a batch transfer.
+
+Constructors:
+
+<a id="constr-splice-amuletrules-inputapprewardcoupon-60885"></a>
+- `InputAppRewardCoupon (ContractId AppRewardCoupon)`
+<a id="constr-splice-amuletrules-inputvalidatorrewardcoupon-18692"></a>
+- `InputValidatorRewardCoupon (ContractId ValidatorRewardCoupon)`
+<a id="constr-splice-amuletrules-inputsvrewardcoupon-94444"></a>
+- `InputSvRewardCoupon (ContractId SvRewardCoupon)`
+<a id="constr-splice-amuletrules-inputamulet-35826"></a>
+- `InputAmulet (ContractId Amulet)`
+<a id="constr-splice-amuletrules-exttransferinput-5819"></a>
+- `ExtTransferInput`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+| optInputValidatorFaucetCoupon | Optional (ContractId ValidatorFaucetCoupon) | Added in CIP-3. Optional validator faucet coupon input into this transfer. |
+<a id="constr-splice-amuletrules-inputvalidatorlivenessactivityrecord-59154"></a>
+- `InputValidatorLivenessActivityRecord (ContractId ValidatorLivenessActivityRecord)`
+<a id="constr-splice-amuletrules-inputunclaimedactivityrecord-17727"></a>
+- `InputUnclaimedActivityRecord (ContractId UnclaimedActivityRecord)`
+<a id="constr-splice-amuletrules-inputdevelopmentfundcoupon-48881"></a>
+- `InputDevelopmentFundCoupon (ContractId DevelopmentFundCoupon)`
+
+Instances:
+
+- `instance Eq TransferInput`
+- `instance Ord TransferInput`
+- `instance Show TransferInput`
+- `instance GetField dummyUnitField TransferInput ()`
+- `instance GetField inputs AmuletRules_BuyMemberTraffic [TransferInput]`
+- `instance GetField inputs AmuletRules_CreateExternalPartySetupProposal [TransferInput]`
+- `instance GetField inputs AmuletRules_CreateTransferPreapproval [TransferInput]`
+- `instance GetField inputs Transfer [TransferInput]`
+- `instance GetField inputs TransferPreapproval_Renew [TransferInput]`
+- `instance GetField inputs TransferPreapproval_Send [TransferInput]`
+- `instance GetField inputs TransferPreapproval_SendV2 [TransferInput]`
+- `instance GetField inputs TransferCommand_Send [TransferInput]`
+- `instance GetField optInputValidatorFaucetCoupon TransferInput (Optional (ContractId ValidatorFaucetCoupon))`
+- `instance SetField dummyUnitField TransferInput ()`
+- `instance SetField inputs AmuletRules_BuyMemberTraffic [TransferInput]`
+- `instance SetField inputs AmuletRules_CreateExternalPartySetupProposal [TransferInput]`
+- `instance SetField inputs AmuletRules_CreateTransferPreapproval [TransferInput]`
+- `instance SetField inputs Transfer [TransferInput]`
+- `instance SetField inputs TransferPreapproval_Renew [TransferInput]`
+- `instance SetField inputs TransferPreapproval_Send [TransferInput]`
+- `instance SetField inputs TransferPreapproval_SendV2 [TransferInput]`
+- `instance SetField inputs TransferCommand_Send [TransferInput]`
+- `instance SetField optInputValidatorFaucetCoupon TransferInput (Optional (ContractId ValidatorFaucetCoupon))`
+
+<a id="type-splice-amuletrules-transferinputssummary-46693"></a>
+
+### `data TransferInputsSummary`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transferinputssummary-65268"></a>
+- `TransferInputsSummary`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| totalAmuletAmount | Decimal |  |
+| totalAppRewardAmount | Decimal |  |
+| totalValidatorRewardAmount | Decimal |  |
+| totalValidatorFaucetAmount | Decimal | Note that the validator faucet amount does not need to be optional in this type, as it is not stored on the ledger. |
+| totalSvRewardAmount | Decimal |  |
+| totalHoldingFees | Decimal |  |
+| amountArchivedAsOfRoundZero | Decimal |  |
+| changeToHoldingFeesRate | Decimal |  |
+| totalUnclaimedActivityRecordAmount | Optional Decimal | Note: Made optional as the addition of this field is checked by the upgrade checker<br/><br/>on package upload because `TransferInputsSummary` is serializable. |
+| totalDevelopmentFundAmount | Optional Decimal | Note: Same rationale as above — made optional to ensure compatibility with<br/><br/>the upgrade checker on package upload because `TransferInputsSummary` is serializable. |
+
+Instances:
+
+- `instance Eq TransferInputsSummary`
+- `instance Show TransferInputsSummary`
+- `instance GetField amountArchivedAsOfRoundZero TransferInputsSummary Decimal`
+- `instance GetField changeToHoldingFeesRate TransferInputsSummary Decimal`
+- `instance GetField totalAmuletAmount TransferInputsSummary Decimal`
+- `instance GetField totalAppRewardAmount TransferInputsSummary Decimal`
+- `instance GetField totalDevelopmentFundAmount TransferInputsSummary (Optional Decimal)`
+- `instance GetField totalHoldingFees TransferInputsSummary Decimal`
+- `instance GetField totalSvRewardAmount TransferInputsSummary Decimal`
+- `instance GetField totalUnclaimedActivityRecordAmount TransferInputsSummary (Optional Decimal)`
+- `instance GetField totalValidatorFaucetAmount TransferInputsSummary Decimal`
+- `instance GetField totalValidatorRewardAmount TransferInputsSummary Decimal`
+- `instance SetField amountArchivedAsOfRoundZero TransferInputsSummary Decimal`
+- `instance SetField changeToHoldingFeesRate TransferInputsSummary Decimal`
+- `instance SetField totalAmuletAmount TransferInputsSummary Decimal`
+- `instance SetField totalAppRewardAmount TransferInputsSummary Decimal`
+- `instance SetField totalDevelopmentFundAmount TransferInputsSummary (Optional Decimal)`
+- `instance SetField totalHoldingFees TransferInputsSummary Decimal`
+- `instance SetField totalSvRewardAmount TransferInputsSummary Decimal`
+- `instance SetField totalUnclaimedActivityRecordAmount TransferInputsSummary (Optional Decimal)`
+- `instance SetField totalValidatorFaucetAmount TransferInputsSummary Decimal`
+- `instance SetField totalValidatorRewardAmount TransferInputsSummary Decimal`
+
+<a id="type-splice-amuletrules-transferoutput-70512"></a>
+
+### `data TransferOutput`
+
+An individual output for a batch transfer.
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transferoutput-68311"></a>
+- `TransferOutput`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party | The receiver who will own the created output amulet. |
+| receiverFeeRatio | Decimal | The ratio of the output fee paid from receiver's output amount.<br/><br/>1.0 means the whole fee is deducted from the specified output amount,<br/><br/>0.0 the whole fee is deducted from the sender's input balance.<br/><br/>If a receiver's fee is not covered by the specified output amount, the transfer is aborted. |
+| amount | Decimal | The amount of amulet to receive, before deducting the receiver's part of the output fee. |
+| lock | Optional TimeLock | The lock to be added, if any. |
+
+Instances:
+
+- `instance Eq TransferOutput`
+- `instance Ord TransferOutput`
+- `instance Show TransferOutput`
+- `instance GetField amount TransferOutput Decimal`
+- `instance GetField lock TransferOutput (Optional TimeLock)`
+- `instance GetField outputs AmuletRules_ComputeFees [TransferOutput]`
+- `instance GetField outputs Transfer [TransferOutput]`
+- `instance GetField receiver TransferOutput Party`
+- `instance GetField receiverFeeRatio TransferOutput Decimal`
+- `instance SetField amount TransferOutput Decimal`
+- `instance SetField lock TransferOutput (Optional TimeLock)`
+- `instance SetField outputs AmuletRules_ComputeFees [TransferOutput]`
+- `instance SetField outputs Transfer [TransferOutput]`
+- `instance SetField receiver TransferOutput Party`
+- `instance SetField receiverFeeRatio TransferOutput Decimal`
+
+<a id="type-splice-amuletrules-transferoutputssummary-22405"></a>
+
+### `type TransferOutputsSummary = [PreprocessedTransferOutput]`
+
+<a id="type-splice-amuletrules-transferpreapprovalcancelresult-51361"></a>
+
+### `data TransferPreapproval_CancelResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transferpreapprovalcancelresult-83086"></a>
+- `TransferPreapproval_CancelResult`
+
+Instances:
+
+- `instance Eq TransferPreapproval_CancelResult`
+- `instance Show TransferPreapproval_CancelResult`
+- `instance HasExercise TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult`
+- `instance HasFromAnyChoice TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult`
+- `instance HasToAnyChoice TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult`
+
+<a id="type-splice-amuletrules-transferpreapprovalexpireresult-89274"></a>
+
+### `data TransferPreapproval_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transferpreapprovalexpireresult-36569"></a>
+- `TransferPreapproval_ExpireResult`
+(no fields)
+
+Instances:
+
+- `instance Eq TransferPreapproval_ExpireResult`
+- `instance Show TransferPreapproval_ExpireResult`
+- `instance HasExercise TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult`
+- `instance HasFromAnyChoice TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult`
+- `instance HasToAnyChoice TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult`
+
+<a id="type-splice-amuletrules-transferpreapprovalrenewresult-23849"></a>
+
+### `data TransferPreapproval_RenewResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transferpreapprovalrenewresult-61232"></a>
+- `TransferPreapproval_RenewResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferPreapprovalCid | ContractId TransferPreapproval |  |
+| transferResult | TransferResult |  |
+| receiver | Party |  |
+| provider | Party |  |
+| amuletPaid | Decimal |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq TransferPreapproval_RenewResult`
+- `instance Show TransferPreapproval_RenewResult`
+- `instance GetField amuletPaid TransferPreapproval_RenewResult Decimal`
+- `instance GetField meta TransferPreapproval_RenewResult (Optional Metadata)`
+- `instance GetField provider TransferPreapproval_RenewResult Party`
+- `instance GetField receiver TransferPreapproval_RenewResult Party`
+- `instance GetField transferPreapprovalCid TransferPreapproval_RenewResult (ContractId TransferPreapproval)`
+- `instance GetField transferResult TransferPreapproval_RenewResult TransferResult`
+- `instance SetField amuletPaid TransferPreapproval_RenewResult Decimal`
+- `instance SetField meta TransferPreapproval_RenewResult (Optional Metadata)`
+- `instance SetField provider TransferPreapproval_RenewResult Party`
+- `instance SetField receiver TransferPreapproval_RenewResult Party`
+- `instance SetField transferPreapprovalCid TransferPreapproval_RenewResult (ContractId TransferPreapproval)`
+- `instance SetField transferResult TransferPreapproval_RenewResult TransferResult`
+- `instance HasExercise TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult`
+- `instance HasFromAnyChoice TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult`
+- `instance HasToAnyChoice TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult`
+
+<a id="type-splice-amuletrules-transferpreapprovalsendresult-68419"></a>
+
+### `data TransferPreapproval_SendResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transferpreapprovalsendresult-67472"></a>
+- `TransferPreapproval_SendResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | TransferResult |  |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq TransferPreapproval_SendResult`
+- `instance Show TransferPreapproval_SendResult`
+- `instance GetField meta TransferPreapproval_SendResult (Optional Metadata)`
+- `instance GetField result TransferPreapproval_SendResult TransferResult`
+- `instance SetField meta TransferPreapproval_SendResult (Optional Metadata)`
+- `instance SetField result TransferPreapproval_SendResult TransferResult`
+- `instance HasExercise TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult`
+- `instance HasFromAnyChoice TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult`
+- `instance HasToAnyChoice TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult`
+
+<a id="type-splice-amuletrules-transferpreapprovalsendv2result-94909"></a>
+
+### `data TransferPreapproval_SendV2Result`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transferpreapprovalsendv2result-33038"></a>
+- `TransferPreapproval_SendV2Result`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | TransferResult |  |
+| meta | Metadata |  |
+
+Instances:
+
+- `instance Eq TransferPreapproval_SendV2Result`
+- `instance Show TransferPreapproval_SendV2Result`
+- `instance GetField meta TransferPreapproval_SendV2Result Metadata`
+- `instance GetField result TransferPreapproval_SendV2Result TransferResult`
+- `instance SetField meta TransferPreapproval_SendV2Result Metadata`
+- `instance SetField result TransferPreapproval_SendV2Result TransferResult`
+- `instance HasExercise TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result`
+- `instance HasFromAnyChoice TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result`
+- `instance HasToAnyChoice TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result`
+
+<a id="type-splice-amuletrules-transferresult-93164"></a>
+
+### `data TransferResult`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transferresult-68399"></a>
+- `TransferResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| round | Round | Round for which this transfer was registered. |
+| summary | TransferSummary | Summary of amount input and outputs, and fees paid. |
+| createdAmulets | [CreatedAmulet] | References to the created output amulets. |
+| senderChangeAmulet | Optional (ContractId Amulet) | Optional reference to the amulet for the change returned to the sender.<br/><br/>Only created if there was some change to be returned after deducting the fee for returning change. |
+| meta | Optional Metadata |  |
+
+Instances:
+
+- `instance Eq TransferResult`
+- `instance Show TransferResult`
+- `instance GetField createdAmulets TransferResult [CreatedAmulet]`
+- `instance GetField meta TransferResult (Optional Metadata)`
+- `instance GetField result TransferPreapproval_SendResult TransferResult`
+- `instance GetField result TransferPreapproval_SendV2Result TransferResult`
+- `instance GetField result TransferCommandResult TransferResult`
+- `instance GetField round TransferResult Round`
+- `instance GetField senderChangeAmulet TransferResult (Optional (ContractId Amulet))`
+- `instance GetField summary TransferResult TransferSummary`
+- `instance GetField transferResult AmuletRules_CreateExternalPartySetupProposalResult TransferResult`
+- `instance GetField transferResult AmuletRules_CreateTransferPreapprovalResult TransferResult`
+- `instance GetField transferResult TransferPreapproval_RenewResult TransferResult`
+- `instance SetField createdAmulets TransferResult [CreatedAmulet]`
+- `instance SetField meta TransferResult (Optional Metadata)`
+- `instance SetField result TransferPreapproval_SendResult TransferResult`
+- `instance SetField result TransferPreapproval_SendV2Result TransferResult`
+- `instance SetField result TransferCommandResult TransferResult`
+- `instance SetField round TransferResult Round`
+- `instance SetField senderChangeAmulet TransferResult (Optional (ContractId Amulet))`
+- `instance SetField summary TransferResult TransferSummary`
+- `instance SetField transferResult AmuletRules_CreateExternalPartySetupProposalResult TransferResult`
+- `instance SetField transferResult AmuletRules_CreateTransferPreapprovalResult TransferResult`
+- `instance SetField transferResult TransferPreapproval_RenewResult TransferResult`
+- `instance HasExercise AmuletRules AmuletRules_Transfer TransferResult`
+- `instance HasFromAnyChoice AmuletRules AmuletRules_Transfer TransferResult`
+- `instance HasToAnyChoice AmuletRules AmuletRules_Transfer TransferResult`
+
+<a id="type-splice-amuletrules-transfersummary-17366"></a>
+
+### `data TransferSummary`
+
+Summary of input and output amounts and fees paid.
+This summary is intended to be used together with the `Transfer` specification
+used to initiate the transfer when displaying a transaction summary. Its fields are intended to
+provide shortcuts for key numbers that are complex to compute off-ledger.
+
+All amounts are denominated in Splice.
+
+Constructors:
+
+<a id="constr-splice-amuletrules-transfersummary-72851"></a>
+- `TransferSummary`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputAppRewardAmount | Decimal | Total amount of app reward coupon issunace input into this transfer. |
+| inputValidatorRewardAmount | Decimal | Total amount of validator rewards coupon issuance input into this transfer. |
+| inputSvRewardAmount | Decimal | Total amount of SV reward coupon issuance input into this transfer. |
+| inputAmuletAmount | Decimal | Total input amount of amulet input into this transfer, before deducting holding fees. |
+| balanceChanges | Map Party BalanceChange | Balance changes per party |
+| holdingFees | Decimal | Holding fees paid by the sender on their input amulets. |
+| outputFees | [Decimal] | Fees paid for the individual output amulets in the order they were specified. |
+| senderChangeFee | Decimal | Fee charged for returning change to the sender, which is the smaller of the<br/><br/>left-over balance after paying for all outputs or one amulet create fee.<br/><br/>In case the left-over balance after paying for all outputs is smaller than a create fee,<br/><br/>all of that balance is consumed by the fee for returning change, and no actual amulet is<br/><br/>created for the sender, i.e., the `senderChangeAmount` is zero. The transfer does though succeed.<br/><br/>For transfers that do not allow returning change to the sender, the left-over balance<br/><br/>after paying for all outputs must be zero, and thus the `senderChangeFee` must be zero as well. |
+| senderChangeAmount | Decimal | The final amount of amulet returned to the sender after paying for all outputs and fees.<br/><br/>If it is zero, then no amulet is created for the sender. |
+| amuletPrice | Decimal | The amulet price at the round this transfer was executed. |
+| inputValidatorFaucetAmount | Optional Decimal | Added in CIP-3. Total amount of validator faucet coupon issuance input into this transfer. |
+| inputUnclaimedActivityRecordAmount | Optional Decimal | Total amount of unclaimed activity record issuance input into this transfer.<br/><br/>Note: Made optional as the addition of this field is checked by the upgrade checker. |
+| inputDevelopmentFundAmount | Optional Decimal | Total amount of development fund coupon issuance input into this transfer.<br/><br/>Note: Made optional as the addition of this field is checked by the upgrade checker. |
+
+Instances:
+
+- `instance Eq TransferSummary`
+- `instance Show TransferSummary`
+- `instance GetField amuletPrice TransferSummary Decimal`
+- `instance GetField balanceChanges TransferSummary (Map Party BalanceChange)`
+- `instance GetField holdingFees TransferSummary Decimal`
+- `instance GetField inputAmuletAmount TransferSummary Decimal`
+- `instance GetField inputAppRewardAmount TransferSummary Decimal`
+- `instance GetField inputDevelopmentFundAmount TransferSummary (Optional Decimal)`
+- `instance GetField inputSvRewardAmount TransferSummary Decimal`
+- `instance GetField inputUnclaimedActivityRecordAmount TransferSummary (Optional Decimal)`
+- `instance GetField inputValidatorFaucetAmount TransferSummary (Optional Decimal)`
+- `instance GetField inputValidatorRewardAmount TransferSummary Decimal`
+- `instance GetField outputFees TransferSummary [Decimal]`
+- `instance GetField senderChangeAmount TransferSummary Decimal`
+- `instance GetField senderChangeFee TransferSummary Decimal`
+- `instance GetField summary AmuletRules_BuyMemberTrafficResult TransferSummary`
+- `instance GetField summary TransferResult TransferSummary`
+- `instance SetField amuletPrice TransferSummary Decimal`
+- `instance SetField balanceChanges TransferSummary (Map Party BalanceChange)`
+- `instance SetField holdingFees TransferSummary Decimal`
+- `instance SetField inputAmuletAmount TransferSummary Decimal`
+- `instance SetField inputAppRewardAmount TransferSummary Decimal`
+- `instance SetField inputDevelopmentFundAmount TransferSummary (Optional Decimal)`
+- `instance SetField inputSvRewardAmount TransferSummary Decimal`
+- `instance SetField inputUnclaimedActivityRecordAmount TransferSummary (Optional Decimal)`
+- `instance SetField inputValidatorFaucetAmount TransferSummary (Optional Decimal)`
+- `instance SetField inputValidatorRewardAmount TransferSummary Decimal`
+- `instance SetField outputFees TransferSummary [Decimal]`
+- `instance SetField senderChangeAmount TransferSummary Decimal`
+- `instance SetField senderChangeFee TransferSummary Decimal`
+- `instance SetField summary AmuletRules_BuyMemberTrafficResult TransferSummary`
+- `instance SetField summary TransferResult TransferSummary`
+
+<a id="type-splice-amuletrules-validatedopenminingrounds-3458"></a>
+
+### `data ValidatedOpenMiningRounds`
+
+Constructors:
+
+<a id="constr-splice-amuletrules-validatedopenminingrounds-35727"></a>
+- `ValidatedOpenMiningRounds`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| oldestRound | OpenMiningRound |  |
+| latestUsableRound | OpenMiningRound |  |
+
+Instances:
+
+- `instance Eq ValidatedOpenMiningRounds`
+- `instance Show ValidatedOpenMiningRounds`
+- `instance GetField latestUsableRound ValidatedOpenMiningRounds OpenMiningRound`
+- `instance GetField oldestRound ValidatedOpenMiningRounds OpenMiningRound`
+- `instance SetField latestUsableRound ValidatedOpenMiningRounds OpenMiningRound`
+- `instance SetField oldestRound ValidatedOpenMiningRounds OpenMiningRound`
+
+## Functions
+
+<a id="function-splice-amuletrules-validateopenminingroundtriple-43417"></a>
+
+### `validateOpenMiningRoundTriple`
+
+```daml
+validateOpenMiningRoundTriple : Party -> OpenMiningRoundTriple -> Update ValidatedOpenMiningRounds
+```
+
+<a id="function-splice-amuletrules-transfercontrollers-28233"></a>
+
+### `transferControllers`
+
+```daml
+transferControllers : Transfer -> Set Party
+```
+
+The controllers for a transfer.
+
+<a id="function-splice-amuletrules-checktransferconstraints-43087"></a>
+
+### `checkTransferConstraints`
+
+```daml
+checkTransferConstraints : Transfer -> TransferSummary -> TransferConfigV2 unit -> Either InvalidTransferReason ()
+```
+
+<a id="function-splice-amuletrules-executetransfer-52573"></a>
+
+### `executeTransfer`
+
+```daml
+executeTransfer : RewardsIssuanceConfig -> TransferContext -> Party -> Transfer -> Update TransferResult
+```
+
+Execute a transfer.
+
+<a id="function-splice-amuletrules-executeexternalpartytransfer-86681"></a>
+
+### `executeExternalPartyTransfer`
+
+```daml
+executeExternalPartyTransfer : Party -> ExternalPartyTransferContext -> Transfer -> Update TransferResult
+```
+
+Execute a transfer for external parties so that the prepared tx remains valid for 24h
+
+<a id="function-splice-amuletrules-executetransfertick-55439"></a>
+
+### `executeTransfer'`
+
+```daml
+executeTransfer' : RewardsIssuanceConfig -> TransferContextSummaryV2 -> Party -> Transfer -> Update TransferResult
+```
+
+<a id="function-splice-amuletrules-summarizeandvalidatecontext-19960"></a>
+
+### `summarizeAndValidateContext`
+
+```daml
+summarizeAndValidateContext : TransferContext -> Party -> Transfer -> Update TransferContextSummaryV2
+```
+
+<a id="function-splice-amuletrules-summarizeandvalidateexternalpartycontext-23832"></a>
+
+### `summarizeAndValidateExternalPartyContext`
+
+```daml
+summarizeAndValidateExternalPartyContext : ExternalPartyTransferContext -> Party -> Transfer -> Update TransferContextSummaryV2
+```
+
+<a id="function-splice-amuletrules-getvalidatorright-23495"></a>
+
+### `getValidatorRight`
+
+```daml
+getValidatorRight : TransferContextSummaryV2 -> Party -> Update (ContractId ValidatorRight)
+```
+
+<a id="function-splice-amuletrules-getissuingmininground-54647"></a>
+
+### `getIssuingMiningRound`
+
+```daml
+getIssuingMiningRound : TransferContextSummaryV2 -> Round -> Update IssuingMiningRound
+```
+
+<a id="function-splice-amuletrules-summarizeandconsumeinputs-14652"></a>
+
+### `summarizeAndConsumeInputs`
+
+```daml
+summarizeAndConsumeInputs : TransferContextSummaryV2 -> Party -> Party -> [TransferInput] -> Update TransferInputsSummary
+```
+
+<a id="function-splice-amuletrules-dedupoutputlockholders-88329"></a>
+
+### `dedupOutputLockHolders`
+
+```daml
+dedupOutputLockHolders : TransferOutput -> TransferOutput
+```
+
+Deduplicate lock-holders to store them and charge for them at most once
+
+<a id="function-splice-amuletrules-preprocessoutputs-54475"></a>
+
+### `preprocessOutputs`
+
+```daml
+preprocessOutputs : TransferConfigV2 Amulet -> [TransferOutput] -> Update TransferOutputsSummary
+```
+
+<a id="function-splice-amuletrules-summarizetransfer-82621"></a>
+
+### `summarizeTransfer`
+
+```daml
+summarizeTransfer : Party -> Round -> Decimal -> TransferConfigV2 Amulet -> TransferInputsSummary -> TransferOutputsSummary -> Update TransferSummary
+```
+
+<a id="function-splice-amuletrules-issuerewards-17863"></a>
+
+### `issueRewards`
+
+```daml
+issueRewards : RewardsIssuanceConfig -> TransferContextSummaryV2 -> Party -> Optional [AppRewardBeneficiary] -> Update ()
+```
+
+<a id="function-splice-amuletrules-createtransferoutputs-14910"></a>
+
+### `createTransferOutputs`
+
+```daml
+createTransferOutputs : Round -> TransferConfigV2 Amulet -> Party -> Party -> TransferSummary -> TransferOutputsSummary -> Update ([CreatedAmulet], Optional (ContractId Amulet))
+```
+
+<a id="function-splice-amuletrules-scalefees-202"></a>
+
+### `scaleFees`
+
+```daml
+scaleFees : Decimal -> TransferConfig USD -> TransferConfig Amulet
+```
+
+Scale the 'AmuletConfig' such that the fees charged are scaled by the same scale factor.
+
+<a id="function-splice-amuletrules-scalefees2-95743"></a>
+
+### `scaleFees2`
+
+```daml
+scaleFees2 : Decimal -> TransferConfigV2 USD -> TransferConfigV2 Amulet
+```
+
+Scale the 'TranserConfigV2' such that the fees charged are scaled by the same scale factor.
+
+<a id="function-splice-amuletrules-transferconfigamuletfromopenround-39144"></a>
+
+### `transferConfigAmuletFromOpenRound`
+
+```daml
+transferConfigAmuletFromOpenRound : OpenMiningRound -> TransferConfig Amulet
+```
+
+<a id="function-splice-amuletrules-validatebuymembertrafficinputs-62954"></a>
+
+### `validateBuyMemberTrafficInputs`
+
+```daml
+validateBuyMemberTrafficInputs : AmuletConfig USD -> Text -> Int -> Either InvalidTransferReason ()
+```
+
+<a id="function-splice-amuletrules-computesynchronizerfees-53837"></a>
+
+### `computeSynchronizerFees`
+
+```daml
+computeSynchronizerFees : Party -> Party -> Int -> AmuletRules -> TransferContext -> Update (Decimal, Decimal)
+```
+
+Computing synchronizer fees
+
+<a id="function-splice-amuletrules-legacyamuletcreatesummary-16866"></a>
+
+### `legacyAmuletCreateSummary`
+
+```daml
+legacyAmuletCreateSummary : Party -> Party -> ContractId OpenMiningRound -> ContractId Amulet -> Update (AmuletCreateSummary (ContractId Amulet))
+```
+
+<a id="function-splice-amuletrules-checkexpecteddso-85182"></a>
+
+### `checkExpectedDso`
+
+```daml
+checkExpectedDso : Party -> Optional Party -> Update ()
+```
+
+<a id="function-splice-amuletrules-exerciseapptransfer-15159"></a>
+
+### `exerciseAppTransfer`
+
+```daml
+exerciseAppTransfer : Party -> AppTransferContext -> Transfer -> Update TransferResult
+```
+
+<a id="function-splice-amuletrules-exercisepaymenttransfer-78288"></a>
+
+### `exercisePaymentTransfer`
+
+```daml
+exercisePaymentTransfer : Party -> PaymentTransferContext -> Transfer -> Update TransferResult
+```
+
+<a id="function-splice-amuletrules-amulettransfercontext-70307"></a>
+
+### `amuletTransferContext`
+
+```daml
+amuletTransferContext : ContractId OpenMiningRound -> Optional (ContractId FeaturedAppRight) -> TransferContext
+```
+
+Helper to construct transfer context with only amulet inputs
+
+<a id="function-splice-amuletrules-createdamulettoholding-42008"></a>
+
+### `createdAmuletToHolding`
+
+```daml
+createdAmuletToHolding : CreatedAmulet -> ContractId Holding
+```
+
+<a id="function-splice-amuletrules-mkinputvalidatorfaucetcoupon-66284"></a>
+
+### `mkInputValidatorFaucetCoupon`
+
+```daml
+mkInputValidatorFaucetCoupon : ContractId ValidatorFaucetCoupon -> TransferInput
+```
+
+Smart constructor for inputing validator faucet coupons into a transfer.
+
+<a id="function-splice-amuletrules-computetransferpreapprovalfee-40643"></a>
+
+### `computeTransferPreapprovalFee`
+
+```daml
+computeTransferPreapprovalFee : RelTime -> AmuletConfig USD -> TransferContext -> Party -> Update (Decimal, Decimal)
+```
+
+<a id="function-splice-amuletrules-splitandburn-28460"></a>
+
+### `splitAndBurn`
+
+```daml
+splitAndBurn : Party -> Decimal -> [TransferInput] -> TransferContext -> Party -> Text -> Update (TransferResult, Metadata)
+```
+
+<a id="function-splice-amuletrules-totalburnfromsummary-61907"></a>
+
+### `totalBurnFromSummary`
+
+```daml
+totalBurnFromSummary : TransferSummary -> Decimal
+```
+
+Compute the total burn done as part of the transfer.
+
+<a id="function-splice-amuletrules-externalpartytransferfromchoicecontext-27714"></a>
+
+### `externalPartyTransferFromChoiceContext`
+
+```daml
+externalPartyTransferFromChoiceContext : Party -> ChoiceContext -> Update ExternalPartyTransferContext
+```
+
+<a id="function-splice-amuletrules-unfeaturedpaymentcontextfromchoicecontext-64473"></a>
+
+### `unfeaturedPaymentContextFromChoiceContext`
+
+```daml
+unfeaturedPaymentContextFromChoiceContext : Party -> ChoiceContext -> Update ExternalPartyTransferContext
+```
+
+Used when we want to ignore a featured app right, even if it is present in the context.
+
+<a id="function-splice-amuletrules-bootstrapexternalpartyconfigstate-17433"></a>
+
+### `bootstrapExternalPartyConfigState`
+
+```daml
+bootstrapExternalPartyConfigState : AmuletRules -> OpenMiningRoundTriple -> Update ()
+```
+
+## Templates
+
+<a id="type-splice-amuletrules-amuletrules-32426"></a>
+
+### Template `AmuletRules`
+
+The rules governing how Amulet users can modify the Amulet state managed by the DSO party.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| configSchedule | Schedule Time (AmuletConfig USD) |  |
+| isDevNet | Bool |  |
+| contractStateSchemaVersion | Optional Int |  |
+
+Choices:
+
+<a id="type-splice-amuletrules-amuletrulesaddfutureamuletconfigschedule-17078"></a>
+
+#### Choice `AmuletRules_AddFutureAmuletConfigSchedule`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_AddFutureAmuletConfigScheduleResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newScheduleItem | (Time, AmuletConfig USD) |  |
+
+<a id="type-splice-amuletrules-amuletrulesadvanceopenminingrounds-86978"></a>
+
+#### Choice `AmuletRules_AdvanceOpenMiningRounds`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_AdvanceOpenMiningRoundsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletPrice | Decimal |  |
+| roundToArchiveCid | ContractId OpenMiningRound |  |
+| middleRoundCid | ContractId OpenMiningRound |  |
+| latestRoundCid | ContractId OpenMiningRound |  |
+
+<a id="type-splice-amuletrules-amuletrulesallocatedevelopmentfundcoupon-20234"></a>
+
+#### Choice `AmuletRules_AllocateDevelopmentFundCoupon`
+
+Allows the Development Fund manager to allocate a specified amount from a
+collection of UnclaimedDevelopmentFundCoupons to a beneficiary, generating a
+DevelopmentFundCoupon and producing a leftover unclaimed coupon if applicable.
+
+Controllers: `fundManager`
+
+Returns: `AmuletRules_AllocateDevelopmentFundCouponResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCids | [ContractId UnclaimedDevelopmentFundCoupon] |  |
+| beneficiary | Party |  |
+| amount | Decimal |  |
+| expiresAt | Time |  |
+| reason | Text |  |
+| fundManager | Party |  |
+
+<a id="type-splice-amuletrules-amuletrulesamuletexpiretransferinstructions-2487"></a>
+
+#### Choice `AmuletRules_Amulet_ExpireTransferInstructions`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_Amulet_ExpireTransferInstructionsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedDso | Party |  |
+| inputs | [AmuletRules_ExpireTransferInstructionInput] |  |
+| observers | [Party] |  |
+
+<a id="type-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstate-17751"></a>
+
+#### Choice `AmuletRules_BootstrapExternalPartyConfigState`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_BootstrapExternalPartyConfigStateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openMiningRoundTriple | OpenMiningRoundTriple |  |
+| expectedDso | Party |  |
+
+<a id="type-splice-amuletrules-amuletrulesbootstraprounds-81536"></a>
+
+#### Choice `AmuletRules_Bootstrap_Rounds`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_Bootstrap_RoundsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletPrice | Decimal |  |
+| round0Duration | RelTime |  |
+| initialRound | Optional Int |  |
+
+<a id="type-splice-amuletrules-amuletrulesbuymembertraffic-66391"></a>
+
+#### Choice `AmuletRules_BuyMemberTraffic`
+
+Controllers: `provider`
+
+Returns: `AmuletRules_BuyMemberTrafficResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputs | [TransferInput] |  |
+| context | TransferContext |  |
+| provider | Party |  |
+| memberId | Text |  |
+| synchronizerId | Text |  |
+| migrationId | Int |  |
+| trafficAmount | Int |  |
+| expectedDso | Optional Party |  |
+
+<a id="type-splice-amuletrules-amuletrulesclaimexpiredrewards-90526"></a>
+
+#### Choice `AmuletRules_ClaimExpiredRewards`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_ClaimExpiredRewardsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+| validatorRewardCouponCids | [ContractId ValidatorRewardCoupon] |  |
+| appCouponCids | [ContractId AppRewardCoupon] |  |
+| svRewardCouponCids | [ContractId SvRewardCoupon] |  |
+| optValidatorFaucetCouponCids | Optional [ContractId ValidatorFaucetCoupon] |  |
+| optValidatorLivenessActivityRecordCids | Optional [ContractId ValidatorLivenessActivityRecord] |  |
+
+<a id="type-splice-amuletrules-amuletrulescomputefees-56243"></a>
+
+#### Choice `AmuletRules_ComputeFees`
+
+Compute the output fees for transfer against the given context
+
+Controllers: `sender`
+
+Returns: `AmuletRules_ComputeFeesResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | TransferContext |  |
+| sender | Party |  |
+| outputs | [TransferOutput] |  |
+| expectedDso | Optional Party |  |
+
+<a id="type-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkers-99721"></a>
+
+#### Choice `AmuletRules_ConvertFeaturedAppActivityMarkers`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| markerCids | [ContractId FeaturedAppActivityMarker] |  |
+| openMiningRoundCid | ContractId OpenMiningRound |  |
+| observers | Optional [Party] | A list of choice observers. This is expected to be set to the union of all providers and beneficiaries to ensure that this creates only one view. |
+
+<a id="type-splice-amuletrules-amuletrulescreateexternalpartysetupproposal-53882"></a>
+
+#### Choice `AmuletRules_CreateExternalPartySetupProposal`
+
+Propose to host an external party
+The provider pre-pays the fees for the creation of a TransferPreapproval contract
+on behalf of the external party when exercising this choice
+
+Controllers: `validator`
+
+Returns: `AmuletRules_CreateExternalPartySetupProposalResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| user | Party |  |
+| validator | Party |  |
+| preapprovalExpiresAt | Time |  |
+| expectedDso | Optional Party |  |
+
+<a id="type-splice-amuletrules-amuletrulescreatetransferpreapproval-31932"></a>
+
+#### Choice `AmuletRules_CreateTransferPreapproval`
+
+Pre-approve incoming amulet transfers
+
+Controllers: `provider`, `receiver`
+
+Returns: `AmuletRules_CreateTransferPreapprovalResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| receiver | Party |  |
+| provider | Party |  |
+| expiresAt | Time |  |
+| expectedDso | Optional Party |  |
+
+<a id="type-splice-amuletrules-amuletrulesdevnetfeatureapp-42587"></a>
+
+#### Choice `AmuletRules_DevNet_FeatureApp`
+
+Controllers: `provider`
+
+Returns: `AmuletRules_DevNet_FeatureAppResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| provider | Party |  |
+
+<a id="type-splice-amuletrules-amuletrulesdevnettap-82572"></a>
+
+#### Choice `AmuletRules_DevNet_Tap`
+
+Controllers: `receiver`
+
+Returns: `AmuletRules_DevNet_TapResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| amount | Decimal |  |
+| openRound | ContractId OpenMiningRound |  |
+
+<a id="type-splice-amuletrules-amuletrulesfetch-60873"></a>
+
+#### Choice `AmuletRules_Fetch`
+
+Controllers: `p`
+
+Returns: `AmuletRules`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| p | Party |  |
+
+<a id="type-splice-amuletrules-amuletrulesmergemembertrafficcontracts-58585"></a>
+
+#### Choice `AmuletRules_MergeMemberTrafficContracts`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MergeMemberTrafficContractsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trafficCids | [ContractId MemberTraffic] |  |
+
+<a id="type-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcoupons-89321"></a>
+
+#### Choice `AmuletRules_MergeUnclaimedDevelopmentFundCoupons`
+
+Batch merge of unclaimed development fund coupons
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedDevelopmentFundCouponCids | [ContractId UnclaimedDevelopmentFundCoupon] |  |
+
+<a id="type-splice-amuletrules-amuletrulesmergeunclaimedrewards-76493"></a>
+
+#### Choice `AmuletRules_MergeUnclaimedRewards`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MergeUnclaimedRewardsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedRewardCids | [ContractId UnclaimedReward] |  |
+
+<a id="type-splice-amuletrules-amuletrulesminingroundarchive-33308"></a>
+
+#### Choice `AmuletRules_MiningRound_Archive`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MiningRound_ArchiveResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+<a id="type-splice-amuletrules-amuletrulesminingroundclose-27964"></a>
+
+#### Choice `AmuletRules_MiningRound_Close`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MiningRound_CloseResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| issuingRoundCid | ContractId IssuingMiningRound |  |
+
+<a id="type-splice-amuletrules-amuletrulesminingroundstartissuing-80649"></a>
+
+#### Choice `AmuletRules_MiningRound_StartIssuing`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_MiningRound_StartIssuingResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| miningRoundCid | ContractId SummarizingMiningRound |  |
+| summary | OpenMiningRoundSummary |  |
+
+<a id="type-splice-amuletrules-amuletrulesmint-76046"></a>
+
+#### Choice `AmuletRules_Mint`
+
+Controllers: `dso`, `receiver`
+
+Returns: `AmuletRules_MintResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| amount | Decimal |  |
+| openRound | ContractId OpenMiningRound |  |
+
+<a id="type-splice-amuletrules-amuletrulesremovefutureamuletconfigschedule-69936"></a>
+
+#### Choice `AmuletRules_RemoveFutureAmuletConfigSchedule`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_RemoveFutureAmuletConfigScheduleResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| scheduleTime | Time |  |
+
+<a id="type-splice-amuletrules-amuletrulessetconfig-85439"></a>
+
+#### Choice `AmuletRules_SetConfig`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_SetConfigResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newConfig | AmuletConfig USD |  |
+| baseConfig | AmuletConfig USD |  |
+
+<a id="type-splice-amuletrules-amuletrulestransfer-23235"></a>
+
+#### Choice `AmuletRules_Transfer`
+
+Controllers: `Set.toList (transferControllers transfer)`
+
+Returns: `TransferResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transfer | Transfer |  |
+| context | TransferContext |  |
+| expectedDso | Optional Party |  |
+
+<a id="type-splice-amuletrules-amuletrulesupdateexternalpartyconfigstates-76929"></a>
+
+#### Choice `AmuletRules_UpdateExternalPartyConfigStates`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_UpdateExternalPartyConfigStatesResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| externalPartyConfigStateCid0 | ContractId ExternalPartyConfigState |  |
+| externalPartyConfigStateCid1 | ContractId ExternalPartyConfigState |  |
+| openMiningRoundTriple | OpenMiningRoundTriple |  |
+
+<a id="type-splice-amuletrules-amuletrulesupdatefutureamuletconfigschedule-15159"></a>
+
+#### Choice `AmuletRules_UpdateFutureAmuletConfigSchedule`
+
+Controllers: `dso`
+
+Returns: `AmuletRules_UpdateFutureAmuletConfigScheduleResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| scheduleItem | (Time, AmuletConfig USD) |  |
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-amuletrules-externalpartysetupproposal-90414"></a>
+
+### Template `ExternalPartySetupProposal`
+
+Signatories: `validator`, `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validator | Party |  |
+| user | Party |  |
+| dso | Party |  |
+| createdAt | Time |  |
+| preapprovalExpiresAt | Time |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `validator`, `dso`
+
+Returns: `()`
+
+<a id="type-splice-amuletrules-externalpartysetupproposalaccept-68720"></a>
+
+#### Choice `ExternalPartySetupProposal_Accept`
+
+Controllers: `user`
+
+Returns: `ExternalPartySetupProposal_AcceptResult`
+
+<a id="type-splice-amuletrules-externalpartysetupproposalreject-30733"></a>
+
+#### Choice `ExternalPartySetupProposal_Reject`
+
+Controllers: `user`
+
+Returns: `ExternalPartySetupProposal_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<a id="type-splice-amuletrules-externalpartysetupproposalwithdraw-43220"></a>
+
+#### Choice `ExternalPartySetupProposal_Withdraw`
+
+Controllers: `validator`
+
+Returns: `ExternalPartySetupProposal_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<a id="type-splice-amuletrules-transferpreapproval-36220"></a>
+
+### Template `TransferPreapproval`
+
+A pre-approval by a receiver to receive Amulet from anybody.
+
+Pre-approvals are indexed by the SVs and served from scan for easy discovery until
+they expire. The cost of providing this discovery service is charged by burning Amulet.
+
+Receivers can either purchase and renew these pre-approvals by themselves,
+or have an app provider do so for them in exchange for the app rewards for
+the amulet transfers completed via the managed pre-approval.
+
+Signatories: `receiver`, `provider`, `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| receiver | Party | The receiver party |
+| provider | Party | The app provider that manages the pre-approval for the receiver. Equal to the receiver for self-managed pre-approvals. |
+| validFrom | Time | This timestamp marks the start of the period for which fees were paid for the pre-approval. Preserved across renewals. |
+| lastRenewedAt | Time | When the pre-approval was last renewed. Set equal to `validFrom` on creation and updated on each renewal. |
+| expiresAt | Time | Provider selected timestamp defining the lifetime of the contract. Can be extended by renewing the contract. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `receiver`, `provider`, `dso`
+
+Returns: `()`
+
+<a id="type-splice-amuletrules-transferpreapprovalcancel-70216"></a>
+
+#### Choice `TransferPreapproval_Cancel`
+
+Controllers: `p`
+
+Returns: `TransferPreapproval_CancelResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| p | Party |  |
+
+<a id="type-splice-amuletrules-transferpreapprovalexpire-84167"></a>
+
+#### Choice `TransferPreapproval_Expire`
+
+Controllers: `dso`
+
+Returns: `TransferPreapproval_ExpireResult`
+
+<a id="type-splice-amuletrules-transferpreapprovalfetch-15083"></a>
+
+#### Choice `TransferPreapproval_Fetch`
+
+Controllers: `p`
+
+Returns: `TransferPreapproval`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| p | Party |  |
+
+<a id="type-splice-amuletrules-transferpreapprovalrenew-31244"></a>
+
+#### Choice `TransferPreapproval_Renew`
+
+Controllers: `provider`
+
+Returns: `TransferPreapproval_RenewResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| newExpiresAt | Time |  |
+
+<a id="type-splice-amuletrules-transferpreapprovalsend-62554"></a>
+
+#### Choice `TransferPreapproval_Send`
+
+Deprecated: Use TransferPreapproval_SendV2 instead.
+
+Controllers: `sender`
+
+Returns: `TransferPreapproval_SendResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| amount | Decimal |  |
+| sender | Party |  |
+| description | Optional Text |  |
+
+<a id="type-splice-amuletrules-transferpreapprovalsendv2-66036"></a>
+
+#### Choice `TransferPreapproval_SendV2`
+
+Controllers: `sender`
+
+Returns: `TransferPreapproval_SendV2Result`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | ExternalPartyTransferContext |  |
+| inputs | [TransferInput] |  |
+| amount | Decimal |  |
+| sender | Party |  |
+| description | Optional Text |  |

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-amulettransferinstruction.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-amulettransferinstruction.mdx
@@ -1,0 +1,60 @@
+---
+title: "Splice.AmuletTransferInstruction"
+description: "Reference documentation for Daml module Splice.AmuletTransferInstruction."
+---
+
+<a id="module-splice-amulettransferinstruction-51350"></a>
+
+# Splice.AmuletTransferInstruction
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Functions
+
+<a id="function-splice-amulettransferinstruction-standardtransfertotwosteptransfer-69205"></a>
+
+### `standardTransferToTwoStepTransfer`
+
+```daml
+standardTransferToTwoStepTransfer : Transfer -> TwoStepTransfer
+```
+
+## Templates
+
+<a id="type-splice-amulettransferinstruction-amulettransferinstruction-76678"></a>
+
+### Template `AmuletTransferInstruction`
+
+A transfer instruction for transferring Amulet tokens pending on receiver
+acceptance.
+
+Signatories: `(DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" transfer))`, `(DA.Internal.Record.getField @"sender" transfer)`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| lockedAmulet | ContractId LockedAmulet | Locked amulet that holds the funds for executing the transfer upon acceptance |
+| transfer | Transfer |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `(DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" transfer))`, `(DA.Internal.Record.getField @"sender" transfer)`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-decentralizedsynchronizer.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-decentralizedsynchronizer.mdx
@@ -1,0 +1,199 @@
+---
+title: "Splice.DecentralizedSynchronizer"
+description: "Reference documentation for Daml module Splice.DecentralizedSynchronizer."
+---
+
+<a id="module-splice-decentralizedsynchronizer-23863"></a>
+
+# Splice.DecentralizedSynchronizer
+
+Types and contracts for managing synchronizer fees
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-decentralizedsynchronizer-amuletdecentralizedsynchronizerconfig-15126"></a>
+
+### `data AmuletDecentralizedSynchronizerConfig`
+
+The configuration of the logical concept of a decentralized synchronizer, which consists over its lifetime
+of a series of actual synchronizers, which are introduced for handling the (rare) occasions of switching
+to a new synchronizer protocol version.
+
+Constructors:
+
+<a id="constr-splice-decentralizedsynchronizer-amuletdecentralizedsynchronizerconfig-80511"></a>
+- `AmuletDecentralizedSynchronizerConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requiredSynchronizers | Set Text | The synchronizer-ids of all synchronizers that Amulet and ANS users should be connected to. |
+| activeSynchronizer | Text | The synchronizer-id of the synchronizer on which the SVs accepts transactions involving the<br/><br/>AmuletRules and related contracts, which must be one of the `requiredSynchronizers`. |
+| fees | SynchronizerFeesConfig | The fees charged for using the decentralized synchronizer. We use the same fees across all active decentralized synchronizers. |
+
+Instances:
+
+- `instance Patchable AmuletDecentralizedSynchronizerConfig`
+- `instance Eq AmuletDecentralizedSynchronizerConfig`
+- `instance Show AmuletDecentralizedSynchronizerConfig`
+- `instance GetField activeSynchronizer AmuletDecentralizedSynchronizerConfig Text`
+- `instance GetField decentralizedSynchronizer (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig`
+- `instance GetField fees AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig`
+- `instance GetField requiredSynchronizers AmuletDecentralizedSynchronizerConfig (Set Text)`
+- `instance SetField activeSynchronizer AmuletDecentralizedSynchronizerConfig Text`
+- `instance SetField decentralizedSynchronizer (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig`
+- `instance SetField fees AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig`
+- `instance SetField requiredSynchronizers AmuletDecentralizedSynchronizerConfig (Set Text)`
+
+<a id="type-splice-decentralizedsynchronizer-baseratetrafficlimits-64372"></a>
+
+### `data BaseRateTrafficLimits`
+
+The limits defining the free base rate delivered by the synchronizer.
+It defines the base rate as allowing at most burstAmount of sequencing traffic within a window of burstWindow seconds.
+
+Constructors:
+
+<a id="constr-splice-decentralizedsynchronizer-baseratetrafficlimits-1937"></a>
+- `BaseRateTrafficLimits`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| burstAmount | Int | The total burstAmount in bytes of sequencing traffic delivered over the burstWindow |
+| burstWindow | RelTime | Time window within which the burstAmount must not be exceeded |
+
+Instances:
+
+- `instance Patchable BaseRateTrafficLimits`
+- `instance Eq BaseRateTrafficLimits`
+- `instance Show BaseRateTrafficLimits`
+- `instance GetField baseRateTrafficLimits SynchronizerFeesConfig BaseRateTrafficLimits`
+- `instance GetField burstAmount BaseRateTrafficLimits Int`
+- `instance GetField burstWindow BaseRateTrafficLimits RelTime`
+- `instance SetField baseRateTrafficLimits SynchronizerFeesConfig BaseRateTrafficLimits`
+- `instance SetField burstAmount BaseRateTrafficLimits Int`
+- `instance SetField burstWindow BaseRateTrafficLimits RelTime`
+
+<a id="type-splice-decentralizedsynchronizer-formembertraffic-62879"></a>
+
+### `data ForMemberTraffic`
+
+Constructors:
+
+<a id="constr-splice-decentralizedsynchronizer-formembertraffic-24640"></a>
+- `ForMemberTraffic`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| memberId | Text |  |
+| synchronizerId | Text |  |
+| migrationId | Int |  |
+
+Instances:
+
+- `instance HasCheckedFetch MemberTraffic ForMemberTraffic`
+- `instance Eq ForMemberTraffic`
+- `instance Show ForMemberTraffic`
+- `instance GetField dso ForMemberTraffic Party`
+- `instance GetField memberId ForMemberTraffic Text`
+- `instance GetField migrationId ForMemberTraffic Int`
+- `instance GetField synchronizerId ForMemberTraffic Text`
+- `instance SetField dso ForMemberTraffic Party`
+- `instance SetField memberId ForMemberTraffic Text`
+- `instance SetField migrationId ForMemberTraffic Int`
+- `instance SetField synchronizerId ForMemberTraffic Text`
+
+<a id="type-splice-decentralizedsynchronizer-synchronizerfeesconfig-12142"></a>
+
+### `data SynchronizerFeesConfig`
+
+Synchronizer fees related configuration to be tracked on the DsoRules contract
+
+Constructors:
+
+<a id="constr-splice-decentralizedsynchronizer-synchronizerfeesconfig-16293"></a>
+- `SynchronizerFeesConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| baseRateTrafficLimits | BaseRateTrafficLimits | Configuration limits for base rate traffic |
+| extraTrafficPrice | Decimal | The price of extra traffic denominated in $/MB |
+| readVsWriteScalingFactor | Int | How much the sending of a message to its recipient costs in terms of bytes written to the synchronizer.<br/><br/>This factor is specified in parts per 10,000 (or per 10 mille)<br/><br/>We charge for sending messages depending on the number of recipients,<br/><br/>as delivering the message incurs a cost as well, albeit usually a much<br/><br/>smaller one than the cost of a write. |
+| minTopupAmount | Int | The minimum amount of extra traffic (in bytes) that must be bought when buying extra traffic.<br/><br/>This ensures that the SVs can amortize the cost of executing that transaction. |
+
+Instances:
+
+- `instance Patchable SynchronizerFeesConfig`
+- `instance Eq SynchronizerFeesConfig`
+- `instance Show SynchronizerFeesConfig`
+- `instance GetField baseRateTrafficLimits SynchronizerFeesConfig BaseRateTrafficLimits`
+- `instance GetField extraTrafficPrice SynchronizerFeesConfig Decimal`
+- `instance GetField fees AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig`
+- `instance GetField minTopupAmount SynchronizerFeesConfig Int`
+- `instance GetField readVsWriteScalingFactor SynchronizerFeesConfig Int`
+- `instance SetField baseRateTrafficLimits SynchronizerFeesConfig BaseRateTrafficLimits`
+- `instance SetField extraTrafficPrice SynchronizerFeesConfig Decimal`
+- `instance SetField fees AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig`
+- `instance SetField minTopupAmount SynchronizerFeesConfig Int`
+- `instance SetField readVsWriteScalingFactor SynchronizerFeesConfig Int`
+
+## Functions
+
+<a id="function-splice-decentralizedsynchronizer-validamuletdecentralizedsynchronizerconfig-57759"></a>
+
+### `validAmuletDecentralizedSynchronizerConfig`
+
+```daml
+validAmuletDecentralizedSynchronizerConfig : AmuletDecentralizedSynchronizerConfig -> Bool
+```
+
+<a id="function-splice-decentralizedsynchronizer-initialmembertraffic-49736"></a>
+
+### `initialMemberTraffic`
+
+```daml
+initialMemberTraffic : Party -> Text -> Text -> Int -> MemberTraffic
+```
+
+## Templates
+
+<a id="type-splice-decentralizedsynchronizer-membertraffic-74049"></a>
+
+### Template `MemberTraffic`
+
+The state of the extra synchronizer traffic purchases of a sequencer sv.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| memberId | Text | The id of the sequencer member (participant or mediator) for which traffic has been purchased |
+| synchronizerId | Text | The id of the synchronizer for which this contract tracks purchased extra traffic |
+| migrationId | Int | The migration id of the synchronizer for which this contract tracks purchased extra traffic |
+| totalPurchased | Int | The number of bytes of extra traffic purchased |
+| numPurchases | Int | Number of times extra traffic has been purchased |
+| amuletSpent | Decimal | Total Amulet spent on extra traffic |
+| usdSpent | Decimal | Total USD spent on extra traffic |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-expiry.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-expiry.mdx
@@ -1,0 +1,144 @@
+---
+title: "Splice.Expiry"
+description: "Reference documentation for Daml module Splice.Expiry."
+---
+
+<a id="module-splice-expiry-80141"></a>
+
+# Splice.Expiry
+
+Functions for computing amulet and lock expiry times and conditions.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-expiry-boundedset-6748"></a>
+
+### `data BoundedSet a`
+
+A symbolic representation of a set of values of type `a` useful for computing upper-bounds.
+
+Constructors:
+
+<a id="constr-splice-expiry-singleton-7610"></a>
+- `Singleton a`
+`Singleton x` represents the singleton set `{x}`
+<a id="constr-splice-expiry-aftermaxbound-46101"></a>
+- `AfterMaxBound`
+`AfterMaxBound` represents the set of all values larger than the maximal value that can be represented by type `a`
+
+Instances:
+
+- `instance Functor BoundedSet`
+- `instance Eq a => Eq (BoundedSet a)`
+- `instance Show a => Show (BoundedSet a)`
+
+<a id="type-splice-expiry-timelock-2221"></a>
+
+### `data TimeLock`
+
+A lock held by multiple parties until its expiry.
+
+Constructors:
+
+<a id="constr-splice-expiry-timelock-44256"></a>
+- `TimeLock`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| holders | [Party] |  |
+| expiresAt | Time |  |
+| optContext | Optional Text | Short, human-readable description of the context in which the amulet is locked.<br/><br/>Intended for wallets to inform the user about the reason for the lock.<br/><br/>Consider what details to share about the context, as that might be private and<br/><br/>the string here will be public information. |
+
+Instances:
+
+- `instance FromAnyValue TimeLock`
+- `instance ToAnyValue TimeLock`
+- `instance Eq TimeLock`
+- `instance Ord TimeLock`
+- `instance Show TimeLock`
+- `instance GetField expiresAt TimeLock Time`
+- `instance GetField holders TimeLock [Party]`
+- `instance GetField lock LockedAmulet TimeLock`
+- `instance GetField lock PreprocessedTransferOutput (Optional TimeLock)`
+- `instance GetField lock TransferOutput (Optional TimeLock)`
+- `instance GetField optContext TimeLock (Optional Text)`
+- `instance SetField expiresAt TimeLock Time`
+- `instance SetField holders TimeLock [Party]`
+- `instance SetField lock LockedAmulet TimeLock`
+- `instance SetField lock PreprocessedTransferOutput (Optional TimeLock)`
+- `instance SetField lock TransferOutput (Optional TimeLock)`
+- `instance SetField optContext TimeLock (Optional Text)`
+
+## Functions
+
+<a id="function-splice-expiry-maxint-28108"></a>
+
+### `maxInt`
+
+```daml
+maxInt : Int
+```
+
+<a id="function-splice-expiry-maxdecimaldiv10-64031"></a>
+
+### `maxDecimalDiv10`
+
+```daml
+maxDecimalDiv10 : Decimal
+```
+
+<a id="function-splice-expiry-mintime-10075"></a>
+
+### `minTime`
+
+```daml
+minTime : Time
+```
+
+The smallest time point that can be represented by the `Time` type.
+
+<a id="function-splice-expiry-maxtime-17293"></a>
+
+### `maxTime`
+
+```daml
+maxTime : Time
+```
+
+The largest time point that can be represented by the `Time` type.
+
+<a id="function-splice-expiry-amountexpiresat-59287"></a>
+
+### `amountExpiresAt`
+
+```daml
+amountExpiresAt : ExpiringAmount -> BoundedSet Round
+```
+
+Compute the round where the amulet expires. i.e. the amulet is fully expired.
+
+<a id="function-splice-expiry-isamuletexpired-66613"></a>
+
+### `isAmuletExpired`
+
+```daml
+isAmuletExpired : Round -> ExpiringAmount -> Bool
+```
+
+`isAmuletExpired openRound amuletAmount` computes whether the expiring `amuletAmount`
+is definitely expired in case the `openRound` is open.

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-externalpartyamuletrules.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-externalpartyamuletrules.mdx
@@ -1,0 +1,389 @@
+---
+title: "Splice.ExternalPartyAmuletRules"
+description: "Reference documentation for Daml module Splice.ExternalPartyAmuletRules."
+---
+
+<a id="module-splice-externalpartyamuletrules-66966"></a>
+
+# Splice.ExternalPartyAmuletRules
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommandresult-84908"></a>
+
+### `data ExternalPartyAmuletRules_CreateTransferCommandResult`
+
+Constructors:
+
+<a id="constr-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommandresult-32161"></a>
+- `ExternalPartyAmuletRules_CreateTransferCommandResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferCommandCid | ContractId TransferCommand |  |
+
+Instances:
+
+- `instance Eq ExternalPartyAmuletRules_CreateTransferCommandResult`
+- `instance Show ExternalPartyAmuletRules_CreateTransferCommandResult`
+- `instance GetField transferCommandCid ExternalPartyAmuletRules_CreateTransferCommandResult (ContractId TransferCommand)`
+- `instance SetField transferCommandCid ExternalPartyAmuletRules_CreateTransferCommandResult (ContractId TransferCommand)`
+- `instance HasExercise ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult`
+- `instance HasFromAnyChoice ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult`
+- `instance HasToAnyChoice ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult`
+
+<a id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationinput-45980"></a>
+
+### `data ExternalPartyAmuletRules_ExpireAmuletAllocationInput`
+
+Constructors:
+
+<a id="constr-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationinput-86145"></a>
+- `ExternalPartyAmuletRules_ExpireAmuletAllocationInput`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationCid | ContractId AmuletAllocation |  |
+| expireLock | Bool |  |
+
+Instances:
+
+- `instance Eq ExternalPartyAmuletRules_ExpireAmuletAllocationInput`
+- `instance Show ExternalPartyAmuletRules_ExpireAmuletAllocationInput`
+- `instance GetField allocationCid ExternalPartyAmuletRules_ExpireAmuletAllocationInput (ContractId AmuletAllocation)`
+- `instance GetField expireLock ExternalPartyAmuletRules_ExpireAmuletAllocationInput Bool`
+- `instance GetField inputs ExternalPartyAmuletRules_ExpireAmuletAllocations [ExternalPartyAmuletRules_ExpireAmuletAllocationInput]`
+- `instance SetField allocationCid ExternalPartyAmuletRules_ExpireAmuletAllocationInput (ContractId AmuletAllocation)`
+- `instance SetField expireLock ExternalPartyAmuletRules_ExpireAmuletAllocationInput Bool`
+- `instance SetField inputs ExternalPartyAmuletRules_ExpireAmuletAllocations [ExternalPartyAmuletRules_ExpireAmuletAllocationInput]`
+
+<a id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationsresult-57118"></a>
+
+### `data ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+
+Constructors:
+
+<a id="constr-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationsresult-31907"></a>
+- `ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| results | [AmuletAllocation_DsoExpireResult] |  |
+
+Instances:
+
+- `instance Eq ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance Show ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance GetField results ExternalPartyAmuletRules_ExpireAmuletAllocationsResult [AmuletAllocation_DsoExpireResult]`
+- `instance SetField results ExternalPartyAmuletRules_ExpireAmuletAllocationsResult [AmuletAllocation_DsoExpireResult]`
+- `instance HasExercise ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance HasFromAnyChoice ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance HasToAnyChoice ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+
+<a id="type-splice-externalpartyamuletrules-transfercommandresult-23924"></a>
+
+### `data TransferCommandResult`
+
+Constructors:
+
+<a id="constr-splice-externalpartyamuletrules-transfercommandresultfailure-75214"></a>
+- `TransferCommandResultFailure`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | InvalidTransferReason |  |
+<a id="constr-splice-externalpartyamuletrules-transfercommandresultsuccess-68641"></a>
+- `TransferCommandResultSuccess`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | TransferResult |  |
+
+Instances:
+
+- `instance Eq TransferCommandResult`
+- `instance Show TransferCommandResult`
+- `instance GetField reason TransferCommandResult InvalidTransferReason`
+- `instance GetField result TransferCommandResult TransferResult`
+- `instance GetField result TransferCommand_SendResult TransferCommandResult`
+- `instance SetField reason TransferCommandResult InvalidTransferReason`
+- `instance SetField result TransferCommandResult TransferResult`
+- `instance SetField result TransferCommand_SendResult TransferCommandResult`
+
+<a id="type-splice-externalpartyamuletrules-transfercommandexpireresult-5229"></a>
+
+### `data TransferCommand_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-externalpartyamuletrules-transfercommandexpireresult-27948"></a>
+- `TransferCommand_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| nonce | Int |  |
+
+Instances:
+
+- `instance Eq TransferCommand_ExpireResult`
+- `instance Show TransferCommand_ExpireResult`
+- `instance GetField nonce TransferCommand_ExpireResult Int`
+- `instance GetField sender TransferCommand_ExpireResult Party`
+- `instance SetField nonce TransferCommand_ExpireResult Int`
+- `instance SetField sender TransferCommand_ExpireResult Party`
+- `instance HasExercise TransferCommand TransferCommand_Expire TransferCommand_ExpireResult`
+- `instance HasFromAnyChoice TransferCommand TransferCommand_Expire TransferCommand_ExpireResult`
+- `instance HasToAnyChoice TransferCommand TransferCommand_Expire TransferCommand_ExpireResult`
+
+<a id="type-splice-externalpartyamuletrules-transfercommandsendresult-21916"></a>
+
+### `data TransferCommand_SendResult`
+
+Constructors:
+
+<a id="constr-splice-externalpartyamuletrules-transfercommandsendresult-15277"></a>
+- `TransferCommand_SendResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | TransferCommandResult |  |
+| sender | Party |  |
+| nonce | Int |  |
+
+Instances:
+
+- `instance Eq TransferCommand_SendResult`
+- `instance Show TransferCommand_SendResult`
+- `instance GetField nonce TransferCommand_SendResult Int`
+- `instance GetField result TransferCommand_SendResult TransferCommandResult`
+- `instance GetField sender TransferCommand_SendResult Party`
+- `instance SetField nonce TransferCommand_SendResult Int`
+- `instance SetField result TransferCommand_SendResult TransferCommandResult`
+- `instance SetField sender TransferCommand_SendResult Party`
+- `instance HasExercise TransferCommand TransferCommand_Send TransferCommand_SendResult`
+- `instance HasFromAnyChoice TransferCommand TransferCommand_Send TransferCommand_SendResult`
+- `instance HasToAnyChoice TransferCommand TransferCommand_Send TransferCommand_SendResult`
+
+<a id="type-splice-externalpartyamuletrules-transfercommandwithdrawresult-60664"></a>
+
+### `data TransferCommand_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-externalpartyamuletrules-transfercommandwithdrawresult-93393"></a>
+- `TransferCommand_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| nonce | Int |  |
+
+Instances:
+
+- `instance Eq TransferCommand_WithdrawResult`
+- `instance Show TransferCommand_WithdrawResult`
+- `instance GetField nonce TransferCommand_WithdrawResult Int`
+- `instance GetField sender TransferCommand_WithdrawResult Party`
+- `instance SetField nonce TransferCommand_WithdrawResult Int`
+- `instance SetField sender TransferCommand_WithdrawResult Party`
+- `instance HasExercise TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult`
+- `instance HasFromAnyChoice TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult`
+- `instance HasToAnyChoice TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult`
+
+## Functions
+
+<a id="function-splice-externalpartyamuletrules-amulettransferfactorytransferimpl-9935"></a>
+
+### `amulet_transferFactory_transferImpl`
+
+```daml
+amulet_transferFactory_transferImpl : ExternalPartyAmuletRules -> ContractId TransferFactory -> TransferFactory_Transfer -> Update TransferInstructionResult
+```
+
+<a id="function-splice-externalpartyamuletrules-amuletallocationfactoryallocateimpl-5710"></a>
+
+### `amulet_allocationFactory_allocateImpl`
+
+```daml
+amulet_allocationFactory_allocateImpl : ExternalPartyAmuletRules -> ContractId AllocationFactory -> AllocationFactory_Allocate -> Update AllocationInstructionResult
+```
+
+<a id="function-splice-externalpartyamuletrules-requireexpectedadminmatch-79926"></a>
+
+### `requireExpectedAdminMatch`
+
+```daml
+requireExpectedAdminMatch : Party -> Party -> Update ()
+```
+
+## Templates
+
+<a id="type-splice-externalpartyamuletrules-externalpartyamuletrules-29682"></a>
+
+### Template `ExternalPartyAmuletRules`
+
+Rules contract that can be used in transactions that require signatures
+from an external party. This is intended to get archived and recreated as rarely as possible
+to support long delays between preparing and signing a transaction.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+
+Interface Instances:
+- `AllocationFactory` for `ExternalPartyAmuletRules`
+- `TransferFactory` for `ExternalPartyAmuletRules`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommand-90877"></a>
+
+#### Choice `ExternalPartyAmuletRules_CreateTransferCommand`
+
+Controllers: `sender`
+
+Returns: `ExternalPartyAmuletRules_CreateTransferCommandResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| receiver | Party |  |
+| delegate | Party |  |
+| amount | Decimal |  |
+| expiresAt | Time |  |
+| nonce | Int |  |
+| description | Optional Text |  |
+| expectedDso | Optional Party |  |
+
+<a id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocations-38439"></a>
+
+#### Choice `ExternalPartyAmuletRules_ExpireAmuletAllocations`
+
+Controllers: `dso`
+
+Returns: `ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedDso | Party |  |
+| inputs | [ExternalPartyAmuletRules_ExpireAmuletAllocationInput] |  |
+| observers | [Party] |  |
+
+<a id="type-splice-externalpartyamuletrules-transfercommand-52429"></a>
+
+### Template `TransferCommand`
+
+Deprecated: The token standard transfer APIs now support 24h signing delays so this contract is no longer required.
+
+One-time delegation to execute a transfer to the given receiver
+for the given amount.
+
+Signatories: `sender`, `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sender | Party |  |
+| receiver | Party |  |
+| delegate | Party | The delegate that actually executes the transfer |
+| amount | Decimal |  |
+| expiresAt | Time | Expiry of the command until when TransferCommand_Send must be called |
+| nonce | Int | Expected nonce value to order and deduplicate concurrent transfers.<br/><br/>Starts at 0 and the next value to use can then be read from TransferCommandCounter and the in-flight TransferCommand contracts. |
+| description | Optional Text |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `sender`, `dso`
+
+Returns: `()`
+
+<a id="type-splice-externalpartyamuletrules-transfercommandexpire-28516"></a>
+
+#### Choice `TransferCommand_Expire`
+
+Controllers: `p`
+
+Returns: `TransferCommand_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| p | Party |  |
+
+<a id="type-splice-externalpartyamuletrules-transfercommandsend-32409"></a>
+
+#### Choice `TransferCommand_Send`
+
+Controllers: `delegate`
+
+Returns: `TransferCommand_SendResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| transferPreapprovalCidO | Optional (ContractId TransferPreapproval) |  |
+| transferCounterCid | ContractId TransferCommandCounter |  |
+
+<a id="type-splice-externalpartyamuletrules-transfercommandwithdraw-90837"></a>
+
+#### Choice `TransferCommand_Withdraw`
+
+Controllers: `sender`
+
+Returns: `TransferCommand_WithdrawResult`
+
+<a id="type-splice-externalpartyamuletrules-transfercommandcounter-30214"></a>
+
+### Template `TransferCommandCounter`
+
+A contract tracking the number of completed TransferCommands per sender,
+which is used to determine the nonces used in TransferCommands for deduplication.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sender | Party |  |
+| nextNonce | Int |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-externalpartyconfigstate.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-externalpartyconfigstate.mdx
@@ -1,0 +1,57 @@
+---
+title: "Splice.ExternalPartyConfigState"
+description: "Reference documentation for Daml module Splice.ExternalPartyConfigState."
+---
+
+<a id="module-splice-externalpartyconfigstate-24656"></a>
+
+# Splice.ExternalPartyConfigState
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Templates
+
+<a id="type-splice-externalpartyconfigstate-externalpartyconfigstate-1378"></a>
+
+### Template `ExternalPartyConfigState`
+
+`ExternalPartyConfigState` stores the configuration required for transfer, allocations, traffic purchases and taps.
+While it exposes a subset of the information also available on `OpenMiningRound`, `ExternalPartyConfigState` contracts
+are active much longer allowing for a 24 delay between preparing and executing a transaction.
+
+There are always two `ExternalPartyConfigState` contracts created approximately `externalPartyConfigStateTickDuration` apart from each other
+and each is active for `2 * externalPartyConfigStateTickDuration`.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| holdingFeesOpenRoundNumber | Round | The round number to use for charging holding fees for newly created contracts. |
+| amuletPrice | Decimal | Amulet price at the time the config state was created. |
+| transferConfig | TransferConfigV2 USD | Transfer config at the time the config state was created. |
+| targetArchiveAfter | Time | Lower bound on the time the contract gets archived, not enforced as a strict upper bound. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-fees.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-fees.mdx
@@ -1,0 +1,326 @@
+---
+title: "Splice.Fees"
+description: "Reference documentation for Daml module Splice.Fees."
+---
+
+<a id="module-splice-fees-99189"></a>
+
+# Splice.Fees
+
+Utility functions for different kinds of fees.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-fees-expiringamount-39537"></a>
+
+### `data ExpiringAmount`
+
+Constructors:
+
+<a id="constr-splice-fees-expiringamount-68564"></a>
+- `ExpiringAmount`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| initialAmount | Decimal |  |
+| createdAt | Round |  |
+| ratePerRound | RatePerRound |  |
+
+Instances:
+
+- `instance Eq ExpiringAmount`
+- `instance Ord ExpiringAmount`
+- `instance Show ExpiringAmount`
+- `instance GetField amount Amulet ExpiringAmount`
+- `instance GetField createdAt ExpiringAmount Round`
+- `instance GetField initialAmount ExpiringAmount Decimal`
+- `instance GetField ratePerRound ExpiringAmount RatePerRound`
+- `instance SetField amount Amulet ExpiringAmount`
+- `instance SetField createdAt ExpiringAmount Round`
+- `instance SetField initialAmount ExpiringAmount Decimal`
+- `instance SetField ratePerRound ExpiringAmount RatePerRound`
+
+<a id="type-splice-fees-fixedfee-53985"></a>
+
+### `data FixedFee`
+
+A fixed fee independent of the action being taken.
+TODO(M3-90): check whether this name matches usage in financial terms, it probably isn't. Should it be 'flat-fee', 'constantfee', ... ???
+
+Constructors:
+
+<a id="constr-splice-fees-fixedfee-53900"></a>
+- `FixedFee`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| fee | Decimal |  |
+
+Instances:
+
+- `instance Patchable FixedFee`
+- `instance Eq FixedFee`
+- `instance Ord FixedFee`
+- `instance Show FixedFee`
+- `instance GetField createFee (TransferConfig unit) FixedFee`
+- `instance GetField fee FixedFee Decimal`
+- `instance GetField lockHolderFee (TransferConfig unit) FixedFee`
+- `instance SetField createFee (TransferConfig unit) FixedFee`
+- `instance SetField fee FixedFee Decimal`
+- `instance SetField lockHolderFee (TransferConfig unit) FixedFee`
+
+<a id="type-splice-fees-rateperday-41902"></a>
+
+### `data RatePerDay`
+
+Constructors:
+
+<a id="constr-splice-fees-rateperday-51003"></a>
+- `RatePerDay`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| rate | Decimal |  |
+
+Instances:
+
+- `instance Eq RatePerDay`
+- `instance Ord RatePerDay`
+- `instance Show RatePerDay`
+- `instance GetField rate RatePerDay Decimal`
+- `instance SetField rate RatePerDay Decimal`
+
+<a id="type-splice-fees-rateperround-90570"></a>
+
+### `data RatePerRound`
+
+Constructors:
+
+<a id="constr-splice-fees-rateperround-75691"></a>
+- `RatePerRound`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| rate | Decimal |  |
+
+Instances:
+
+- `instance Patchable RatePerRound`
+- `instance Eq RatePerRound`
+- `instance Ord RatePerRound`
+- `instance Show RatePerRound`
+- `instance GetField holdingFee (TransferConfig unit) RatePerRound`
+- `instance GetField holdingFee (TransferConfigV2 unit) RatePerRound`
+- `instance GetField rate RatePerRound Decimal`
+- `instance GetField ratePerRound ExpiringAmount RatePerRound`
+- `instance SetField holdingFee (TransferConfig unit) RatePerRound`
+- `instance SetField holdingFee (TransferConfigV2 unit) RatePerRound`
+- `instance SetField rate RatePerRound Decimal`
+- `instance SetField ratePerRound ExpiringAmount RatePerRound`
+
+<a id="type-splice-fees-steppedrate-36691"></a>
+
+### `data SteppedRate`
+
+A rate defined as a piecewise linear function, e.g.,
+`SteppedRate 0.01 [(100.0, 0.001), (1000.0, 0.0001), (1000000, 0.00001)]
+corresponds to 1% of the first 100, 0.1% between 100 and 1000, 0.01% between 1000 and 1000000
+and 0.001% for everything above that.
+
+Constructors:
+
+<a id="constr-splice-fees-steppedrate-72856"></a>
+- `SteppedRate`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| initialRate | Decimal |  |
+| steps | [(Decimal, Decimal)] |  |
+
+Instances:
+
+- `instance Patchable SteppedRate`
+- `instance Eq SteppedRate`
+- `instance Ord SteppedRate`
+- `instance Show SteppedRate`
+- `instance GetField initialRate SteppedRate Decimal`
+- `instance GetField steps SteppedRate [(Decimal, Decimal)]`
+- `instance GetField transferFee (TransferConfig unit) SteppedRate`
+- `instance SetField initialRate SteppedRate Decimal`
+- `instance SetField steps SteppedRate [(Decimal, Decimal)]`
+- `instance SetField transferFee (TransferConfig unit) SteppedRate`
+
+## Functions
+
+<a id="function-splice-fees-reltimetomicros-80866"></a>
+
+### `relTimeToMicros`
+
+```daml
+relTimeToMicros : RelTime -> Decimal
+```
+
+<a id="function-splice-fees-microsperday-26445"></a>
+
+### `microsPerDay`
+
+```daml
+microsPerDay : Decimal
+```
+
+<a id="function-splice-fees-reltimetodays-39078"></a>
+
+### `relTimeToDays`
+
+```daml
+relTimeToDays : RelTime -> Decimal
+```
+
+<a id="function-splice-fees-daystoreltime-342"></a>
+
+### `daysToRelTime`
+
+```daml
+daysToRelTime : Decimal -> RelTime
+```
+
+<a id="function-splice-fees-reltimetoseconds-31347"></a>
+
+### `relTimeToSeconds`
+
+```daml
+relTimeToSeconds : RelTime -> Decimal
+```
+
+<a id="function-splice-fees-chargerateperround-14136"></a>
+
+### `chargeRatePerRound`
+
+```daml
+chargeRatePerRound : RatePerRound -> RelRound -> Decimal
+```
+
+<a id="function-splice-fees-scalerateperround-96257"></a>
+
+### `scaleRatePerRound`
+
+```daml
+scaleRatePerRound : Decimal -> RatePerRound -> RatePerRound
+```
+
+Scale a round rate such that
+
+ALL s r dt. s * chargeRatePerRound r dt = chargeRatePerRound (s `scaleRatePerRound` r) dt
+
+<a id="function-splice-fees-positiverateperround-2835"></a>
+
+### `positiveRatePerRound`
+
+```daml
+positiveRatePerRound : RatePerRound -> Bool
+```
+
+<a id="function-splice-fees-scalefixedfee-12994"></a>
+
+### `scaleFixedFee`
+
+```daml
+scaleFixedFee : Decimal -> FixedFee -> FixedFee
+```
+
+<a id="function-splice-fees-positivefixedfee-97380"></a>
+
+### `positiveFixedFee`
+
+```daml
+positiveFixedFee : FixedFee -> Bool
+```
+
+<a id="function-splice-fees-validsteppedrate-82534"></a>
+
+### `validSteppedRate`
+
+```daml
+validSteppedRate : SteppedRate -> Bool
+```
+
+<a id="function-splice-fees-chargesteppedrate-67705"></a>
+
+### `chargeSteppedRate`
+
+```daml
+chargeSteppedRate : SteppedRate -> Decimal -> Decimal
+```
+
+<a id="function-splice-fees-gochargesteppedrate-62505"></a>
+
+### `goChargeSteppedRate`
+
+```daml
+goChargeSteppedRate : (Decimal, Decimal, Decimal) -> [(Decimal, Decimal)] -> Decimal
+```
+
+<a id="function-splice-fees-scalesteppedrate-86486"></a>
+
+### `scaleSteppedRate`
+
+```daml
+scaleSteppedRate : Decimal -> SteppedRate -> SteppedRate
+```
+
+Scale a fixed-plus-variable rate such that
+
+ALL s r q. s * chargeSteppedRate r (q/s) = chargeSteppedRate (s `scaleSteppedRate` r) q
+
+<a id="function-splice-fees-validexpiringamount-89306"></a>
+
+### `validExpiringAmount`
+
+```daml
+validExpiringAmount : ExpiringAmount -> Bool
+```
+
+<a id="function-splice-fees-expiringamount-85661"></a>
+
+### `expiringAmount`
+
+```daml
+expiringAmount : RatePerRound -> Decimal -> Round -> ExpiringAmount
+```
+
+Smart constructor for an expiring amount.
+
+<a id="function-splice-fees-getvalueasofround0-94025"></a>
+
+### `getValueAsOfRound0`
+
+```daml
+getValueAsOfRound0 : ExpiringAmount -> Decimal
+```
+
+<a id="function-splice-fees-chargerateperday-61208"></a>
+
+### `chargeRatePerDay`
+
+```daml
+chargeRatePerDay : RatePerDay -> RelTime -> Decimal
+```
+
+<a id="function-splice-fees-rateperroundtorateperday-46486"></a>
+
+### `ratePerRoundToRatePerDay`
+
+```daml
+ratePerRoundToRatePerDay : RatePerRound -> RelTime -> RatePerDay
+```

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-issuance.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-issuance.mdx
@@ -1,0 +1,244 @@
+---
+title: "Splice.Issuance"
+description: "Reference documentation for Daml module Splice.Issuance."
+---
+
+<a id="module-splice-issuance-46787"></a>
+
+# Splice.Issuance
+
+Amulet rewards issuance configuration and computation.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-issuance-issuanceconfig-93012"></a>
+
+### `data IssuanceConfig`
+
+Constructors:
+
+<a id="constr-splice-issuance-issuanceconfig-42917"></a>
+- `IssuanceConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletToIssuePerYear | Decimal |  |
+| validatorRewardPercentage | Decimal |  |
+| appRewardPercentage | Decimal |  |
+| validatorRewardCap | Decimal |  |
+| featuredAppRewardCap | Decimal |  |
+| unfeaturedAppRewardCap | Decimal |  |
+| optValidatorFaucetCap | Optional Decimal | Maximal amount in $ for the per-validator issuance of validator faucet coupons;<br/><br/>Introduced as part of CIP-0003. Will default to 0.00 USD once CIP-0096 becomes effective. |
+| optDevelopmentFundPercentage | Optional Decimal | Percentage of each mint emission allocated to the Development Fund under CIP-0082. |
+
+Instances:
+
+- `instance Patchable IssuanceConfig`
+- `instance Eq IssuanceConfig`
+- `instance Show IssuanceConfig`
+- `instance GetField amuletToIssuePerYear IssuanceConfig Decimal`
+- `instance GetField appRewardPercentage IssuanceConfig Decimal`
+- `instance GetField featuredAppRewardCap IssuanceConfig Decimal`
+- `instance GetField issuanceConfig OpenMiningRound IssuanceConfig`
+- `instance GetField issuanceConfig SummarizingMiningRound IssuanceConfig`
+- `instance GetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
+- `instance GetField optDevelopmentFundPercentage IssuanceConfig (Optional Decimal)`
+- `instance GetField optValidatorFaucetCap IssuanceConfig (Optional Decimal)`
+- `instance GetField unfeaturedAppRewardCap IssuanceConfig Decimal`
+- `instance GetField validatorRewardCap IssuanceConfig Decimal`
+- `instance GetField validatorRewardPercentage IssuanceConfig Decimal`
+- `instance SetField amuletToIssuePerYear IssuanceConfig Decimal`
+- `instance SetField appRewardPercentage IssuanceConfig Decimal`
+- `instance SetField featuredAppRewardCap IssuanceConfig Decimal`
+- `instance SetField issuanceConfig OpenMiningRound IssuanceConfig`
+- `instance SetField issuanceConfig SummarizingMiningRound IssuanceConfig`
+- `instance SetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
+- `instance SetField optDevelopmentFundPercentage IssuanceConfig (Optional Decimal)`
+- `instance SetField optValidatorFaucetCap IssuanceConfig (Optional Decimal)`
+- `instance SetField unfeaturedAppRewardCap IssuanceConfig Decimal`
+- `instance SetField validatorRewardCap IssuanceConfig Decimal`
+- `instance SetField validatorRewardPercentage IssuanceConfig Decimal`
+
+<a id="type-splice-issuance-issuancetranche-71318"></a>
+
+### `data IssuanceTranche`
+
+Constructors:
+
+<a id="constr-splice-issuance-issuancetranche-27573"></a>
+- `IssuanceTranche`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| rewardsToIssue | Decimal | Total amulets to issue as rewards in this tranche |
+| issuancePerCoupon | Decimal | Issuence per reward coupon for this tranche |
+| unclaimedRewards | Decimal | Amulets to issue in this tranche that were not claimed |
+
+Instances:
+
+- `instance GetField issuancePerCoupon IssuanceTranche Decimal`
+- `instance GetField rewardsToIssue IssuanceTranche Decimal`
+- `instance GetField unclaimedRewards IssuanceTranche Decimal`
+- `instance SetField issuancePerCoupon IssuanceTranche Decimal`
+- `instance SetField rewardsToIssue IssuanceTranche Decimal`
+- `instance SetField unclaimedRewards IssuanceTranche Decimal`
+
+<a id="type-splice-issuance-issuingroundparameters-47575"></a>
+
+### `data IssuingRoundParameters`
+
+Parameters to use in a round that issues amulet as rewards for collected coupons.
+
+Constructors:
+
+<a id="constr-splice-issuance-issuingroundparameters-60486"></a>
+- `IssuingRoundParameters`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| issuancePerValidatorRewardCoupon | Decimal |  |
+| issuancePerFeaturedAppRewardCoupon | Decimal |  |
+| issuancePerUnfeaturedAppRewardCoupon | Decimal |  |
+| issuancePerSvRewardCoupon | Decimal |  |
+| unclaimedAppRewards | Decimal |  |
+| unclaimedValidatorRewards | Decimal |  |
+| unclaimedSvRewards | Decimal | Can be non-zero due to rounding, or no SV having had the chance to claim their coupons. |
+| issuancePerValidatorFaucetCoupon | Decimal |  |
+| optAmuletsToIssueToDevelopmentFund | Optional Decimal | Note: Made optional as the addition of this field is checked by the upgrade checker<br/><br/>on package upload because `IssuingRoundParameters` is serializable. |
+
+Instances:
+
+- `instance Eq IssuingRoundParameters`
+- `instance Show IssuingRoundParameters`
+- `instance GetField issuancePerFeaturedAppRewardCoupon IssuingRoundParameters Decimal`
+- `instance GetField issuancePerSvRewardCoupon IssuingRoundParameters Decimal`
+- `instance GetField issuancePerUnfeaturedAppRewardCoupon IssuingRoundParameters Decimal`
+- `instance GetField issuancePerValidatorFaucetCoupon IssuingRoundParameters Decimal`
+- `instance GetField issuancePerValidatorRewardCoupon IssuingRoundParameters Decimal`
+- `instance GetField optAmuletsToIssueToDevelopmentFund IssuingRoundParameters (Optional Decimal)`
+- `instance GetField unclaimedAppRewards IssuingRoundParameters Decimal`
+- `instance GetField unclaimedSvRewards IssuingRoundParameters Decimal`
+- `instance GetField unclaimedValidatorRewards IssuingRoundParameters Decimal`
+- `instance SetField issuancePerFeaturedAppRewardCoupon IssuingRoundParameters Decimal`
+- `instance SetField issuancePerSvRewardCoupon IssuingRoundParameters Decimal`
+- `instance SetField issuancePerUnfeaturedAppRewardCoupon IssuingRoundParameters Decimal`
+- `instance SetField issuancePerValidatorFaucetCoupon IssuingRoundParameters Decimal`
+- `instance SetField issuancePerValidatorRewardCoupon IssuingRoundParameters Decimal`
+- `instance SetField optAmuletsToIssueToDevelopmentFund IssuingRoundParameters (Optional Decimal)`
+- `instance SetField unclaimedAppRewards IssuingRoundParameters Decimal`
+- `instance SetField unclaimedSvRewards IssuingRoundParameters Decimal`
+- `instance SetField unclaimedValidatorRewards IssuingRoundParameters Decimal`
+
+<a id="type-splice-issuance-openminingroundsummary-90943"></a>
+
+### `data OpenMiningRoundSummary`
+
+A summary of total reward coupons issued against a specific open mining round.
+
+Constructors:
+
+<a id="constr-splice-issuance-openminingroundsummary-16618"></a>
+- `OpenMiningRoundSummary`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| totalValidatorRewardCoupons | Decimal |  |
+| totalFeaturedAppRewardCoupons | Decimal |  |
+| totalUnfeaturedAppRewardCoupons | Decimal |  |
+| totalSvRewardWeight | Int |  |
+| optTotalValidatorFaucetCoupons | Optional Int | Introduced as part of CIP-3. |
+
+Instances:
+
+- `instance Eq OpenMiningRoundSummary`
+- `instance Show OpenMiningRoundSummary`
+- `instance GetField optTotalValidatorFaucetCoupons OpenMiningRoundSummary (Optional Int)`
+- `instance GetField summary AmuletRules_MiningRound_StartIssuing OpenMiningRoundSummary`
+- `instance GetField totalFeaturedAppRewardCoupons OpenMiningRoundSummary Decimal`
+- `instance GetField totalSvRewardWeight OpenMiningRoundSummary Int`
+- `instance GetField totalUnfeaturedAppRewardCoupons OpenMiningRoundSummary Decimal`
+- `instance GetField totalValidatorRewardCoupons OpenMiningRoundSummary Decimal`
+- `instance SetField optTotalValidatorFaucetCoupons OpenMiningRoundSummary (Optional Int)`
+- `instance SetField summary AmuletRules_MiningRound_StartIssuing OpenMiningRoundSummary`
+- `instance SetField totalFeaturedAppRewardCoupons OpenMiningRoundSummary Decimal`
+- `instance SetField totalSvRewardWeight OpenMiningRoundSummary Int`
+- `instance SetField totalUnfeaturedAppRewardCoupons OpenMiningRoundSummary Decimal`
+- `instance SetField totalValidatorRewardCoupons OpenMiningRoundSummary Decimal`
+
+## Functions
+
+<a id="function-splice-issuance-getvalidatorfaucetcap-50474"></a>
+
+### `getValidatorFaucetCap`
+
+```daml
+getValidatorFaucetCap : IssuanceConfig -> Decimal
+```
+
+Getter with the right default value for the validator faucet cap.
+Use this consistently instead of accessing the field directly.
+
+<a id="function-splice-issuance-validissuancecurve-81463"></a>
+
+### `validIssuanceCurve`
+
+```daml
+validIssuanceCurve : Schedule RelTime IssuanceConfig -> Bool
+```
+
+<a id="function-splice-issuance-validissuanceconfig-25363"></a>
+
+### `validIssuanceConfig`
+
+```daml
+validIssuanceConfig : IssuanceConfig -> Bool
+```
+
+<a id="function-splice-issuance-gettotalvalidatorfaucetcoupons-98130"></a>
+
+### `getTotalValidatorFaucetCoupons`
+
+```daml
+getTotalValidatorFaucetCoupons : OpenMiningRoundSummary -> Int
+```
+
+<a id="function-splice-issuance-validateopenminingroundsummary-65797"></a>
+
+### `validateOpenMiningRoundSummary`
+
+```daml
+validateOpenMiningRoundSummary : CanAssert m => OpenMiningRoundSummary -> m ()
+```
+
+<a id="function-splice-issuance-computeissuingroundparameters-5863"></a>
+
+### `computeIssuingRoundParameters`
+
+```daml
+computeIssuingRoundParameters : RelTime -> Decimal -> IssuanceConfig -> OpenMiningRoundSummary -> IssuingRoundParameters
+```
+
+<a id="function-splice-issuance-computeissuancetranche-10230"></a>
+
+### `computeIssuanceTranche`
+
+```daml
+computeIssuanceTranche : Decimal -> Decimal -> Decimal -> IssuanceTranche
+```
+
+`computeIssuanceTranche rewardsToIssue capPerCoupon totalCoupons`
+
+computes parameters that issue as many rewards per coupon as possible up to
+a maximum of `capPerCoupon` amulets.

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-relround.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-relround.mdx
@@ -1,0 +1,67 @@
+---
+title: "Splice.RelRound"
+description: "Reference documentation for Daml module Splice.RelRound."
+---
+
+<a id="module-splice-relround-92157"></a>
+
+# Splice.RelRound
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-relround-relround-10584"></a>
+
+### `data RelRound`
+
+The equivalent of RelTime for rounds, i.e., a delta between
+two rounds
+
+Constructors:
+
+<a id="constr-splice-relround-relround-94237"></a>
+- `RelRound`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| diff | Int |  |
+
+Instances:
+
+- `instance Eq RelRound`
+- `instance Ord RelRound`
+- `instance Show RelRound`
+- `instance GetField diff RelRound Int`
+- `instance SetField diff RelRound Int`
+
+## Functions
+
+<a id="function-splice-relround-addrelround-11446"></a>
+
+### `addRelRound`
+
+```daml
+addRelRound : Round -> RelRound -> Round
+```
+
+<a id="function-splice-relround-subround-39329"></a>
+
+### `subRound`
+
+```daml
+subRound : Round -> Round -> RelRound
+```

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-round.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-round.mdx
@@ -1,0 +1,181 @@
+---
+title: "Splice.Round"
+description: "Reference documentation for Daml module Splice.Round."
+---
+
+<a id="module-splice-round-72925"></a>
+
+# Splice.Round
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Functions
+
+<a id="function-splice-round-getissuingminingroundissuancepervalidatorfaucetcoupon-99508"></a>
+
+### `getIssuingMiningRoundIssuancePerValidatorFaucetCoupon`
+
+```daml
+getIssuingMiningRoundIssuancePerValidatorFaucetCoupon : IssuingMiningRound -> Decimal
+```
+
+Accessor with defaulting for the optional issuancePerValidatorFaucetCoupon field
+
+<a id="function-splice-round-getclosedminingroundissuancepervalidatorfaucetcoupon-25673"></a>
+
+### `getClosedMiningRoundIssuancePerValidatorFaucetCoupon`
+
+```daml
+getClosedMiningRoundIssuancePerValidatorFaucetCoupon : ClosedMiningRound -> Decimal
+```
+
+Accessor with defaulting for the optional issuancePerValidatorFaucetCoupon field
+
+## Templates
+
+<a id="type-splice-round-closedmininground-12506"></a>
+
+### Template `ClosedMiningRound`
+
+A record that a specific mining round has been closed, which can
+be used to archive expired rewards.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| round | Round |  |
+| issuancePerValidatorRewardCoupon | Decimal |  |
+| issuancePerFeaturedAppRewardCoupon | Decimal |  |
+| issuancePerUnfeaturedAppRewardCoupon | Decimal |  |
+| issuancePerSvRewardCoupon | Decimal |  |
+| optIssuancePerValidatorFaucetCoupon | Optional Decimal | Introduced in CIP-3 |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-round-issuingmininground-98097"></a>
+
+### Template `IssuingMiningRound`
+
+A mining round for whose rewards amulets are being issued.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| round | Round |  |
+| issuancePerValidatorRewardCoupon | Decimal |  |
+| issuancePerFeaturedAppRewardCoupon | Decimal |  |
+| issuancePerUnfeaturedAppRewardCoupon | Decimal |  |
+| issuancePerSvRewardCoupon | Decimal |  |
+| opensAt | Time | Time after which rewards from this mining round can be collected |
+| targetClosesAt | Time | Time when this round is expected to close during standard DSO. The round SHOULD NOT be archived before this time. |
+| optIssuancePerValidatorFaucetCoupon | Optional Decimal | Introduced in CIP-3 |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-round-openmininground-90060"></a>
+
+### Template `OpenMiningRound`
+
+A mining round for which new rewards can be registered.
+Note that multiple mining rounds can be open at the same time to give some
+time for propagating a new open round, while still registering rewards
+against the previous open round.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| round | Round |  |
+| amuletPrice | Decimal |  |
+| opensAt | Time | Time after which transfers can use this mining round |
+| targetClosesAt | Time | Time when this round is expected to be closed as part of standard DSO. The round SHOULD NOT be archived before this time. |
+| issuingFor | RelTime | Timepoint on the issuance curve that was used to determing the issuance configuration for this round. |
+| transferConfigUsd | TransferConfig USD | Configuration determining the fees and limits in USD for Amulet transfers |
+| issuanceConfig | IssuanceConfig | Configuration for issuance of this round. |
+| tickDuration | RelTime | Duration of a tick, which is the duration of half a round. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-round-openminingroundfetch-48019"></a>
+
+#### Choice `OpenMiningRound_Fetch`
+
+Controllers: `p`
+
+Returns: `OpenMiningRound`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| p | Party |  |
+
+<a id="type-splice-round-summarizingmininground-36579"></a>
+
+### Template `SummarizingMiningRound`
+
+A mining round for which the total sum of registered rewards
+is being computed. Rewards can no longer be registered aginst such a round.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| round | Round |  |
+| amuletPrice | Decimal |  |
+| issuanceConfig | IssuanceConfig |  |
+| tickDuration | RelTime |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-schedule.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-schedule.mdx
@@ -1,0 +1,144 @@
+---
+title: "Splice.Schedule"
+description: "Reference documentation for Daml module Splice.Schedule."
+---
+
+<a id="module-splice-schedule-45837"></a>
+
+# Splice.Schedule
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-schedule-schedule-35504"></a>
+
+### `data Schedule t a`
+
+A schedule of values that change over time.
+
+Constructors:
+
+<a id="constr-splice-schedule-schedule-12101"></a>
+- `Schedule`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| initialValue | a | Initial value to use until the future values come into effect. |
+| futureValues | [(t, a)] | sorted in ascending order |
+
+Instances:
+
+- `instance (Patchable t, Patchable a, Ord t, Eq a) => Patchable (Schedule t a)`
+- `instance Functor (Schedule t)`
+- `instance (Eq a, Eq t) => Eq (Schedule t a)`
+- `instance (Show a, Show t) => Show (Schedule t a)`
+- `instance GetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance GetField futureValues (Schedule t a) [(t, a)]`
+- `instance GetField initialValue (Schedule t a) a`
+- `instance GetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
+- `instance SetField configSchedule AmuletRules (Schedule Time (AmuletConfig USD))`
+- `instance SetField futureValues (Schedule t a) [(t, a)]`
+- `instance SetField initialValue (Schedule t a) a`
+- `instance SetField issuanceCurve (AmuletConfig unit) (Schedule RelTime IssuanceConfig)`
+
+## Functions
+
+<a id="function-splice-schedule-getvalueasof-1611"></a>
+
+### `getValueAsOf`
+
+```daml
+getValueAsOf : Ord t => t -> Schedule t a -> a
+```
+
+Get the value as of a specific time
+
+<a id="function-splice-schedule-getvalueasofledgertime-35649"></a>
+
+### `getValueAsOfLedgerTime`
+
+```daml
+getValueAsOfLedgerTime : Schedule Time a -> Update a
+```
+
+Variant of `getValueAsOf` that communicates workflow-level bounds.
+
+<a id="function-splice-schedule-validschedule-3679"></a>
+
+### `validSchedule`
+
+```daml
+validSchedule : Ord t => Schedule t a -> (a -> Bool) -> Bool
+```
+
+Check the validity of a schedule given a function to check the validity of its values
+
+<a id="function-splice-schedule-allvalues-28049"></a>
+
+### `allValues`
+
+```daml
+allValues : Schedule t a -> [a]
+```
+
+<a id="function-splice-schedule-nextchangescheduledat-43849"></a>
+
+### `nextChangeScheduledAt`
+
+```daml
+nextChangeScheduledAt : Schedule t a -> Optional t
+```
+
+<a id="function-splice-schedule-prune-18462"></a>
+
+### `prune`
+
+```daml
+prune : Ord t => t -> Schedule t a -> Schedule t a
+```
+
+<a id="function-splice-schedule-splitattime-35540"></a>
+
+### `splitAtTime`
+
+```daml
+splitAtTime : Ord t => [(t, a)] -> t -> ([(t, a)], Optional (t, a), [(t, a)])
+```
+
+<a id="function-splice-schedule-insert-53714"></a>
+
+### `insert`
+
+```daml
+insert : Ord t => (t, a) -> Schedule t a -> Schedule t a
+```
+
+<a id="function-splice-schedule-remove-70441"></a>
+
+### `remove`
+
+```daml
+remove : Ord t => t -> Schedule t a -> Schedule t a
+```
+
+<a id="function-splice-schedule-update-39134"></a>
+
+### `update`
+
+```daml
+update : Ord t => (t, a) -> Schedule t a -> Schedule t a
+```

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-types.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-types.mdx
@@ -1,0 +1,212 @@
+---
+title: "Splice.Types"
+description: "Reference documentation for Daml module Splice.Types."
+---
+
+<a id="module-splice-types-4572"></a>
+
+# Splice.Types
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-types-fordso-8725"></a>
+
+### `data ForDso`
+
+The group of contracts managed by the DSO party.
+
+Used for checked fetches.
+
+Constructors:
+
+<a id="constr-splice-types-fordso-8586"></a>
+- `ForDso`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+
+Instances:
+
+- `instance HasCheckedFetch DevelopmentFundCoupon ForDso`
+- `instance HasCheckedFetch FeaturedAppActivityMarker ForDso`
+- `instance HasCheckedFetch UnclaimedDevelopmentFundCoupon ForDso`
+- `instance HasCheckedFetch UnclaimedReward ForDso`
+- `instance HasCheckedFetch ValidatorRewardCoupon ForDso`
+- `instance HasCheckedFetch AmuletAllocation ForDso`
+- `instance HasCheckedFetch AmuletRules ForDso`
+- `instance HasCheckedFetch AllocationView ForDso`
+- `instance HasCheckedFetch TransferInstructionView ForDso`
+- `instance HasCheckedFetch MemberTraffic ForDso`
+- `instance HasCheckedFetch TransferCommand ForDso`
+- `instance HasCheckedFetch ExternalPartyConfigState ForDso`
+- `instance HasCheckedFetch ClosedMiningRound ForDso`
+- `instance HasCheckedFetch IssuingMiningRound ForDso`
+- `instance HasCheckedFetch OpenMiningRound ForDso`
+- `instance HasCheckedFetch SummarizingMiningRound ForDso`
+- `instance HasCheckedFetch ValidatorLicense ForDso`
+- `instance Eq ForDso`
+- `instance Show ForDso`
+- `instance GetField dso ForDso Party`
+- `instance SetField dso ForDso Party`
+
+<a id="type-splice-types-forowner-62144"></a>
+
+### `data ForOwner`
+
+The group of contracts managed by the DSO party and owned by a specific party.
+
+Used for checked fetches.
+
+Constructors:
+
+<a id="constr-splice-types-forowner-89915"></a>
+- `ForOwner`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| owner | Party |  |
+
+Instances:
+
+- `instance HasCheckedFetch Amulet ForOwner`
+- `instance HasCheckedFetch AppRewardCoupon ForOwner`
+- `instance HasCheckedFetch DevelopmentFundCoupon ForOwner`
+- `instance HasCheckedFetch FeaturedAppActivityMarker ForOwner`
+- `instance HasCheckedFetch LockedAmulet ForOwner`
+- `instance HasCheckedFetch SvRewardCoupon ForOwner`
+- `instance HasCheckedFetch UnclaimedActivityRecord ForOwner`
+- `instance HasCheckedFetch TransferPreapproval ForOwner`
+- `instance HasCheckedFetch HoldingView ForOwner`
+- `instance HasCheckedFetch TransferCommandCounter ForOwner`
+- `instance HasCheckedFetch ValidatorFaucetCoupon ForOwner`
+- `instance HasCheckedFetch ValidatorLivenessActivityRecord ForOwner`
+- `instance Eq ForOwner`
+- `instance Show ForOwner`
+- `instance GetField dso ForOwner Party`
+- `instance GetField owner ForOwner Party`
+- `instance SetField dso ForOwner Party`
+- `instance SetField owner ForOwner Party`
+
+<a id="type-splice-types-forround-72197"></a>
+
+### `data ForRound`
+
+The group of contracts managed by the DSO party for a specific mining round.
+
+Used for checked fetches.
+
+Constructors:
+
+<a id="constr-splice-types-forround-96474"></a>
+- `ForRound`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| round | Round |  |
+
+Instances:
+
+- `instance HasCheckedFetch ClosedMiningRound ForRound`
+- `instance HasCheckedFetch IssuingMiningRound ForRound`
+- `instance HasCheckedFetch OpenMiningRound ForRound`
+- `instance HasCheckedFetch SummarizingMiningRound ForRound`
+- `instance Eq ForRound`
+- `instance Show ForRound`
+- `instance GetField dso ForRound Party`
+- `instance GetField round ForRound Round`
+- `instance SetField dso ForRound Party`
+- `instance SetField round ForRound Round`
+
+<a id="type-splice-types-round-16181"></a>
+
+### `data Round`
+
+Constructors:
+
+<a id="constr-splice-types-round-29804"></a>
+- `Round`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| number | Int |  |
+
+Instances:
+
+- `instance Eq Round`
+- `instance Ord Round`
+- `instance Show Round`
+- `instance GetField createdAt ExpiringAmount Round`
+- `instance GetField firstReceivedFor FaucetState Round`
+- `instance GetField holdingFeesOpenRoundNumber ExternalPartyConfigState Round`
+- `instance GetField initialRound AmuletRules_Bootstrap_RoundsResult (Optional Round)`
+- `instance GetField issuingMiningRounds TransferContext (Map Round (ContractId IssuingMiningRound))`
+- `instance GetField issuingMiningRounds TransferContextSummary (Map Round IssuingMiningRound)`
+- `instance GetField issuingMiningRounds TransferContextSummaryV2 (Map Round IssuingMiningRound)`
+- `instance GetField lastReceivedFor FaucetState Round`
+- `instance GetField number Round Int`
+- `instance GetField openRoundNumber TransferContextSummaryV2 Round`
+- `instance GetField round (AmuletCreateSummary amuletContractId) Round`
+- `instance GetField round AmuletExpireSummary Round`
+- `instance GetField round AppRewardCoupon Round`
+- `instance GetField round SvRewardCoupon Round`
+- `instance GetField round ValidatorRewardCoupon Round`
+- `instance GetField round AmuletRules_BuyMemberTrafficResult Round`
+- `instance GetField round TransferResult Round`
+- `instance GetField round ClosedMiningRound Round`
+- `instance GetField round IssuingMiningRound Round`
+- `instance GetField round OpenMiningRound Round`
+- `instance GetField round SummarizingMiningRound Round`
+- `instance GetField round ForRound Round`
+- `instance GetField round ValidatorFaucetCoupon Round`
+- `instance GetField round ValidatorLivenessActivityRecord Round`
+- `instance SetField createdAt ExpiringAmount Round`
+- `instance SetField firstReceivedFor FaucetState Round`
+- `instance SetField holdingFeesOpenRoundNumber ExternalPartyConfigState Round`
+- `instance SetField initialRound AmuletRules_Bootstrap_RoundsResult (Optional Round)`
+- `instance SetField issuingMiningRounds TransferContext (Map Round (ContractId IssuingMiningRound))`
+- `instance SetField issuingMiningRounds TransferContextSummary (Map Round IssuingMiningRound)`
+- `instance SetField issuingMiningRounds TransferContextSummaryV2 (Map Round IssuingMiningRound)`
+- `instance SetField lastReceivedFor FaucetState Round`
+- `instance SetField number Round Int`
+- `instance SetField openRoundNumber TransferContextSummaryV2 Round`
+- `instance SetField round (AmuletCreateSummary amuletContractId) Round`
+- `instance SetField round AmuletExpireSummary Round`
+- `instance SetField round AppRewardCoupon Round`
+- `instance SetField round SvRewardCoupon Round`
+- `instance SetField round ValidatorRewardCoupon Round`
+- `instance SetField round AmuletRules_BuyMemberTrafficResult Round`
+- `instance SetField round TransferResult Round`
+- `instance SetField round ClosedMiningRound Round`
+- `instance SetField round IssuingMiningRound Round`
+- `instance SetField round OpenMiningRound Round`
+- `instance SetField round SummarizingMiningRound Round`
+- `instance SetField round ForRound Round`
+- `instance SetField round ValidatorFaucetCoupon Round`
+- `instance SetField round ValidatorLivenessActivityRecord Round`
+
+## Functions
+
+<a id="function-splice-types-isdefinedround-76197"></a>
+
+### `isDefinedRound`
+
+```daml
+isDefinedRound : Round -> Bool
+```
+
+Check if a round has a positive round number

--- a/docs-main/reference/splice-daml-api/splice-amulet/splice-validatorlicense.mdx
+++ b/docs-main/reference/splice-daml-api/splice-amulet/splice-validatorlicense.mdx
@@ -1,0 +1,473 @@
+---
+title: "Splice.ValidatorLicense"
+description: "Reference documentation for Daml module Splice.ValidatorLicense."
+---
+
+<a id="module-splice-validatorlicense-59297"></a>
+
+# Splice.ValidatorLicense
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-validatorlicense-faucetstate-67607"></a>
+
+### `data FaucetState`
+
+Constructors:
+
+<a id="constr-splice-validatorlicense-faucetstate-48340"></a>
+- `FaucetState`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| firstReceivedFor | Round | The first round for which a coupon was received. |
+| lastReceivedFor | Round | The last round for which a coupon was received. |
+| numCouponsMissed | Int | The number of rounds for which no coupon was received. |
+
+Instances:
+
+- `instance Eq FaucetState`
+- `instance Show FaucetState`
+- `instance GetField faucetState ValidatorLicense (Optional FaucetState)`
+- `instance GetField firstReceivedFor FaucetState Round`
+- `instance GetField lastReceivedFor FaucetState Round`
+- `instance GetField numCouponsMissed FaucetState Int`
+- `instance SetField faucetState ValidatorLicense (Optional FaucetState)`
+- `instance SetField firstReceivedFor FaucetState Round`
+- `instance SetField lastReceivedFor FaucetState Round`
+- `instance SetField numCouponsMissed FaucetState Int`
+
+<a id="type-splice-validatorlicense-validatorfaucetcoupondsoexpireresult-29807"></a>
+
+### `data ValidatorFaucetCoupon_DsoExpireResult`
+
+Constructors:
+
+<a id="constr-splice-validatorlicense-validatorfaucetcoupondsoexpireresult-83728"></a>
+- `ValidatorFaucetCoupon_DsoExpireResult`
+
+Instances:
+
+- `instance HasExercise ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult`
+- `instance HasFromAnyChoice ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult`
+- `instance HasToAnyChoice ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult`
+
+<a id="type-splice-validatorlicense-validatorlicensemetadata-6055"></a>
+
+### `data ValidatorLicenseMetadata`
+
+Constructors:
+
+<a id="constr-splice-validatorlicense-validatorlicensemetadata-35622"></a>
+- `ValidatorLicenseMetadata`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| lastUpdatedAt | Time | The last time the validator metadata was updated |
+| version | Text | The version the validator is currently on |
+| contactPoint | Text | A contact point that can be used to reach the operator of the validator in case there are issues with the validator.<br/><br/>This can be an email address or a slack user name. |
+
+Instances:
+
+- `instance Eq ValidatorLicenseMetadata`
+- `instance Show ValidatorLicenseMetadata`
+- `instance GetField contactPoint ValidatorLicenseMetadata Text`
+- `instance GetField lastUpdatedAt ValidatorLicenseMetadata Time`
+- `instance GetField metadata ValidatorLicense (Optional ValidatorLicenseMetadata)`
+- `instance GetField version ValidatorLicenseMetadata Text`
+- `instance SetField contactPoint ValidatorLicenseMetadata Text`
+- `instance SetField lastUpdatedAt ValidatorLicenseMetadata Time`
+- `instance SetField metadata ValidatorLicense (Optional ValidatorLicenseMetadata)`
+- `instance SetField version ValidatorLicenseMetadata Text`
+
+<a id="type-splice-validatorlicense-validatorlicensecancelresult-12117"></a>
+
+### `data ValidatorLicense_CancelResult`
+
+Constructors:
+
+<a id="constr-splice-validatorlicense-validatorlicensecancelresult-95954"></a>
+- `ValidatorLicense_CancelResult`
+
+Instances:
+
+- `instance HasExercise ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult`
+
+<a id="type-splice-validatorlicense-validatorlicensereceivefaucetcouponresult-11121"></a>
+
+### `data ValidatorLicense_ReceiveFaucetCouponResult`
+
+Constructors:
+
+<a id="constr-splice-validatorlicense-validatorlicensereceivefaucetcouponresult-52224"></a>
+- `ValidatorLicense_ReceiveFaucetCouponResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| licenseCid | ContractId ValidatorLicense |  |
+| couponCid | ContractId ValidatorFaucetCoupon |  |
+
+Instances:
+
+- `instance GetField couponCid ValidatorLicense_ReceiveFaucetCouponResult (ContractId ValidatorFaucetCoupon)`
+- `instance GetField licenseCid ValidatorLicense_ReceiveFaucetCouponResult (ContractId ValidatorLicense)`
+- `instance SetField couponCid ValidatorLicense_ReceiveFaucetCouponResult (ContractId ValidatorFaucetCoupon)`
+- `instance SetField licenseCid ValidatorLicense_ReceiveFaucetCouponResult (ContractId ValidatorLicense)`
+- `instance HasExercise ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult`
+
+<a id="type-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivityresult-68079"></a>
+
+### `data ValidatorLicense_RecordValidatorLivenessActivityResult`
+
+Constructors:
+
+<a id="constr-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivityresult-77154"></a>
+- `ValidatorLicense_RecordValidatorLivenessActivityResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| licenseCid | ContractId ValidatorLicense |  |
+| couponCid | ContractId ValidatorLivenessActivityRecord |  |
+
+Instances:
+
+- `instance GetField couponCid ValidatorLicense_RecordValidatorLivenessActivityResult (ContractId ValidatorLivenessActivityRecord)`
+- `instance GetField licenseCid ValidatorLicense_RecordValidatorLivenessActivityResult (ContractId ValidatorLicense)`
+- `instance SetField couponCid ValidatorLicense_RecordValidatorLivenessActivityResult (ContractId ValidatorLivenessActivityRecord)`
+- `instance SetField licenseCid ValidatorLicense_RecordValidatorLivenessActivityResult (ContractId ValidatorLicense)`
+- `instance HasExercise ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult`
+
+<a id="type-splice-validatorlicense-validatorlicensereportactiveresult-44973"></a>
+
+### `data ValidatorLicense_ReportActiveResult`
+
+Constructors:
+
+<a id="constr-splice-validatorlicense-validatorlicensereportactiveresult-39594"></a>
+- `ValidatorLicense_ReportActiveResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| licenseCid | ContractId ValidatorLicense |  |
+
+Instances:
+
+- `instance GetField licenseCid ValidatorLicense_ReportActiveResult (ContractId ValidatorLicense)`
+- `instance SetField licenseCid ValidatorLicense_ReportActiveResult (ContractId ValidatorLicense)`
+- `instance HasExercise ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult`
+
+<a id="type-splice-validatorlicense-validatorlicenseupdatemetadataresult-84967"></a>
+
+### `data ValidatorLicense_UpdateMetadataResult`
+
+Constructors:
+
+<a id="constr-splice-validatorlicense-validatorlicenseupdatemetadataresult-7568"></a>
+- `ValidatorLicense_UpdateMetadataResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| licenseCid | ContractId ValidatorLicense |  |
+
+Instances:
+
+- `instance GetField licenseCid ValidatorLicense_UpdateMetadataResult (ContractId ValidatorLicense)`
+- `instance SetField licenseCid ValidatorLicense_UpdateMetadataResult (ContractId ValidatorLicense)`
+- `instance HasExercise ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult`
+
+<a id="type-splice-validatorlicense-validatorlicensewithdrawresult-32027"></a>
+
+### `data ValidatorLicense_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-validatorlicense-validatorlicensewithdrawresult-54540"></a>
+- `ValidatorLicense_WithdrawResult`
+
+Instances:
+
+- `instance HasExercise ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult`
+- `instance HasFromAnyChoice ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult`
+- `instance HasToAnyChoice ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult`
+
+<a id="type-splice-validatorlicense-validatorlivenessactivityrecorddsoexpireresult-68284"></a>
+
+### `data ValidatorLivenessActivityRecord_DsoExpireResult`
+
+Constructors:
+
+<a id="constr-splice-validatorlicense-validatorlivenessactivityrecorddsoexpireresult-79751"></a>
+- `ValidatorLivenessActivityRecord_DsoExpireResult`
+
+Instances:
+
+- `instance HasExercise ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult`
+- `instance HasFromAnyChoice ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult`
+- `instance HasToAnyChoice ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult`
+
+## Functions
+
+<a id="function-splice-validatorlicense-metadataupdatemininterval-59469"></a>
+
+### `metadataUpdateMinInterval`
+
+```daml
+metadataUpdateMinInterval : RelTime
+```
+
+<a id="function-splice-validatorlicense-activityreportmininterval-78854"></a>
+
+### `activityReportMinInterval`
+
+```daml
+activityReportMinInterval : RelTime
+```
+
+<a id="function-splice-validatorlicense-metadataupdateallowed-42050"></a>
+
+### `metadataUpdateAllowed`
+
+```daml
+metadataUpdateAllowed : Time -> Time -> Bool
+```
+
+<a id="function-splice-validatorlicense-activityreportallowed-34361"></a>
+
+### `activityReportAllowed`
+
+```daml
+activityReportAllowed : Time -> Time -> Bool
+```
+
+<a id="function-splice-validatorlicense-validvalidatorlicense-11839"></a>
+
+### `validValidatorLicense`
+
+```daml
+validValidatorLicense : ValidatorLicense -> Bool
+```
+
+<a id="function-splice-validatorlicense-maxidentifierlength-1659"></a>
+
+### `maxIdentifierLength`
+
+```daml
+maxIdentifierLength : Int
+```
+
+<a id="function-splice-validatorlicense-validvalidatorlicensemetadata-75992"></a>
+
+### `validValidatorLicenseMetadata`
+
+```daml
+validValidatorLicenseMetadata : ValidatorLicenseMetadata -> Bool
+```
+
+## Templates
+
+<a id="type-splice-validatorlicense-validatorfaucetcoupon-19254"></a>
+
+### Template `ValidatorFaucetCoupon`
+
+__Deprecated__: use `ValidatorLicense_RecordValidatorLivenessActivity` instead, as that one
+can be expired without requiring a confirmation from the validator node.
+
+Signatories: `dso`, `validator`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| validator | Party |  |
+| round | Round |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`, `validator`
+
+Returns: `()`
+
+<a id="type-splice-validatorlicense-validatorfaucetcoupondsoexpire-65722"></a>
+
+#### Choice `ValidatorFaucetCoupon_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `ValidatorFaucetCoupon_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |
+
+<a id="type-splice-validatorlicense-validatorlicense-33456"></a>
+
+### Template `ValidatorLicense`
+
+The existence of a validator license is what makes a validator an (onboarded) validator.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validator | Party | The validator (party) that this license is about. |
+| sponsor | Party | The SV node that sponsored the onboarding. |
+| dso | Party | The party representing the operations of the decentralized synchronizer. |
+| faucetState | Optional FaucetState |  |
+| metadata | Optional ValidatorLicenseMetadata |  |
+| lastActiveAt | Optional Time | Last time this validator was active. Tracked to get a view on the set of validator nodes that are up and running. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-validatorlicense-validatorlicensecancel-74620"></a>
+
+#### Choice `ValidatorLicense_Cancel`
+
+Controllers: `validator`
+
+Returns: `ValidatorLicense_CancelResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<a id="type-splice-validatorlicense-validatorlicensereceivefaucetcoupon-91156"></a>
+
+#### Choice `ValidatorLicense_ReceiveFaucetCoupon`
+
+Controllers: `validator`
+
+Returns: `ValidatorLicense_ReceiveFaucetCouponResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openRoundCid | ContractId OpenMiningRound |  |
+
+<a id="type-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivity-79262"></a>
+
+#### Choice `ValidatorLicense_RecordValidatorLivenessActivity`
+
+Controllers: `validator`
+
+Returns: `ValidatorLicense_RecordValidatorLivenessActivityResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| openRoundCid | ContractId OpenMiningRound |  |
+
+<a id="type-splice-validatorlicense-validatorlicensereportactive-46832"></a>
+
+#### Choice `ValidatorLicense_ReportActive`
+
+Choice for validators with disabled wallets to report themselves as active.
+Validators that receive amulets will report through ReceiveFaucetCoupon.
+
+Controllers: `validator`
+
+Returns: `ValidatorLicense_ReportActiveResult`
+
+<a id="type-splice-validatorlicense-validatorlicenseupdatemetadata-65458"></a>
+
+#### Choice `ValidatorLicense_UpdateMetadata`
+
+Controllers: `validator`
+
+Returns: `ValidatorLicense_UpdateMetadataResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| version | Text |  |
+| contactPoint | Text |  |
+
+<a id="type-splice-validatorlicense-validatorlicensewithdraw-63410"></a>
+
+#### Choice `ValidatorLicense_Withdraw`
+
+Controllers: `dso`
+
+Returns: `ValidatorLicense_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<a id="type-splice-validatorlicense-validatorlivenessactivityrecord-17293"></a>
+
+### Template `ValidatorLivenessActivityRecord`
+
+A copy of the ValidatorFaucetCoupon template with the only difference being that the validator is an observer instead of signatory.
+This is to allow to expire the coupon without the validator's involvement.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| validator | Party |  |
+| round | Round |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-validatorlicense-validatorlivenessactivityrecorddsoexpire-78737"></a>
+
+#### Choice `ValidatorLivenessActivityRecord_DsoExpire`
+
+Controllers: `dso`
+
+Returns: `ValidatorLivenessActivityRecord_DsoExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRoundCid | ContractId ClosedMiningRound |  |

--- a/docs-main/reference/splice-daml-api/splice-api-featured-app-v1/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-featured-app-v1/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-api-featured-app-v1 docs"
+description: "Reference documentation for splice-api-featured-app-v1 docs modules."
+---
+
+# splice-api-featured-app-v1 docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Api.FeaturedAppRightV1`](/reference/splice-daml-api/splice-api-featured-app-v1/splice-api-featuredapprightv1) | `Module` | The API for featured apps to record their activity. | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Api.FeaturedAppRightV1](/reference/splice-daml-api/splice-api-featured-app-v1/splice-api-featuredapprightv1)

--- a/docs-main/reference/splice-daml-api/splice-api-featured-app-v1/splice-api-featuredapprightv1.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-featured-app-v1/splice-api-featuredapprightv1.mdx
@@ -1,0 +1,201 @@
+---
+title: "Splice.Api.FeaturedAppRightV1"
+description: "Reference documentation for Daml module Splice.Api.FeaturedAppRightV1."
+---
+
+<a id="module-splice-api-featuredapprightv1-64680"></a>
+
+# Splice.Api.FeaturedAppRightV1
+
+The API for featured apps to record their activity.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-api-featuredapprightv1-apprewardbeneficiary-32645"></a>
+
+### `data AppRewardBeneficiary`
+
+Specification of a beneficiary of featured app rewards.
+
+Constructors:
+
+<a id="constr-splice-api-featuredapprightv1-apprewardbeneficiary-16584"></a>
+- `AppRewardBeneficiary`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+| weight | Decimal | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint. |
+
+Instances:
+
+- `instance Eq AppRewardBeneficiary`
+- `instance Ord AppRewardBeneficiary`
+- `instance Show AppRewardBeneficiary`
+- `instance GetField beneficiaries FeaturedAppRight_CreateActivityMarker [AppRewardBeneficiary]`
+- `instance GetField beneficiary AppRewardBeneficiary Party`
+- `instance GetField weight AppRewardBeneficiary Decimal`
+- `instance SetField beneficiaries FeaturedAppRight_CreateActivityMarker [AppRewardBeneficiary]`
+- `instance SetField beneficiary AppRewardBeneficiary Party`
+- `instance SetField weight AppRewardBeneficiary Decimal`
+
+<a id="type-splice-api-featuredapprightv1-featuredappactivitymarkerview-84352"></a>
+
+### `data FeaturedAppActivityMarkerView`
+
+Constructors:
+
+<a id="constr-splice-api-featuredapprightv1-featuredappactivitymarkerview-55819"></a>
+- `FeaturedAppActivityMarkerView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party | The DSO party. |
+| provider | Party | The featured app provider. |
+| beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+| weight | Decimal | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint. |
+
+Instances:
+
+- `instance Eq FeaturedAppActivityMarkerView`
+- `instance Show FeaturedAppActivityMarkerView`
+- `instance HasFromAnyView FeaturedAppActivityMarker FeaturedAppActivityMarkerView`
+- `instance HasInterfaceView FeaturedAppActivityMarker FeaturedAppActivityMarkerView`
+- `instance GetField beneficiary FeaturedAppActivityMarkerView Party`
+- `instance GetField dso FeaturedAppActivityMarkerView Party`
+- `instance GetField provider FeaturedAppActivityMarkerView Party`
+- `instance GetField weight FeaturedAppActivityMarkerView Decimal`
+- `instance SetField beneficiary FeaturedAppActivityMarkerView Party`
+- `instance SetField dso FeaturedAppActivityMarkerView Party`
+- `instance SetField provider FeaturedAppActivityMarkerView Party`
+- `instance SetField weight FeaturedAppActivityMarkerView Decimal`
+
+<a id="type-splice-api-featuredapprightv1-featuredapprightview-50078"></a>
+
+### `data FeaturedAppRightView`
+
+Constructors:
+
+<a id="constr-splice-api-featuredapprightv1-featuredapprightview-35459"></a>
+- `FeaturedAppRightView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party | The DSO party. |
+| provider | Party | The featured app provider. |
+
+Instances:
+
+- `instance Eq FeaturedAppRightView`
+- `instance Show FeaturedAppRightView`
+- `instance HasFromAnyView FeaturedAppRight FeaturedAppRightView`
+- `instance HasInterfaceView FeaturedAppRight FeaturedAppRightView`
+- `instance GetField dso FeaturedAppRightView Party`
+- `instance GetField provider FeaturedAppRightView Party`
+- `instance SetField dso FeaturedAppRightView Party`
+- `instance SetField provider FeaturedAppRightView Party`
+
+<a id="type-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerresult-54383"></a>
+
+### `data FeaturedAppRight_CreateActivityMarkerResult`
+
+Result of calling the `FeaturedAppRight_CreateActivityMarker` choice.
+
+Constructors:
+
+<a id="constr-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerresult-43104"></a>
+- `FeaturedAppRight_CreateActivityMarkerResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| activityMarkerCids | [ContractId FeaturedAppActivityMarker] | The set of activity markers created by the choice. |
+
+Instances:
+
+- `instance HasMethod FeaturedAppRight featuredAppRight_CreateActivityMarkerImpl (ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult)`
+- `instance GetField activityMarkerCids FeaturedAppRight_CreateActivityMarkerResult [ContractId FeaturedAppActivityMarker]`
+- `instance SetField activityMarkerCids FeaturedAppRight_CreateActivityMarkerResult [ContractId FeaturedAppActivityMarker]`
+- `instance HasExercise FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasExerciseGuarded FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasFromAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasToAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+
+## Functions
+
+<a id="function-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerimpl-71588"></a>
+
+### `featuredAppRight_CreateActivityMarkerImpl`
+
+```daml
+featuredAppRight_CreateActivityMarkerImpl : FeaturedAppRight -> ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult
+```
+
+## Interfaces
+
+<a id="type-splice-api-featuredapprightv1-featuredappactivitymarker-46407"></a>
+
+### Interface `FeaturedAppActivityMarker`
+
+A marker created by a featured application for activity generated from that app. This is used
+to record activity other than amulet transfers, which have built-in support for recording featured app activity.
+
+View Type: `FeaturedAppActivityMarkerView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<a id="type-splice-api-featuredapprightv1-featuredappright-34177"></a>
+
+### Interface `FeaturedAppRight`
+
+An interface for contracts allowing application providers to record their featured activity.
+Note that most instances of amulet will likely define some fair usage constraints.
+
+View Type: `FeaturedAppRightView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<a id="type-splice-api-featuredapprightv1-featuredapprightcreateactivitymarker-36646"></a>
+
+#### Choice `FeaturedAppRight_CreateActivityMarker`
+
+Record activity due to a featured app.
+
+Controllers: `(DA.Internal.Record.getField @"provider" (view this))`
+
+Returns: `FeaturedAppRight_CreateActivityMarkerResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiaries | [AppRewardBeneficiary] | The set of beneficiaries and weights that define how the rewards should be split up<br/><br/>between the beneficiary parties.<br/><br/>Implementations SHOULD check that the weights are positive and add up to 1.0.<br/><br/>Implementations MAY also impose a limit on the maximum number of beneficiaries. |
+
+Methods:
+
+#### Method `featuredAppRight_CreateActivityMarkerImpl`
+
+Type: `ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult`

--- a/docs-main/reference/splice-daml-api/splice-api-featured-app-v2/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-featured-app-v2/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-api-featured-app-v2 docs"
+description: "Reference documentation for splice-api-featured-app-v2 docs modules."
+---
+
+# splice-api-featured-app-v2 docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Api.FeaturedAppRightV2`](/reference/splice-daml-api/splice-api-featured-app-v2/splice-api-featuredapprightv2) | `Module` | The API for featured apps to record their activity. | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Api.FeaturedAppRightV2](/reference/splice-daml-api/splice-api-featured-app-v2/splice-api-featuredapprightv2)

--- a/docs-main/reference/splice-daml-api/splice-api-featured-app-v2/splice-api-featuredapprightv2.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-featured-app-v2/splice-api-featuredapprightv2.mdx
@@ -1,0 +1,206 @@
+---
+title: "Splice.Api.FeaturedAppRightV2"
+description: "Reference documentation for Daml module Splice.Api.FeaturedAppRightV2."
+---
+
+<a id="module-splice-api-featuredapprightv2-80033"></a>
+
+# Splice.Api.FeaturedAppRightV2
+
+The API for featured apps to record their activity.
+
+This package extends FeaturedAppRightV1 with support for specifying
+
+a weight when creating a marker to improve efficiency.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-api-featuredapprightv2-apprewardbeneficiary-35536"></a>
+
+### `data AppRewardBeneficiary`
+
+Specification of a beneficiary of featured app rewards.
+
+Constructors:
+
+<a id="constr-splice-api-featuredapprightv2-apprewardbeneficiary-41661"></a>
+- `AppRewardBeneficiary`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+| weight | Decimal | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint. |
+
+Instances:
+
+- `instance Eq AppRewardBeneficiary`
+- `instance Ord AppRewardBeneficiary`
+- `instance Show AppRewardBeneficiary`
+- `instance GetField beneficiaries FeaturedAppRight_CreateActivityMarker [AppRewardBeneficiary]`
+- `instance GetField beneficiary AppRewardBeneficiary Party`
+- `instance GetField weight AppRewardBeneficiary Decimal`
+- `instance SetField beneficiaries FeaturedAppRight_CreateActivityMarker [AppRewardBeneficiary]`
+- `instance SetField beneficiary AppRewardBeneficiary Party`
+- `instance SetField weight AppRewardBeneficiary Decimal`
+
+<a id="type-splice-api-featuredapprightv2-featuredappactivitymarkerview-70739"></a>
+
+### `data FeaturedAppActivityMarkerView`
+
+Constructors:
+
+<a id="constr-splice-api-featuredapprightv2-featuredappactivitymarkerview-19000"></a>
+- `FeaturedAppActivityMarkerView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party | The DSO party. |
+| provider | Party | The featured app provider. |
+| beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+| weight | Decimal | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint. |
+
+Instances:
+
+- `instance Eq FeaturedAppActivityMarkerView`
+- `instance Show FeaturedAppActivityMarkerView`
+- `instance HasFromAnyView FeaturedAppActivityMarker FeaturedAppActivityMarkerView`
+- `instance HasInterfaceView FeaturedAppActivityMarker FeaturedAppActivityMarkerView`
+- `instance GetField beneficiary FeaturedAppActivityMarkerView Party`
+- `instance GetField dso FeaturedAppActivityMarkerView Party`
+- `instance GetField provider FeaturedAppActivityMarkerView Party`
+- `instance GetField weight FeaturedAppActivityMarkerView Decimal`
+- `instance SetField beneficiary FeaturedAppActivityMarkerView Party`
+- `instance SetField dso FeaturedAppActivityMarkerView Party`
+- `instance SetField provider FeaturedAppActivityMarkerView Party`
+- `instance SetField weight FeaturedAppActivityMarkerView Decimal`
+
+<a id="type-splice-api-featuredapprightv2-featuredapprightview-58075"></a>
+
+### `data FeaturedAppRightView`
+
+Constructors:
+
+<a id="constr-splice-api-featuredapprightv2-featuredapprightview-48166"></a>
+- `FeaturedAppRightView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party | The DSO party. |
+| provider | Party | The featured app provider. |
+
+Instances:
+
+- `instance Eq FeaturedAppRightView`
+- `instance Show FeaturedAppRightView`
+- `instance HasFromAnyView FeaturedAppRight FeaturedAppRightView`
+- `instance HasInterfaceView FeaturedAppRight FeaturedAppRightView`
+- `instance GetField dso FeaturedAppRightView Party`
+- `instance GetField provider FeaturedAppRightView Party`
+- `instance SetField dso FeaturedAppRightView Party`
+- `instance SetField provider FeaturedAppRightView Party`
+
+<a id="type-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerresult-27928"></a>
+
+### `data FeaturedAppRight_CreateActivityMarkerResult`
+
+Result of calling the `FeaturedAppRight_CreateActivityMarker` choice.
+
+Constructors:
+
+<a id="constr-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerresult-95607"></a>
+- `FeaturedAppRight_CreateActivityMarkerResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| activityMarkerCids | [ContractId FeaturedAppActivityMarker] | The set of activity markers created by the choice. |
+
+Instances:
+
+- `instance HasMethod FeaturedAppRight featuredAppRight_CreateActivityMarkerImpl (ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult)`
+- `instance GetField activityMarkerCids FeaturedAppRight_CreateActivityMarkerResult [ContractId FeaturedAppActivityMarker]`
+- `instance SetField activityMarkerCids FeaturedAppRight_CreateActivityMarkerResult [ContractId FeaturedAppActivityMarker]`
+- `instance HasExercise FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasExerciseGuarded FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasFromAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasToAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult`
+
+## Functions
+
+<a id="function-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerimpl-7767"></a>
+
+### `featuredAppRight_CreateActivityMarkerImpl`
+
+```daml
+featuredAppRight_CreateActivityMarkerImpl : FeaturedAppRight -> ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult
+```
+
+## Interfaces
+
+<a id="type-splice-api-featuredapprightv2-featuredappactivitymarker-59464"></a>
+
+### Interface `FeaturedAppActivityMarker`
+
+A marker created by a featured application for activity generated from that app. This is used
+to record activity other than amulet transfers, which have built-in support for recording featured app activity.
+
+View Type: `FeaturedAppActivityMarkerView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<a id="type-splice-api-featuredapprightv2-featuredappright-28172"></a>
+
+### Interface `FeaturedAppRight`
+
+An interface for contracts allowing application providers to record their featured activity.
+Note that most instances of amulet will likely define some fair usage constraints.
+
+View Type: `FeaturedAppRightView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<a id="type-splice-api-featuredapprightv2-featuredapprightcreateactivitymarker-77229"></a>
+
+#### Choice `FeaturedAppRight_CreateActivityMarker`
+
+Record activity due to a featured app.
+
+Controllers: `(DA.Internal.Record.getField @"provider" (view this))`
+
+Returns: `FeaturedAppRight_CreateActivityMarkerResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiaries | [AppRewardBeneficiary] | The set of beneficiaries and weights that define how the rewards should be split up<br/><br/>between the beneficiary parties.<br/><br/>Implementations SHOULD check that the weights are positive and add up to 1.0.<br/><br/>Implementations MAY also impose a limit on the maximum number of beneficiaries. |
+| weight | Optional Decimal | A weight for the resulting markers. None defaults to a weight of 1.0.<br/><br/>Specifying a weight of 5 for example makes the resulting markers equivalent<br/><br/>to 5 markers of weight 1 in terms of rewards they generate.<br/><br/>The weight must be >= 1.0<br/><br/>Implementations MAY impose an upper limit on the weight. |
+
+Methods:
+
+#### Method `featuredAppRight_CreateActivityMarkerImpl`
+
+Type: `ContractId FeaturedAppRight -> FeaturedAppRight_CreateActivityMarker -> Update FeaturedAppRight_CreateActivityMarkerResult`

--- a/docs-main/reference/splice-daml-api/splice-api-token-allocation-instruction-v1/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-allocation-instruction-v1/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-api-token-allocation-instruction-v1 docs"
+description: "Reference documentation for splice-api-token-allocation-instruction-v1 docs modules."
+---
+
+# splice-api-token-allocation-instruction-v1 docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Api.Token.AllocationInstructionV1`](/reference/splice-daml-api/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1) | `Module` | Interfaces to enable wallets to instruct the registry to create allocations. | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Api.Token.AllocationInstructionV1](/reference/splice-daml-api/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1)

--- a/docs-main/reference/splice-daml-api/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1.mdx
@@ -1,0 +1,343 @@
+---
+title: "Splice.Api.Token.AllocationInstructionV1"
+description: "Reference documentation for Daml module Splice.Api.Token.AllocationInstructionV1."
+---
+
+<a id="module-splice-api-token-allocationinstructionv1-81747"></a>
+
+# Splice.Api.Token.AllocationInstructionV1
+
+Interfaces to enable wallets to instruct the registry to create allocations.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-api-token-allocationinstructionv1-allocationfactoryview-21751"></a>
+
+### `data AllocationFactoryView`
+
+View for `AllocationFactory`.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationinstructionv1-allocationfactoryview-66354"></a>
+- `AllocationFactoryView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| admin | Party | The party representing the registry app that administers the instruments<br/><br/>for which this allocation factory can be used. |
+| meta | Metadata | Additional metadata specific to the allocation factory, used for extensibility. |
+
+Instances:
+
+- `instance Eq AllocationFactoryView`
+- `instance Show AllocationFactoryView`
+- `instance HasMethod AllocationFactory allocationFactory_publicFetchImpl (ContractId AllocationFactory -> AllocationFactory_PublicFetch -> Update AllocationFactoryView)`
+- `instance HasFromAnyView AllocationFactory AllocationFactoryView`
+- `instance HasInterfaceView AllocationFactory AllocationFactoryView`
+- `instance GetField admin AllocationFactoryView Party`
+- `instance GetField meta AllocationFactoryView Metadata`
+- `instance SetField admin AllocationFactoryView Party`
+- `instance SetField meta AllocationFactoryView Metadata`
+- `instance HasExercise AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView`
+- `instance HasExerciseGuarded AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView`
+- `instance HasFromAnyChoice AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView`
+- `instance HasToAnyChoice AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView`
+
+<a id="type-splice-api-token-allocationinstructionv1-allocationinstructionresult-30943"></a>
+
+### `data AllocationInstructionResult`
+
+The result of instructing an allocation or advancing the state of an allocation instruction.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresult-54130"></a>
+- `AllocationInstructionResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| output | AllocationInstructionResult_Output | The output of the step. |
+| senderChangeCids | [ContractId Holding] | New holdings owned by the sender created to return "change". Can be used<br/><br/>by callers to batch creating or updating multiple allocation instructions<br/><br/>in a single Daml transaction. |
+| meta | Metadata | Additional metadata specific to the allocation instruction, used for extensibility; e.g., fees charged. |
+
+Instances:
+
+- `instance Eq AllocationInstructionResult`
+- `instance Show AllocationInstructionResult`
+- `instance HasMethod AllocationFactory allocationFactory_allocateImpl (ContractId AllocationFactory -> AllocationFactory_Allocate -> Update AllocationInstructionResult)`
+- `instance HasMethod AllocationInstruction allocationInstruction_updateImpl (ContractId AllocationInstruction -> AllocationInstruction_Update -> Update AllocationInstructionResult)`
+- `instance HasMethod AllocationInstruction allocationInstruction_withdrawImpl (ContractId AllocationInstruction -> AllocationInstruction_Withdraw -> Update AllocationInstructionResult)`
+- `instance GetField meta AllocationInstructionResult Metadata`
+- `instance GetField output AllocationInstructionResult AllocationInstructionResult_Output`
+- `instance GetField senderChangeCids AllocationInstructionResult [ContractId Holding]`
+- `instance SetField meta AllocationInstructionResult Metadata`
+- `instance SetField output AllocationInstructionResult AllocationInstructionResult_Output`
+- `instance SetField senderChangeCids AllocationInstructionResult [ContractId Holding]`
+- `instance HasExercise AllocationFactory AllocationFactory_Allocate AllocationInstructionResult`
+- `instance HasExercise AllocationInstruction AllocationInstruction_Update AllocationInstructionResult`
+- `instance HasExercise AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult`
+- `instance HasExerciseGuarded AllocationFactory AllocationFactory_Allocate AllocationInstructionResult`
+- `instance HasExerciseGuarded AllocationInstruction AllocationInstruction_Update AllocationInstructionResult`
+- `instance HasExerciseGuarded AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult`
+- `instance HasFromAnyChoice AllocationFactory AllocationFactory_Allocate AllocationInstructionResult`
+- `instance HasFromAnyChoice AllocationInstruction AllocationInstruction_Update AllocationInstructionResult`
+- `instance HasFromAnyChoice AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult`
+- `instance HasToAnyChoice AllocationFactory AllocationFactory_Allocate AllocationInstructionResult`
+- `instance HasToAnyChoice AllocationInstruction AllocationInstruction_Update AllocationInstructionResult`
+- `instance HasToAnyChoice AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult`
+
+<a id="type-splice-api-token-allocationinstructionv1-allocationinstructionresultoutput-46212"></a>
+
+### `data AllocationInstructionResult_Output`
+
+The output of instructing an allocation or advancing the state of an allocation instruction.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultpending-58494"></a>
+- `AllocationInstructionResult_Pending`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationInstructionCid | ContractId AllocationInstruction | Contract id of the allocation instruction representing the pending state. |
+Use this result to communicate that the creation of the allocation is pending further steps.
+<a id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultcompleted-89210"></a>
+- `AllocationInstructionResult_Completed`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationCid | ContractId Allocation | The newly created allocation. |
+Use this result to communicate that the allocation was created.
+<a id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultfailed-56799"></a>
+- `AllocationInstructionResult_Failed`
+Use this result to communicate that the creation of the allocation did not succeed and
+all holdings reserved for funding the allocation have been released.
+
+Instances:
+
+- `instance Eq AllocationInstructionResult_Output`
+- `instance Show AllocationInstructionResult_Output`
+- `instance GetField allocationCid AllocationInstructionResult_Output (ContractId Allocation)`
+- `instance GetField allocationInstructionCid AllocationInstructionResult_Output (ContractId AllocationInstruction)`
+- `instance GetField output AllocationInstructionResult AllocationInstructionResult_Output`
+- `instance SetField allocationCid AllocationInstructionResult_Output (ContractId Allocation)`
+- `instance SetField allocationInstructionCid AllocationInstructionResult_Output (ContractId AllocationInstruction)`
+- `instance SetField output AllocationInstructionResult AllocationInstructionResult_Output`
+
+<a id="type-splice-api-token-allocationinstructionv1-allocationinstructionview-72001"></a>
+
+### `data AllocationInstructionView`
+
+View for `AllocationInstruction`.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationinstructionv1-allocationinstructionview-32140"></a>
+- `AllocationInstructionView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| originalInstructionCid | Optional (ContractId AllocationInstruction) | The contract id of the original allocation instruction contract.<br/><br/>Used by the wallet to track the lineage of allocation instructions through multiple steps.<br/><br/>Only set if the registry evolves the allocation instruction in multiple steps. |
+| allocation | AllocationSpecification | The allocation that this instruction should create. |
+| pendingActions | Map Party Text | The pending actions to be taken by different actors to create the allocation.<br/><br/>^ This field can by used to report on the progress of registry specific<br/><br/>workflows that are required to prepare the allocation. |
+| requestedAt | Time | The time at which the allocation was requested. |
+| inputHoldingCids | [ContractId Holding] | The holdings to be used to fund the allocation.<br/><br/>MAY be empty for registries that do not represent their holdings on-ledger. |
+| meta | Metadata | Additional metadata specific to the allocation instruction, used for<br/><br/>extensibility; e.g., more detailed status information. |
+
+Instances:
+
+- `instance Eq AllocationInstructionView`
+- `instance Show AllocationInstructionView`
+- `instance HasFromAnyView AllocationInstruction AllocationInstructionView`
+- `instance HasInterfaceView AllocationInstruction AllocationInstructionView`
+- `instance GetField allocation AllocationInstructionView AllocationSpecification`
+- `instance GetField inputHoldingCids AllocationInstructionView [ContractId Holding]`
+- `instance GetField meta AllocationInstructionView Metadata`
+- `instance GetField originalInstructionCid AllocationInstructionView (Optional (ContractId AllocationInstruction))`
+- `instance GetField pendingActions AllocationInstructionView (Map Party Text)`
+- `instance GetField requestedAt AllocationInstructionView Time`
+- `instance SetField allocation AllocationInstructionView AllocationSpecification`
+- `instance SetField inputHoldingCids AllocationInstructionView [ContractId Holding]`
+- `instance SetField meta AllocationInstructionView Metadata`
+- `instance SetField originalInstructionCid AllocationInstructionView (Optional (ContractId AllocationInstruction))`
+- `instance SetField pendingActions AllocationInstructionView (Map Party Text)`
+- `instance SetField requestedAt AllocationInstructionView Time`
+
+## Functions
+
+<a id="function-splice-api-token-allocationinstructionv1-allocationinstructionwithdrawimpl-26170"></a>
+
+### `allocationInstruction_withdrawImpl`
+
+```daml
+allocationInstruction_withdrawImpl : AllocationInstruction -> ContractId AllocationInstruction -> AllocationInstruction_Withdraw -> Update AllocationInstructionResult
+```
+
+<a id="function-splice-api-token-allocationinstructionv1-allocationinstructionupdateimpl-49061"></a>
+
+### `allocationInstruction_updateImpl`
+
+```daml
+allocationInstruction_updateImpl : AllocationInstruction -> ContractId AllocationInstruction -> AllocationInstruction_Update -> Update AllocationInstructionResult
+```
+
+<a id="function-splice-api-token-allocationinstructionv1-allocationfactoryallocateimpl-1231"></a>
+
+### `allocationFactory_allocateImpl`
+
+```daml
+allocationFactory_allocateImpl : AllocationFactory -> ContractId AllocationFactory -> AllocationFactory_Allocate -> Update AllocationInstructionResult
+```
+
+<a id="function-splice-api-token-allocationinstructionv1-allocationfactorypublicfetchimpl-77778"></a>
+
+### `allocationFactory_publicFetchImpl`
+
+```daml
+allocationFactory_publicFetchImpl : AllocationFactory -> ContractId AllocationFactory -> AllocationFactory_PublicFetch -> Update AllocationFactoryView
+```
+
+## Interfaces
+
+<a id="type-splice-api-token-allocationinstructionv1-allocationfactory-42588"></a>
+
+### Interface `AllocationFactory`
+
+Contracts implementing `AllocationFactory` are retrieved from the registry app and are
+used by the wallet to create allocation instructions (or allocations directly).
+
+View Type: `AllocationFactoryView`
+
+Choices:
+
+<a id="type-splice-api-token-allocationinstructionv1-allocationfactoryallocate-8885"></a>
+
+#### Choice `AllocationFactory_Allocate`
+
+Generic choice for the sender's wallet to request the allocation of
+assets to a specific leg of a settlement. It depends on the registry
+whether this results in the allocation being created directly
+or in an allocation instruction being created instead.
+
+Controllers: `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))`
+
+Returns: `AllocationInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| allocation | AllocationSpecification | The allocation which should be created. |
+| requestedAt | Time | The time at which the allocation was requested. |
+| inputHoldingCids | [ContractId Holding] | The holdings that SHOULD be used to fund the allocation.<br/><br/>MAY be empty for registries that do not represent their holdings on-ledger; or<br/><br/>for registries that support automatic selection of holdings for allocations.<br/><br/>If specified, then the successful allocation MUST archive all of these holdings, so<br/><br/>that the execution of the allocation conflicts with any other allocations<br/><br/>using these holdings. Thereby allowing that the sender can use<br/><br/>deliberate contention on holdings to prevent duplicate allocations. |
+| extraArgs | ExtraArgs | Additional choice arguments. |
+
+<a id="type-splice-api-token-allocationinstructionv1-allocationfactorypublicfetch-20324"></a>
+
+#### Choice `AllocationFactory_PublicFetch`
+
+Controllers: `actor`
+
+Returns: `AllocationFactoryView`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| actor | Party |  |
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+Methods:
+
+#### Method `allocationFactory_allocateImpl`
+
+Type: `ContractId AllocationFactory -> AllocationFactory_Allocate -> Update AllocationInstructionResult`
+
+#### Method `allocationFactory_publicFetchImpl`
+
+Type: `ContractId AllocationFactory -> AllocationFactory_PublicFetch -> Update AllocationFactoryView`
+
+<a id="type-splice-api-token-allocationinstructionv1-allocationinstruction-29622"></a>
+
+### Interface `AllocationInstruction`
+
+An interface for tracking the status of an allocation instruction,
+i.e., a request to a registry app to create an allocation.
+
+Registries MAY evolve the allocation instruction in multiple steps. They SHOULD
+do so using only the choices on this interface, so that wallets can reliably
+parse the transaction history and determine whether the creation of the allocation ultimately
+succeeded or failed.
+
+View Type: `AllocationInstructionView`
+
+Choices:
+
+<a id="type-splice-api-token-allocationinstructionv1-allocationinstructionupdate-50223"></a>
+
+#### Choice `AllocationInstruction_Update`
+
+Update the state of the allocation instruction. Used by the registry to
+execute registry internal workflow steps that advance the state of the
+allocation instruction. A reason may be communicated via the metadata.
+
+Controllers: `(DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this)))))`, `extraActors`
+
+Returns: `AllocationInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraActors | [Party] | Extra actors authorizing the update. Implementations MUST check that<br/><br/>this field contains the expected actors for the specific update. |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<a id="type-splice-api-token-allocationinstructionv1-allocationinstructionwithdraw-35988"></a>
+
+#### Choice `AllocationInstruction_Withdraw`
+
+Withdraw the allocation instruction as the sender.
+
+Controllers: `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this))))`
+
+Returns: `AllocationInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+Methods:
+
+#### Method `allocationInstruction_updateImpl`
+
+Type: `ContractId AllocationInstruction -> AllocationInstruction_Update -> Update AllocationInstructionResult`
+
+#### Method `allocationInstruction_withdrawImpl`
+
+Type: `ContractId AllocationInstruction -> AllocationInstruction_Withdraw -> Update AllocationInstructionResult`

--- a/docs-main/reference/splice-daml-api/splice-api-token-allocation-request-v1/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-allocation-request-v1/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-api-token-allocation-request-v1 docs"
+description: "Reference documentation for splice-api-token-allocation-request-v1 docs modules."
+---
+
+# splice-api-token-allocation-request-v1 docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Api.Token.AllocationRequestV1`](/reference/splice-daml-api/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1) | `Module` | This module defines the interface for an AllocationRequest, which is an interface that can | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Api.Token.AllocationRequestV1](/reference/splice-daml-api/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1)

--- a/docs-main/reference/splice-daml-api/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1.mdx
@@ -1,0 +1,152 @@
+---
+title: "Splice.Api.Token.AllocationRequestV1"
+description: "Reference documentation for Daml module Splice.Api.Token.AllocationRequestV1."
+---
+
+<a id="module-splice-api-token-allocationrequestv1-2106"></a>
+
+# Splice.Api.Token.AllocationRequestV1
+
+This module defines the interface for an `AllocationRequest`, which is an interface that can
+
+be implemented by an app to request specific allocations from their users
+
+for the purpose of settling a DvP or a payment as part of an app's workflow.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-api-token-allocationrequestv1-allocationrequestview-51417"></a>
+
+### `data AllocationRequestView`
+
+View of `AllocationRequest`.
+
+Implementations SHOULD make sure that at least all senders of the transfer legs
+are observers of the implementing contract, so that their wallet can show
+the request to them.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationrequestv1-allocationrequestview-59188"></a>
+- `AllocationRequestView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| settlement | SettlementInfo | Settlement for which the assets are requested to be allocated. |
+| transferLegs | TextMap TransferLeg | Transfer legs that are requested to be allocated for the execution of the settlement<br/><br/>keyed by their identifier.<br/><br/>This may or may not be a complete list of transfer legs that are part of the settlement,<br/><br/>depending on the confidentiality requirements of the app. |
+| meta | Metadata | Additional metadata specific to the allocation request, used for extensibility. |
+
+Instances:
+
+- `instance Eq AllocationRequestView`
+- `instance Show AllocationRequestView`
+- `instance HasFromAnyView AllocationRequest AllocationRequestView`
+- `instance HasInterfaceView AllocationRequest AllocationRequestView`
+- `instance GetField meta AllocationRequestView Metadata`
+- `instance GetField settlement AllocationRequestView SettlementInfo`
+- `instance GetField transferLegs AllocationRequestView (TextMap TransferLeg)`
+- `instance SetField meta AllocationRequestView Metadata`
+- `instance SetField settlement AllocationRequestView SettlementInfo`
+- `instance SetField transferLegs AllocationRequestView (TextMap TransferLeg)`
+
+## Functions
+
+<a id="function-splice-api-token-allocationrequestv1-allocationrequestrejectimpl-48931"></a>
+
+### `allocationRequest_RejectImpl`
+
+```daml
+allocationRequest_RejectImpl : AllocationRequest -> ContractId AllocationRequest -> AllocationRequest_Reject -> Update ChoiceExecutionMetadata
+```
+
+<a id="function-splice-api-token-allocationrequestv1-allocationrequestwithdrawimpl-31866"></a>
+
+### `allocationRequest_WithdrawImpl`
+
+```daml
+allocationRequest_WithdrawImpl : AllocationRequest -> ContractId AllocationRequest -> AllocationRequest_Withdraw -> Update ChoiceExecutionMetadata
+```
+
+## Interfaces
+
+<a id="type-splice-api-token-allocationrequestv1-allocationrequest-90278"></a>
+
+### Interface `AllocationRequest`
+
+A request by an app for allocations to be created to enable the execution of a settlement.
+
+Apps are free to use a single request spanning all senders or one request per sender.
+
+View Type: `AllocationRequestView`
+
+Choices:
+
+<a id="type-splice-api-token-allocationrequestv1-allocationrequestreject-89381"></a>
+
+#### Choice `AllocationRequest_Reject`
+
+Reject an allocation request.
+
+Implementations SHOULD allow any sender of a transfer leg to reject the allocation request,
+and thereby signal that they are definitely not going to create a matching allocation for the settlement.
+
+Controllers: `actor`
+
+Returns: `ChoiceExecutionMetadata`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party | The party rejecting the allocation request. |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<a id="type-splice-api-token-allocationrequestv1-allocationrequestwithdraw-15628"></a>
+
+#### Choice `AllocationRequest_Withdraw`
+
+Withdraw an allocation request as the executor.
+
+Used by executors to withdraw the allocation request if they are unable to execute it;
+e.g., because a trade has been cancelled.
+
+Controllers: `(DA.Internal.Record.getField @"executor" (DA.Internal.Record.getField @"settlement" (view this)))`
+
+Returns: `ChoiceExecutionMetadata`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+Methods:
+
+#### Method `allocationRequest_RejectImpl`
+
+Type: `ContractId AllocationRequest -> AllocationRequest_Reject -> Update ChoiceExecutionMetadata`
+
+#### Method `allocationRequest_WithdrawImpl`
+
+Type: `ContractId AllocationRequest -> AllocationRequest_Withdraw -> Update ChoiceExecutionMetadata`

--- a/docs-main/reference/splice-daml-api/splice-api-token-allocation-v1/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-allocation-v1/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-api-token-allocation-v1 docs"
+description: "Reference documentation for splice-api-token-allocation-v1 docs modules."
+---
+
+# splice-api-token-allocation-v1 docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Api.Token.AllocationV1`](/reference/splice-daml-api/splice-api-token-allocation-v1/splice-api-token-allocationv1) | `Module` | This module defines the Allocation interface and supporting types. | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Api.Token.AllocationV1](/reference/splice-daml-api/splice-api-token-allocation-v1/splice-api-token-allocationv1)

--- a/docs-main/reference/splice-daml-api/splice-api-token-allocation-v1/splice-api-token-allocationv1.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-allocation-v1/splice-api-token-allocationv1.mdx
@@ -1,0 +1,414 @@
+---
+title: "Splice.Api.Token.AllocationV1"
+description: "Reference documentation for Daml module Splice.Api.Token.AllocationV1."
+---
+
+<a id="module-splice-api-token-allocationv1-39050"></a>
+
+# Splice.Api.Token.AllocationV1
+
+This module defines the `Allocation` interface and supporting types.
+
+Contracts implementing the `Allocation` interface represent a reservation of
+
+assets to transfer them as part of an atomic on-ledger settlement requested
+
+by an app.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-api-token-allocationv1-allocationspecification-94148"></a>
+
+### `data AllocationSpecification`
+
+The specification of an allocation of assets to a specific leg of a settlement.
+
+In contrast to an `AllocationView` this just specifies what should be allocated,
+but not the holdings that are backing the allocation.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationv1-allocationspecification-66543"></a>
+- `AllocationSpecification`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| settlement | SettlementInfo | The settlement for whose execution the assets are being allocated. |
+| transferLegId | Text | A unique identifer for the transfer leg within the settlement. |
+| transferLeg | TransferLeg | The transfer for which the assets are being allocated. |
+
+Instances:
+
+- `instance Eq AllocationSpecification`
+- `instance Show AllocationSpecification`
+- `instance GetField allocation AllocationView AllocationSpecification`
+- `instance GetField settlement AllocationSpecification SettlementInfo`
+- `instance GetField transferLeg AllocationSpecification TransferLeg`
+- `instance GetField transferLegId AllocationSpecification Text`
+- `instance SetField allocation AllocationView AllocationSpecification`
+- `instance SetField settlement AllocationSpecification SettlementInfo`
+- `instance SetField transferLeg AllocationSpecification TransferLeg`
+- `instance SetField transferLegId AllocationSpecification Text`
+
+<a id="type-splice-api-token-allocationv1-allocationview-9103"></a>
+
+### `data AllocationView`
+
+View of a funded allocation of assets to a specific leg of a settlement.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationv1-allocationview-89090"></a>
+- `AllocationView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocation | AllocationSpecification | The settlement for whose execution the assets are being allocated. |
+| holdingCids | [ContractId Holding] | The holdings that are backing this allocation.<br/><br/>Provided so that that wallets can correlate the allocation with the<br/><br/>holdings.<br/><br/>MAY be empty for registries that do not represent their holdings on-ledger. |
+| meta | Metadata | Additional metadata specific to the allocation, used for extensibility. |
+
+Instances:
+
+- `instance Eq AllocationView`
+- `instance Show AllocationView`
+- `instance HasFromAnyView Allocation AllocationView`
+- `instance HasInterfaceView Allocation AllocationView`
+- `instance GetField allocation AllocationView AllocationSpecification`
+- `instance GetField holdingCids AllocationView [ContractId Holding]`
+- `instance GetField meta AllocationView Metadata`
+- `instance SetField allocation AllocationView AllocationSpecification`
+- `instance SetField holdingCids AllocationView [ContractId Holding]`
+- `instance SetField meta AllocationView Metadata`
+
+<a id="type-splice-api-token-allocationv1-allocationcancelresult-26037"></a>
+
+### `data Allocation_CancelResult`
+
+The result of the `Allocation_Cancel` choice.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationv1-allocationcancelresult-74846"></a>
+- `Allocation_CancelResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| senderHoldingCids | [ContractId Holding] | The holdings that were released back to the sender. |
+| meta | Metadata | Additional metadata specific to the allocation, used for extensibility. |
+
+Instances:
+
+- `instance Eq Allocation_CancelResult`
+- `instance Show Allocation_CancelResult`
+- `instance HasMethod Allocation allocation_cancelImpl (ContractId Allocation -> Allocation_Cancel -> Update Allocation_CancelResult)`
+- `instance GetField meta Allocation_CancelResult Metadata`
+- `instance GetField senderHoldingCids Allocation_CancelResult [ContractId Holding]`
+- `instance SetField meta Allocation_CancelResult Metadata`
+- `instance SetField senderHoldingCids Allocation_CancelResult [ContractId Holding]`
+- `instance HasExercise Allocation Allocation_Cancel Allocation_CancelResult`
+- `instance HasExerciseGuarded Allocation Allocation_Cancel Allocation_CancelResult`
+- `instance HasFromAnyChoice Allocation Allocation_Cancel Allocation_CancelResult`
+- `instance HasToAnyChoice Allocation Allocation_Cancel Allocation_CancelResult`
+
+<a id="type-splice-api-token-allocationv1-allocationexecutetransferresult-74160"></a>
+
+### `data Allocation_ExecuteTransferResult`
+
+The result of the `Allocation_ExecuteTransfer` choice.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationv1-allocationexecutetransferresult-50341"></a>
+- `Allocation_ExecuteTransferResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| senderHoldingCids | [ContractId Holding] | The holdings that were created for the sender. Can be used to return<br/><br/>"change" to the sender if required. |
+| receiverHoldingCids | [ContractId Holding] | The holdings that were created for the receiver. |
+| meta | Metadata | Additional metadata specific to the transfer instruction, used for extensibility. |
+
+Instances:
+
+- `instance Eq Allocation_ExecuteTransferResult`
+- `instance Show Allocation_ExecuteTransferResult`
+- `instance HasMethod Allocation allocation_executeTransferImpl (ContractId Allocation -> Allocation_ExecuteTransfer -> Update Allocation_ExecuteTransferResult)`
+- `instance GetField meta Allocation_ExecuteTransferResult Metadata`
+- `instance GetField receiverHoldingCids Allocation_ExecuteTransferResult [ContractId Holding]`
+- `instance GetField senderHoldingCids Allocation_ExecuteTransferResult [ContractId Holding]`
+- `instance SetField meta Allocation_ExecuteTransferResult Metadata`
+- `instance SetField receiverHoldingCids Allocation_ExecuteTransferResult [ContractId Holding]`
+- `instance SetField senderHoldingCids Allocation_ExecuteTransferResult [ContractId Holding]`
+- `instance HasExercise Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult`
+- `instance HasExerciseGuarded Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult`
+- `instance HasFromAnyChoice Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult`
+- `instance HasToAnyChoice Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult`
+
+<a id="type-splice-api-token-allocationv1-allocationwithdrawresult-40879"></a>
+
+### `data Allocation_WithdrawResult`
+
+The result of the `Allocation_Withdraw` choice.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationv1-allocationwithdrawresult-86620"></a>
+- `Allocation_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| senderHoldingCids | [ContractId Holding] | The holdings that were released back to the sender. |
+| meta | Metadata | Additional metadata specific to the allocation, used for extensibility. |
+
+Instances:
+
+- `instance Eq Allocation_WithdrawResult`
+- `instance Show Allocation_WithdrawResult`
+- `instance HasMethod Allocation allocation_withdrawImpl (ContractId Allocation -> Allocation_Withdraw -> Update Allocation_WithdrawResult)`
+- `instance GetField meta Allocation_WithdrawResult Metadata`
+- `instance GetField senderHoldingCids Allocation_WithdrawResult [ContractId Holding]`
+- `instance SetField meta Allocation_WithdrawResult Metadata`
+- `instance SetField senderHoldingCids Allocation_WithdrawResult [ContractId Holding]`
+- `instance HasExercise Allocation Allocation_Withdraw Allocation_WithdrawResult`
+- `instance HasExerciseGuarded Allocation Allocation_Withdraw Allocation_WithdrawResult`
+- `instance HasFromAnyChoice Allocation Allocation_Withdraw Allocation_WithdrawResult`
+- `instance HasToAnyChoice Allocation Allocation_Withdraw Allocation_WithdrawResult`
+
+<a id="type-splice-api-token-allocationv1-reference-53456"></a>
+
+### `data Reference`
+
+A generic type to refer to data defined within an app.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationv1-reference-11427"></a>
+- `Reference`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| id | Text | The key that identifies the data. Can be set to the empty string if the contract-id is provided and is sufficient. |
+| cid | Optional AnyContractId | Optional contract-id to use for referring to contracts.<br/><br/>This field is there for technical reasons, as contract-ids cannot be converted to text from within Daml,<br/><br/>which is due to their full textual representation being only known after transactions have been prepared. |
+
+Instances:
+
+- `instance Eq Reference`
+- `instance Show Reference`
+- `instance GetField cid Reference (Optional AnyContractId)`
+- `instance GetField id Reference Text`
+- `instance GetField settlementRef SettlementInfo Reference`
+- `instance SetField cid Reference (Optional AnyContractId)`
+- `instance SetField id Reference Text`
+- `instance SetField settlementRef SettlementInfo Reference`
+
+<a id="type-splice-api-token-allocationv1-settlementinfo-4367"></a>
+
+### `data SettlementInfo`
+
+The minimal set of information about a settlement that an app would like to execute.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationv1-settlementinfo-25294"></a>
+- `SettlementInfo`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| executor | Party | The party that is responsible for executing the settlement. |
+| settlementRef | Reference | Reference to the settlement that app would like to execute. |
+| requestedAt | Time | When the settlement was requested. Provided for display and debugging purposes,<br/><br/>but SHOULD be in the past. |
+| allocateBefore | Time | Until when (exclusive) the senders are given time to allocate their assets.<br/><br/>This field has a particular relevance with respect to instrument versioning / corporate<br/><br/>actions, in that the settlement pertains to the instrument version resulting from the<br/><br/>processing of all corporate actions falling strictly before the `allocateBefore` time. |
+| settleBefore | Time | Until when (exclusive) the executor is given time to execute the settlement.<br/><br/>SHOULD be strictly after `allocateBefore`. |
+| meta | Metadata | Additional metadata about the settlement, used for extensibility. |
+
+Instances:
+
+- `instance Eq SettlementInfo`
+- `instance Show SettlementInfo`
+- `instance GetField allocateBefore SettlementInfo Time`
+- `instance GetField executor SettlementInfo Party`
+- `instance GetField meta SettlementInfo Metadata`
+- `instance GetField requestedAt SettlementInfo Time`
+- `instance GetField settleBefore SettlementInfo Time`
+- `instance GetField settlement AllocationSpecification SettlementInfo`
+- `instance GetField settlementRef SettlementInfo Reference`
+- `instance SetField allocateBefore SettlementInfo Time`
+- `instance SetField executor SettlementInfo Party`
+- `instance SetField meta SettlementInfo Metadata`
+- `instance SetField requestedAt SettlementInfo Time`
+- `instance SetField settleBefore SettlementInfo Time`
+- `instance SetField settlement AllocationSpecification SettlementInfo`
+- `instance SetField settlementRef SettlementInfo Reference`
+
+<a id="type-splice-api-token-allocationv1-transferleg-71662"></a>
+
+### `data TransferLeg`
+
+A specification of a transfer of holdings between two parties for the
+purpose of a settlement, which often requires the atomic execution of multiple legs.
+
+Constructors:
+
+<a id="constr-splice-api-token-allocationv1-transferleg-72717"></a>
+- `TransferLeg`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party | The sender of the transfer. |
+| receiver | Party | The receiver of the transfer. |
+| amount | Decimal | The amount to transfer. |
+| instrumentId | InstrumentId | The instrument identifier. |
+| meta | Metadata | Additional metadata about the transfer leg, used for extensibility. |
+
+Instances:
+
+- `instance Eq TransferLeg`
+- `instance Ord TransferLeg`
+- `instance Show TransferLeg`
+- `instance GetField amount TransferLeg Decimal`
+- `instance GetField instrumentId TransferLeg InstrumentId`
+- `instance GetField meta TransferLeg Metadata`
+- `instance GetField receiver TransferLeg Party`
+- `instance GetField sender TransferLeg Party`
+- `instance GetField transferLeg AllocationSpecification TransferLeg`
+- `instance SetField amount TransferLeg Decimal`
+- `instance SetField instrumentId TransferLeg InstrumentId`
+- `instance SetField meta TransferLeg Metadata`
+- `instance SetField receiver TransferLeg Party`
+- `instance SetField sender TransferLeg Party`
+- `instance SetField transferLeg AllocationSpecification TransferLeg`
+
+## Functions
+
+<a id="function-splice-api-token-allocationv1-allocationcontrollers-10222"></a>
+
+### `allocationControllers`
+
+```daml
+allocationControllers : AllocationView -> [Party]
+```
+
+Convenience function to refer to the union of sender, receiver, and
+executor of the settlement, which jointly control the execution of the
+allocation.
+
+<a id="function-splice-api-token-allocationv1-allocationexecutetransferimpl-90251"></a>
+
+### `allocation_executeTransferImpl`
+
+```daml
+allocation_executeTransferImpl : Allocation -> ContractId Allocation -> Allocation_ExecuteTransfer -> Update Allocation_ExecuteTransferResult
+```
+
+<a id="function-splice-api-token-allocationv1-allocationcancelimpl-12334"></a>
+
+### `allocation_cancelImpl`
+
+```daml
+allocation_cancelImpl : Allocation -> ContractId Allocation -> Allocation_Cancel -> Update Allocation_CancelResult
+```
+
+<a id="function-splice-api-token-allocationv1-allocationwithdrawimpl-40108"></a>
+
+### `allocation_withdrawImpl`
+
+```daml
+allocation_withdrawImpl : Allocation -> ContractId Allocation -> Allocation_Withdraw -> Update Allocation_WithdrawResult
+```
+
+## Interfaces
+
+<a id="type-splice-api-token-allocationv1-allocation-9928"></a>
+
+### Interface `Allocation`
+
+A contract representing an allocation of some amount of aasset holdings to
+a specific leg of a settlement.
+
+View Type: `AllocationView`
+
+Choices:
+
+<a id="type-splice-api-token-allocationv1-allocationcancel-25504"></a>
+
+#### Choice `Allocation_Cancel`
+
+Cancel the allocation. Requires authorization from sender, receiver, and
+executor.
+
+Typically this authorization is granted by sender and receiver to the
+executor as part of the contract coordinating the settlement, so that
+that the executor can release the allocated assets early in case the
+settlement is aborted or it has definitely failed.
+
+Controllers: `allocationControllers (view this)`
+
+Returns: `Allocation_CancelResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<a id="type-splice-api-token-allocationv1-allocationexecutetransfer-74529"></a>
+
+#### Choice `Allocation_ExecuteTransfer`
+
+Execute the transfer of the allocated assets. Intended to be used to execute the settlement.
+This choice SHOULD succeed provided the `settlement.settleBefore` deadline has not yet passed.
+
+Controllers: `allocationControllers (view this)`
+
+Returns: `Allocation_ExecuteTransferResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<a id="type-splice-api-token-allocationv1-allocationwithdraw-60458"></a>
+
+#### Choice `Allocation_Withdraw`
+
+Withdraw the allocated assets. Used by the sender to withdraw the assets before settlement
+was completed. This SHOULD not fail settlement if the sender has still time to allocate the
+assets again; i.e., the `settlement.allocateBefore` deadline has not yet passed.
+
+Controllers: `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this))))`
+
+Returns: `Allocation_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+Methods:
+
+#### Method `allocation_cancelImpl`
+
+Type: `ContractId Allocation -> Allocation_Cancel -> Update Allocation_CancelResult`
+
+#### Method `allocation_executeTransferImpl`
+
+Type: `ContractId Allocation -> Allocation_ExecuteTransfer -> Update Allocation_ExecuteTransferResult`
+
+#### Method `allocation_withdrawImpl`
+
+Type: `ContractId Allocation -> Allocation_Withdraw -> Update Allocation_WithdrawResult`

--- a/docs-main/reference/splice-daml-api/splice-api-token-burn-mint-v1/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-burn-mint-v1/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-api-token-burn-mint-v1 docs"
+description: "Reference documentation for splice-api-token-burn-mint-v1 docs modules."
+---
+
+# splice-api-token-burn-mint-v1 docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Api.Token.BurnMintV1`](/reference/splice-daml-api/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1) | `Module` | An interface for registries to expose burn/mint operations in a generic way | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Api.Token.BurnMintV1](/reference/splice-daml-api/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1)

--- a/docs-main/reference/splice-daml-api/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1.mdx
@@ -1,0 +1,206 @@
+---
+title: "Splice.Api.Token.BurnMintV1"
+description: "Reference documentation for Daml module Splice.Api.Token.BurnMintV1."
+---
+
+<a id="module-splice-api-token-burnmintv1-45547"></a>
+
+# Splice.Api.Token.BurnMintV1
+
+An interface for registries to expose burn/mint operations in a generic way
+
+for bridges to use them, and for wallets to parse their use.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-api-token-burnmintv1-burnmintfactoryview-72718"></a>
+
+### `data BurnMintFactoryView`
+
+The view of a `BurnMintFactory`.
+
+Constructors:
+
+<a id="constr-splice-api-token-burnmintv1-burnmintfactoryview-23617"></a>
+- `BurnMintFactoryView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| admin | Party | The party representing the registry app that administers the instruments<br/><br/>for which this burnt-mint factory can be used. |
+| meta | Metadata | Additional metadata specific to the burn-mint factory, used for extensibility. |
+
+Instances:
+
+- `instance Eq BurnMintFactoryView`
+- `instance Show BurnMintFactoryView`
+- `instance HasMethod BurnMintFactory burnMintFactory_publicFetchImpl (ContractId BurnMintFactory -> BurnMintFactory_PublicFetch -> Update BurnMintFactoryView)`
+- `instance HasFromAnyView BurnMintFactory BurnMintFactoryView`
+- `instance HasInterfaceView BurnMintFactory BurnMintFactoryView`
+- `instance GetField admin BurnMintFactoryView Party`
+- `instance GetField meta BurnMintFactoryView Metadata`
+- `instance SetField admin BurnMintFactoryView Party`
+- `instance SetField meta BurnMintFactoryView Metadata`
+- `instance HasExercise BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView`
+- `instance HasExerciseGuarded BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView`
+- `instance HasFromAnyChoice BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView`
+- `instance HasToAnyChoice BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView`
+
+<a id="type-splice-api-token-burnmintv1-burnmintfactoryburnmintresult-61365"></a>
+
+### `data BurnMintFactory_BurnMintResult`
+
+The result of calling the `BurnMintFactory_BurnMint` choice.
+
+Constructors:
+
+<a id="constr-splice-api-token-burnmintv1-burnmintfactoryburnmintresult-13976"></a>
+- `BurnMintFactory_BurnMintResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| outputCids | [ContractId Holding] | The holdings created by the choice.<br/><br/>Must contain exactly the outputs specified in the choice argument in the same order. |
+
+Instances:
+
+- `instance Eq BurnMintFactory_BurnMintResult`
+- `instance Show BurnMintFactory_BurnMintResult`
+- `instance HasMethod BurnMintFactory burnMintFactory_burnMintImpl (ContractId BurnMintFactory -> BurnMintFactory_BurnMint -> Update BurnMintFactory_BurnMintResult)`
+- `instance GetField outputCids BurnMintFactory_BurnMintResult [ContractId Holding]`
+- `instance SetField outputCids BurnMintFactory_BurnMintResult [ContractId Holding]`
+- `instance HasExercise BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult`
+- `instance HasExerciseGuarded BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult`
+- `instance HasFromAnyChoice BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult`
+- `instance HasToAnyChoice BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult`
+
+<a id="type-splice-api-token-burnmintv1-burnmintoutput-36483"></a>
+
+### `data BurnMintOutput`
+
+The specification of a holding to create as part of the burn/mint operation.
+
+Constructors:
+
+<a id="constr-splice-api-token-burnmintv1-burnmintoutput-15750"></a>
+- `BurnMintOutput`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| owner | Party | The owner of the holding to create. |
+| amount | Decimal | The amount of the holding to create. |
+| context | ChoiceContext | Context specific to this output which can be used to support locking<br/><br/>or other registry-specific features. |
+
+Instances:
+
+- `instance Eq BurnMintOutput`
+- `instance Show BurnMintOutput`
+- `instance GetField amount BurnMintOutput Decimal`
+- `instance GetField context BurnMintOutput ChoiceContext`
+- `instance GetField outputs BurnMintFactory_BurnMint [BurnMintOutput]`
+- `instance GetField owner BurnMintOutput Party`
+- `instance SetField amount BurnMintOutput Decimal`
+- `instance SetField context BurnMintOutput ChoiceContext`
+- `instance SetField outputs BurnMintFactory_BurnMint [BurnMintOutput]`
+- `instance SetField owner BurnMintOutput Party`
+
+## Functions
+
+<a id="function-splice-api-token-burnmintv1-burnmintfactoryburnmintimpl-9738"></a>
+
+### `burnMintFactory_burnMintImpl`
+
+```daml
+burnMintFactory_burnMintImpl : BurnMintFactory -> ContractId BurnMintFactory -> BurnMintFactory_BurnMint -> Update BurnMintFactory_BurnMintResult
+```
+
+<a id="function-splice-api-token-burnmintv1-burnmintfactorypublicfetchimpl-75623"></a>
+
+### `burnMintFactory_publicFetchImpl`
+
+```daml
+burnMintFactory_publicFetchImpl : BurnMintFactory -> ContractId BurnMintFactory -> BurnMintFactory_PublicFetch -> Update BurnMintFactoryView
+```
+
+## Interfaces
+
+<a id="type-splice-api-token-burnmintv1-burnmintfactory-79205"></a>
+
+### Interface `BurnMintFactory`
+
+A factory for generic burn/mint operations.
+
+View Type: `BurnMintFactoryView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<a id="type-splice-api-token-burnmintv1-burnmintfactoryburnmint-20312"></a>
+
+#### Choice `BurnMintFactory_BurnMint`
+
+Burn the holdings in `inputHoldingCids` and create holdings with the
+owners and amounts specified in outputs.
+
+Note that this is jointly authorized by the admin and the `extraActors`.
+The `admin` thus controls all calls to this choice, and some implementations might
+required `extraActors` to be present, e.g., the owners of the minted and burnt holdings.
+
+Implementations are free to restrict the implementation of this choice
+including failing on all inputs or not implementing this interface at all.
+
+Controllers: `(DA.Internal.Record.getField @"admin" (view this)) :: extraActors`
+
+Returns: `BurnMintFactory_BurnMintResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected `admin` party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| instrumentId | InstrumentId | The instrument id of the holdings.<br/><br/>All holdings in `inputHoldingCids` as well as the resulting output holdings MUST<br/><br/>have this instrument id. |
+| inputHoldingCids | [ContractId Holding] | The holdings that should be burnt.<br/><br/>All holdings in `inputHoldingCids` MUST be archived by this choice.<br/><br/>Implementations MAY enforce additional restrictions such as all `inputHoldingCids`<br/><br/>belonging to the same owner. |
+| outputs | [BurnMintOutput] | The holdings that should be created. The choice MUST create new holdings with the given amounts. |
+| extraActors | [Party] | Extra actors, the full actors required are the admin + extraActors. This is often the owners of inputHoldingCids and outputs<br/><br/>but we allow different sets of actors to support token implementations with different authorization setups. |
+| extraArgs | ExtraArgs | Additional context. Implementations SHOULD include a `splice.lfdecentralizedtrust.org/reason`<br/><br/>key in the metadata to provide a human readable description for explain why the<br/><br/>`BurnMintFactory_BurnMint` choice was called, so that generic wallets can display it to the user. |
+
+<a id="type-splice-api-token-burnmintv1-burnmintfactorypublicfetch-64185"></a>
+
+#### Choice `BurnMintFactory_PublicFetch`
+
+Controllers: `actor`
+
+Returns: `BurnMintFactoryView`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| actor | Party | The party fetching the data. |
+
+Methods:
+
+#### Method `burnMintFactory_burnMintImpl`
+
+Type: `ContractId BurnMintFactory -> BurnMintFactory_BurnMint -> Update BurnMintFactory_BurnMintResult`
+
+#### Method `burnMintFactory_publicFetchImpl`
+
+Type: `ContractId BurnMintFactory -> BurnMintFactory_PublicFetch -> Update BurnMintFactoryView`

--- a/docs-main/reference/splice-daml-api/splice-api-token-holding-v1/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-holding-v1/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-api-token-holding-v1 docs"
+description: "Reference documentation for splice-api-token-holding-v1 docs modules."
+---
+
+# splice-api-token-holding-v1 docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Api.Token.HoldingV1`](/reference/splice-daml-api/splice-api-token-holding-v1/splice-api-token-holdingv1) | `Module` | Types and interfaces for retrieving an investor's holdings. | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Api.Token.HoldingV1](/reference/splice-daml-api/splice-api-token-holding-v1/splice-api-token-holdingv1)

--- a/docs-main/reference/splice-daml-api/splice-api-token-holding-v1/splice-api-token-holdingv1.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-holding-v1/splice-api-token-holdingv1.mdx
@@ -1,0 +1,141 @@
+---
+title: "Splice.Api.Token.HoldingV1"
+description: "Reference documentation for Daml module Splice.Api.Token.HoldingV1."
+---
+
+<a id="module-splice-api-token-holdingv1-43900"></a>
+
+# Splice.Api.Token.HoldingV1
+
+Types and interfaces for retrieving an investor's holdings.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-api-token-holdingv1-holdingview-83501"></a>
+
+### `data HoldingView`
+
+View for `Holding`.
+
+Constructors:
+
+<a id="constr-splice-api-token-holdingv1-holdingview-75848"></a>
+- `HoldingView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| owner | Party | Owner of the holding. |
+| instrumentId | InstrumentId | Instrument being held. |
+| amount | Decimal | Size of the holding. |
+| lock | Optional Lock | Lock on the holding.<br/><br/>Registries SHOULD allow holdings with expired locks as inputs to<br/><br/>transfers to enable a combined unlocking + use choice. |
+| meta | Metadata | Metadata. |
+
+Instances:
+
+- `instance Eq HoldingView`
+- `instance Show HoldingView`
+- `instance HasFromAnyView Holding HoldingView`
+- `instance HasInterfaceView Holding HoldingView`
+- `instance GetField amount HoldingView Decimal`
+- `instance GetField instrumentId HoldingView InstrumentId`
+- `instance GetField lock HoldingView (Optional Lock)`
+- `instance GetField meta HoldingView Metadata`
+- `instance GetField owner HoldingView Party`
+- `instance SetField amount HoldingView Decimal`
+- `instance SetField instrumentId HoldingView InstrumentId`
+- `instance SetField lock HoldingView (Optional Lock)`
+- `instance SetField meta HoldingView Metadata`
+- `instance SetField owner HoldingView Party`
+
+<a id="type-splice-api-token-holdingv1-instrumentid-28218"></a>
+
+### `data InstrumentId`
+
+A globally unique identifier for instruments.
+
+Constructors:
+
+<a id="constr-splice-api-token-holdingv1-instrumentid-17961"></a>
+- `InstrumentId`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| admin | Party | The party representing the registry app that administers the instrument. |
+| id | Text | The identifier used for the instrument by the instrument admin.<br/><br/>This identifier MUST be unique and unambiguous per instrument admin. |
+
+Instances:
+
+- `instance Eq InstrumentId`
+- `instance Ord InstrumentId`
+- `instance Show InstrumentId`
+- `instance GetField admin InstrumentId Party`
+- `instance GetField id InstrumentId Text`
+- `instance GetField instrumentId HoldingView InstrumentId`
+- `instance SetField admin InstrumentId Party`
+- `instance SetField id InstrumentId Text`
+- `instance SetField instrumentId HoldingView InstrumentId`
+
+<a id="type-splice-api-token-holdingv1-lock-70295"></a>
+
+### `data Lock`
+
+Details of a lock.
+
+Constructors:
+
+<a id="constr-splice-api-token-holdingv1-lock-56452"></a>
+- `Lock`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| holders | [Party] | Unique list of parties which are locking the contract.<br/><br/>(Represented as a list, as that has the better JSON encoding.) |
+| expiresAt | Optional Time | Absolute, inclusive deadline as of which the lock expires. |
+| expiresAfter | Optional RelTime | Duration after which the created lock expires. Measured relative<br/><br/>to the ledger time that the locked holding contract was created.<br/><br/>If both `expiresAt` and `expiresAfter` are set, the lock expires at<br/><br/>the earlier of the two times. |
+| context | Optional Text | Short, human-readable description of the context of the lock.<br/><br/>Used by wallets to enable users to understand the reason for the lock.<br/><br/>Note that the visibility of the content in this field might be wider<br/><br/>than the visibility of the contracts in the context. You should thus<br/><br/>carefully decide what information is safe to put in the lock context. |
+
+Instances:
+
+- `instance Eq Lock`
+- `instance Ord Lock`
+- `instance Show Lock`
+- `instance GetField context Lock (Optional Text)`
+- `instance GetField expiresAfter Lock (Optional RelTime)`
+- `instance GetField expiresAt Lock (Optional Time)`
+- `instance GetField holders Lock [Party]`
+- `instance GetField lock HoldingView (Optional Lock)`
+- `instance SetField context Lock (Optional Text)`
+- `instance SetField expiresAfter Lock (Optional RelTime)`
+- `instance SetField expiresAt Lock (Optional Time)`
+- `instance SetField holders Lock [Party]`
+- `instance SetField lock HoldingView (Optional Lock)`
+
+## Interfaces
+
+<a id="type-splice-api-token-holdingv1-holding-25898"></a>
+
+### Interface `Holding`
+
+Holding interface.
+
+View Type: `HoldingView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-api-token-metadata-v1/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-metadata-v1/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-api-token-metadata-v1 docs"
+description: "Reference documentation for splice-api-token-metadata-v1 docs modules."
+---
+
+# splice-api-token-metadata-v1 docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Api.Token.MetadataV1`](/reference/splice-daml-api/splice-api-token-metadata-v1/splice-api-token-metadatav1) | `Module` | Types and interfaces for retrieving metadata about tokens. | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Api.Token.MetadataV1](/reference/splice-daml-api/splice-api-token-metadata-v1/splice-api-token-metadatav1)

--- a/docs-main/reference/splice-daml-api/splice-api-token-metadata-v1/splice-api-token-metadatav1.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-metadata-v1/splice-api-token-metadatav1.mdx
@@ -1,0 +1,239 @@
+---
+title: "Splice.Api.Token.MetadataV1"
+description: "Reference documentation for Daml module Splice.Api.Token.MetadataV1."
+---
+
+<a id="module-splice-api-token-metadatav1-34807"></a>
+
+# Splice.Api.Token.MetadataV1
+
+Types and interfaces for retrieving metadata about tokens.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-api-token-metadatav1-anycontractid-4875"></a>
+
+### `type AnyContractId = ContractId AnyContract`
+
+A reference to some contract id. Use `coerceContractId` to convert from and to this type.
+
+<a id="type-splice-api-token-metadatav1-anycontractview-55353"></a>
+
+### `data AnyContractView`
+
+Not used. See the `AnyContract` interface for more information.
+
+Constructors:
+
+<a id="constr-splice-api-token-metadatav1-anycontractview-50558"></a>
+- `AnyContractView`
+(no fields)
+
+Instances:
+
+- `instance HasFromAnyView AnyContract AnyContractView`
+- `instance HasInterfaceView AnyContract AnyContractView`
+
+<a id="type-splice-api-token-metadatav1-anyvalue-34700"></a>
+
+### `data AnyValue`
+
+A generic representation of serializable Daml values.
+
+Used to pass arbitrary data across interface boundaries. For example to pass
+data from an an app backend to an interface choice implementation.
+
+Constructors:
+
+<a id="constr-splice-api-token-metadatav1-avtext-20580"></a>
+- `AV_Text Text`
+<a id="constr-splice-api-token-metadatav1-avint-52425"></a>
+- `AV_Int Int`
+<a id="constr-splice-api-token-metadatav1-avdecimal-71267"></a>
+- `AV_Decimal Decimal`
+<a id="constr-splice-api-token-metadatav1-avbool-76457"></a>
+- `AV_Bool Bool`
+<a id="constr-splice-api-token-metadatav1-avdate-46205"></a>
+- `AV_Date Date`
+<a id="constr-splice-api-token-metadatav1-avtime-30398"></a>
+- `AV_Time Time`
+<a id="constr-splice-api-token-metadatav1-avreltime-31008"></a>
+- `AV_RelTime RelTime`
+<a id="constr-splice-api-token-metadatav1-avparty-78344"></a>
+- `AV_Party Party`
+<a id="constr-splice-api-token-metadatav1-avcontractid-3242"></a>
+- `AV_ContractId AnyContractId`
+<a id="constr-splice-api-token-metadatav1-avlist-50505"></a>
+- `AV_List [AnyValue]`
+<a id="constr-splice-api-token-metadatav1-avmap-39932"></a>
+- `AV_Map (TextMap AnyValue)`
+
+Instances:
+
+- `instance Eq AnyValue`
+- `instance Show AnyValue`
+- `instance GetField values ChoiceContext (TextMap AnyValue)`
+- `instance SetField values ChoiceContext (TextMap AnyValue)`
+
+<a id="type-splice-api-token-metadatav1-choicecontext-5566"></a>
+
+### `data ChoiceContext`
+
+A type for passing extra data from an app's backends to the choices of that app
+exercised in commands submitted by app users.
+
+Constructors:
+
+<a id="constr-splice-api-token-metadatav1-choicecontext-36049"></a>
+- `ChoiceContext`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| values | TextMap AnyValue | The values passed in by the app backend to the choice.<br/><br/>The keys are considered internal to the app and should not be read by<br/><br/>third-party code. |
+
+Instances:
+
+- `instance Eq ChoiceContext`
+- `instance Show ChoiceContext`
+- `instance GetField context ExtraArgs ChoiceContext`
+- `instance GetField values ChoiceContext (TextMap AnyValue)`
+- `instance SetField context ExtraArgs ChoiceContext`
+- `instance SetField values ChoiceContext (TextMap AnyValue)`
+
+<a id="type-splice-api-token-metadatav1-choiceexecutionmetadata-98464"></a>
+
+### `data ChoiceExecutionMetadata`
+
+A generic result for choices that do not need to return specific data.
+
+Constructors:
+
+<a id="constr-splice-api-token-metadatav1-choiceexecutionmetadata-73543"></a>
+- `ChoiceExecutionMetadata`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| meta | Metadata | Additional metadata specific to the result of exercising the choice, used for extensibility. |
+
+Instances:
+
+- `instance Eq ChoiceExecutionMetadata`
+- `instance Show ChoiceExecutionMetadata`
+- `instance GetField meta ChoiceExecutionMetadata Metadata`
+- `instance SetField meta ChoiceExecutionMetadata Metadata`
+
+<a id="type-splice-api-token-metadatav1-extraargs-90869"></a>
+
+### `data ExtraArgs`
+
+A common type for passing both the choice context and the metadata to a choice.
+
+Constructors:
+
+<a id="constr-splice-api-token-metadatav1-extraargs-16750"></a>
+- `ExtraArgs`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | ChoiceContext | Extra arguments to be passed to the implementation of an interface choice.<br/><br/>These are provided via an off-ledger API by the app implementing the interface. |
+| meta | Metadata | Additional metadata to pass in.<br/><br/>In contrast to the `extraArgs`, these are provided by the caller of the choice.<br/><br/>The expectation is that the meaning of metadata fields will be agreed on<br/><br/>in later standards, or on a case-by-case basis between the caller and the<br/><br/>implementer of the interface. |
+
+Instances:
+
+- `instance Eq ExtraArgs`
+- `instance Show ExtraArgs`
+- `instance GetField context ExtraArgs ChoiceContext`
+- `instance GetField meta ExtraArgs Metadata`
+- `instance SetField context ExtraArgs ChoiceContext`
+- `instance SetField meta ExtraArgs Metadata`
+
+<a id="type-splice-api-token-metadatav1-metadata-21206"></a>
+
+### `data Metadata`
+
+Machine-readable metadata intended for communicating additional information
+using well-known keys between systems. This is mainly used to allow for the post-hoc
+expansion of the information associated with contracts and choice arguments and results.
+
+Modeled after by k8s support for annotations: <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>.
+
+Implementors SHOULD follow the same conventions for allocating keys as used by k8s; i.e.,
+they SHOULD be prefixed using the DNS name of the app defining the key.
+
+Implementors SHOULD keep metadata small, as on-ledger data is costly.
+
+Constructors:
+
+<a id="constr-splice-api-token-metadatav1-metadata-84299"></a>
+- `Metadata`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| values | TextMap Text | Key-value pairs of metadata entries. |
+
+Instances:
+
+- `instance Eq Metadata`
+- `instance Ord Metadata`
+- `instance Show Metadata`
+- `instance GetField meta ChoiceExecutionMetadata Metadata`
+- `instance GetField meta ExtraArgs Metadata`
+- `instance GetField values Metadata (TextMap Text)`
+- `instance SetField meta ChoiceExecutionMetadata Metadata`
+- `instance SetField meta ExtraArgs Metadata`
+- `instance SetField values Metadata (TextMap Text)`
+
+## Functions
+
+<a id="function-splice-api-token-metadatav1-emptychoicecontext-1208"></a>
+
+### `emptyChoiceContext`
+
+```daml
+emptyChoiceContext : ChoiceContext
+```
+
+Empty choice context.
+
+<a id="function-splice-api-token-metadatav1-emptymetadata-88176"></a>
+
+### `emptyMetadata`
+
+```daml
+emptyMetadata : Metadata
+```
+
+Empty metadata.
+
+## Interfaces
+
+<a id="type-splice-api-token-metadatav1-anycontract-39598"></a>
+
+### Interface `AnyContract`
+
+Interface used to represent arbitrary contracts.
+Note that this is not expected to be implemented by any template,
+so it should only be used in the form `ContractId AnyContract` and through `coerceContractId`
+but not through any of the interface functions like `fetchFromInterface` that check whether the template actually implements the interface.
+
+View Type: `AnyContractView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-api-token-transfer-instruction-v1/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-transfer-instruction-v1/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-api-token-transfer-instruction-v1 docs"
+description: "Reference documentation for splice-api-token-transfer-instruction-v1 docs modules."
+---
+
+# splice-api-token-transfer-instruction-v1 docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Api.Token.TransferInstructionV1`](/reference/splice-daml-api/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1) | `Module` | Instruct transfers of holdings between parties. | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Api.Token.TransferInstructionV1](/reference/splice-daml-api/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1)

--- a/docs-main/reference/splice-daml-api/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1.mdx
+++ b/docs-main/reference/splice-daml-api/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1.mdx
@@ -1,0 +1,484 @@
+---
+title: "Splice.Api.Token.TransferInstructionV1"
+description: "Reference documentation for Daml module Splice.Api.Token.TransferInstructionV1."
+---
+
+<a id="module-splice-api-token-transferinstructionv1-72974"></a>
+
+# Splice.Api.Token.TransferInstructionV1
+
+Instruct transfers of holdings between parties.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-api-token-transferinstructionv1-transfer-51973"></a>
+
+### `data Transfer`
+
+A specification of a transfer of holdings between two parties.
+
+Constructors:
+
+<a id="constr-splice-api-token-transferinstructionv1-transfer-5022"></a>
+- `Transfer`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party | The sender of the transfer. |
+| receiver | Party | The receiver of the transfer. |
+| amount | Decimal | The amount to transfer. |
+| instrumentId | InstrumentId | The instrument identifier. |
+| requestedAt | Time | Wallet provided timestamp when the transfer was requested.<br/><br/>MUST be in the past when instructing the transfer. |
+| executeBefore | Time | Until when (exclusive) the transfer may be executed. MUST be in the<br/><br/>future when instructing the transfer.<br/><br/>Registries SHOULD NOT execute the transfer instruction after this time,<br/><br/>so that senders can retry creating a new transfer instruction after this time. |
+| inputHoldingCids | [ContractId Holding] | The holding contracts that should be used to fund the transfer.<br/><br/>MAY be empty if the registry supports automatic selection of holdings for transfers<br/><br/>or does not represent holdings on-ledger.<br/><br/>If specified, then the transfer MUST archive all of these holdings, so<br/><br/>that the execution of the transfer conflicts with any other transfers<br/><br/>using these holdings. Thereby allowing that the sender can use<br/><br/>deliberate contention on holdings to prevent duplicate transfers. |
+| meta | Metadata | Metadata. |
+
+Instances:
+
+- `instance Eq Transfer`
+- `instance Show Transfer`
+- `instance GetField amount Transfer Decimal`
+- `instance GetField executeBefore Transfer Time`
+- `instance GetField inputHoldingCids Transfer [ContractId Holding]`
+- `instance GetField instrumentId Transfer InstrumentId`
+- `instance GetField meta Transfer Metadata`
+- `instance GetField receiver Transfer Party`
+- `instance GetField requestedAt Transfer Time`
+- `instance GetField sender Transfer Party`
+- `instance GetField transfer TransferFactory_Transfer Transfer`
+- `instance GetField transfer TransferInstructionView Transfer`
+- `instance SetField amount Transfer Decimal`
+- `instance SetField executeBefore Transfer Time`
+- `instance SetField inputHoldingCids Transfer [ContractId Holding]`
+- `instance SetField instrumentId Transfer InstrumentId`
+- `instance SetField meta Transfer Metadata`
+- `instance SetField receiver Transfer Party`
+- `instance SetField requestedAt Transfer Time`
+- `instance SetField sender Transfer Party`
+- `instance SetField transfer TransferFactory_Transfer Transfer`
+- `instance SetField transfer TransferInstructionView Transfer`
+
+<a id="type-splice-api-token-transferinstructionv1-transferfactoryview-36679"></a>
+
+### `data TransferFactoryView`
+
+View for `TransferFactory`.
+
+Constructors:
+
+<a id="constr-splice-api-token-transferinstructionv1-transferfactoryview-43930"></a>
+- `TransferFactoryView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| admin | Party | The party representing the registry app that administers the instruments for<br/><br/>which this transfer factory can be used. |
+| meta | Metadata | Additional metadata specific to the transfer factory, used for extensibility. |
+
+Instances:
+
+- `instance Eq TransferFactoryView`
+- `instance Show TransferFactoryView`
+- `instance HasMethod TransferFactory transferFactory_publicFetchImpl (ContractId TransferFactory -> TransferFactory_PublicFetch -> Update TransferFactoryView)`
+- `instance HasFromAnyView TransferFactory TransferFactoryView`
+- `instance HasInterfaceView TransferFactory TransferFactoryView`
+- `instance GetField admin TransferFactoryView Party`
+- `instance GetField meta TransferFactoryView Metadata`
+- `instance SetField admin TransferFactoryView Party`
+- `instance SetField meta TransferFactoryView Metadata`
+- `instance HasExercise TransferFactory TransferFactory_PublicFetch TransferFactoryView`
+- `instance HasExerciseGuarded TransferFactory TransferFactory_PublicFetch TransferFactoryView`
+- `instance HasFromAnyChoice TransferFactory TransferFactory_PublicFetch TransferFactoryView`
+- `instance HasToAnyChoice TransferFactory TransferFactory_PublicFetch TransferFactoryView`
+
+<a id="type-splice-api-token-transferinstructionv1-transferinstructionresult-24735"></a>
+
+### `data TransferInstructionResult`
+
+The result of instructing a transfer or advancing the state of a transfer instruction.
+
+Constructors:
+
+<a id="constr-splice-api-token-transferinstructionv1-transferinstructionresult-25274"></a>
+- `TransferInstructionResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| output | TransferInstructionResult_Output | The output of the step. |
+| senderChangeCids | [ContractId Holding] | New holdings owned by the sender created to return "change". Can be used<br/><br/>by callers to batch creating or updating multiple transfer instructions<br/><br/>in a single Daml transaction. |
+| meta | Metadata | Additional metadata specific to the transfer instruction, used for extensibility; e.g., fees charged. |
+
+Instances:
+
+- `instance Eq TransferInstructionResult`
+- `instance Show TransferInstructionResult`
+- `instance HasMethod TransferFactory transferFactory_transferImpl (ContractId TransferFactory -> TransferFactory_Transfer -> Update TransferInstructionResult)`
+- `instance HasMethod TransferInstruction transferInstruction_acceptImpl (ContractId TransferInstruction -> TransferInstruction_Accept -> Update TransferInstructionResult)`
+- `instance HasMethod TransferInstruction transferInstruction_rejectImpl (ContractId TransferInstruction -> TransferInstruction_Reject -> Update TransferInstructionResult)`
+- `instance HasMethod TransferInstruction transferInstruction_updateImpl (ContractId TransferInstruction -> TransferInstruction_Update -> Update TransferInstructionResult)`
+- `instance HasMethod TransferInstruction transferInstruction_withdrawImpl (ContractId TransferInstruction -> TransferInstruction_Withdraw -> Update TransferInstructionResult)`
+- `instance GetField meta TransferInstructionResult Metadata`
+- `instance GetField output TransferInstructionResult TransferInstructionResult_Output`
+- `instance GetField senderChangeCids TransferInstructionResult [ContractId Holding]`
+- `instance SetField meta TransferInstructionResult Metadata`
+- `instance SetField output TransferInstructionResult TransferInstructionResult_Output`
+- `instance SetField senderChangeCids TransferInstructionResult [ContractId Holding]`
+- `instance HasExercise TransferFactory TransferFactory_Transfer TransferInstructionResult`
+- `instance HasExercise TransferInstruction TransferInstruction_Accept TransferInstructionResult`
+- `instance HasExercise TransferInstruction TransferInstruction_Reject TransferInstructionResult`
+- `instance HasExercise TransferInstruction TransferInstruction_Update TransferInstructionResult`
+- `instance HasExercise TransferInstruction TransferInstruction_Withdraw TransferInstructionResult`
+- `instance HasExerciseGuarded TransferFactory TransferFactory_Transfer TransferInstructionResult`
+- `instance HasExerciseGuarded TransferInstruction TransferInstruction_Accept TransferInstructionResult`
+- `instance HasExerciseGuarded TransferInstruction TransferInstruction_Reject TransferInstructionResult`
+- `instance HasExerciseGuarded TransferInstruction TransferInstruction_Update TransferInstructionResult`
+- `instance HasExerciseGuarded TransferInstruction TransferInstruction_Withdraw TransferInstructionResult`
+- `instance HasFromAnyChoice TransferFactory TransferFactory_Transfer TransferInstructionResult`
+- `instance HasFromAnyChoice TransferInstruction TransferInstruction_Accept TransferInstructionResult`
+- `instance HasFromAnyChoice TransferInstruction TransferInstruction_Reject TransferInstructionResult`
+- `instance HasFromAnyChoice TransferInstruction TransferInstruction_Update TransferInstructionResult`
+- `instance HasFromAnyChoice TransferInstruction TransferInstruction_Withdraw TransferInstructionResult`
+- `instance HasToAnyChoice TransferFactory TransferFactory_Transfer TransferInstructionResult`
+- `instance HasToAnyChoice TransferInstruction TransferInstruction_Accept TransferInstructionResult`
+- `instance HasToAnyChoice TransferInstruction TransferInstruction_Reject TransferInstructionResult`
+- `instance HasToAnyChoice TransferInstruction TransferInstruction_Update TransferInstructionResult`
+- `instance HasToAnyChoice TransferInstruction TransferInstruction_Withdraw TransferInstructionResult`
+
+<a id="type-splice-api-token-transferinstructionv1-transferinstructionresultoutput-59824"></a>
+
+### `data TransferInstructionResult_Output`
+
+The output of instructing a transfer or advancing the state of a transfer instruction.
+
+Constructors:
+
+<a id="constr-splice-api-token-transferinstructionv1-transferinstructionresultpending-18902"></a>
+- `TransferInstructionResult_Pending`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferInstructionCid | ContractId TransferInstruction | Contract id of the transfer instruction representing the pending state. |
+Use this result to communicate that the transfer is pending further steps.
+<a id="constr-splice-api-token-transferinstructionv1-transferinstructionresultcompleted-47798"></a>
+- `TransferInstructionResult_Completed`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiverHoldingCids | [ContractId Holding] | The newly created holdings owned by the receiver as part of successfully<br/><br/>completing the transfer. |
+Use this result to communicate that the transfer succeeded and the receiver
+has received their holdings.
+<a id="constr-splice-api-token-transferinstructionv1-transferinstructionresultfailed-21543"></a>
+- `TransferInstructionResult_Failed`
+Use this result to communicate that the transfer did not succeed and all holdings (minus fees)
+have been returned to the sender.
+
+Instances:
+
+- `instance Eq TransferInstructionResult_Output`
+- `instance Show TransferInstructionResult_Output`
+- `instance GetField output TransferInstructionResult TransferInstructionResult_Output`
+- `instance GetField receiverHoldingCids TransferInstructionResult_Output [ContractId Holding]`
+- `instance GetField transferInstructionCid TransferInstructionResult_Output (ContractId TransferInstruction)`
+- `instance SetField output TransferInstructionResult TransferInstructionResult_Output`
+- `instance SetField receiverHoldingCids TransferInstructionResult_Output [ContractId Holding]`
+- `instance SetField transferInstructionCid TransferInstructionResult_Output (ContractId TransferInstruction)`
+
+<a id="type-splice-api-token-transferinstructionv1-transferinstructionstatus-36298"></a>
+
+### `data TransferInstructionStatus`
+
+Status of a transfer instruction.
+
+Constructors:
+
+<a id="constr-splice-api-token-transferinstructionv1-transferpendingreceiveracceptance-84710"></a>
+- `TransferPendingReceiverAcceptance`
+The transfer is pending acceptance by the receiver.
+<a id="constr-splice-api-token-transferinstructionv1-transferpendinginternalworkflow-24806"></a>
+- `TransferPendingInternalWorkflow`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| pendingActions | Map Party Text | The actions that a party could take to advance the transfer.<br/><br/>This field can by used to inform wallet users whether they need to take an action or not. |
+The transfer is pending actions to be taken as part of registry internal workflows.
+
+Instances:
+
+- `instance Eq TransferInstructionStatus`
+- `instance Show TransferInstructionStatus`
+- `instance GetField pendingActions TransferInstructionStatus (Map Party Text)`
+- `instance GetField status TransferInstructionView TransferInstructionStatus`
+- `instance SetField pendingActions TransferInstructionStatus (Map Party Text)`
+- `instance SetField status TransferInstructionView TransferInstructionStatus`
+
+<a id="type-splice-api-token-transferinstructionv1-transferinstructionview-46309"></a>
+
+### `data TransferInstructionView`
+
+View for `TransferInstruction`.
+
+Constructors:
+
+<a id="constr-splice-api-token-transferinstructionv1-transferinstructionview-88808"></a>
+- `TransferInstructionView`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| originalInstructionCid | Optional (ContractId TransferInstruction) | The contract id of the original transfer instruction contract.<br/><br/>Used by the wallet to track the lineage of transfer instructions through multiple steps.<br/><br/>Only set if the registry evolves the transfer instruction in multiple steps. |
+| transfer | Transfer | The transfer specified by the transfer instruction. |
+| status | TransferInstructionStatus | The status of the transfer instruction. |
+| meta | Metadata | Additional metadata specific to the transfer instruction, used for extensibility; e.g., more detailed status information. |
+
+Instances:
+
+- `instance Eq TransferInstructionView`
+- `instance Show TransferInstructionView`
+- `instance HasFromAnyView TransferInstruction TransferInstructionView`
+- `instance HasInterfaceView TransferInstruction TransferInstructionView`
+- `instance GetField meta TransferInstructionView Metadata`
+- `instance GetField originalInstructionCid TransferInstructionView (Optional (ContractId TransferInstruction))`
+- `instance GetField status TransferInstructionView TransferInstructionStatus`
+- `instance GetField transfer TransferInstructionView Transfer`
+- `instance SetField meta TransferInstructionView Metadata`
+- `instance SetField originalInstructionCid TransferInstructionView (Optional (ContractId TransferInstruction))`
+- `instance SetField status TransferInstructionView TransferInstructionStatus`
+- `instance SetField transfer TransferInstructionView Transfer`
+
+## Functions
+
+<a id="function-splice-api-token-transferinstructionv1-transferinstructionacceptimpl-78274"></a>
+
+### `transferInstruction_acceptImpl`
+
+```daml
+transferInstruction_acceptImpl : TransferInstruction -> ContractId TransferInstruction -> TransferInstruction_Accept -> Update TransferInstructionResult
+```
+
+<a id="function-splice-api-token-transferinstructionv1-transferinstructionrejectimpl-50311"></a>
+
+### `transferInstruction_rejectImpl`
+
+```daml
+transferInstruction_rejectImpl : TransferInstruction -> ContractId TransferInstruction -> TransferInstruction_Reject -> Update TransferInstructionResult
+```
+
+<a id="function-splice-api-token-transferinstructionv1-transferinstructionwithdrawimpl-10586"></a>
+
+### `transferInstruction_withdrawImpl`
+
+```daml
+transferInstruction_withdrawImpl : TransferInstruction -> ContractId TransferInstruction -> TransferInstruction_Withdraw -> Update TransferInstructionResult
+```
+
+<a id="function-splice-api-token-transferinstructionv1-transferinstructionupdateimpl-73329"></a>
+
+### `transferInstruction_updateImpl`
+
+```daml
+transferInstruction_updateImpl : TransferInstruction -> ContractId TransferInstruction -> TransferInstruction_Update -> Update TransferInstructionResult
+```
+
+<a id="function-splice-api-token-transferinstructionv1-transferfactorytransferimpl-82483"></a>
+
+### `transferFactory_transferImpl`
+
+```daml
+transferFactory_transferImpl : TransferFactory -> ContractId TransferFactory -> TransferFactory_Transfer -> Update TransferInstructionResult
+```
+
+<a id="function-splice-api-token-transferinstructionv1-transferfactorypublicfetchimpl-930"></a>
+
+### `transferFactory_publicFetchImpl`
+
+```daml
+transferFactory_publicFetchImpl : TransferFactory -> ContractId TransferFactory -> TransferFactory_PublicFetch -> Update TransferFactoryView
+```
+
+## Interfaces
+
+<a id="type-splice-api-token-transferinstructionv1-transferfactory-55548"></a>
+
+### Interface `TransferFactory`
+
+A factory contract to instruct transfers of holdings between parties.
+
+View Type: `TransferFactoryView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<a id="type-splice-api-token-transferinstructionv1-transferfactorypublicfetch-56912"></a>
+
+#### Choice `TransferFactory_PublicFetch`
+
+Fetch the view of the factory contract.
+
+Controllers: `actor`
+
+Returns: `TransferFactoryView`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| actor | Party | The party fetching the contract. |
+
+<a id="type-splice-api-token-transferinstructionv1-transferfactorytransfer-25365"></a>
+
+#### Choice `TransferFactory_Transfer`
+
+Instruct the registry to execute a transfer.
+Implementations MUST ensure that this choice fails if `transfer.executeBefore` is in the past.
+
+Controllers: `(DA.Internal.Record.getField @"sender" transfer)`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches<br/><br/>the admin of the factory.<br/><br/>Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against<br/><br/>their own participant. That way they can ensure that it is safe to exercise a choice<br/><br/>on a factory contract acquired from an untrusted source *provided*<br/><br/>all vetted Daml packages only contain interface implementations<br/><br/>that check the expected admin party. |
+| transfer | Transfer | The transfer to execute. |
+| extraArgs | ExtraArgs | The extra arguments to pass to the transfer implementation. |
+
+Methods:
+
+#### Method `transferFactory_publicFetchImpl`
+
+Type: `ContractId TransferFactory -> TransferFactory_PublicFetch -> Update TransferFactoryView`
+
+#### Method `transferFactory_transferImpl`
+
+Type: `ContractId TransferFactory -> TransferFactory_Transfer -> Update TransferInstructionResult`
+
+<a id="type-splice-api-token-transferinstructionv1-transferinstruction-69882"></a>
+
+### Interface `TransferInstruction`
+
+An interface for tracking the status of a transfer instruction,
+i.e., a request to a registry app to execute a transfer.
+
+Registries MAY evolve the transfer instruction in multiple steps. They SHOULD
+do so using only the choices on this interface, so that wallets can reliably
+parse the transaction history and determine whether the instruction ultimately
+succeeded or failed.
+
+View Type: `TransferInstructionView`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `Signatories of implementing template`
+
+Returns: `()`
+
+<a id="type-splice-api-token-transferinstructionv1-transferinstructionaccept-36884"></a>
+
+#### Choice `TransferInstruction_Accept`
+
+Accept the transfer as the receiver.
+
+This choice is only available if the instruction is in
+`TransferPendingReceiverAcceptance` state.
+
+Note that while implementations will typically return `TransferInstructionResult_Completed`,
+this is not guaranteed. The result of the choice is implementation-specific and MAY
+be any of the three possible results.
+
+Controllers: `(DA.Internal.Record.getField @"receiver" (DA.Internal.Record.getField @"transfer" (view this)))`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<a id="type-splice-api-token-transferinstructionv1-transferinstructionreject-89645"></a>
+
+#### Choice `TransferInstruction_Reject`
+
+Reject the transfer as the receiver.
+
+This choice is only available if the instruction is in
+`TransferPendingReceiverAcceptance` state.
+
+Controllers: `(DA.Internal.Record.getField @"receiver" (DA.Internal.Record.getField @"transfer" (view this)))`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<a id="type-splice-api-token-transferinstructionv1-transferinstructionupdate-27423"></a>
+
+#### Choice `TransferInstruction_Update`
+
+Update the state of the transfer instruction. Used by the registry to
+execute registry internal workflow steps that advance the state of the
+transfer instruction. A reason may be communicated via the metadata.
+
+Controllers: `(DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" (DA.Internal.Record.getField @"transfer" (view this))))`, `extraActors`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraActors | [Party] | Extra actors authorizing the update. Implementations MUST check that<br/><br/>this field contains the expected actors for the specific update. |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+<a id="type-splice-api-token-transferinstructionv1-transferinstructionwithdraw-43648"></a>
+
+#### Choice `TransferInstruction_Withdraw`
+
+Withdraw the transfer instruction as the sender.
+
+Controllers: `(DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transfer" (view this)))`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+
+Methods:
+
+#### Method `transferInstruction_acceptImpl`
+
+Type: `ContractId TransferInstruction -> TransferInstruction_Accept -> Update TransferInstructionResult`
+
+#### Method `transferInstruction_rejectImpl`
+
+Type: `ContractId TransferInstruction -> TransferInstruction_Reject -> Update TransferInstructionResult`
+
+#### Method `transferInstruction_updateImpl`
+
+Type: `ContractId TransferInstruction -> TransferInstruction_Update -> Update TransferInstructionResult`
+
+#### Method `transferInstruction_withdrawImpl`
+
+Type: `ContractId TransferInstruction -> TransferInstruction_Withdraw -> Update TransferInstructionResult`

--- a/docs-main/reference/splice-daml-api/splice-dso-governance/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-dso-governance/index.mdx
@@ -1,0 +1,36 @@
+---
+title: "splice-dso-governance docs"
+description: "Reference documentation for splice-dso-governance docs modules."
+---
+
+# splice-dso-governance docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.CometBft`](/reference/splice-daml-api/splice-dso-governance/splice-cometbft) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.DSO.AmuletPrice`](/reference/splice-daml-api/splice-dso-governance/splice-dso-amuletprice) | `Module` | Templates and code for the SVs to agree on a amulet price using median-based voting. | `0.5.18` | - | - | - |
+| [`Splice.DSO.DecentralizedSynchronizer`](/reference/splice-daml-api/splice-dso-governance/splice-dso-decentralizedsynchronizer) | `Module` | Data structures and contracts related managing the decentralized synchronizer. | `0.5.18` | - | - | - |
+| [`Splice.DSO.SvState`](/reference/splice-daml-api/splice-dso-governance/splice-dso-svstate) | `Module` | Templates to track per-sv state. | `0.5.18` | - | - | - |
+| [`Splice.DsoBootstrap`](/reference/splice-daml-api/splice-dso-governance/splice-dsobootstrap) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.DsoRules`](/reference/splice-daml-api/splice-dso-governance/splice-dsorules) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.SvOnboarding`](/reference/splice-daml-api/splice-dso-governance/splice-svonboarding) | `Module` | - | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 7 | 0 | 0 |
+
+## Reference
+
+- [Splice.CometBft](/reference/splice-daml-api/splice-dso-governance/splice-cometbft)
+- [Splice.DSO.AmuletPrice](/reference/splice-daml-api/splice-dso-governance/splice-dso-amuletprice)
+- [Splice.DSO.DecentralizedSynchronizer](/reference/splice-daml-api/splice-dso-governance/splice-dso-decentralizedsynchronizer)
+- [Splice.DSO.SvState](/reference/splice-daml-api/splice-dso-governance/splice-dso-svstate)
+- [Splice.DsoBootstrap](/reference/splice-daml-api/splice-dso-governance/splice-dsobootstrap)
+- [Splice.DsoRules](/reference/splice-daml-api/splice-dso-governance/splice-dsorules)
+- [Splice.SvOnboarding](/reference/splice-daml-api/splice-dso-governance/splice-svonboarding)

--- a/docs-main/reference/splice-daml-api/splice-dso-governance/splice-cometbft.mdx
+++ b/docs-main/reference/splice-daml-api/splice-dso-governance/splice-cometbft.mdx
@@ -1,0 +1,211 @@
+---
+title: "Splice.CometBft"
+description: "Reference documentation for Daml module Splice.CometBft."
+---
+
+<a id="module-splice-cometbft-61948"></a>
+
+# Splice.CometBft
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-cometbft-cometbftconfig-79018"></a>
+
+### `data CometBftConfig`
+
+Config for all CometBFT nodes and keys under the control of a single SV node operator.
+
+Constructors:
+
+<a id="constr-splice-cometbft-cometbftconfig-91607"></a>
+- `CometBftConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| nodes | Map Text CometBftNodeConfig | A map from CometBft node-ids to their configuration. |
+| governanceKeys | [GovernanceKeyConfig] |  |
+| sequencingKeys | [SequencingKeyConfig] |  |
+
+Instances:
+
+- `instance Patchable CometBftConfig`
+- `instance Eq CometBftConfig`
+- `instance Show CometBftConfig`
+- `instance GetField cometBft SynchronizerNodeConfig CometBftConfig`
+- `instance GetField governanceKeys CometBftConfig [GovernanceKeyConfig]`
+- `instance GetField nodes CometBftConfig (Map Text CometBftNodeConfig)`
+- `instance GetField sequencingKeys CometBftConfig [SequencingKeyConfig]`
+- `instance SetField cometBft SynchronizerNodeConfig CometBftConfig`
+- `instance SetField governanceKeys CometBftConfig [GovernanceKeyConfig]`
+- `instance SetField nodes CometBftConfig (Map Text CometBftNodeConfig)`
+- `instance SetField sequencingKeys CometBftConfig [SequencingKeyConfig]`
+
+<a id="type-splice-cometbft-cometbftconfiglimits-81004"></a>
+
+### `data CometBftConfigLimits`
+
+Limits on the configurations that SV node operators can choose for their CometBFT nodes and keys.
+
+Constructors:
+
+<a id="constr-splice-cometbft-cometbftconfiglimits-44281"></a>
+- `CometBftConfigLimits`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| maxNumCometBftNodes | Int |  |
+| maxNumGovernanceKeys | Int |  |
+| maxNumSequencingKeys | Int |  |
+| maxNodeIdLength | Int |  |
+| maxPubKeyLength | Int |  |
+
+Instances:
+
+- `instance Patchable CometBftConfigLimits`
+- `instance Eq CometBftConfigLimits`
+- `instance Show CometBftConfigLimits`
+- `instance GetField cometBft SynchronizerNodeConfigLimits CometBftConfigLimits`
+- `instance GetField maxNodeIdLength CometBftConfigLimits Int`
+- `instance GetField maxNumCometBftNodes CometBftConfigLimits Int`
+- `instance GetField maxNumGovernanceKeys CometBftConfigLimits Int`
+- `instance GetField maxNumSequencingKeys CometBftConfigLimits Int`
+- `instance GetField maxPubKeyLength CometBftConfigLimits Int`
+- `instance SetField cometBft SynchronizerNodeConfigLimits CometBftConfigLimits`
+- `instance SetField maxNodeIdLength CometBftConfigLimits Int`
+- `instance SetField maxNumCometBftNodes CometBftConfigLimits Int`
+- `instance SetField maxNumGovernanceKeys CometBftConfigLimits Int`
+- `instance SetField maxNumSequencingKeys CometBftConfigLimits Int`
+- `instance SetField maxPubKeyLength CometBftConfigLimits Int`
+
+<a id="type-splice-cometbft-cometbftnodeconfig-40106"></a>
+
+### `data CometBftNodeConfig`
+
+Config for a single CometBFT node.
+
+Constructors:
+
+<a id="constr-splice-cometbft-cometbftnodeconfig-66571"></a>
+- `CometBftNodeConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validatorPubKey | Text |  |
+| votingPower | Int |  |
+
+Instances:
+
+- `instance Patchable CometBftNodeConfig`
+- `instance Eq CometBftNodeConfig`
+- `instance Show CometBftNodeConfig`
+- `instance GetField nodes CometBftConfig (Map Text CometBftNodeConfig)`
+- `instance GetField validatorPubKey CometBftNodeConfig Text`
+- `instance GetField votingPower CometBftNodeConfig Int`
+- `instance SetField nodes CometBftConfig (Map Text CometBftNodeConfig)`
+- `instance SetField validatorPubKey CometBftNodeConfig Text`
+- `instance SetField votingPower CometBftNodeConfig Int`
+
+<a id="type-splice-cometbft-governancekeyconfig-71820"></a>
+
+### `data GovernanceKeyConfig`
+
+Config for a key used by the SvApp to create CometBFT network governance transactions.
+
+Constructors:
+
+<a id="constr-splice-cometbft-governancekeyconfig-53123"></a>
+- `GovernanceKeyConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| pubKey | Text |  |
+
+Instances:
+
+- `instance Patchable GovernanceKeyConfig`
+- `instance Eq GovernanceKeyConfig`
+- `instance Ord GovernanceKeyConfig`
+- `instance Show GovernanceKeyConfig`
+- `instance GetField governanceKeys CometBftConfig [GovernanceKeyConfig]`
+- `instance GetField pubKey GovernanceKeyConfig Text`
+- `instance SetField governanceKeys CometBftConfig [GovernanceKeyConfig]`
+- `instance SetField pubKey GovernanceKeyConfig Text`
+
+<a id="type-splice-cometbft-sequencingkeyconfig-30402"></a>
+
+### `data SequencingKeyConfig`
+
+Config for a key used by the CometBFT Sequencer Driver to sequence messages via the CometBFT network.
+
+Constructors:
+
+<a id="constr-splice-cometbft-sequencingkeyconfig-16921"></a>
+- `SequencingKeyConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| pubKey | Text |  |
+
+Instances:
+
+- `instance Patchable SequencingKeyConfig`
+- `instance Eq SequencingKeyConfig`
+- `instance Ord SequencingKeyConfig`
+- `instance Show SequencingKeyConfig`
+- `instance GetField pubKey SequencingKeyConfig Text`
+- `instance GetField sequencingKeys CometBftConfig [SequencingKeyConfig]`
+- `instance SetField pubKey SequencingKeyConfig Text`
+- `instance SetField sequencingKeys CometBftConfig [SequencingKeyConfig]`
+
+## Functions
+
+<a id="function-splice-cometbft-emptycometbftconfig-94578"></a>
+
+### `emptyCometBftConfig`
+
+```daml
+emptyCometBftConfig : CometBftConfig
+```
+
+<a id="function-splice-cometbft-defaultcometbftconfiglimits-24082"></a>
+
+### `defaultCometBftConfigLimits`
+
+```daml
+defaultCometBftConfigLimits : CometBftConfigLimits
+```
+
+<a id="function-splice-cometbft-validcometbftconfig-37027"></a>
+
+### `validCometBftConfig`
+
+```daml
+validCometBftConfig : CometBftConfigLimits -> CometBftConfig -> Bool
+```
+
+<a id="function-splice-cometbft-validcometbftnodeconfig-27003"></a>
+
+### `validCometBftNodeConfig`
+
+```daml
+validCometBftNodeConfig : CometBftConfigLimits -> (Text, CometBftNodeConfig) -> Bool
+```
+
+<a id="function-splice-cometbft-totalvotingpower-81580"></a>
+
+### `totalVotingPower`
+
+```daml
+totalVotingPower : CometBftConfig -> Int
+```

--- a/docs-main/reference/splice-daml-api/splice-dso-governance/splice-dso-amuletprice.mdx
+++ b/docs-main/reference/splice-daml-api/splice-dso-governance/splice-dso-amuletprice.mdx
@@ -1,0 +1,81 @@
+---
+title: "Splice.DSO.AmuletPrice"
+description: "Reference documentation for Daml module Splice.DSO.AmuletPrice."
+---
+
+<a id="module-splice-dso-amuletprice-58480"></a>
+
+# Splice.DSO.AmuletPrice
+
+Templates and code for the SVs to agree on a amulet price using median-based voting.
+
+Every sv can change its desired amulet price at any time they like provided they
+
+wait at least one tick duration (2.5 minutes by default) between changes.
+
+New `OpenMiningRounds` are always openened with the median of the amulet prices voted for
+
+by the SVs.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Functions
+
+<a id="function-splice-dso-amuletprice-fetchmedianamuletprice-30507"></a>
+
+### `fetchMedianAmuletPrice`
+
+```daml
+fetchMedianAmuletPrice : Party -> [Party] -> [ContractId AmuletPriceVote] -> Update Decimal
+```
+
+<a id="function-splice-dso-amuletprice-median-98146"></a>
+
+### `median`
+
+```daml
+median : [Decimal] -> Decimal
+```
+
+See https://en.wikipedia.org/wiki/Median
+
+## Templates
+
+<a id="type-splice-dso-amuletprice-amuletpricevote-96658"></a>
+
+### Template `AmuletPriceVote`
+
+A vote by an SV for their desired amulet price.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv | Party |  |
+| amuletPrice | Optional Decimal | Set to None for new svs, but defined thereafter. |
+| lastUpdatedAt | Time | The last time this price was updated. Tracked to limit svs from<br/><br/>changing their vote more than once per tick. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-dso-governance/splice-dso-decentralizedsynchronizer.mdx
+++ b/docs-main/reference/splice-daml-api/splice-dso-governance/splice-dso-decentralizedsynchronizer.mdx
@@ -1,0 +1,347 @@
+---
+title: "Splice.DSO.DecentralizedSynchronizer"
+description: "Reference documentation for Daml module Splice.DSO.DecentralizedSynchronizer."
+---
+
+<a id="module-splice-dso-decentralizedsynchronizer-50859"></a>
+
+# Splice.DSO.DecentralizedSynchronizer
+
+Data structures and contracts related managing the decentralized synchronizer.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-dso-decentralizedsynchronizer-dsodecentralizedsynchronizerconfig-15965"></a>
+
+### `data DsoDecentralizedSynchronizerConfig`
+
+The decentralized synchronizer consists of a series of actual synchronizers.
+New synchronizers are created by the SVs for the rare case of needing to roll-out
+a BFT protocol upgrade that cannot be rolled out in a backwards compatible fashion.
+
+Note that synchronizers themselves are formed by a cluster of nodes run by the SVs.
+As can be seen form `SynchronizerNodeConfig` each sv runs multiple different kinds of
+physical nodes.
+
+Constructors:
+
+<a id="constr-splice-dso-decentralizedsynchronizer-dsodecentralizedsynchronizerconfig-75458"></a>
+- `DsoDecentralizedSynchronizerConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| synchronizers | Map Text SynchronizerConfig | The actual synchronizers, numbered sequentially. |
+| lastSynchronizerId | Text | The last allocated synchronizer Id. |
+| activeSynchronizerId | Text | The synchronizer to be used for managing standard DSO and Amulet workflows. |
+
+Instances:
+
+- `instance Patchable DsoDecentralizedSynchronizerConfig`
+- `instance Eq DsoDecentralizedSynchronizerConfig`
+- `instance Show DsoDecentralizedSynchronizerConfig`
+- `instance GetField activeSynchronizerId DsoDecentralizedSynchronizerConfig Text`
+- `instance GetField decentralizedSynchronizer DsoRulesConfig DsoDecentralizedSynchronizerConfig`
+- `instance GetField lastSynchronizerId DsoDecentralizedSynchronizerConfig Text`
+- `instance GetField synchronizers DsoDecentralizedSynchronizerConfig (Map Text SynchronizerConfig)`
+- `instance SetField activeSynchronizerId DsoDecentralizedSynchronizerConfig Text`
+- `instance SetField decentralizedSynchronizer DsoRulesConfig DsoDecentralizedSynchronizerConfig`
+- `instance SetField lastSynchronizerId DsoDecentralizedSynchronizerConfig Text`
+- `instance SetField synchronizers DsoDecentralizedSynchronizerConfig (Map Text SynchronizerConfig)`
+
+<a id="type-splice-dso-decentralizedsynchronizer-legacysequencerconfig-76078"></a>
+
+### `data LegacySequencerConfig`
+
+Config for a legacy sequencer, i.e., a migration id that is still up but paused. This is useful to allow validators to catch up.
+
+Constructors:
+
+<a id="constr-splice-dso-decentralizedsynchronizer-legacysequencerconfig-74515"></a>
+- `LegacySequencerConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| migrationId | Int | The synchronizer migration id corresponding to this sequencer. |
+| sequencerId | Text | The id of the sequencer. |
+| url | Text | The public accessible url of the sequencer. |
+
+Instances:
+
+- `instance Patchable LegacySequencerConfig`
+- `instance Eq LegacySequencerConfig`
+- `instance Show LegacySequencerConfig`
+- `instance GetField legacySequencerConfig SynchronizerNodeConfig (Optional LegacySequencerConfig)`
+- `instance GetField migrationId LegacySequencerConfig Int`
+- `instance GetField sequencerId LegacySequencerConfig Text`
+- `instance GetField url LegacySequencerConfig Text`
+- `instance SetField legacySequencerConfig SynchronizerNodeConfig (Optional LegacySequencerConfig)`
+- `instance SetField migrationId LegacySequencerConfig Int`
+- `instance SetField sequencerId LegacySequencerConfig Text`
+- `instance SetField url LegacySequencerConfig Text`
+
+<a id="type-splice-dso-decentralizedsynchronizer-mediatorconfig-99298"></a>
+
+### `data MediatorConfig`
+
+Config for a mediator.
+
+Constructors:
+
+<a id="constr-splice-dso-decentralizedsynchronizer-mediatorconfig-88513"></a>
+- `MediatorConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| mediatorId | Text | The id of the mediator. |
+
+Instances:
+
+- `instance Patchable MediatorConfig`
+- `instance Eq MediatorConfig`
+- `instance Show MediatorConfig`
+- `instance GetField mediator SynchronizerNodeConfig (Optional MediatorConfig)`
+- `instance GetField mediatorId MediatorConfig Text`
+- `instance SetField mediator SynchronizerNodeConfig (Optional MediatorConfig)`
+- `instance SetField mediatorId MediatorConfig Text`
+
+<a id="type-splice-dso-decentralizedsynchronizer-scanconfig-87910"></a>
+
+### `data ScanConfig`
+
+Config for a Scan instance.
+
+Constructors:
+
+<a id="constr-splice-dso-decentralizedsynchronizer-scanconfig-27525"></a>
+- `ScanConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| publicUrl | Text | The publicly accessible URL of the Scan instance. |
+
+Instances:
+
+- `instance Patchable ScanConfig`
+- `instance Eq ScanConfig`
+- `instance Show ScanConfig`
+- `instance GetField publicUrl ScanConfig Text`
+- `instance GetField scan SynchronizerNodeConfig (Optional ScanConfig)`
+- `instance SetField publicUrl ScanConfig Text`
+- `instance SetField scan SynchronizerNodeConfig (Optional ScanConfig)`
+
+<a id="type-splice-dso-decentralizedsynchronizer-sequencerconfig-38423"></a>
+
+### `data SequencerConfig`
+
+Config for a sequencer.
+
+Constructors:
+
+<a id="constr-splice-dso-decentralizedsynchronizer-sequencerconfig-73098"></a>
+- `SequencerConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| migrationId | Int | The synchronizer migration id corresponding to this sequencer. |
+| sequencerId | Text | The id of the sequencer. |
+| url | Text | The public accessible url of the sequencer. |
+| availableAfter | Optional Time | Any participant should subscribe this sequencer after this time.<br/><br/>^ If not set the sequencer is not yet accessible |
+
+Instances:
+
+- `instance Patchable SequencerConfig`
+- `instance Eq SequencerConfig`
+- `instance Show SequencerConfig`
+- `instance GetField availableAfter SequencerConfig (Optional Time)`
+- `instance GetField migrationId SequencerConfig Int`
+- `instance GetField sequencer SynchronizerNodeConfig (Optional SequencerConfig)`
+- `instance GetField sequencerId SequencerConfig Text`
+- `instance GetField url SequencerConfig Text`
+- `instance SetField availableAfter SequencerConfig (Optional Time)`
+- `instance SetField migrationId SequencerConfig Int`
+- `instance SetField sequencer SynchronizerNodeConfig (Optional SequencerConfig)`
+- `instance SetField sequencerId SequencerConfig Text`
+- `instance SetField url SequencerConfig Text`
+
+<a id="type-splice-dso-decentralizedsynchronizer-synchronizerconfig-49093"></a>
+
+### `data SynchronizerConfig`
+
+The DSO-level configuration of a synchronizer. This contains the shared parameters
+of the synchronizer.
+
+Constructors:
+
+<a id="constr-splice-dso-decentralizedsynchronizer-synchronizerconfig-62326"></a>
+- `SynchronizerConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| state | SynchronizerState | The state of this synchronizer |
+| cometBftGenesisJson | Text | The CometBftGenesis json value required for new svs to bring up<br/><br/>their CometBft nodes for this synchronizer. |
+| acsCommitmentReconciliationInterval | Optional Int | Participants connected to the decentralized synchronizer exchange ACS commitment messages<br/><br/>every reconciliation interval seconds. |
+
+Instances:
+
+- `instance Patchable SynchronizerConfig`
+- `instance Eq SynchronizerConfig`
+- `instance Show SynchronizerConfig`
+- `instance GetField acsCommitmentReconciliationInterval SynchronizerConfig (Optional Int)`
+- `instance GetField cometBftGenesisJson SynchronizerConfig Text`
+- `instance GetField state SynchronizerConfig SynchronizerState`
+- `instance GetField synchronizers DsoDecentralizedSynchronizerConfig (Map Text SynchronizerConfig)`
+- `instance SetField acsCommitmentReconciliationInterval SynchronizerConfig (Optional Int)`
+- `instance SetField cometBftGenesisJson SynchronizerConfig Text`
+- `instance SetField state SynchronizerConfig SynchronizerState`
+- `instance SetField synchronizers DsoDecentralizedSynchronizerConfig (Map Text SynchronizerConfig)`
+
+<a id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfig-10457"></a>
+
+### `data SynchronizerNodeConfig`
+
+The configuration of a sv's node for a particular synchronizer.
+
+Constructors:
+
+<a id="constr-splice-dso-decentralizedsynchronizer-synchronizernodeconfig-64798"></a>
+- `SynchronizerNodeConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cometBft | CometBftConfig | The configuration of this sv's CometBFT nodes and keys. |
+| sequencer | Optional SequencerConfig | The configuration of this sv's optional local sequencer. |
+| mediator | Optional MediatorConfig | The configuration of this sv's optional local mediator. |
+| scan | Optional ScanConfig | The configuration of this sv's optional Scan instance. |
+| legacySequencerConfig | Optional LegacySequencerConfig | The legacy sequencer config for the prior migration id that is still up. We store this so it can be published on scan and validators can catchup. |
+
+Instances:
+
+- `instance Patchable SynchronizerNodeConfig`
+- `instance Eq SynchronizerNodeConfig`
+- `instance Show SynchronizerNodeConfig`
+- `instance GetField cometBft SynchronizerNodeConfig CometBftConfig`
+- `instance GetField legacySequencerConfig SynchronizerNodeConfig (Optional LegacySequencerConfig)`
+- `instance GetField mediator SynchronizerNodeConfig (Optional MediatorConfig)`
+- `instance GetField newNodeConfig DsoRules_SetSynchronizerNodeConfig SynchronizerNodeConfig`
+- `instance GetField scan SynchronizerNodeConfig (Optional ScanConfig)`
+- `instance GetField sequencer SynchronizerNodeConfig (Optional SequencerConfig)`
+- `instance SetField cometBft SynchronizerNodeConfig CometBftConfig`
+- `instance SetField legacySequencerConfig SynchronizerNodeConfig (Optional LegacySequencerConfig)`
+- `instance SetField mediator SynchronizerNodeConfig (Optional MediatorConfig)`
+- `instance SetField newNodeConfig DsoRules_SetSynchronizerNodeConfig SynchronizerNodeConfig`
+- `instance SetField scan SynchronizerNodeConfig (Optional ScanConfig)`
+- `instance SetField sequencer SynchronizerNodeConfig (Optional SequencerConfig)`
+
+<a id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfiglimits-3659"></a>
+
+### `data SynchronizerNodeConfigLimits`
+
+Constructors:
+
+<a id="constr-splice-dso-decentralizedsynchronizer-synchronizernodeconfiglimits-16072"></a>
+- `SynchronizerNodeConfigLimits`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cometBft | CometBftConfigLimits |  |
+
+Instances:
+
+- `instance Patchable SynchronizerNodeConfigLimits`
+- `instance Eq SynchronizerNodeConfigLimits`
+- `instance Show SynchronizerNodeConfigLimits`
+- `instance GetField cometBft SynchronizerNodeConfigLimits CometBftConfigLimits`
+- `instance GetField synchronizerNodeConfigLimits DsoRulesConfig SynchronizerNodeConfigLimits`
+- `instance SetField cometBft SynchronizerNodeConfigLimits CometBftConfigLimits`
+- `instance SetField synchronizerNodeConfigLimits DsoRulesConfig SynchronizerNodeConfigLimits`
+
+<a id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfigmap-59848"></a>
+
+### `type SynchronizerNodeConfigMap = Map Text SynchronizerNodeConfig`
+
+A map from synchronizer-ids to the configuration of a sv's node for this synchronizer.
+
+Instances:
+
+- `instance GetField sv1SynchronizerNodes DsoBootstrap SynchronizerNodeConfigMap`
+- `instance GetField synchronizerNodes NodeState SynchronizerNodeConfigMap`
+- `instance SetField sv1SynchronizerNodes DsoBootstrap SynchronizerNodeConfigMap`
+- `instance SetField synchronizerNodes NodeState SynchronizerNodeConfigMap`
+
+<a id="type-splice-dso-decentralizedsynchronizer-synchronizerstate-25483"></a>
+
+### `data SynchronizerState`
+
+The state of a synchronizer.
+
+Constructors:
+
+<a id="constr-splice-dso-decentralizedsynchronizer-dsbootstrapping-64886"></a>
+- `DS_Bootstrapping`
+The synchronizer is still being bootstrapped, and SVs are required to
+provision their nodes for it.
+<a id="constr-splice-dso-decentralizedsynchronizer-dsoperational-99130"></a>
+- `DS_Operational`
+The synchronizer is operational, and thus can be used as
+the active synchronizer.
+<a id="constr-splice-dso-decentralizedsynchronizer-dsdecomissioned-12812"></a>
+- `DS_Decomissioned`
+The synchronizer has been decommissioned and svs are now allowed to shutdown
+their nodes for that synchronizer. We track this state explicitly instead of just
+deleting the synchronizer config, as decomissioning likely takes a while, and we
+want to avoid confusion among SV operators when they see errors raised from
+some of their synchronizer nodes.
+<a id="constr-splice-dso-decentralizedsynchronizer-extsynchronizerstate-26922"></a>
+- `ExtSynchronizerState`
+Extension constructor to work around the current lack of upgrading for variants in Daml 3.0.
+Will serve as the default value in a containing record in case of an extension.
+
+Instances:
+
+- `instance Patchable SynchronizerState`
+- `instance Eq SynchronizerState`
+- `instance Show SynchronizerState`
+- `instance GetField state SynchronizerConfig SynchronizerState`
+- `instance SetField state SynchronizerConfig SynchronizerState`
+
+## Functions
+
+<a id="function-splice-dso-decentralizedsynchronizer-nosynchronizernodes-89430"></a>
+
+### `noSynchronizerNodes`
+
+```daml
+noSynchronizerNodes : SynchronizerNodeConfigMap
+```
+
+<a id="function-splice-dso-decentralizedsynchronizer-emptysynchronizernodeconfig-56591"></a>
+
+### `emptySynchronizerNodeConfig`
+
+```daml
+emptySynchronizerNodeConfig : SynchronizerNodeConfig
+```
+
+<a id="function-splice-dso-decentralizedsynchronizer-validsynchronizernodeconfig-25090"></a>
+
+### `validSynchronizerNodeConfig`
+
+```daml
+validSynchronizerNodeConfig : SynchronizerNodeConfigLimits -> SynchronizerNodeConfig -> Bool
+```
+
+<a id="function-splice-dso-decentralizedsynchronizer-defaultsynchronizernodeconfiglimits-67119"></a>
+
+### `defaultSynchronizerNodeConfigLimits`
+
+```daml
+defaultSynchronizerNodeConfigLimits : SynchronizerNodeConfigLimits
+```

--- a/docs-main/reference/splice-daml-api/splice-dso-governance/splice-dso-svstate.mdx
+++ b/docs-main/reference/splice-daml-api/splice-dso-governance/splice-dso-svstate.mdx
@@ -1,0 +1,259 @@
+---
+title: "Splice.DSO.SvState"
+description: "Reference documentation for Daml module Splice.DSO.SvState."
+---
+
+<a id="module-splice-dso-svstate-17621"></a>
+
+# Splice.DSO.SvState
+
+Templates to track per-sv state.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-dso-svstate-forsv-86032"></a>
+
+### `data ForSv`
+
+Constructors:
+
+<a id="constr-splice-dso-svstate-forsv-25145"></a>
+- `ForSv`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| svName | Text |  |
+
+Instances:
+
+- `instance HasCheckedFetch SvRewardState ForSv`
+- `instance Eq ForSv`
+- `instance Show ForSv`
+- `instance GetField dso ForSv Party`
+- `instance GetField svName ForSv Text`
+- `instance SetField dso ForSv Party`
+- `instance SetField svName ForSv Text`
+
+<a id="type-splice-dso-svstate-forsvnode-12988"></a>
+
+### `data ForSvNode`
+
+Constructors:
+
+<a id="constr-splice-dso-svstate-forsvnode-35713"></a>
+- `ForSvNode`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv | Party |  |
+| svName | Text |  |
+
+Instances:
+
+- `instance HasCheckedFetch SvNodeState ForSvNode`
+- `instance HasCheckedFetch SvStatusReport ForSvNode`
+- `instance Eq ForSvNode`
+- `instance Show ForSvNode`
+- `instance GetField dso ForSvNode Party`
+- `instance GetField sv ForSvNode Party`
+- `instance GetField svName ForSvNode Text`
+- `instance SetField dso ForSvNode Party`
+- `instance SetField sv ForSvNode Party`
+- `instance SetField svName ForSvNode Text`
+
+<a id="type-splice-dso-svstate-nodestate-84781"></a>
+
+### `data NodeState`
+
+Constructors:
+
+<a id="constr-splice-dso-svstate-nodestate-4328"></a>
+- `NodeState`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| synchronizerNodes | SynchronizerNodeConfigMap | The config for a synchronizer's CometBFT, sequencer, mediator and scan nodes under control of an SV party. |
+
+Instances:
+
+- `instance Eq NodeState`
+- `instance Show NodeState`
+- `instance GetField state SvNodeState NodeState`
+- `instance GetField synchronizerNodes NodeState SynchronizerNodeConfigMap`
+- `instance SetField state SvNodeState NodeState`
+- `instance SetField synchronizerNodes NodeState SynchronizerNodeConfigMap`
+
+<a id="type-splice-dso-svstate-rewardstate-93172"></a>
+
+### `data RewardState`
+
+Reward collection state of an SV.
+
+Note that we keep some extra aggregates in this state to make it easier to interpret it.
+In principle, these could be derived from the transaction history, but that
+would be much more onerous to implement.
+
+Constructors:
+
+<a id="constr-splice-dso-svstate-rewardstate-16777"></a>
+- `RewardState`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| numRoundsMissed | Int | Number of rounds for which they missed collecting coupons. |
+| numRoundsCollected | Int | Number of rounds for which they collected coupons. |
+| lastRoundCollected | Round | Last round for which they collected reward coupons. |
+| numCouponsIssued | Int | Number of SV reward coupons issued by them for their beneficiaries. |
+
+Instances:
+
+- `instance Eq RewardState`
+- `instance Show RewardState`
+- `instance GetField lastRoundCollected RewardState Round`
+- `instance GetField numCouponsIssued RewardState Int`
+- `instance GetField numRoundsCollected RewardState Int`
+- `instance GetField numRoundsMissed RewardState Int`
+- `instance GetField state SvRewardState RewardState`
+- `instance SetField lastRoundCollected RewardState Round`
+- `instance SetField numCouponsIssued RewardState Int`
+- `instance SetField numRoundsCollected RewardState Int`
+- `instance SetField numRoundsMissed RewardState Int`
+- `instance SetField state SvRewardState RewardState`
+
+<a id="type-splice-dso-svstate-svstatus-81954"></a>
+
+### `data SvStatus`
+
+The status of an SV as seen from their SV node's perspective.
+We generally add values here that are expected to regularly increase, so that
+SV node operators can run alerting off of them.
+
+Constructors:
+
+<a id="constr-splice-dso-svstate-svstatus-71949"></a>
+- `SvStatus`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| createdAt | Time | The wall clock time of the SV node at the time when the SV node started to<br/><br/>gather the data points in this report to submit them. |
+| cometBftHeight | Int | The height of the CometBFT chain at the time of submission |
+| mediatorSynchronizerTime | Time | The latest synchronizer time observed on the mediator at the time of submission |
+| participantSynchronizerTime | Time | The latest synchronizer time observed on the participant at the time of submission |
+| latestOpenRound | Round | The maximum round number of the OpenMiningRound contracts at the time of submission |
+
+Instances:
+
+- `instance Eq SvStatus`
+- `instance Show SvStatus`
+- `instance GetField cometBftHeight SvStatus Int`
+- `instance GetField createdAt SvStatus Time`
+- `instance GetField latestOpenRound SvStatus Round`
+- `instance GetField mediatorSynchronizerTime SvStatus Time`
+- `instance GetField participantSynchronizerTime SvStatus Time`
+- `instance GetField status SvStatusReport (Optional SvStatus)`
+- `instance GetField status DsoRules_SubmitStatusReport SvStatus`
+- `instance SetField cometBftHeight SvStatus Int`
+- `instance SetField createdAt SvStatus Time`
+- `instance SetField latestOpenRound SvStatus Round`
+- `instance SetField mediatorSynchronizerTime SvStatus Time`
+- `instance SetField participantSynchronizerTime SvStatus Time`
+- `instance SetField status SvStatusReport (Optional SvStatus)`
+- `instance SetField status DsoRules_SubmitStatusReport SvStatus`
+
+## Templates
+
+<a id="type-splice-dso-svstate-svnodestate-44938"></a>
+
+### Template `SvNodeState`
+
+State of a node managed by an SV operator party.
+
+There is exactly one such state per SV operator party.
+Even though every SV can operate at most one node at any one time,
+there can though be multiple SV node states per SV, as the state of offboarded
+nodes is kept around for debugging purposes.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv | Party | The SV operator party identifying the node. |
+| svName | Text | The SV name in whose name the node is operated. |
+| state | NodeState |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-dso-svstate-svrewardstate-90395"></a>
+
+### Template `SvRewardState`
+
+State of reward collection for a sv identified by their sv name.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| svName | Text |  |
+| state | RewardState |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-dso-svstate-svstatusreport-18374"></a>
+
+### Template `SvStatusReport`
+
+A singleton contract per SV party that is used to regularly submit status reports.
+
+Individual status reports serve as a heartbeat for a specific SV party and its associoated SV node
+; and to distribute that SVs view on the network to all other SVs.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv | Party | The SV party that submitted this report. |
+| svName | Text | The name of the SV operator whose operator party was used to submit this report. |
+| number | Int | The number of this report, starting from 0. |
+| status | Optional SvStatus | None is used when initially creating the contract upon sv addition. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-dso-governance/splice-dsobootstrap.mdx
+++ b/docs-main/reference/splice-daml-api/splice-dso-governance/splice-dsobootstrap.mdx
@@ -1,0 +1,86 @@
+---
+title: "Splice.DsoBootstrap"
+description: "Reference documentation for Daml module Splice.DsoBootstrap."
+---
+
+<a id="module-splice-dsobootstrap-6192"></a>
+
+# Splice.DsoBootstrap
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-dsobootstrap-dsobootstrapbootstrapresult-11174"></a>
+
+### `data DsoBootstrap_BootstrapResult`
+
+Constructors:
+
+<a id="constr-splice-dsobootstrap-dsobootstrapbootstrapresult-22331"></a>
+- `DsoBootstrap_BootstrapResult`
+
+Instances:
+
+- `instance HasExercise DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult`
+- `instance HasFromAnyChoice DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult`
+- `instance HasToAnyChoice DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult`
+
+## Templates
+
+<a id="type-splice-dsobootstrap-dsobootstrap-38046"></a>
+
+### Template `DsoBootstrap`
+
+A template for bootstrapping DsoRules and AmuletRules.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| sv1Party | Party | the SV that bootstraps the network |
+| sv1Name | Text | human-readable name of SV1 |
+| sv1RewardWeight | Int | the weight of SV1 in the reward distribution |
+| sv1ParticipantId | Text | the id of the participant of the SV that bootstraps the synchronizer |
+| sv1SynchronizerNodes | SynchronizerNodeConfigMap | Synchronizer nodes on which this workflow runs |
+| round0Duration | RelTime |  |
+| amuletConfig | AmuletConfig USD |  |
+| amuletPrice | Decimal |  |
+| ansRulesConfig | AnsRulesConfig |  |
+| config | DsoRulesConfig |  |
+| initialTrafficState | Map Text TrafficState |  |
+| isDevNet | Bool |  |
+| initialRound | Optional Int |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-dsobootstrap-dsobootstrapbootstrap-56803"></a>
+
+#### Choice `DsoBootstrap_Bootstrap`
+
+Controllers: `dso`
+
+Returns: `DsoBootstrap_BootstrapResult`

--- a/docs-main/reference/splice-daml-api/splice-dso-governance/splice-dsorules.mdx
+++ b/docs-main/reference/splice-daml-api/splice-dso-governance/splice-dsorules.mdx
@@ -1,0 +1,2966 @@
+---
+title: "Splice.DsoRules"
+description: "Reference documentation for Daml module Splice.DsoRules."
+---
+
+<a id="module-splice-dsorules-86281"></a>
+
+# Splice.DsoRules
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-dsorules-actionrequiringconfirmation-45397"></a>
+
+### `data ActionRequiringConfirmation`
+
+Actions that require confirmation from SV nodes before they can be executed.
+
+There are two processes for executing such actions:
+1. Any SV can request a vote to execute such an action upon which the other SV's
+   can respond with their votes for whether they accept the execution or not.
+   This process requires votes from 2/3 of all SVs* for the action to be considered definitive
+   and it can be used for all actions that require confirmation.
+2. Some of the actions that require confirmations should be executed automatically
+   once the ledger and the wall-clocks of the SV nodes are in a particular state.
+   These actions are confirmed by each SV node automatically once the action's precondition is met.
+   Once 2/3 of all SV's confirmations* are visible to the DSO delegate it executes them.
+
+* Simplified for clarity; see `requiredNumVotes` for exact formula.
+
+Process 2 is an optimization of Process 1 for the case where no disagreement to the
+action is expected.
+
+We expect honest SV nodes to only create confirmations for actions
+whose preconditions are met. We also rely on the execution of these actions to be
+idempotent, as more than the required number of confirmations can be created.
+
+Note also that having these two processes also aids in distinguishing between manually initiated
+ad-hoc votes and the regular confirmations that need to happen during standard DSO.
+
+Constructors:
+
+<a id="constr-splice-dsorules-arcdsorules-25826"></a>
+- `ARC_DsoRules`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dsoAction | DsoRules_ActionRequiringConfirmation |  |
+<a id="constr-splice-dsorules-arcamuletrules-45909"></a>
+- `ARC_AmuletRules`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesAction | AmuletRules_ActionRequiringConfirmation |  |
+<a id="constr-splice-dsorules-arcansentrycontext-51355"></a>
+- `ARC_AnsEntryContext`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntryContextCid | ContractId AnsEntryContext |  |
+| ansEntryContextAction | AnsEntryContext_ActionRequiringConfirmation |  |
+<a id="constr-splice-dsorules-extactionrequiringconformation-24220"></a>
+- `ExtActionRequiringConformation`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0<br/><br/>This on takes care of providing extensibility for the specific variants below. |
+
+Instances:
+
+- `instance Eq ActionRequiringConfirmation`
+- `instance Show ActionRequiringConfirmation`
+- `instance GetField action Confirmation ActionRequiringConfirmation`
+- `instance GetField action DsoRules_ConfirmAction ActionRequiringConfirmation`
+- `instance GetField action DsoRules_ExecuteConfirmedAction ActionRequiringConfirmation`
+- `instance GetField action DsoRules_RequestVote ActionRequiringConfirmation`
+- `instance GetField action VoteRequest ActionRequiringConfirmation`
+- `instance GetField amuletRulesAction ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation`
+- `instance GetField ansEntryContextAction ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation`
+- `instance GetField ansEntryContextCid ActionRequiringConfirmation (ContractId AnsEntryContext)`
+- `instance GetField dsoAction ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation`
+- `instance GetField dummyUnitField ActionRequiringConfirmation ()`
+- `instance SetField action Confirmation ActionRequiringConfirmation`
+- `instance SetField action DsoRules_ConfirmAction ActionRequiringConfirmation`
+- `instance SetField action DsoRules_ExecuteConfirmedAction ActionRequiringConfirmation`
+- `instance SetField action DsoRules_RequestVote ActionRequiringConfirmation`
+- `instance SetField action VoteRequest ActionRequiringConfirmation`
+- `instance SetField amuletRulesAction ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation`
+- `instance SetField ansEntryContextAction ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation`
+- `instance SetField ansEntryContextCid ActionRequiringConfirmation (ContractId AnsEntryContext)`
+- `instance SetField dsoAction ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation`
+- `instance SetField dummyUnitField ActionRequiringConfirmation ()`
+
+<a id="type-splice-dsorules-amuletrulesactionrequiringconfirmation-62783"></a>
+
+### `data AmuletRules_ActionRequiringConfirmation`
+
+Constructors:
+
+<a id="constr-splice-dsorules-crarcminingroundstartissuing-47375"></a>
+- `CRARC_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuing`
+Automated action to start an issuing round once the summary of the reward coupons have been computed.
+<a id="constr-splice-dsorules-crarcminingroundarchive-10786"></a>
+- `CRARC_MiningRound_Archive AmuletRules_MiningRound_Archive`
+Automated action to archive a closed mining round once no expired reward coupons are left.
+<a id="constr-splice-dsorules-crarcaddfutureamuletconfigschedule-50004"></a>
+- `CRARC_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigSchedule`
+**Deprecated, use CRARC_SetConfig instead**: Voted action to add a config schedule to the `AmuletRules`.
+<a id="constr-splice-dsorules-crarcremovefutureamuletconfigschedule-28322"></a>
+- `CRARC_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigSchedule`
+**Deprecated, use CRARC_SetConfig instead**: Voted action to remove a config schedule from the `AmuletRules`.
+<a id="constr-splice-dsorules-crarcupdatefutureamuletconfigschedule-3041"></a>
+- `CRARC_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigSchedule`
+**Deprecated, use CRARC_SetConfig instead**: Voted action to update a config schedule in the `AmuletRules`.
+<a id="constr-splice-dsorules-crarcsetconfig-80537"></a>
+- `CRARC_SetConfig AmuletRules_SetConfig`
+Voted action to change the `AmuletConfig`. Not idempotent.
+
+Instances:
+
+- `instance Eq AmuletRules_ActionRequiringConfirmation`
+- `instance Show AmuletRules_ActionRequiringConfirmation`
+- `instance GetField amuletRulesAction ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation`
+- `instance SetField amuletRulesAction ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation`
+
+<a id="type-splice-dsorules-ansentrycontextactionrequiringconfirmation-11149"></a>
+
+### `data AnsEntryContext_ActionRequiringConfirmation`
+
+Constructors:
+
+<a id="constr-splice-dsorules-ansrarccollectinitialentrypayment-99049"></a>
+- `ANSRARC_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPayment`
+Automated action to collect initial payment of an ans entry.
+<a id="constr-splice-dsorules-ansrarcrejectentryinitialpayment-1047"></a>
+- `ANSRARC_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPayment`
+Automated action to reject initial payment of an ans entry.
+
+Instances:
+
+- `instance Eq AnsEntryContext_ActionRequiringConfirmation`
+- `instance Show AnsEntryContext_ActionRequiringConfirmation`
+- `instance GetField ansEntryContextAction ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation`
+- `instance SetField ansEntryContextAction ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation`
+
+<a id="type-splice-dsorules-confirmationexpireresult-10666"></a>
+
+### `data Confirmation_ExpireResult`
+
+Choice return types
+
+Constructors:
+
+<a id="constr-splice-dsorules-confirmationexpireresult-43205"></a>
+- `Confirmation_ExpireResult`
+
+Instances:
+
+- `instance HasExercise Confirmation Confirmation_Expire Confirmation_ExpireResult`
+- `instance HasFromAnyChoice Confirmation Confirmation_Expire Confirmation_ExpireResult`
+- `instance HasToAnyChoice Confirmation Confirmation_Expire Confirmation_ExpireResult`
+
+<a id="type-splice-dsorules-dsorulesconfig-6376"></a>
+
+### `data DsoRulesConfig`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesconfig-32625"></a>
+- `DsoRulesConfig`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| numUnclaimedRewardsThreshold | Int | The minimum number of unclaimed rewards required for merging |
+| numMemberTrafficContractsThreshold | Int | The minimum number of member traffic contracts required for merging |
+| actionConfirmationTimeout | RelTime | The TTL for contracts representing a confirmation |
+| svOnboardingRequestTimeout | RelTime | The TTL for contracts representing an incomplete onboarding |
+| svOnboardingConfirmedTimeout | RelTime | The TTL for contracts representing an SV confirmation |
+| voteRequestTimeout | RelTime | The TTL for a `VoteRequest` and its associated `Vote` s |
+| dsoDelegateInactiveTimeout | RelTime | The amount of time given to the DSO delegate to complete an action it should take care of<br/><br/>^ __Deprecated__ in favor of delegateless automation. |
+| synchronizerNodeConfigLimits | SynchronizerNodeConfigLimits | Limits to enforce on the svs' `SynchronizerNodeConfig` |
+| maxTextLength | Int | Generic upper limit on text fields in choices and contracts. |
+| decentralizedSynchronizer | DsoDecentralizedSynchronizerConfig |  |
+| nextScheduledSynchronizerUpgrade | Optional SynchronizerUpgradeSchedule |  |
+| voteCooldownTime | Optional RelTime | The minimum time between two votes by the same SV. |
+
+Instances:
+
+- `instance Patchable DsoRulesConfig`
+- `instance Eq DsoRulesConfig`
+- `instance Show DsoRulesConfig`
+- `instance GetField actionConfirmationTimeout DsoRulesConfig RelTime`
+- `instance GetField baseConfig DsoRules_SetConfig (Optional DsoRulesConfig)`
+- `instance GetField config DsoBootstrap DsoRulesConfig`
+- `instance GetField config DsoRules DsoRulesConfig`
+- `instance GetField decentralizedSynchronizer DsoRulesConfig DsoDecentralizedSynchronizerConfig`
+- `instance GetField dsoDelegateInactiveTimeout DsoRulesConfig RelTime`
+- `instance GetField maxTextLength DsoRulesConfig Int`
+- `instance GetField newConfig DsoRules_SetConfig DsoRulesConfig`
+- `instance GetField nextScheduledSynchronizerUpgrade DsoRulesConfig (Optional SynchronizerUpgradeSchedule)`
+- `instance GetField numMemberTrafficContractsThreshold DsoRulesConfig Int`
+- `instance GetField numUnclaimedRewardsThreshold DsoRulesConfig Int`
+- `instance GetField svOnboardingConfirmedTimeout DsoRulesConfig RelTime`
+- `instance GetField svOnboardingRequestTimeout DsoRulesConfig RelTime`
+- `instance GetField synchronizerNodeConfigLimits DsoRulesConfig SynchronizerNodeConfigLimits`
+- `instance GetField voteCooldownTime DsoRulesConfig (Optional RelTime)`
+- `instance GetField voteRequestTimeout DsoRulesConfig RelTime`
+- `instance SetField actionConfirmationTimeout DsoRulesConfig RelTime`
+- `instance SetField baseConfig DsoRules_SetConfig (Optional DsoRulesConfig)`
+- `instance SetField config DsoBootstrap DsoRulesConfig`
+- `instance SetField config DsoRules DsoRulesConfig`
+- `instance SetField decentralizedSynchronizer DsoRulesConfig DsoDecentralizedSynchronizerConfig`
+- `instance SetField dsoDelegateInactiveTimeout DsoRulesConfig RelTime`
+- `instance SetField maxTextLength DsoRulesConfig Int`
+- `instance SetField newConfig DsoRules_SetConfig DsoRulesConfig`
+- `instance SetField nextScheduledSynchronizerUpgrade DsoRulesConfig (Optional SynchronizerUpgradeSchedule)`
+- `instance SetField numMemberTrafficContractsThreshold DsoRulesConfig Int`
+- `instance SetField numUnclaimedRewardsThreshold DsoRulesConfig Int`
+- `instance SetField svOnboardingConfirmedTimeout DsoRulesConfig RelTime`
+- `instance SetField svOnboardingRequestTimeout DsoRulesConfig RelTime`
+- `instance SetField synchronizerNodeConfigLimits DsoRulesConfig SynchronizerNodeConfigLimits`
+- `instance SetField voteCooldownTime DsoRulesConfig (Optional RelTime)`
+- `instance SetField voteRequestTimeout DsoRulesConfig RelTime`
+
+<a id="type-splice-dsorules-dsorulesactionrequiringconfirmation-12600"></a>
+
+### `data DsoRules_ActionRequiringConfirmation`
+
+Constructors:
+
+<a id="constr-splice-dsorules-srarcaddsv-12841"></a>
+- `SRARC_AddSv DsoRules_AddSv`
+Voted action to directly add an SV
+<a id="constr-splice-dsorules-srarcoffboardsv-63692"></a>
+- `SRARC_OffboardSv DsoRules_OffboardSv`
+Voted action to remove an SV
+<a id="constr-splice-dsorules-srarcconfirmsvonboarding-51509"></a>
+- `SRARC_ConfirmSvOnboarding DsoRules_ConfirmSvOnboarding`
+Automated action to confirm that a party can become an SV.
+<a id="constr-splice-dsorules-srarcgrantfeaturedappright-84890"></a>
+- `SRARC_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRight`
+Voted action to grant a featured app right. Not idempotent.
+<a id="constr-splice-dsorules-srarcrevokefeaturedappright-73851"></a>
+- `SRARC_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRight`
+Revoke a specific featured app right.
+<a id="constr-splice-dsorules-srarcsetconfig-39305"></a>
+- `SRARC_SetConfig DsoRules_SetConfig`
+Voted action to change the `DsoRulesConfig`. Not idempotent.
+<a id="constr-splice-dsorules-srarcupdatesvrewardweight-81705"></a>
+- `SRARC_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeight`
+Voted action to update the reward weight of an SV.
+<a id="constr-splice-dsorules-srarccreateexternalpartyamuletrules-49124"></a>
+- `SRARC_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRules`
+Create ExternalPartyAmuletRules contract if it has not been created as part of network bootstrapping.
+<a id="constr-splice-dsorules-srarccreatetransfercommandcounter-88632"></a>
+- `SRARC_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounter`
+Create TransferCommandCounter contract for the given sender if it does not already exist
+<a id="constr-splice-dsorules-srarccreateunallocatedunclaimedactivityrecord-97784"></a>
+- `SRARC_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecord`
+Voted action to create an UnallocatedUnclaimedActivityRecord contract.
+<a id="constr-splice-dsorules-srarccreatebootstrapexternalpartyconfigstateinstruction-49456"></a>
+- `SRARC_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstruction`
+Create BootstrapExternalPartyConfigStateInstruction
+
+Instances:
+
+- `instance Eq DsoRules_ActionRequiringConfirmation`
+- `instance Show DsoRules_ActionRequiringConfirmation`
+- `instance GetField dsoAction ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation`
+- `instance SetField dsoAction ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation`
+
+<a id="type-splice-dsorules-dsorulesaddconfirmedsvresult-53040"></a>
+
+### `data DsoRules_AddConfirmedSvResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesaddconfirmedsvresult-81391"></a>
+- `DsoRules_AddConfirmedSvResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_AddConfirmedSvResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_AddConfirmedSvResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult`
+- `instance HasToAnyChoice DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult`
+
+<a id="type-splice-dsorules-dsorulesaddsvresult-53972"></a>
+
+### `data DsoRules_AddSvResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesaddsvresult-63557"></a>
+- `DsoRules_AddSvResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_AddSvResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_AddSvResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_AddSv DsoRules_AddSvResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_AddSv DsoRules_AddSvResult`
+- `instance HasToAnyChoice DsoRules DsoRules_AddSv DsoRules_AddSvResult`
+
+<a id="type-splice-dsorules-dsorulesadvanceopenminingroundsresult-57405"></a>
+
+### `data DsoRules_AdvanceOpenMiningRoundsResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesadvanceopenminingroundsresult-30524"></a>
+- `DsoRules_AdvanceOpenMiningRoundsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| summarizingRound | ContractId SummarizingMiningRound |  |
+| openRound | ContractId OpenMiningRound |  |
+
+Instances:
+
+- `instance GetField openRound DsoRules_AdvanceOpenMiningRoundsResult (ContractId OpenMiningRound)`
+- `instance GetField summarizingRound DsoRules_AdvanceOpenMiningRoundsResult (ContractId SummarizingMiningRound)`
+- `instance SetField openRound DsoRules_AdvanceOpenMiningRoundsResult (ContractId OpenMiningRound)`
+- `instance SetField summarizingRound DsoRules_AdvanceOpenMiningRoundsResult (ContractId SummarizingMiningRound)`
+- `instance HasExercise DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult`
+
+<a id="type-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecordresult-87254"></a>
+
+### `data DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecordresult-24573"></a>
+- `DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedActivityRecordCid | ContractId UnclaimedActivityRecord |  |
+| optUnclaimedRewardCid | Optional (ContractId UnclaimedReward) |  |
+
+Instances:
+
+- `instance GetField optUnclaimedRewardCid DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult (Optional (ContractId UnclaimedReward))`
+- `instance GetField unclaimedActivityRecordCid DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult (ContractId UnclaimedActivityRecord)`
+- `instance SetField optUnclaimedRewardCid DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult (Optional (ContractId UnclaimedReward))`
+- `instance SetField unclaimedActivityRecordCid DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult (ContractId UnclaimedActivityRecord)`
+- `instance HasExercise DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+- `instance HasToAnyChoice DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+
+<a id="type-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkersresult-72068"></a>
+
+### `data DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkersresult-81577"></a>
+- `DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | AmuletRules_ConvertFeaturedAppActivityMarkersResult |  |
+
+Instances:
+
+- `instance GetField result DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance SetField result DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance HasExercise DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+- `instance HasToAnyChoice DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+<a id="type-splice-dsorules-dsorulesamuletexpireresult-67290"></a>
+
+### `data DsoRules_Amulet_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesamuletexpireresult-61799"></a>
+- `DsoRules_Amulet_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireSummary |  |
+
+Instances:
+
+- `instance GetField expireSum DsoRules_Amulet_ExpireResult AmuletExpireSummary`
+- `instance SetField expireSum DsoRules_Amulet_ExpireResult AmuletExpireSummary`
+- `instance HasExercise DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult`
+- `instance HasToAnyChoice DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult`
+
+<a id="type-splice-dsorules-dsorulesamuletexpiretransferinstructionsresult-29864"></a>
+
+### `data DsoRules_Amulet_ExpireTransferInstructionsResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesamuletexpiretransferinstructionsresult-36781"></a>
+- `DsoRules_Amulet_ExpireTransferInstructionsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | AmuletRules_Amulet_ExpireTransferInstructionsResult |  |
+
+Instances:
+
+- `instance Eq DsoRules_Amulet_ExpireTransferInstructionsResult`
+- `instance Show DsoRules_Amulet_ExpireTransferInstructionsResult`
+- `instance GetField result DsoRules_Amulet_ExpireTransferInstructionsResult AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance SetField result DsoRules_Amulet_ExpireTransferInstructionsResult AmuletRules_Amulet_ExpireTransferInstructionsResult`
+- `instance HasExercise DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult`
+
+<a id="type-splice-dsorules-dsorulesamuletexpirev2result-94072"></a>
+
+### `data DsoRules_Amulet_ExpireV2Result`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesamuletexpirev2result-84829"></a>
+- `DsoRules_Amulet_ExpireV2Result`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireV2Summary |  |
+
+Instances:
+
+- `instance GetField expireSum DsoRules_Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance SetField expireSum DsoRules_Amulet_ExpireV2Result AmuletExpireV2Summary`
+- `instance HasExercise DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result`
+- `instance HasFromAnyChoice DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result`
+- `instance HasToAnyChoice DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result`
+
+<a id="type-splice-dsorules-dsorulesarchiveoutdatedelectionrequestresult-78881"></a>
+
+### `data DsoRules_ArchiveOutdatedElectionRequestResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesarchiveoutdatedelectionrequestresult-72534"></a>
+- `DsoRules_ArchiveOutdatedElectionRequestResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult`
+
+<a id="type-splice-dsorules-dsorulesarchivesvonboardingrequestresult-76462"></a>
+
+### `data DsoRules_ArchiveSvOnboardingRequestResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesarchivesvonboardingrequestresult-86253"></a>
+- `DsoRules_ArchiveSvOnboardingRequestResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult`
+
+<a id="type-splice-dsorules-dsorulesbootstrapexternalpartyconfigstateresult-77872"></a>
+
+### `data DsoRules_BootstrapExternalPartyConfigStateResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesbootstrapexternalpartyconfigstateresult-70741"></a>
+- `DsoRules_BootstrapExternalPartyConfigStateResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult`
+- `instance HasToAnyChoice DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult`
+
+<a id="type-splice-dsorules-dsorulescastvoteresult-84724"></a>
+
+### `data DsoRules_CastVoteResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulescastvoteresult-18147"></a>
+- `DsoRules_CastVoteResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| voteRequest | ContractId VoteRequest |  |
+
+Instances:
+
+- `instance GetField voteRequest DsoRules_CastVoteResult (ContractId VoteRequest)`
+- `instance SetField voteRequest DsoRules_CastVoteResult (ContractId VoteRequest)`
+- `instance HasExercise DsoRules DsoRules_CastVote DsoRules_CastVoteResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CastVote DsoRules_CastVoteResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CastVote DsoRules_CastVoteResult`
+
+<a id="type-splice-dsorules-dsorulesclaimexpiredrewardsresult-70369"></a>
+
+### `data DsoRules_ClaimExpiredRewardsResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesclaimexpiredrewardsresult-56160"></a>
+- `DsoRules_ClaimExpiredRewardsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedReward | Optional (ContractId UnclaimedReward) |  |
+
+Instances:
+
+- `instance GetField unclaimedReward DsoRules_ClaimExpiredRewardsResult (Optional (ContractId UnclaimedReward))`
+- `instance SetField unclaimedReward DsoRules_ClaimExpiredRewardsResult (Optional (ContractId UnclaimedReward))`
+- `instance HasExercise DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult`
+
+<a id="type-splice-dsorules-dsorulesclosevoterequestresult-49382"></a>
+
+### `data DsoRules_CloseVoteRequestResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesclosevoterequestresult-14349"></a>
+- `DsoRules_CloseVoteRequestResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| request | VoteRequest | The original vote request. |
+| completedAt | Time | When the vote request was completed. |
+| offboardedVoters | [Text] | SVs that voted but were offboarded before the vote completed. |
+| abstainingSvs | [Text] | SVs that did not vote. |
+| outcome | VoteRequestOutcome | The final result of the vote. |
+
+Instances:
+
+- `instance Eq DsoRules_CloseVoteRequestResult`
+- `instance Show DsoRules_CloseVoteRequestResult`
+- `instance GetField abstainingSvs DsoRules_CloseVoteRequestResult [Text]`
+- `instance GetField completedAt DsoRules_CloseVoteRequestResult Time`
+- `instance GetField offboardedVoters DsoRules_CloseVoteRequestResult [Text]`
+- `instance GetField outcome DsoRules_CloseVoteRequestResult VoteRequestOutcome`
+- `instance GetField request DsoRules_CloseVoteRequestResult VoteRequest`
+- `instance SetField abstainingSvs DsoRules_CloseVoteRequestResult [Text]`
+- `instance SetField completedAt DsoRules_CloseVoteRequestResult Time`
+- `instance SetField offboardedVoters DsoRules_CloseVoteRequestResult [Text]`
+- `instance SetField outcome DsoRules_CloseVoteRequestResult VoteRequestOutcome`
+- `instance SetField request DsoRules_CloseVoteRequestResult VoteRequest`
+- `instance HasExercise DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult`
+
+<a id="type-splice-dsorules-dsorulescollectentryrenewalpaymentresult-57091"></a>
+
+### `data DsoRules_CollectEntryRenewalPaymentResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulescollectentryrenewalpaymentresult-87832"></a>
+- `DsoRules_CollectEntryRenewalPaymentResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntry | ContractId AnsEntry |  |
+| subscriptionState | ContractId SubscriptionIdleState |  |
+
+Instances:
+
+- `instance GetField ansEntry DsoRules_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance GetField subscriptionState DsoRules_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance SetField ansEntry DsoRules_CollectEntryRenewalPaymentResult (ContractId AnsEntry)`
+- `instance SetField subscriptionState DsoRules_CollectEntryRenewalPaymentResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult`
+
+<a id="type-splice-dsorules-dsorulesconfirmactionresult-28024"></a>
+
+### `data DsoRules_ConfirmActionResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesconfirmactionresult-48341"></a>
+- `DsoRules_ConfirmActionResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| confirmation | ContractId Confirmation |  |
+
+Instances:
+
+- `instance GetField confirmation DsoRules_ConfirmActionResult (ContractId Confirmation)`
+- `instance SetField confirmation DsoRules_ConfirmActionResult (ContractId Confirmation)`
+- `instance HasExercise DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult`
+
+<a id="type-splice-dsorules-dsorulesconfirmsvonboardingresult-99416"></a>
+
+### `data DsoRules_ConfirmSvOnboardingResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesconfirmsvonboardingresult-46665"></a>
+- `DsoRules_ConfirmSvOnboardingResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| onboardingConfirmed | ContractId SvOnboardingConfirmed |  |
+
+Instances:
+
+- `instance GetField onboardingConfirmed DsoRules_ConfirmSvOnboardingResult (ContractId SvOnboardingConfirmed)`
+- `instance SetField onboardingConfirmed DsoRules_ConfirmSvOnboardingResult (ContractId SvOnboardingConfirmed)`
+- `instance HasExercise DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult`
+
+<a id="type-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstructionresult-32985"></a>
+
+### `data DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstructionresult-84146"></a>
+- `DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| instructionCid | ContractId BootstrapExternalPartyConfigStateInstruction |  |
+
+Instances:
+
+- `instance Eq DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+- `instance Show DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+- `instance GetField instructionCid DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult (ContractId BootstrapExternalPartyConfigStateInstruction)`
+- `instance SetField instructionCid DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult (ContractId BootstrapExternalPartyConfigStateInstruction)`
+- `instance HasExercise DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+
+<a id="type-splice-dsorules-dsorulescreateexternalpartyamuletrulesresult-12409"></a>
+
+### `data DsoRules_CreateExternalPartyAmuletRulesResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulescreateexternalpartyamuletrulesresult-52650"></a>
+- `DsoRules_CreateExternalPartyAmuletRulesResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| externalPartyAmuletRulesCid | ContractId ExternalPartyAmuletRules |  |
+
+Instances:
+
+- `instance Eq DsoRules_CreateExternalPartyAmuletRulesResult`
+- `instance Show DsoRules_CreateExternalPartyAmuletRulesResult`
+- `instance GetField externalPartyAmuletRulesCid DsoRules_CreateExternalPartyAmuletRulesResult (ContractId ExternalPartyAmuletRules)`
+- `instance SetField externalPartyAmuletRulesCid DsoRules_CreateExternalPartyAmuletRulesResult (ContractId ExternalPartyAmuletRules)`
+- `instance HasExercise DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult`
+
+<a id="type-splice-dsorules-dsorulescreatetransfercommandcounterresult-97297"></a>
+
+### `data DsoRules_CreateTransferCommandCounterResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulescreatetransfercommandcounterresult-46310"></a>
+- `DsoRules_CreateTransferCommandCounterResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferCommandCounterCid | ContractId TransferCommandCounter |  |
+
+Instances:
+
+- `instance Eq DsoRules_CreateTransferCommandCounterResult`
+- `instance Show DsoRules_CreateTransferCommandCounterResult`
+- `instance GetField transferCommandCounterCid DsoRules_CreateTransferCommandCounterResult (ContractId TransferCommandCounter)`
+- `instance SetField transferCommandCounterCid DsoRules_CreateTransferCommandCounterResult (ContractId TransferCommandCounter)`
+- `instance HasExercise DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult`
+
+<a id="type-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecordresult-76541"></a>
+
+### `data DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecordresult-18490"></a>
+- `DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unallocatedUnclaimedActivityRecordCid | ContractId UnallocatedUnclaimedActivityRecord |  |
+
+Instances:
+
+- `instance GetField unallocatedUnclaimedActivityRecordCid DsoRules_CreateUnallocatedUnclaimedActivityRecordResult (ContractId UnallocatedUnclaimedActivityRecord)`
+- `instance SetField unallocatedUnclaimedActivityRecordCid DsoRules_CreateUnallocatedUnclaimedActivityRecordResult (ContractId UnallocatedUnclaimedActivityRecord)`
+- `instance HasExercise DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+- `instance HasToAnyChoice DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+
+<a id="type-splice-dsorules-dsoruleselectdsodelegateresult-99561"></a>
+
+### `data DsoRules_ElectDsoDelegateResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsoruleselectdsodelegateresult-71514"></a>
+- `DsoRules_ElectDsoDelegateResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_ElectDsoDelegateResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_ElectDsoDelegateResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult`
+
+<a id="type-splice-dsorules-dsorulesexecuteconfirmedactionresult-43893"></a>
+
+### `data DsoRules_ExecuteConfirmedActionResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesexecuteconfirmedactionresult-89578"></a>
+- `DsoRules_ExecuteConfirmedActionResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult`
+
+<a id="type-splice-dsorules-dsorulesexpireamuletallocationsresult-27100"></a>
+
+### `data DsoRules_ExpireAmuletAllocationsResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesexpireamuletallocationsresult-29457"></a>
+- `DsoRules_ExpireAmuletAllocationsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | ExternalPartyAmuletRules_ExpireAmuletAllocationsResult |  |
+
+Instances:
+
+- `instance Eq DsoRules_ExpireAmuletAllocationsResult`
+- `instance Show DsoRules_ExpireAmuletAllocationsResult`
+- `instance GetField result DsoRules_ExpireAmuletAllocationsResult ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance SetField result DsoRules_ExpireAmuletAllocationsResult ExternalPartyAmuletRules_ExpireAmuletAllocationsResult`
+- `instance HasExercise DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult`
+
+<a id="type-splice-dsorules-dsorulesexpireansentryresult-16762"></a>
+
+### `data DsoRules_ExpireAnsEntryResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesexpireansentryresult-6565"></a>
+- `DsoRules_ExpireAnsEntryResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult`
+
+<a id="type-splice-dsorules-dsorulesexpiredevelopmentfundcouponresult-36543"></a>
+
+### `data DsoRules_ExpireDevelopmentFundCouponResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesexpiredevelopmentfundcouponresult-44574"></a>
+- `DsoRules_ExpireDevelopmentFundCouponResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | DevelopmentFundCoupon_DsoExpireResult |  |
+
+Instances:
+
+- `instance GetField result DsoRules_ExpireDevelopmentFundCouponResult DevelopmentFundCoupon_DsoExpireResult`
+- `instance SetField result DsoRules_ExpireDevelopmentFundCouponResult DevelopmentFundCoupon_DsoExpireResult`
+- `instance HasExercise DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult`
+
+<a id="type-splice-dsorules-dsorulesexpirestaleconfirmationresult-27719"></a>
+
+### `data DsoRules_ExpireStaleConfirmationResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesexpirestaleconfirmationresult-33614"></a>
+- `DsoRules_ExpireStaleConfirmationResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult`
+
+<a id="type-splice-dsorules-dsorulesexpiresubscriptionresult-45469"></a>
+
+### `data DsoRules_ExpireSubscriptionResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesexpiresubscriptionresult-70870"></a>
+- `DsoRules_ExpireSubscriptionResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult`
+
+<a id="type-splice-dsorules-dsorulesexpiresvonboardingconfirmedresult-38796"></a>
+
+### `data DsoRules_ExpireSvOnboardingConfirmedResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesexpiresvonboardingconfirmedresult-53333"></a>
+- `DsoRules_ExpireSvOnboardingConfirmedResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_ExpireSvOnboardingConfirmedResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_ExpireSvOnboardingConfirmedResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult`
+
+<a id="type-splice-dsorules-dsorulesexpiresvonboardingrequestresult-2670"></a>
+
+### `data DsoRules_ExpireSvOnboardingRequestResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesexpiresvonboardingrequestresult-9407"></a>
+- `DsoRules_ExpireSvOnboardingRequestResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult`
+
+<a id="type-splice-dsorules-dsorulesexpiretransferpreapprovalresult-76064"></a>
+
+### `data DsoRules_ExpireTransferPreapprovalResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesexpiretransferpreapprovalresult-84197"></a>
+- `DsoRules_ExpireTransferPreapprovalResult`
+
+Instances:
+
+- `instance Eq DsoRules_ExpireTransferPreapprovalResult`
+- `instance Show DsoRules_ExpireTransferPreapprovalResult`
+- `instance HasExercise DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult`
+
+<a id="type-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecordresult-30228"></a>
+
+### `data DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecordresult-25947"></a>
+- `DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+
+<a id="type-splice-dsorules-dsorulesexpireunclaimedactivityrecordresult-92345"></a>
+
+### `data DsoRules_ExpireUnclaimedActivityRecordResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesexpireunclaimedactivityrecordresult-78492"></a>
+- `DsoRules_ExpireUnclaimedActivityRecordResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedRewardCid | ContractId UnclaimedReward |  |
+
+Instances:
+
+- `instance GetField unclaimedRewardCid DsoRules_ExpireUnclaimedActivityRecordResult (ContractId UnclaimedReward)`
+- `instance SetField unclaimedRewardCid DsoRules_ExpireUnclaimedActivityRecordResult (ContractId UnclaimedReward)`
+- `instance HasExercise DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult`
+
+<a id="type-splice-dsorules-dsorulesgarbagecollectamuletpricevotesresult-20154"></a>
+
+### `data DsoRules_GarbageCollectAmuletPriceVotesResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesgarbagecollectamuletpricevotesresult-33073"></a>
+- `DsoRules_GarbageCollectAmuletPriceVotesResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult`
+- `instance HasToAnyChoice DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult`
+
+<a id="type-splice-dsorules-dsorulesgrantfeaturedapprightresult-6067"></a>
+
+### `data DsoRules_GrantFeaturedAppRightResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesgrantfeaturedapprightresult-3282"></a>
+- `DsoRules_GrantFeaturedAppRightResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppRight | ContractId FeaturedAppRight |  |
+
+Instances:
+
+- `instance GetField featuredAppRight DsoRules_GrantFeaturedAppRightResult (ContractId FeaturedAppRight)`
+- `instance SetField featuredAppRight DsoRules_GrantFeaturedAppRightResult (ContractId FeaturedAppRight)`
+- `instance HasExercise DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult`
+- `instance HasToAnyChoice DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult`
+
+<a id="type-splice-dsorules-dsoruleslockedamuletexpireamuletresult-11398"></a>
+
+### `data DsoRules_LockedAmulet_ExpireAmuletResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsoruleslockedamuletexpireamuletresult-46735"></a>
+- `DsoRules_LockedAmulet_ExpireAmuletResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireSummary |  |
+
+Instances:
+
+- `instance GetField expireSum DsoRules_LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance SetField expireSum DsoRules_LockedAmulet_ExpireAmuletResult AmuletExpireSummary`
+- `instance HasExercise DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult`
+- `instance HasToAnyChoice DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult`
+
+<a id="type-splice-dsorules-dsoruleslockedamuletexpireamuletv2result-75516"></a>
+
+### `data DsoRules_LockedAmulet_ExpireAmuletV2Result`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsoruleslockedamuletexpireamuletv2result-22605"></a>
+- `DsoRules_LockedAmulet_ExpireAmuletV2Result`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| expireSum | AmuletExpireV2Summary |  |
+
+Instances:
+
+- `instance GetField expireSum DsoRules_LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance SetField expireSum DsoRules_LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary`
+- `instance HasExercise DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result`
+- `instance HasFromAnyChoice DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result`
+- `instance HasToAnyChoice DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result`
+
+<a id="type-splice-dsorules-dsorulesmergemembertrafficcontractsresult-1402"></a>
+
+### `data DsoRules_MergeMemberTrafficContractsResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesmergemembertrafficcontractsresult-22987"></a>
+- `DsoRules_MergeMemberTrafficContractsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| memberTraffic | ContractId MemberTraffic |  |
+
+Instances:
+
+- `instance GetField memberTraffic DsoRules_MergeMemberTrafficContractsResult (ContractId MemberTraffic)`
+- `instance SetField memberTraffic DsoRules_MergeMemberTrafficContractsResult (ContractId MemberTraffic)`
+- `instance HasExercise DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult`
+
+<a id="type-splice-dsorules-dsorulesmergesvrewardstateresult-26494"></a>
+
+### `data DsoRules_MergeSvRewardStateResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesmergesvrewardstateresult-58441"></a>
+- `DsoRules_MergeSvRewardStateResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svRewardState | ContractId SvRewardState |  |
+
+Instances:
+
+- `instance GetField svRewardState DsoRules_MergeSvRewardStateResult (ContractId SvRewardState)`
+- `instance SetField svRewardState DsoRules_MergeSvRewardStateResult (ContractId SvRewardState)`
+- `instance HasExercise DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult`
+
+<a id="type-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcouponsresult-91402"></a>
+
+### `data DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcouponsresult-95789"></a>
+- `DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult |  |
+
+Instances:
+
+- `instance GetField result DsoRules_MergeUnclaimedDevelopmentFundCouponsResult AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance SetField result DsoRules_MergeUnclaimedDevelopmentFundCouponsResult AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance HasExercise DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+<a id="type-splice-dsorules-dsorulesmergeunclaimedrewardsresult-75266"></a>
+
+### `data DsoRules_MergeUnclaimedRewardsResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesmergeunclaimedrewardsresult-90979"></a>
+- `DsoRules_MergeUnclaimedRewardsResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedReward | ContractId UnclaimedReward |  |
+
+Instances:
+
+- `instance GetField unclaimedReward DsoRules_MergeUnclaimedRewardsResult (ContractId UnclaimedReward)`
+- `instance SetField unclaimedReward DsoRules_MergeUnclaimedRewardsResult (ContractId UnclaimedReward)`
+- `instance HasExercise DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult`
+
+<a id="type-splice-dsorules-dsorulesmergevalidatorlicenseresult-11621"></a>
+
+### `data DsoRules_MergeValidatorLicenseResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesmergevalidatorlicenseresult-87256"></a>
+- `DsoRules_MergeValidatorLicenseResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validatorLicense | ContractId ValidatorLicense |  |
+
+Instances:
+
+- `instance GetField validatorLicense DsoRules_MergeValidatorLicenseResult (ContractId ValidatorLicense)`
+- `instance SetField validatorLicense DsoRules_MergeValidatorLicenseResult (ContractId ValidatorLicense)`
+- `instance HasExercise DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult`
+
+<a id="type-splice-dsorules-dsorulesminingroundcloseresult-29143"></a>
+
+### `data DsoRules_MiningRound_CloseResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesminingroundcloseresult-49506"></a>
+- `DsoRules_MiningRound_CloseResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| closedRound | ContractId ClosedMiningRound |  |
+
+Instances:
+
+- `instance GetField closedRound DsoRules_MiningRound_CloseResult (ContractId ClosedMiningRound)`
+- `instance SetField closedRound DsoRules_MiningRound_CloseResult (ContractId ClosedMiningRound)`
+- `instance HasExercise DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult`
+- `instance HasToAnyChoice DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult`
+
+<a id="type-splice-dsorules-dsorulesoffboardsvresult-15733"></a>
+
+### `data DsoRules_OffboardSvResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesoffboardsvresult-15494"></a>
+- `DsoRules_OffboardSvResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_OffboardSvResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_OffboardSvResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult`
+- `instance HasToAnyChoice DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult`
+
+<a id="type-splice-dsorules-dsorulesonboardvalidatorresult-97208"></a>
+
+### `data DsoRules_OnboardValidatorResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesonboardvalidatorresult-75375"></a>
+- `DsoRules_OnboardValidatorResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validatorLicense | ContractId ValidatorLicense |  |
+
+Instances:
+
+- `instance GetField validatorLicense DsoRules_OnboardValidatorResult (ContractId ValidatorLicense)`
+- `instance SetField validatorLicense DsoRules_OnboardValidatorResult (ContractId ValidatorLicense)`
+- `instance HasExercise DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult`
+- `instance HasToAnyChoice DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult`
+
+<a id="type-splice-dsorules-dsorulespruneamuletconfigscheduleresult-66013"></a>
+
+### `data DsoRules_PruneAmuletConfigScheduleResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulespruneamuletconfigscheduleresult-2640"></a>
+- `DsoRules_PruneAmuletConfigScheduleResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+
+Instances:
+
+- `instance GetField amuletRulesCid DsoRules_PruneAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance SetField amuletRulesCid DsoRules_PruneAmuletConfigScheduleResult (ContractId AmuletRules)`
+- `instance HasExercise DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult`
+- `instance HasToAnyChoice DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult`
+
+<a id="type-splice-dsorules-dsorulesreceivesvrewardcouponresult-91325"></a>
+
+### `data DsoRules_ReceiveSvRewardCouponResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesreceivesvrewardcouponresult-74804"></a>
+- `DsoRules_ReceiveSvRewardCouponResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svRewardState | ContractId SvRewardState |  |
+| svRewardCoupons | [ContractId SvRewardCoupon] |  |
+
+Instances:
+
+- `instance GetField svRewardCoupons DsoRules_ReceiveSvRewardCouponResult [ContractId SvRewardCoupon]`
+- `instance GetField svRewardState DsoRules_ReceiveSvRewardCouponResult (ContractId SvRewardState)`
+- `instance SetField svRewardCoupons DsoRules_ReceiveSvRewardCouponResult [ContractId SvRewardCoupon]`
+- `instance SetField svRewardState DsoRules_ReceiveSvRewardCouponResult (ContractId SvRewardState)`
+- `instance HasExercise DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult`
+- `instance HasToAnyChoice DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult`
+
+<a id="type-splice-dsorules-dsorulesrequestelectionresult-48590"></a>
+
+### `data DsoRules_RequestElectionResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesrequestelectionresult-48843"></a>
+- `DsoRules_RequestElectionResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| electionRequestCid | ContractId ElectionRequest |  |
+
+Instances:
+
+- `instance GetField electionRequestCid DsoRules_RequestElectionResult (ContractId ElectionRequest)`
+- `instance SetField electionRequestCid DsoRules_RequestElectionResult (ContractId ElectionRequest)`
+- `instance HasExercise DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult`
+
+<a id="type-splice-dsorules-dsorulesrequestvoteresult-78559"></a>
+
+### `data DsoRules_RequestVoteResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesrequestvoteresult-22502"></a>
+- `DsoRules_RequestVoteResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| voteRequest | ContractId VoteRequest |  |
+
+Instances:
+
+- `instance GetField voteRequest DsoRules_RequestVoteResult (ContractId VoteRequest)`
+- `instance SetField voteRequest DsoRules_RequestVoteResult (ContractId VoteRequest)`
+- `instance HasExercise DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult`
+- `instance HasToAnyChoice DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult`
+
+<a id="type-splice-dsorules-dsorulesrevokefeaturedapprightresult-31874"></a>
+
+### `data DsoRules_RevokeFeaturedAppRightResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesrevokefeaturedapprightresult-56949"></a>
+- `DsoRules_RevokeFeaturedAppRightResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult`
+- `instance HasToAnyChoice DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult`
+
+<a id="type-splice-dsorules-dsorulessetconfigresult-20888"></a>
+
+### `data DsoRules_SetConfigResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulessetconfigresult-7861"></a>
+- `DsoRules_SetConfigResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_SetConfigResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_SetConfigResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_SetConfig DsoRules_SetConfigResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_SetConfig DsoRules_SetConfigResult`
+- `instance HasToAnyChoice DsoRules DsoRules_SetConfig DsoRules_SetConfigResult`
+
+<a id="type-splice-dsorules-dsorulessetsynchronizernodeconfigresult-80120"></a>
+
+### `data DsoRules_SetSynchronizerNodeConfigResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulessetsynchronizernodeconfigresult-93925"></a>
+- `DsoRules_SetSynchronizerNodeConfigResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svNodeState | ContractId SvNodeState |  |
+
+Instances:
+
+- `instance GetField svNodeState DsoRules_SetSynchronizerNodeConfigResult (ContractId SvNodeState)`
+- `instance SetField svNodeState DsoRules_SetSynchronizerNodeConfigResult (ContractId SvNodeState)`
+- `instance HasExercise DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult`
+- `instance HasToAnyChoice DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult`
+
+<a id="type-splice-dsorules-dsorulesstartsvonboardingresult-18158"></a>
+
+### `data DsoRules_StartSvOnboardingResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesstartsvonboardingresult-27583"></a>
+- `DsoRules_StartSvOnboardingResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| onboardingRequest | ContractId SvOnboardingRequest |  |
+
+Instances:
+
+- `instance GetField onboardingRequest DsoRules_StartSvOnboardingResult (ContractId SvOnboardingRequest)`
+- `instance SetField onboardingRequest DsoRules_StartSvOnboardingResult (ContractId SvOnboardingRequest)`
+- `instance HasExercise DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult`
+- `instance HasToAnyChoice DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult`
+
+<a id="type-splice-dsorules-dsorulessubmitstatusreportresult-52083"></a>
+
+### `data DsoRules_SubmitStatusReportResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulessubmitstatusreportresult-24832"></a>
+- `DsoRules_SubmitStatusReportResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newReport | ContractId SvStatusReport |  |
+
+Instances:
+
+- `instance GetField newReport DsoRules_SubmitStatusReportResult (ContractId SvStatusReport)`
+- `instance SetField newReport DsoRules_SubmitStatusReportResult (ContractId SvStatusReport)`
+- `instance HasExercise DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult`
+- `instance HasToAnyChoice DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult`
+
+<a id="type-splice-dsorules-dsorulesterminatesubscriptionresult-840"></a>
+
+### `data DsoRules_TerminateSubscriptionResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesterminatesubscriptionresult-26229"></a>
+- `DsoRules_TerminateSubscriptionResult`
+
+Instances:
+
+- `instance HasExercise DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult`
+- `instance HasToAnyChoice DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult`
+
+<a id="type-splice-dsorules-dsorulesupdateamuletpricevoteresult-31774"></a>
+
+### `data DsoRules_UpdateAmuletPriceVoteResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesupdateamuletpricevoteresult-27803"></a>
+- `DsoRules_UpdateAmuletPriceVoteResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletPriceVote | ContractId AmuletPriceVote |  |
+
+Instances:
+
+- `instance GetField amuletPriceVote DsoRules_UpdateAmuletPriceVoteResult (ContractId AmuletPriceVote)`
+- `instance SetField amuletPriceVote DsoRules_UpdateAmuletPriceVoteResult (ContractId AmuletPriceVote)`
+- `instance HasExercise DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult`
+- `instance HasToAnyChoice DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult`
+
+<a id="type-splice-dsorules-dsorulesupdateexternalpartyconfigstatesresult-26858"></a>
+
+### `data DsoRules_UpdateExternalPartyConfigStatesResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesupdateexternalpartyconfigstatesresult-3139"></a>
+- `DsoRules_UpdateExternalPartyConfigStatesResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newExternalPartyConfigStateCid | ContractId ExternalPartyConfigState |  |
+
+Instances:
+
+- `instance Eq DsoRules_UpdateExternalPartyConfigStatesResult`
+- `instance Show DsoRules_UpdateExternalPartyConfigStatesResult`
+- `instance GetField newExternalPartyConfigStateCid DsoRules_UpdateExternalPartyConfigStatesResult (ContractId ExternalPartyConfigState)`
+- `instance SetField newExternalPartyConfigStateCid DsoRules_UpdateExternalPartyConfigStatesResult (ContractId ExternalPartyConfigState)`
+- `instance HasExercise DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult`
+- `instance HasToAnyChoice DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult`
+
+<a id="type-splice-dsorules-dsorulesupdatesvrewardweightresult-38140"></a>
+
+### `data DsoRules_UpdateSvRewardWeightResult`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsorulesupdatesvrewardweightresult-2499"></a>
+- `DsoRules_UpdateSvRewardWeightResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newDsoRules | ContractId DsoRules |  |
+
+Instances:
+
+- `instance GetField newDsoRules DsoRules_UpdateSvRewardWeightResult (ContractId DsoRules)`
+- `instance SetField newDsoRules DsoRules_UpdateSvRewardWeightResult (ContractId DsoRules)`
+- `instance HasExercise DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult`
+- `instance HasFromAnyChoice DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult`
+- `instance HasToAnyChoice DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult`
+
+<a id="type-splice-dsorules-dsosummary-18963"></a>
+
+### `data DsoSummary`
+
+Constructors:
+
+<a id="constr-splice-dsorules-dsosummary-70086"></a>
+- `DsoSummary`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dsoDelegate | Party | __Deprecated__ in favor of delegateless automation. |
+| numSvs | Int |  |
+| requiredNumVotes | Int | The number of votes required for considering a confirmation, or a request for a vote |
+
+Instances:
+
+- `instance Eq DsoSummary`
+- `instance Show DsoSummary`
+- `instance GetField dsoDelegate DsoSummary Party`
+- `instance GetField numSvs DsoSummary Int`
+- `instance GetField requiredNumVotes DsoSummary Int`
+- `instance SetField dsoDelegate DsoSummary Party`
+- `instance SetField numSvs DsoSummary Int`
+- `instance SetField requiredNumVotes DsoSummary Int`
+
+<a id="type-splice-dsorules-electionrequestreason-11906"></a>
+
+### `data ElectionRequestReason`
+
+__Deprecated__ in favor of delegateless automation.
+
+Constructors:
+
+<a id="constr-splice-dsorules-errdsodelegateunavailable-67703"></a>
+- `ERR_DsoDelegateUnavailable`
+<a id="constr-splice-dsorules-errotherreason-56585"></a>
+- `ERR_OtherReason Text`
+<a id="constr-splice-dsorules-extelectionrequestreason-65169"></a>
+- `ExtElectionRequestReason`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+
+Instances:
+
+- `instance Eq ElectionRequestReason`
+- `instance Ord ElectionRequestReason`
+- `instance Show ElectionRequestReason`
+- `instance GetField dummyUnitField ElectionRequestReason ()`
+- `instance GetField reason DsoRules_RequestElection ElectionRequestReason`
+- `instance GetField reason ElectionRequest ElectionRequestReason`
+- `instance SetField dummyUnitField ElectionRequestReason ()`
+- `instance SetField reason DsoRules_RequestElection ElectionRequestReason`
+- `instance SetField reason ElectionRequest ElectionRequestReason`
+
+<a id="type-splice-dsorules-offboardedsvinfo-61414"></a>
+
+### `data OffboardedSvInfo`
+
+Information about offboarded svs
+
+Constructors:
+
+<a id="constr-splice-dsorules-offboardedsvinfo-34519"></a>
+- `OffboardedSvInfo`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| name | Text | Human-readable name; must be unique. |
+| participantId | Text | Participant ID of the offboarded SV. |
+
+Instances:
+
+- `instance Eq OffboardedSvInfo`
+- `instance Show OffboardedSvInfo`
+- `instance GetField name OffboardedSvInfo Text`
+- `instance GetField offboardedSvs DsoRules (Map Party OffboardedSvInfo)`
+- `instance GetField participantId OffboardedSvInfo Text`
+- `instance SetField name OffboardedSvInfo Text`
+- `instance SetField offboardedSvs DsoRules (Map Party OffboardedSvInfo)`
+- `instance SetField participantId OffboardedSvInfo Text`
+
+<a id="type-splice-dsorules-reason-36941"></a>
+
+### `data Reason`
+
+Constructors:
+
+<a id="constr-splice-dsorules-reason-51132"></a>
+- `Reason`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| url | Text | Url pointing to additional background on the reason, e.g., using a https://w3c-ccg.github.io/hashlink/ |
+| body | Text | Freeform text intended for human consumption. |
+
+Instances:
+
+- `instance Eq Reason`
+- `instance Show Reason`
+- `instance GetField body Reason Text`
+- `instance GetField reason DsoRules_RequestVote Reason`
+- `instance GetField reason Vote Reason`
+- `instance GetField reason VoteRequest Reason`
+- `instance GetField url Reason Text`
+- `instance SetField body Reason Text`
+- `instance SetField reason DsoRules_RequestVote Reason`
+- `instance SetField reason Vote Reason`
+- `instance SetField reason VoteRequest Reason`
+- `instance SetField url Reason Text`
+
+<a id="type-splice-dsorules-svinfo-76274"></a>
+
+### `data SvInfo`
+
+Information about SVs relevant to DSO governance.
+
+Constructors:
+
+<a id="constr-splice-dsorules-svinfo-69131"></a>
+- `SvInfo`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| name | Text | Human-readable name; must be unique. |
+| joinedAsOfRound | Round | Round in which the SV joined |
+| svRewardWeight | Int | Weight of the SV in the SV reward distribution. |
+| participantId | Text | Participant ID of the SV, stored here as PartyToParticipant mappings are tracked via state on the DsoRules + SvOnboardingConfirmed contracts. |
+
+Instances:
+
+- `instance Eq SvInfo`
+- `instance Show SvInfo`
+- `instance GetField joinedAsOfRound SvInfo Round`
+- `instance GetField name SvInfo Text`
+- `instance GetField participantId SvInfo Text`
+- `instance GetField svRewardWeight SvInfo Int`
+- `instance GetField svs DsoRules (Map Party SvInfo)`
+- `instance SetField joinedAsOfRound SvInfo Round`
+- `instance SetField name SvInfo Text`
+- `instance SetField participantId SvInfo Text`
+- `instance SetField svRewardWeight SvInfo Int`
+- `instance SetField svs DsoRules (Map Party SvInfo)`
+
+<a id="type-splice-dsorules-synchronizerupgradeschedule-64447"></a>
+
+### `data SynchronizerUpgradeSchedule`
+
+Constructors:
+
+<a id="constr-splice-dsorules-synchronizerupgradeschedule-53308"></a>
+- `SynchronizerUpgradeSchedule`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| time | Time | The time at which the migration is scheduled to start. |
+| migrationId | Int | The incremental integer ID of the migration. |
+
+Instances:
+
+- `instance Patchable SynchronizerUpgradeSchedule`
+- `instance Eq SynchronizerUpgradeSchedule`
+- `instance Show SynchronizerUpgradeSchedule`
+- `instance GetField migrationId SynchronizerUpgradeSchedule Int`
+- `instance GetField nextScheduledSynchronizerUpgrade DsoRulesConfig (Optional SynchronizerUpgradeSchedule)`
+- `instance GetField time SynchronizerUpgradeSchedule Time`
+- `instance SetField migrationId SynchronizerUpgradeSchedule Int`
+- `instance SetField nextScheduledSynchronizerUpgrade DsoRulesConfig (Optional SynchronizerUpgradeSchedule)`
+- `instance SetField time SynchronizerUpgradeSchedule Time`
+
+<a id="type-splice-dsorules-trafficstate-38069"></a>
+
+### `data TrafficState`
+
+Constructors:
+
+<a id="constr-splice-dsorules-trafficstate-23304"></a>
+- `TrafficState`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| consumedTraffic | Int | Bytes of extra traffic consumed before the decentralized synchronizer was bootstrapped. |
+
+Instances:
+
+- `instance Eq TrafficState`
+- `instance Show TrafficState`
+- `instance GetField consumedTraffic TrafficState Int`
+- `instance GetField initialTrafficState DsoBootstrap (Map Text TrafficState)`
+- `instance GetField initialTrafficState DsoRules (Map Text TrafficState)`
+- `instance SetField consumedTraffic TrafficState Int`
+- `instance SetField initialTrafficState DsoBootstrap (Map Text TrafficState)`
+- `instance SetField initialTrafficState DsoRules (Map Text TrafficState)`
+
+<a id="type-splice-dsorules-vote-50851"></a>
+
+### `data Vote`
+
+A vote cast by an SV.
+
+Constructors:
+
+<a id="constr-splice-dsorules-vote-51690"></a>
+- `Vote`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party | The SV party used to submit the vote. |
+| accept | Bool | Whether the responder accepted the request to execute the action or not. |
+| reason | Reason | The reason for voting this way. |
+| optCastAt | Optional Time | The time when the vote was cast. Used to rate-limit the casting of votes. |
+
+Instances:
+
+- `instance Eq Vote`
+- `instance Show Vote`
+- `instance GetField accept Vote Bool`
+- `instance GetField optCastAt Vote (Optional Time)`
+- `instance GetField reason Vote Reason`
+- `instance GetField sv Vote Party`
+- `instance GetField vote DsoRules_CastVote Vote`
+- `instance GetField votes VoteRequest (Map Text Vote)`
+- `instance SetField accept Vote Bool`
+- `instance SetField optCastAt Vote (Optional Time)`
+- `instance SetField reason Vote Reason`
+- `instance SetField sv Vote Party`
+- `instance SetField vote DsoRules_CastVote Vote`
+- `instance SetField votes VoteRequest (Map Text Vote)`
+
+<a id="type-splice-dsorules-voterequestoutcome-63724"></a>
+
+### `data VoteRequestOutcome`
+
+Constructors:
+
+<a id="constr-splice-dsorules-vroacceptedbutactionfailed-51100"></a>
+- `VRO_AcceptedButActionFailed`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| description | Text | Description of the failure. |
+<a id="constr-splice-dsorules-vroaccepted-67803"></a>
+- `VRO_Accepted`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| effectiveAt | Time | Time when the action will be effective. |
+<a id="constr-splice-dsorules-vrorejected-43182"></a>
+- `VRO_Rejected`
+<a id="constr-splice-dsorules-vroexpired-35522"></a>
+- `VRO_Expired`
+<a id="constr-splice-dsorules-extvoterequestoutcome-76073"></a>
+- `ExtVoteRequestOutcome`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () |  |
+
+Instances:
+
+- `instance Eq VoteRequestOutcome`
+- `instance Show VoteRequestOutcome`
+- `instance GetField description VoteRequestOutcome Text`
+- `instance GetField dummyUnitField VoteRequestOutcome ()`
+- `instance GetField effectiveAt VoteRequestOutcome Time`
+- `instance GetField outcome DsoRules_CloseVoteRequestResult VoteRequestOutcome`
+- `instance SetField description VoteRequestOutcome Text`
+- `instance SetField dummyUnitField VoteRequestOutcome ()`
+- `instance SetField effectiveAt VoteRequestOutcome Time`
+- `instance SetField outcome DsoRules_CloseVoteRequestResult VoteRequestOutcome`
+
+<a id="type-splice-dsorules-votingstate-60200"></a>
+
+### `data VotingState a`
+
+__Deprecated__ in favor of delegateless automation.
+Functions implementing instant-runoff voting
+
+Constructors:
+
+<a id="constr-splice-dsorules-votingstate-26047"></a>
+- `VotingState`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| rankings | Map a [[a]] | Candidate and the remaining rankings in case that candidate is eliminated. |
+| loosers | Set a | Loosers are tracked explicitly and removed lazily to avoid the cubic runtime<br/><br/>that would result from filtering the remaining rankings eagerly. |
+
+Instances:
+
+- `instance Ord a => Eq (VotingState a)`
+- `instance (Show a, Ord a) => Show (VotingState a)`
+- `instance GetField loosers (VotingState a) (Set a)`
+- `instance GetField rankings (VotingState a) (Map a [[a]])`
+- `instance SetField loosers (VotingState a) (Set a)`
+- `instance SetField rankings (VotingState a) (Map a [[a]])`
+
+## Functions
+
+<a id="function-splice-dsorules-getvotecooldowntime-44916"></a>
+
+### `getVoteCooldownTime`
+
+```daml
+getVoteCooldownTime : DsoRulesConfig -> RelTime
+```
+
+Read the `voteCooldownTime` from the `DsoRulesConfig` with a default value of 1 minute.
+
+<a id="function-splice-dsorules-pruneatleastone-36934"></a>
+
+### `pruneAtLeastOne`
+
+```daml
+pruneAtLeastOne : Ord t => t -> Schedule t a -> Optional (Schedule t a)
+```
+
+<a id="function-splice-dsorules-summarizedso-49860"></a>
+
+### `summarizeDso`
+
+```daml
+summarizeDso : DsoRules -> DsoSummary
+```
+
+<a id="function-splice-dsorules-executeactionrequiringconfirmation-87907"></a>
+
+### `executeActionRequiringConfirmation`
+
+```daml
+executeActionRequiringConfirmation : Party -> ContractId DsoRules -> Optional (ContractId AmuletRules) -> ActionRequiringConfirmation -> Update ()
+```
+
+Execute an action which requires certain number of confirmations from SVs.
+Each confirmed action can at most be executed once.
+
+<a id="function-splice-dsorules-requirewellformedreason-26428"></a>
+
+### `requireWellformedReason`
+
+```daml
+requireWellformedReason : DsoRulesConfig -> Reason -> Update ()
+```
+
+<a id="function-splice-dsorules-requirewellformedvote-94014"></a>
+
+### `requireWellformedVote`
+
+```daml
+requireWellformedVote : DsoRulesConfig -> Vote -> Update ()
+```
+
+<a id="function-splice-dsorules-ensurenotexpired-58839"></a>
+
+### `ensureNotExpired`
+
+```daml
+ensureNotExpired : Time -> Update ()
+```
+
+<a id="function-splice-dsorules-actionrequiringconfirmationeffectiveat-38122"></a>
+
+### `actionRequiringConfirmationEffectiveAt`
+
+```daml
+actionRequiringConfirmationEffectiveAt : ActionRequiringConfirmation -> Optional Time
+```
+
+Get the future-dated effectiveAt of an action requiring confirmation.
+
+<a id="function-splice-dsorules-getsvinfo-85569"></a>
+
+### `getSvInfo`
+
+```daml
+getSvInfo : Party -> DsoRules -> Update SvInfo
+```
+
+<a id="function-splice-dsorules-lookupsvinfobyname-29850"></a>
+
+### `lookupSvInfoByName`
+
+```daml
+lookupSvInfoByName : Text -> DsoRules -> Optional (Party, SvInfo)
+```
+
+<a id="function-splice-dsorules-svhasbeenonboardedbefore-57101"></a>
+
+### `svHasBeenOnboardedBefore`
+
+```daml
+svHasBeenOnboardedBefore : Text -> DsoRules -> Bool
+```
+
+Returns True if an SV with that name is either currently onboarded
+or an SV with that name has been onboarded before and is now in offboardedSvs.
+
+<a id="function-splice-dsorules-ensureneveroperatednode-60956"></a>
+
+### `ensureNeverOperatedNode`
+
+```daml
+ensureNeverOperatedNode : Party -> DsoRules -> Update ()
+```
+
+<a id="function-splice-dsorules-dsorulesaddsv-73633"></a>
+
+### `dsoRules_addSv`
+
+```daml
+dsoRules_addSv : DsoRules -> DsoRules_AddSv -> Update (ContractId DsoRules)
+```
+
+<a id="function-splice-dsorules-createpersvcontracts-25068"></a>
+
+### `createPerSvContracts`
+
+```daml
+createPerSvContracts : DsoRules -> DsoRules_AddSv -> Update ()
+```
+
+<a id="function-splice-dsorules-createpersvpartycontracts-3309"></a>
+
+### `createPerSvPartyContracts`
+
+```daml
+createPerSvPartyContracts : Party -> Party -> Text -> SynchronizerNodeConfigMap -> Optional Decimal -> RelTime -> Update ()
+```
+
+<a id="function-splice-dsorules-getandvalidatesvparty-72916"></a>
+
+### `getAndValidateSvParty`
+
+```daml
+getAndValidateSvParty : DsoRules -> Optional Party -> Update Party
+```
+
+<a id="function-splice-dsorules-enforcecooldown-11925"></a>
+
+### `enforceCooldown`
+
+```daml
+enforceCooldown : Text -> RelTime -> Optional Time -> Update ()
+```
+
+Enforce that an action is not performed again before a cooldown period has passed.
+
+## Templates
+
+<a id="type-splice-dsorules-bootstrapexternalpartyconfigstateinstruction-72557"></a>
+
+### Template `BootstrapExternalPartyConfigStateInstruction`
+
+Instruction to bootstrap the external party config state.
+This exists so that the `ActionRequiringConfirmation` for this is independent of the
+current rounds which we need so that we can do deduplication by action hash
+in our automation.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-dsorules-confirmation-62984"></a>
+
+### Template `Confirmation`
+
+A confirmation for the SVs to take action as part of standard DSO.
+Used for executing automated actions in a shortened process.
+See the comments on `ActionRequiringConfirmation` for details.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| confirmer | Party |  |
+| action | ActionRequiringConfirmation |  |
+| expiresAt | Time |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-dsorules-confirmationexpire-84183"></a>
+
+#### Choice `Confirmation_Expire`
+
+Controllers: `dso`
+
+Returns: `Confirmation_ExpireResult`
+
+<a id="type-splice-dsorules-dsorules-35440"></a>
+
+### Template `DsoRules`
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| epoch | Int |  |
+| svs | Map Party SvInfo |  |
+| offboardedSvs | Map Party OffboardedSvInfo |  |
+| dsoDelegate | Party | __Deprecated__ in favor of delegateless automation. |
+| config | DsoRulesConfig |  |
+| initialTrafficState | Map Text TrafficState | Map from participant/mediator ID to its traffic state at the time of synchronizer bootstrapping. Used for testing, empty in prod. |
+| isDevNet | Bool |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-dsorules-dsorulesaddconfirmedsv-22105"></a>
+
+#### Choice `DsoRules_AddConfirmedSv`
+
+Controllers: `sv`
+
+Returns: `DsoRules_AddConfirmedSvResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+| svOnboardingConfirmedCid | ContractId SvOnboardingConfirmed |  |
+| earliestRoundCid | ContractId OpenMiningRound |  |
+| middleRoundCid | ContractId OpenMiningRound |  |
+| latestRoundCid | ContractId OpenMiningRound |  |
+| amuletRulesCid | ContractId AmuletRules |  |
+
+<a id="type-splice-dsorules-dsorulesaddsv-44293"></a>
+
+#### Choice `DsoRules_AddSv`
+
+Controllers: `dso`
+
+Returns: `DsoRules_AddSvResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newSvParty | Party |  |
+| newSvName | Text |  |
+| newSvRewardWeight | Int |  |
+| newSvParticipantId | Text |  |
+| joinedAsOfRound | Round |  |
+
+<a id="type-splice-dsorules-dsorulesadvanceopenminingrounds-34192"></a>
+
+#### Choice `DsoRules_AdvanceOpenMiningRounds`
+
+Controllers: `sv`
+
+Returns: `DsoRules_AdvanceOpenMiningRoundsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| roundToArchiveCid | ContractId OpenMiningRound |  |
+| middleRoundCid | ContractId OpenMiningRound |  |
+| latestRoundCid | ContractId OpenMiningRound |  |
+| amuletPriceVoteCids | [ContractId AmuletPriceVote] |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecord-56787"></a>
+
+#### Choice `DsoRules_AllocateUnallocatedUnclaimedActivityRecord`
+
+Controllers: `sv`
+
+Returns: `DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unallocatedUnclaimedActivityRecordCid | ContractId UnallocatedUnclaimedActivityRecord |  |
+| amuletRulesCid | ContractId AmuletRules |  |
+| unclaimedRewardsToBurnCids | [ContractId UnclaimedReward] | A sufficient list of `UnclaimedReward` to be archived.<br/><br/>It must cover at least the requested amount. |
+| sv | Party |  |
+
+<a id="type-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkers-52437"></a>
+
+#### Choice `DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers`
+
+Controllers: `sv`
+
+Returns: `DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| argument | AmuletRules_ConvertFeaturedAppActivityMarkers |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesamuletexpire-71495"></a>
+
+#### Choice `DsoRules_Amulet_Expire`
+
+Controllers: `sv`
+
+Returns: `DsoRules_Amulet_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId Amulet |  |
+| choiceArg | Amulet_Expire |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesamuletexpiretransferinstructions-57305"></a>
+
+#### Choice `DsoRules_Amulet_ExpireTransferInstructions`
+
+Controllers: `sv`
+
+Returns: `DsoRules_Amulet_ExpireTransferInstructionsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| transferInsts | AmuletRules_Amulet_ExpireTransferInstructions |  |
+| sv | Party |  |
+
+<a id="type-splice-dsorules-dsorulesamuletexpirev2-61973"></a>
+
+#### Choice `DsoRules_Amulet_ExpireV2`
+
+Controllers: `sv`
+
+Returns: `DsoRules_Amulet_ExpireV2Result`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId Amulet |  |
+| choiceArg | Amulet_ExpireV2 |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesarchiveoutdatedelectionrequest-55064"></a>
+
+#### Choice `DsoRules_ArchiveOutdatedElectionRequest`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ArchiveOutdatedElectionRequestResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requestCid | ContractId ElectionRequest |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesarchivesvonboardingrequest-72075"></a>
+
+#### Choice `DsoRules_ArchiveSvOnboardingRequest`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ArchiveSvOnboardingRequestResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svOnboardingRequestCid | ContractId SvOnboardingRequest |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesbootstrapexternalpartyconfigstate-94209"></a>
+
+#### Choice `DsoRules_BootstrapExternalPartyConfigState`
+
+Controllers: `sv`
+
+Returns: `DsoRules_BootstrapExternalPartyConfigStateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| instructionCid | ContractId BootstrapExternalPartyConfigStateInstruction |  |
+| openMiningRoundTriple | OpenMiningRoundTriple |  |
+| sv | Party |  |
+
+<a id="type-splice-dsorules-dsorulescastvote-63161"></a>
+
+#### Choice `DsoRules_CastVote`
+
+Controllers: `(DA.Internal.Record.getField @"sv" vote)`
+
+Returns: `DsoRules_CastVoteResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requestCid | ContractId VoteRequest |  |
+| vote | Vote |  |
+
+<a id="type-splice-dsorules-dsorulesclaimexpiredrewards-16372"></a>
+
+#### Choice `DsoRules_ClaimExpiredRewards`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ClaimExpiredRewardsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| choiceArg | AmuletRules_ClaimExpiredRewards |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesclosevoterequest-87527"></a>
+
+#### Choice `DsoRules_CloseVoteRequest`
+
+Controllers: `sv`
+
+Returns: `DsoRules_CloseVoteRequestResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requestCid | ContractId VoteRequest |  |
+| amuletRulesCid | Optional (ContractId AmuletRules) |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulescollectentryrenewalpayment-93166"></a>
+
+#### Choice `DsoRules_CollectEntryRenewalPayment`
+
+Controllers: `sv`
+
+Returns: `DsoRules_CollectEntryRenewalPaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntryContextCid | ContractId AnsEntryContext |  |
+| choiceArg | AnsEntryContext_CollectEntryRenewalPayment |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesconfirmaction-67097"></a>
+
+#### Choice `DsoRules_ConfirmAction`
+
+Controllers: `confirmer`
+
+Returns: `DsoRules_ConfirmActionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| confirmer | Party |  |
+| action | ActionRequiringConfirmation |  |
+
+<a id="type-splice-dsorules-dsorulesconfirmsvonboarding-94029"></a>
+
+#### Choice `DsoRules_ConfirmSvOnboarding`
+
+Controllers: `dso`
+
+Returns: `DsoRules_ConfirmSvOnboardingResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newSvParty | Party |  |
+| newSvName | Text |  |
+| newParticipantId | Text |  |
+| newSvRewardWeight | Int |  |
+| reason | Text |  |
+
+<a id="type-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstruction-1552"></a>
+
+#### Choice `DsoRules_CreateBootstrapExternalPartyConfigStateInstruction`
+
+Controllers: `dso`
+
+Returns: `DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult`
+
+<a id="type-splice-dsorules-dsorulescreateexternalpartyamuletrules-62448"></a>
+
+#### Choice `DsoRules_CreateExternalPartyAmuletRules`
+
+Controllers: `dso`
+
+Returns: `DsoRules_CreateExternalPartyAmuletRulesResult`
+
+<a id="type-splice-dsorules-dsorulescreatetransfercommandcounter-44220"></a>
+
+#### Choice `DsoRules_CreateTransferCommandCounter`
+
+Controllers: `dso`
+
+Returns: `DsoRules_CreateTransferCommandCounterResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+
+<a id="type-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecord-78616"></a>
+
+#### Choice `DsoRules_CreateUnallocatedUnclaimedActivityRecord`
+
+Controllers: `dso`
+
+Returns: `DsoRules_CreateUnallocatedUnclaimedActivityRecordResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiary | Party |  |
+| amount | Decimal |  |
+| reason | Text |  |
+| expiresAt | Time |  |
+
+<a id="type-splice-dsorules-dsoruleselectdsodelegate-82924"></a>
+
+#### Choice `DsoRules_ElectDsoDelegate`
+
+Controllers: `actor`
+
+Returns: `DsoRules_ElectDsoDelegateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+| requestCids | [ContractId ElectionRequest] |  |
+
+<a id="type-splice-dsorules-dsorulesexecuteconfirmedaction-18028"></a>
+
+#### Choice `DsoRules_ExecuteConfirmedAction`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExecuteConfirmedActionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| action | ActionRequiringConfirmation |  |
+| amuletRulesCid | Optional (ContractId AmuletRules) |  |
+| confirmationCids | [ContractId Confirmation] |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesexpireamuletallocations-76865"></a>
+
+#### Choice `DsoRules_ExpireAmuletAllocations`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireAmuletAllocationsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| extAmuletRulesCid | ContractId ExternalPartyAmuletRules |  |
+| expireAllocations | ExternalPartyAmuletRules_ExpireAmuletAllocations |  |
+| sv | Party |  |
+
+<a id="type-splice-dsorules-dsorulesexpireansentry-58167"></a>
+
+#### Choice `DsoRules_ExpireAnsEntry`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireAnsEntryResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntryCid | ContractId AnsEntry |  |
+| choiceArg | AnsEntry_Expire |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesexpiredevelopmentfundcoupon-65446"></a>
+
+#### Choice `DsoRules_ExpireDevelopmentFundCoupon`
+
+Expires a DevelopmentFundCoupon and produces an UnclaimedDevelopmentFundCoupon with the same amount.
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireDevelopmentFundCouponResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| developmentFundCouponCid | ContractId DevelopmentFundCoupon |  |
+| sv | Party |  |
+
+<a id="type-splice-dsorules-dsorulesexpirestaleconfirmation-23846"></a>
+
+#### Choice `DsoRules_ExpireStaleConfirmation`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireStaleConfirmationResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| staleConfirmationCid | ContractId Confirmation |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesexpiresubscription-15972"></a>
+
+#### Choice `DsoRules_ExpireSubscription`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireSubscriptionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntryContextCid | ContractId AnsEntryContext |  |
+| subscriptionIdleStateCid | ContractId SubscriptionIdleState |  |
+| choiceArg | SubscriptionIdleState_ExpireSubscription |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesexpiresvonboardingconfirmed-60809"></a>
+
+#### Choice `DsoRules_ExpireSvOnboardingConfirmed`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireSvOnboardingConfirmedResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId SvOnboardingConfirmed |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesexpiresvonboardingrequest-63611"></a>
+
+#### Choice `DsoRules_ExpireSvOnboardingRequest`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireSvOnboardingRequestResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId SvOnboardingRequest |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesexpiretransferpreapproval-91729"></a>
+
+#### Choice `DsoRules_ExpireTransferPreapproval`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireTransferPreapprovalResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferPreapprovalCid | ContractId TransferPreapproval |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecord-90041"></a>
+
+#### Choice `DsoRules_ExpireUnallocatedUnclaimedActivityRecord`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unallocatedUnclaimedActivityRecordCid | ContractId UnallocatedUnclaimedActivityRecord |  |
+| sv | Party |  |
+
+<a id="type-splice-dsorules-dsorulesexpireunclaimedactivityrecord-57856"></a>
+
+#### Choice `DsoRules_ExpireUnclaimedActivityRecord`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ExpireUnclaimedActivityRecordResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| unclaimedActivityRecordCid | ContractId UnclaimedActivityRecord |  |
+| sv | Party |  |
+
+<a id="type-splice-dsorules-dsorulesgarbagecollectamuletpricevotes-77719"></a>
+
+#### Choice `DsoRules_GarbageCollectAmuletPriceVotes`
+
+Garbage-collect AmuletPriceVotes from removed svs and duplicate ones that might
+happen due to a too quick removal and re-addition of a sv.
+We expect this to be run as an OnAssignedContractTrigger for the DsoRules contract.
+
+Note: we do not archive the AmuletPriceVote of an SV on its removal,
+as that would allow that SV to block the removal via updating its AmuletPriceVote at the right time.
+
+TODO(#10063): drop this code in favor of just keeping AmuletPriceVotes around.
+
+Controllers: `sv`
+
+Returns: `DsoRules_GarbageCollectAmuletPriceVotesResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| nonSvVoteCids | [ContractId AmuletPriceVote] |  |
+| duplicateVoteCids | [[ContractId AmuletPriceVote]] |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesgrantfeaturedappright-79910"></a>
+
+#### Choice `DsoRules_GrantFeaturedAppRight`
+
+Controllers: `dso`
+
+Returns: `DsoRules_GrantFeaturedAppRightResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| provider | Party |  |
+
+<a id="type-splice-dsorules-dsoruleslockedamuletexpireamulet-28275"></a>
+
+#### Choice `DsoRules_LockedAmulet_ExpireAmulet`
+
+Controllers: `sv`
+
+Returns: `DsoRules_LockedAmulet_ExpireAmuletResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId LockedAmulet |  |
+| choiceArg | LockedAmulet_ExpireAmulet |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsoruleslockedamuletexpireamuletv2-91833"></a>
+
+#### Choice `DsoRules_LockedAmulet_ExpireAmuletV2`
+
+Controllers: `sv`
+
+Returns: `DsoRules_LockedAmulet_ExpireAmuletV2Result`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId LockedAmulet |  |
+| choiceArg | LockedAmulet_ExpireAmuletV2 |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesmergemembertrafficcontracts-34275"></a>
+
+#### Choice `DsoRules_MergeMemberTrafficContracts`
+
+Controllers: `sv`
+
+Returns: `DsoRules_MergeMemberTrafficContractsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| trafficCids | [ContractId MemberTraffic] |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesmergesvrewardstate-39851"></a>
+
+#### Choice `DsoRules_MergeSvRewardState`
+
+Note this choice only exists to clean up duplicate contracts caused by the bug in #12495.
+There should never be duplicates going forward.
+
+Controllers: `sv`
+
+Returns: `DsoRules_MergeSvRewardStateResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svName | Text |  |
+| rewardStateCids | [ContractId SvRewardState] |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcoupons-23755"></a>
+
+#### Choice `DsoRules_MergeUnclaimedDevelopmentFundCoupons`
+
+Batch merge of of development fund coupons.
+
+Controllers: `sv`
+
+Returns: `DsoRules_MergeUnclaimedDevelopmentFundCouponsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| choiceArg | AmuletRules_MergeUnclaimedDevelopmentFundCoupons |  |
+| sv | Party |  |
+
+<a id="type-splice-dsorules-dsorulesmergeunclaimedrewards-12383"></a>
+
+#### Choice `DsoRules_MergeUnclaimedRewards`
+
+Controllers: `sv`
+
+Returns: `DsoRules_MergeUnclaimedRewardsResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| unclaimedRewardCids | [ContractId UnclaimedReward] |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesmergevalidatorlicense-65804"></a>
+
+#### Choice `DsoRules_MergeValidatorLicense`
+
+Note: removes the old duplicated licenses and creates a new one with the highest lastReceivedFor round
+There should never be duplicates going forward.
+
+Controllers: `sv`
+
+Returns: `DsoRules_MergeValidatorLicenseResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| validatorLicenseCids | [ContractId ValidatorLicense] |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesminingroundclose-28010"></a>
+
+#### Choice `DsoRules_MiningRound_Close`
+
+Controllers: `sv`
+
+Returns: `DsoRules_MiningRound_CloseResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| issuingRoundCid | ContractId IssuingMiningRound |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesoffboardsv-78636"></a>
+
+#### Choice `DsoRules_OffboardSv`
+
+Controllers: `dso`
+
+Returns: `DsoRules_OffboardSvResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+
+<a id="type-splice-dsorules-dsorulesonboardvalidator-23909"></a>
+
+#### Choice `DsoRules_OnboardValidator`
+
+Controllers: `sponsor`
+
+Returns: `DsoRules_OnboardValidatorResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sponsor | Party |  |
+| validator | Party |  |
+| version | Optional Text |  |
+| contactPoint | Optional Text |  |
+
+<a id="type-splice-dsorules-dsorulespruneamuletconfigschedule-70948"></a>
+
+#### Choice `DsoRules_PruneAmuletConfigSchedule`
+
+Controllers: `sv`
+
+Returns: `DsoRules_PruneAmuletConfigScheduleResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesreceivesvrewardcoupon-83972"></a>
+
+#### Choice `DsoRules_ReceiveSvRewardCoupon`
+
+Controllers: `sv`
+
+Returns: `DsoRules_ReceiveSvRewardCouponResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+| openRoundCid | ContractId OpenMiningRound |  |
+| rewardStateCid | ContractId SvRewardState |  |
+| beneficiaries | [(Party, Int)] |  |
+
+<a id="type-splice-dsorules-dsorulesrequestelection-327"></a>
+
+#### Choice `DsoRules_RequestElection`
+
+Controllers: `requester`
+
+Returns: `DsoRules_RequestElectionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requester | Party |  |
+| reason | ElectionRequestReason |  |
+| ranking | [Party] |  |
+
+<a id="type-splice-dsorules-dsorulesrequestvote-27270"></a>
+
+#### Choice `DsoRules_RequestVote`
+
+Controllers: `requester`
+
+Returns: `DsoRules_RequestVoteResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requester | Party |  |
+| action | ActionRequiringConfirmation |  |
+| reason | Reason |  |
+| voteRequestTimeout | Optional RelTime |  |
+| targetEffectiveAt | Optional Time |  |
+
+<a id="type-splice-dsorules-dsorulesrevokefeaturedappright-46223"></a>
+
+#### Choice `DsoRules_RevokeFeaturedAppRight`
+
+Controllers: `dso`
+
+Returns: `DsoRules_RevokeFeaturedAppRightResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| rightCid | ContractId FeaturedAppRight |  |
+
+<a id="type-splice-dsorules-dsorulessetconfig-76713"></a>
+
+#### Choice `DsoRules_SetConfig`
+
+Controllers: `dso`
+
+Returns: `DsoRules_SetConfigResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| newConfig | DsoRulesConfig |  |
+| baseConfig | Optional DsoRulesConfig |  |
+
+<a id="type-splice-dsorules-dsorulessetsynchronizernodeconfig-79561"></a>
+
+#### Choice `DsoRules_SetSynchronizerNodeConfig`
+
+Controllers: `sv`
+
+Returns: `DsoRules_SetSynchronizerNodeConfigResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+| synchronizerId | Text |  |
+| newNodeConfig | SynchronizerNodeConfig |  |
+| nodeStateCid | ContractId SvNodeState |  |
+
+<a id="type-splice-dsorules-dsorulesstartsvonboarding-74859"></a>
+
+#### Choice `DsoRules_StartSvOnboarding`
+
+Controllers: `sponsor`
+
+Returns: `DsoRules_StartSvOnboardingResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| candidateName | Text |  |
+| candidateParty | Party |  |
+| candidateParticipantId | Text |  |
+| token | Text |  |
+| sponsor | Party |  |
+
+<a id="type-splice-dsorules-dsorulessubmitstatusreport-89950"></a>
+
+#### Choice `DsoRules_SubmitStatusReport`
+
+Controllers: `sv`
+
+Returns: `DsoRules_SubmitStatusReportResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+| previousReportCid | ContractId SvStatusReport |  |
+| status | SvStatus |  |
+
+<a id="type-splice-dsorules-dsorulesterminatesubscription-67561"></a>
+
+#### Choice `DsoRules_TerminateSubscription`
+
+Controllers: `sv`
+
+Returns: `DsoRules_TerminateSubscriptionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| ansEntryContextCid | ContractId AnsEntryContext |  |
+| terminatedSubscriptionCid | ContractId TerminatedSubscription |  |
+| sv | Optional Party |  |
+
+<a id="type-splice-dsorules-dsorulesupdateamuletpricevote-33547"></a>
+
+#### Choice `DsoRules_UpdateAmuletPriceVote`
+
+Controllers: `sv`
+
+Returns: `DsoRules_UpdateAmuletPriceVoteResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party |  |
+| voteCid | ContractId AmuletPriceVote |  |
+| amuletPrice | Decimal |  |
+
+<a id="type-splice-dsorules-dsorulesupdateexternalpartyconfigstates-33819"></a>
+
+#### Choice `DsoRules_UpdateExternalPartyConfigStates`
+
+Controllers: `sv`
+
+Returns: `DsoRules_UpdateExternalPartyConfigStatesResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+| externalPartyConfigStateCid0 | ContractId ExternalPartyConfigState |  |
+| externalPartyConfigStateCid1 | ContractId ExternalPartyConfigState |  |
+| openMiningRoundTriple | OpenMiningRoundTriple |  |
+| sv | Party |  |
+
+<a id="type-splice-dsorules-dsorulesupdatesvrewardweight-33689"></a>
+
+#### Choice `DsoRules_UpdateSvRewardWeight`
+
+Controllers: `dso`
+
+Returns: `DsoRules_UpdateSvRewardWeightResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svParty | Party |  |
+| newRewardWeight | Int |  |
+
+<a id="type-splice-dsorules-electionrequest-92680"></a>
+
+### Template `ElectionRequest`
+
+__Deprecated__ in favor of delegateless automation.
+
+A request to elect a new DSO delegate.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| requester | Party |  |
+| epoch | Int |  |
+| reason | ElectionRequestReason |  |
+| ranking | [Party] |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-dsorules-unallocatedunclaimedactivityrecord-15769"></a>
+
+### Template `UnallocatedUnclaimedActivityRecord`
+
+A governance-approved record representing intent to reward a beneficiary.
+Once sufficient `UnclaimedReward` contracts are allocated and archived,
+this contract results in the creation of a mintable `UnclaimedActivityRecord`.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| beneficiary | Party | The owner of the `Amulet` to be minted |
+| amount | Decimal | The amount of `Amulet` to be minted |
+| reason | Text | A reason to mint the `Amulet` |
+| expiresAt | Time | Selected timestamp defining the lifetime of the UnclaimedActivityRecord contract. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-dsorules-voterequest-12683"></a>
+
+### Template `VoteRequest`
+
+A request for the other svs to vote on the execution of an action requiring confirmation.
+We use this for implementing on-ledger governance actions triggered by SV operators in a uniform way.
+
+See the comments on `ActionRequiringConfirmation` for details.
+
+Version 3, which introduces effectivity in vote request.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| requester | Text | The SV that requested to execute the action. |
+| action | ActionRequiringConfirmation | The action whose confirmation is required. |
+| reason | Reason | The reason for requesting the execution of the action. Typically a reference to some off-ledger justification. |
+| voteBefore | Time | The time before which votes are accepted, and SHOULD be submitted. |
+| votes | Map Text Vote | The votes cast by current or previous SVs. These may be previous SVs in case<br/><br/>there was an SV change after the vote was requested. |
+| trackingCid | Optional (ContractId VoteRequest) | An optional tracking ContractId to be used for tracking the vote request through its updates.<br/><br/>This is always set to the first ContractId of the original vote request (None on creation). |
+| targetEffectiveAt | Optional Time | The time when the action is targeted to be made effective. If None, the action is immediately effective upon 2/3 votes in favor. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+## Orphan Typeclass Instances
+
+- `instance HasCheckedFetch FeaturedAppRight ForDso`

--- a/docs-main/reference/splice-daml-api/splice-dso-governance/splice-svonboarding.mdx
+++ b/docs-main/reference/splice-daml-api/splice-dso-governance/splice-svonboarding.mdx
@@ -1,0 +1,134 @@
+---
+title: "Splice.SvOnboarding"
+description: "Reference documentation for Daml module Splice.SvOnboarding."
+---
+
+<a id="module-splice-svonboarding-92564"></a>
+
+# Splice.SvOnboarding
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-svonboarding-svonboardingconfirmedexpireresult-89548"></a>
+
+### `data SvOnboardingConfirmed_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-svonboarding-svonboardingconfirmedexpireresult-55325"></a>
+- `SvOnboardingConfirmed_ExpireResult`
+
+Instances:
+
+- `instance HasExercise SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult`
+- `instance HasFromAnyChoice SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult`
+- `instance HasToAnyChoice SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult`
+
+<a id="type-splice-svonboarding-svonboardingrequestexpireresult-6542"></a>
+
+### `data SvOnboardingRequest_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-svonboarding-svonboardingrequestexpireresult-87875"></a>
+- `SvOnboardingRequest_ExpireResult`
+
+Instances:
+
+- `instance HasExercise SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult`
+- `instance HasFromAnyChoice SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult`
+- `instance HasToAnyChoice SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult`
+
+## Templates
+
+<a id="type-splice-svonboarding-svonboardingconfirmed-6814"></a>
+
+### Template `SvOnboardingConfirmed`
+
+A confirmation for approval of a candidate SV.
+
+Once this contract is created, the workflows to onboard that SVs node starts.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| svParty | Party |  |
+| svName | Text |  |
+| svRewardWeight | Int |  |
+| svParticipantId | Text |  |
+| reason | Text |  |
+| dso | Party |  |
+| expiresAt | Time | When this contract can be archived. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-svonboarding-svonboardingconfirmedexpire-37945"></a>
+
+#### Choice `SvOnboardingConfirmed_Expire`
+
+Controllers: `dso`
+
+Returns: `SvOnboardingConfirmed_ExpireResult`
+
+<a id="type-splice-svonboarding-svonboardingrequest-71856"></a>
+
+### Template `SvOnboardingRequest`
+
+Template used by the SVs to collect confirmations for the onboarding of an SV candidate.
+The existence of this contract triggers SV automation that creates confirmation contracts for
+the candidate if the token is a valid `SvOnboardingToken` and matches an `ApprovedSvIdentity`.
+
+Signatories: `dso`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| candidateName | Text | Human-readable name of the SV candidate. Must match the one in `ApprovedSvIdentity`! |
+| candidateParty | Party | PartyId of the candidate SV party. |
+| candidateParticipantId | Text | ParticipantId of the candidate SV. |
+| token | Text | An encoded and signed `SvOnboardingToken` that confirms the candidate's identity. |
+| sponsor | Party | The established SV node that created this contract. |
+| dso | Party |  |
+| expiresAt | Time | When this contract can be archived even if the onboarding did not succeed. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `dso`
+
+Returns: `()`
+
+<a id="type-splice-svonboarding-svonboardingrequestexpire-23755"></a>
+
+#### Choice `SvOnboardingRequest_Expire`
+
+Controllers: `dso`
+
+Returns: `SvOnboardingRequest_ExpireResult`

--- a/docs-main/reference/splice-daml-api/splice-token-test-trading-app/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-token-test-trading-app/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-token-test-trading-app docs"
+description: "Reference documentation for splice-token-test-trading-app docs modules."
+---
+
+# splice-token-test-trading-app docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Testing.Apps.TradingApp`](/reference/splice-daml-api/splice-token-test-trading-app/splice-testing-apps-tradingapp) | `Module` | An example of how to build an OTC trading app for multi-leg standard token trades. | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Testing.Apps.TradingApp](/reference/splice-daml-api/splice-token-test-trading-app/splice-testing-apps-tradingapp)

--- a/docs-main/reference/splice-daml-api/splice-token-test-trading-app/splice-testing-apps-tradingapp.mdx
+++ b/docs-main/reference/splice-daml-api/splice-token-test-trading-app/splice-testing-apps-tradingapp.mdx
@@ -1,0 +1,205 @@
+---
+title: "Splice.Testing.Apps.TradingApp"
+description: "Reference documentation for Daml module Splice.Testing.Apps.TradingApp."
+---
+
+<a id="module-splice-testing-apps-tradingapp-19891"></a>
+
+# Splice.Testing.Apps.TradingApp
+
+An example of how to build an OTC trading app for multi-leg standard token trades.
+
+Used as part of the testing infrastructure to test the DvP workflows based on the token standard.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Functions
+
+<a id="function-splice-testing-apps-tradingapp-tradeallocations-16894"></a>
+
+### `tradeAllocations`
+
+```daml
+tradeAllocations : SettlementInfo -> TextMap TransferLeg -> TextMap AllocationSpecification
+```
+
+<a id="function-splice-testing-apps-tradingapp-tradingparties-11886"></a>
+
+### `tradingParties`
+
+```daml
+tradingParties : TextMap TransferLeg -> Set Party
+```
+
+<a id="function-splice-testing-apps-tradingapp-require-88127"></a>
+
+### `require`
+
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
+
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
+
+<a id="function-splice-testing-apps-tradingapp-maketraderef-67526"></a>
+
+### `makeTradeRef`
+
+```daml
+makeTradeRef : ContractId OTCTradeProposal -> Reference
+```
+
+<a id="function-splice-testing-apps-tradingapp-ziptextmaps-57279"></a>
+
+### `zipTextMaps`
+
+```daml
+zipTextMaps : TextMap a -> TextMap b -> TextMap (Optional a, Optional b)
+```
+
+<a id="function-splice-testing-apps-tradingapp-fortextmapwithkey-78275"></a>
+
+### `forTextMapWithKey`
+
+```daml
+forTextMapWithKey : Applicative f => TextMap a -> (Text -> a -> f b) -> f (TextMap b)
+```
+
+## Templates
+
+<a id="type-splice-testing-apps-tradingapp-otctrade-80775"></a>
+
+### Template `OTCTrade`
+
+Signatories: `venue`, `tradingParties transferLegs`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| venue | Party |  |
+| transferLegs | TextMap TransferLeg |  |
+| tradeCid | ContractId OTCTradeProposal |  |
+| createdAt | Time |  |
+| prepareUntil | Time |  |
+| settleBefore | Time |  |
+
+Interface Instances:
+- `AllocationRequest` for `OTCTrade`
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `venue`, `tradingParties transferLegs`
+
+Returns: `()`
+
+<a id="type-splice-testing-apps-tradingapp-otctradecancel-34465"></a>
+
+#### Choice `OTCTrade_Cancel`
+
+Controllers: `venue`
+
+Returns: `TextMap (Optional Allocation_CancelResult)`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationsWithContext | TextMap (ContractId Allocation, ExtraArgs) |  |
+
+<a id="type-splice-testing-apps-tradingapp-otctradesettle-9210"></a>
+
+#### Choice `OTCTrade_Settle`
+
+Controllers: `venue`
+
+Returns: `TextMap Allocation_ExecuteTransferResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationsWithContext | TextMap (ContractId Allocation, ExtraArgs) |  |
+
+<a id="type-splice-testing-apps-tradingapp-otctradeproposal-78093"></a>
+
+### Template `OTCTradeProposal`
+
+Signatories: `approvers`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| venue | Party |  |
+| tradeCid | Optional (ContractId OTCTradeProposal) |  |
+| transferLegs | TextMap TransferLeg |  |
+| approvers | [Party] | Parties that have approved the proposal |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `approvers`
+
+Returns: `()`
+
+<a id="type-splice-testing-apps-tradingapp-otctradeproposalaccept-97549"></a>
+
+#### Choice `OTCTradeProposal_Accept`
+
+Controllers: `approver`
+
+Returns: `ContractId OTCTradeProposal`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| approver | Party |  |
+
+<a id="type-splice-testing-apps-tradingapp-otctradeproposalinitiatesettlement-54617"></a>
+
+#### Choice `OTCTradeProposal_InitiateSettlement`
+
+Controllers: `venue`
+
+Returns: `ContractId OTCTrade`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| prepareUntil | Time |  |
+| settleBefore | Time |  |
+
+<a id="type-splice-testing-apps-tradingapp-otctradeproposalreject-13148"></a>
+
+#### Choice `OTCTradeProposal_Reject`
+
+Controllers: `trader`
+
+Returns: `()`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trader | Party |  |

--- a/docs-main/reference/splice-daml-api/splice-util-batched-markers/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-util-batched-markers/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-util-batched-markers docs"
+description: "Reference documentation for splice-util-batched-markers docs modules."
+---
+
+# splice-util-batched-markers docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Util.FeaturedApp.BatchedMarkersProxy`](/reference/splice-daml-api/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy) | `Module` | This module provides a BatchedMarkersProxy that can be used | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Util.FeaturedApp.BatchedMarkersProxy](/reference/splice-daml-api/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy)

--- a/docs-main/reference/splice-daml-api/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy.mdx
+++ b/docs-main/reference/splice-daml-api/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy.mdx
@@ -1,0 +1,125 @@
+---
+title: "Splice.Util.FeaturedApp.BatchedMarkersProxy"
+description: "Reference documentation for Daml module Splice.Util.FeaturedApp.BatchedMarkersProxy."
+---
+
+<a id="module-splice-util-featuredapp-batchedmarkersproxy-25197"></a>
+
+# Splice.Util.FeaturedApp.BatchedMarkersProxy
+
+This module provides a BatchedMarkersProxy that can be used
+
+to create multiple markers in one view.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersresult-99671"></a>
+
+### `data BatchedMarkersProxy_CreateMarkersResult`
+
+Constructors:
+
+<a id="constr-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersresult-77896"></a>
+- `BatchedMarkersProxy_CreateMarkersResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| results | [[FeaturedAppRight_CreateActivityMarkerResult]] |  |
+
+Instances:
+
+- `instance GetField results BatchedMarkersProxy_CreateMarkersResult [[FeaturedAppRight_CreateActivityMarkerResult]]`
+- `instance SetField results BatchedMarkersProxy_CreateMarkersResult [[FeaturedAppRight_CreateActivityMarkerResult]]`
+- `instance HasExercise BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult`
+- `instance HasFromAnyChoice BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult`
+- `instance HasToAnyChoice BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult`
+
+<a id="type-splice-util-featuredapp-batchedmarkersproxy-rewardbatch-19803"></a>
+
+### `data RewardBatch`
+
+Constructors:
+
+<a id="constr-splice-util-featuredapp-batchedmarkersproxy-rewardbatch-87344"></a>
+- `RewardBatch`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiaries | [AppRewardBeneficiary] |  |
+| numMarkers | Int |  |
+
+Instances:
+
+- `instance Eq RewardBatch`
+- `instance Show RewardBatch`
+- `instance GetField batches BatchedMarkersProxy_CreateMarkers [RewardBatch]`
+- `instance GetField beneficiaries RewardBatch [AppRewardBeneficiary]`
+- `instance GetField numMarkers RewardBatch Int`
+- `instance SetField batches BatchedMarkersProxy_CreateMarkers [RewardBatch]`
+- `instance SetField beneficiaries RewardBatch [AppRewardBeneficiary]`
+- `instance SetField numMarkers RewardBatch Int`
+
+## Functions
+
+<a id="function-splice-util-featuredapp-batchedmarkersproxy-require-64969"></a>
+
+### `require`
+
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
+
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
+
+## Templates
+
+<a id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxy-55016"></a>
+
+### Template `BatchedMarkersProxy`
+
+Signatories: `provider`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| provider | Party |  |
+| dso | Party |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `provider`
+
+Returns: `()`
+
+<a id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkers-27654"></a>
+
+#### Choice `BatchedMarkersProxy_CreateMarkers`
+
+Controllers: `provider`
+
+Returns: `BatchedMarkersProxy_CreateMarkersResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppRightCid | ContractId FeaturedAppRight |  |
+| batches | [RewardBatch] |  |

--- a/docs-main/reference/splice-daml-api/splice-util-featured-app-proxies/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-util-featured-app-proxies/index.mdx
@@ -1,0 +1,26 @@
+---
+title: "splice-util-featured-app-proxies docs"
+description: "Reference documentation for splice-util-featured-app-proxies docs modules."
+---
+
+# splice-util-featured-app-proxies docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Util.FeaturedApp.DelegateProxy`](/reference/splice-daml-api/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy) | `Module` | Utility template for proxying token standard choices so that featured app markers | `0.5.18` | - | - | - |
+| [`Splice.Util.FeaturedApp.WalletUserProxy`](/reference/splice-daml-api/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy) | `Module` | Utility template for proxying token standard choices so that featured app markers | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 2 | 0 | 0 |
+
+## Reference
+
+- [Splice.Util.FeaturedApp.DelegateProxy](/reference/splice-daml-api/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy)
+- [Splice.Util.FeaturedApp.WalletUserProxy](/reference/splice-daml-api/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy)

--- a/docs-main/reference/splice-daml-api/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy.mdx
+++ b/docs-main/reference/splice-daml-api/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy.mdx
@@ -1,0 +1,260 @@
+---
+title: "Splice.Util.FeaturedApp.DelegateProxy"
+description: "Reference documentation for Daml module Splice.Util.FeaturedApp.DelegateProxy."
+---
+
+<a id="module-splice-util-featuredapp-delegateproxy-30718"></a>
+
+# Splice.Util.FeaturedApp.DelegateProxy
+
+Utility template for proxying token standard choices so that featured app markers
+
+are created when using extra parties for operating an app.
+
+You can either use this template directly, or copy the code
+
+under a **different package name** and a **different module name**.
+
+Note: use the `WalletUserProxy` if you are building a wallet app and want your users
+
+to create featured app markers for you.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-util-featuredapp-delegateproxy-proxyarg-10352"></a>
+
+### `data ProxyArg arg`
+
+Generic argument to the proxy choices.
+
+Constructors:
+
+<a id="constr-splice-util-featuredapp-delegateproxy-proxyarg-5545"></a>
+- `ProxyArg`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| choiceArg | arg | The argument to the choice that the delegate is exercising. |
+| featuredAppRightCid | ContractId FeaturedAppRight | The featured app right contract of the provider. |
+| beneficiaries | [AppRewardBeneficiary] | The beneficiaries for the activity marker. |
+
+Instances:
+
+- `instance Eq arg => Eq (ProxyArg arg)`
+- `instance Show arg => Show (ProxyArg arg)`
+- `instance GetField beneficiaries (ProxyArg arg) [AppRewardBeneficiary]`
+- `instance GetField choiceArg (ProxyArg arg) arg`
+- `instance GetField featuredAppRightCid (ProxyArg arg) (ContractId FeaturedAppRight)`
+- `instance GetField proxyArg DelegateProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)`
+- `instance GetField proxyArg DelegateProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)`
+- `instance GetField proxyArg DelegateProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)`
+- `instance GetField proxyArg DelegateProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)`
+- `instance GetField proxyArg DelegateProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)`
+- `instance GetField proxyArg DelegateProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)`
+- `instance SetField beneficiaries (ProxyArg arg) [AppRewardBeneficiary]`
+- `instance SetField choiceArg (ProxyArg arg) arg`
+- `instance SetField featuredAppRightCid (ProxyArg arg) (ContractId FeaturedAppRight)`
+- `instance SetField proxyArg DelegateProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)`
+- `instance SetField proxyArg DelegateProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)`
+- `instance SetField proxyArg DelegateProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)`
+- `instance SetField proxyArg DelegateProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)`
+- `instance SetField proxyArg DelegateProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)`
+- `instance SetField proxyArg DelegateProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)`
+
+<a id="type-splice-util-featuredapp-delegateproxy-proxyresult-3914"></a>
+
+### `data ProxyResult r`
+
+Generic result of the proxy choices.
+
+Constructors:
+
+<a id="constr-splice-util-featuredapp-delegateproxy-proxyresult-43225"></a>
+- `ProxyResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| markerResult | FeaturedAppRight_CreateActivityMarkerResult |  |
+| choiceResult | r |  |
+
+Instances:
+
+- `instance GetField choiceResult (ProxyResult r) r`
+- `instance GetField markerResult (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult`
+- `instance SetField choiceResult (ProxyResult r) r`
+- `instance SetField markerResult (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasExercise DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasExercise DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasExercise DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasExercise DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasExercise DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasExercise DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
+
+## Functions
+
+<a id="function-splice-util-featuredapp-delegateproxy-exerciseproxychoice-9818"></a>
+
+### `exerciseProxyChoice`
+
+```daml
+exerciseProxyChoice : HasExercise t ch r => DelegateProxy -> ContractId t -> ProxyArg ch -> Update (ProxyResult r)
+```
+
+Shared code to execute the proxied choice.
+
+<a id="function-splice-util-featuredapp-delegateproxy-require-76960"></a>
+
+### `require`
+
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
+
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
+
+## Templates
+
+<a id="type-splice-util-featuredapp-delegateproxy-delegateproxy-71400"></a>
+
+### Template `DelegateProxy`
+
+A proxy for a delegate to create featured app markers jointly with using token standard workflows.
+The delegate is given full control over the creation of the markers.
+
+This is for example useful when using one or more parties for app operation purposes.
+Using this proxy allows the operational parties to properly attribute their activity to the featured app,
+which is represented by the app provider party.
+
+Signatories: `provider`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| provider | Party | The app provider whose featured app right should be used |
+| delegate | Party | The delegate interacting with the token standard workflow |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `provider`
+
+Returns: `()`
+
+<a id="type-splice-util-featuredapp-delegateproxy-delegateproxyallocationfactoryallocate-41540"></a>
+
+#### Choice `DelegateProxy_AllocationFactory_Allocate`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult AllocationInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId AllocationFactory |  |
+| proxyArg | ProxyArg AllocationFactory_Allocate |  |
+
+<a id="type-splice-util-featuredapp-delegateproxy-delegateproxyallocationwithdraw-47558"></a>
+
+#### Choice `DelegateProxy_Allocation_Withdraw`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult Allocation_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId Allocation |  |
+| proxyArg | ProxyArg Allocation_Withdraw |  |
+
+<a id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferfactorytransfer-85873"></a>
+
+#### Choice `DelegateProxy_TransferFactory_Transfer`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferFactory |  |
+| proxyArg | ProxyArg TransferFactory_Transfer |  |
+
+<a id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionaccept-5120"></a>
+
+#### Choice `DelegateProxy_TransferInstruction_Accept`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Accept |  |
+
+<a id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionreject-73393"></a>
+
+#### Choice `DelegateProxy_TransferInstruction_Reject`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Reject |  |
+
+<a id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionwithdraw-896"></a>
+
+#### Choice `DelegateProxy_TransferInstruction_Withdraw`
+
+Controllers: `delegate`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Withdraw |  |

--- a/docs-main/reference/splice-daml-api/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy.mdx
+++ b/docs-main/reference/splice-daml-api/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy.mdx
@@ -1,0 +1,432 @@
+---
+title: "Splice.Util.FeaturedApp.WalletUserProxy"
+description: "Reference documentation for Daml module Splice.Util.FeaturedApp.WalletUserProxy."
+---
+
+<a id="module-splice-util-featuredapp-walletuserproxy-40223"></a>
+
+# Splice.Util.FeaturedApp.WalletUserProxy
+
+Utility template for proxying token standard choices so that featured app markers
+
+are created for a wallet app provider by their users when they are using
+
+token standard workflows.
+
+You can either use this template directly, or copy the code
+
+under a **different package name** and a **different module name**.
+
+Note: use the `DelegateProxy` if you are building an app that uses multiple parties
+
+for its own operations.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-util-featuredapp-walletuserproxy-instrumentholdingmap-68187"></a>
+
+### `type InstrumentHoldingMap = Map InstrumentId [ContractId Holding]`
+
+Instances:
+
+- `instance GetField senderChangeMap WalletUserProxy_BatchTransferResult InstrumentHoldingMap`
+- `instance SetField senderChangeMap WalletUserProxy_BatchTransferResult InstrumentHoldingMap`
+
+<a id="type-splice-util-featuredapp-walletuserproxy-proxyarg-78125"></a>
+
+### `data ProxyArg arg`
+
+Generic argument to the proxy choices.
+
+Constructors:
+
+<a id="constr-splice-util-featuredapp-walletuserproxy-proxyarg-32408"></a>
+- `ProxyArg`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| user | Party | The wallet user that is using the wallet to exercise a choice. |
+| choiceArg | arg | The argument to the choice that the user is exercising. |
+| featuredAppRightCid | ContractId FeaturedAppRight | The featured app right contract of the provider. |
+
+Instances:
+
+- `instance Eq arg => Eq (ProxyArg arg)`
+- `instance Show arg => Show (ProxyArg arg)`
+- `instance GetField choiceArg (ProxyArg arg) arg`
+- `instance GetField featuredAppRightCid (ProxyArg arg) (ContractId FeaturedAppRight)`
+- `instance GetField proxyArg WalletUserProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)`
+- `instance GetField proxyArg WalletUserProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)`
+- `instance GetField proxyArg WalletUserProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)`
+- `instance GetField proxyArg WalletUserProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)`
+- `instance GetField proxyArg WalletUserProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)`
+- `instance GetField proxyArg WalletUserProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)`
+- `instance GetField user (ProxyArg arg) Party`
+- `instance SetField choiceArg (ProxyArg arg) arg`
+- `instance SetField featuredAppRightCid (ProxyArg arg) (ContractId FeaturedAppRight)`
+- `instance SetField proxyArg WalletUserProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)`
+- `instance SetField proxyArg WalletUserProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)`
+- `instance SetField proxyArg WalletUserProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)`
+- `instance SetField proxyArg WalletUserProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)`
+- `instance SetField proxyArg WalletUserProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)`
+- `instance SetField proxyArg WalletUserProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)`
+- `instance SetField user (ProxyArg arg) Party`
+
+<a id="type-splice-util-featuredapp-walletuserproxy-proxyresult-11789"></a>
+
+### `data ProxyResult r`
+
+Generic result of the proxy choices.
+
+Constructors:
+
+<a id="constr-splice-util-featuredapp-walletuserproxy-proxyresult-146"></a>
+- `ProxyResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| markerResult | FeaturedAppRight_CreateActivityMarkerResult |  |
+| choiceResult | r |  |
+
+Instances:
+
+- `instance GetField choiceResult (ProxyResult r) r`
+- `instance GetField markerResult (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult`
+- `instance SetField choiceResult (ProxyResult r) r`
+- `instance SetField markerResult (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult`
+- `instance HasExercise WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasExercise WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasExercise WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasExercise WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasExercise WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasExercise WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)`
+
+<a id="type-splice-util-featuredapp-walletuserproxy-transferfactorycall-48419"></a>
+
+### `data TransferFactoryCall`
+
+A call to the token standard factory to initiate a token standard transfer.
+Specialized because it is used in the batch transfer choice below.
+
+Constructors:
+
+<a id="constr-splice-util-featuredapp-walletuserproxy-transferfactorycall-65712"></a>
+- `TransferFactoryCall`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| factoryCid | ContractId TransferFactory |  |
+| choiceArg | TransferFactory_Transfer |  |
+
+Instances:
+
+- `instance Eq TransferFactoryCall`
+- `instance Show TransferFactoryCall`
+- `instance GetField choiceArg TransferFactoryCall TransferFactory_Transfer`
+- `instance GetField factoryCid TransferFactoryCall (ContractId TransferFactory)`
+- `instance GetField transferCalls WalletUserProxy_BatchTransfer [TransferFactoryCall]`
+- `instance SetField choiceArg TransferFactoryCall TransferFactory_Transfer`
+- `instance SetField factoryCid TransferFactoryCall (ContractId TransferFactory)`
+- `instance SetField transferCalls WalletUserProxy_BatchTransfer [TransferFactoryCall]`
+
+<a id="type-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransferresult-21051"></a>
+
+### `data WalletUserProxy_BatchTransferResult`
+
+Constructors:
+
+<a id="constr-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransferresult-77048"></a>
+- `WalletUserProxy_BatchTransferResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferResults | [TransferInstructionResult] |  |
+| senderChangeMap | InstrumentHoldingMap |  |
+
+Instances:
+
+- `instance Eq WalletUserProxy_BatchTransferResult`
+- `instance Show WalletUserProxy_BatchTransferResult`
+- `instance GetField senderChangeMap WalletUserProxy_BatchTransferResult InstrumentHoldingMap`
+- `instance GetField transferResults WalletUserProxy_BatchTransferResult [TransferInstructionResult]`
+- `instance SetField senderChangeMap WalletUserProxy_BatchTransferResult InstrumentHoldingMap`
+- `instance SetField transferResults WalletUserProxy_BatchTransferResult [TransferInstructionResult]`
+- `instance HasExercise WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult`
+- `instance HasFromAnyChoice WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult`
+- `instance HasToAnyChoice WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult`
+
+## Functions
+
+<a id="function-splice-util-featuredapp-walletuserproxy-getfirstsender-96870"></a>
+
+### `getFirstSender`
+
+```daml
+getFirstSender : [TransferFactoryCall] -> Party
+```
+
+Determine the sender of the transfer in the first call.
+
+<a id="function-splice-util-featuredapp-walletuserproxy-runbatch-13560"></a>
+
+### `runBatch`
+
+```daml
+runBatch : WalletUserProxy -> WalletUserProxy_BatchTransfer -> Update WalletUserProxy_BatchTransferResult
+```
+
+Validate the batch call and run it
+
+<a id="function-splice-util-featuredapp-walletuserproxy-executetransfercalls-34186"></a>
+
+### `executeTransferCalls`
+
+```daml
+executeTransferCalls : WalletUserProxy -> Party -> Optional (ContractId FeaturedAppRight) -> [TransferFactoryCall] -> InstrumentHoldingMap -> [TransferInstructionResult] -> Update WalletUserProxy_BatchTransferResult
+```
+
+Run the individual transfer calls in the batch with proper threading of input holdings.
+
+<a id="function-splice-util-featuredapp-walletuserproxy-exerciseproxychoice-45581"></a>
+
+### `exerciseProxyChoice`
+
+```daml
+exerciseProxyChoice : HasExercise t ch r => WalletUserProxy -> ContractId t -> ProxyArg ch -> (ContractId t -> Update Party) -> Update (ProxyResult r)
+```
+
+Shared code to execute the proxied choice.
+
+<a id="function-splice-util-featuredapp-walletuserproxy-validateappright-75174"></a>
+
+### `validateAppRight`
+
+```daml
+validateAppRight : WalletUserProxy -> ContractId FeaturedAppRight -> Update ()
+```
+
+<a id="function-splice-util-featuredapp-walletuserproxy-checkallowlist-76724"></a>
+
+### `checkAllowList`
+
+```daml
+checkAllowList : Optional [Party] -> Party -> Update ()
+```
+
+<a id="function-splice-util-featuredapp-walletuserproxy-createappmarker-13733"></a>
+
+### `createAppMarker`
+
+```daml
+createAppMarker : WalletUserProxy -> Party -> ContractId FeaturedAppRight -> Update FeaturedAppRight_CreateActivityMarkerResult
+```
+
+<a id="function-splice-util-featuredapp-walletuserproxy-proxybeneficiaries-11168"></a>
+
+### `proxyBeneficiaries`
+
+```daml
+proxyBeneficiaries : WalletUserProxy -> Party -> [AppRewardBeneficiary]
+```
+
+Get the list of beneficiaries for the featured app marker.
+
+<a id="function-splice-util-featuredapp-walletuserproxy-validproxy-47629"></a>
+
+### `validProxy`
+
+```daml
+validProxy : WalletUserProxy -> Bool
+```
+
+<a id="function-splice-util-featuredapp-walletuserproxy-require-57479"></a>
+
+### `require`
+
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
+
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
+
+## Templates
+
+<a id="type-splice-util-featuredapp-walletuserproxy-walletuserproxy-95528"></a>
+
+### Template `WalletUserProxy`
+
+A proxy to attribute the activity of a wallet user to the wallet app provider.
+
+The intended usage is for the wallet app provider to
+1. create a `WalletUserProxy` contract with the `provider` set to the app provider's party
+2. setup their wallet frontend such that users call the proxy's choices instead of the original token standard choices.
+
+Note that the weights are specified on the proxy contract, so that they are under the providers
+control. If they were specified on the choices, then the user could in principle change them,
+and grant themselves a higher reward than intended.
+
+Note also that the batch transfer support can be used without having a featured app right.
+
+Signatories: `provider`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| provider | Party | The app provider whose featured app right should be triggered |
+| providerWeight | Decimal | Reward weight for the provider |
+| userWeight | Decimal | Reward weight for the user, set to 0.0 if the user should not receive a reward |
+| extraBeneficiaries | [AppRewardBeneficiary] | Extra beneficiaries to add |
+| optAllowList | Optional [Party] | An optional allow list of parties that can use the proxy |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `provider`
+
+Returns: `()`
+
+<a id="type-splice-util-featuredapp-walletuserproxy-walletuserproxyallocationfactoryallocate-70856"></a>
+
+#### Choice `WalletUserProxy_AllocationFactory_Allocate`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult AllocationInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId AllocationFactory |  |
+| proxyArg | ProxyArg AllocationFactory_Allocate |  |
+
+<a id="type-splice-util-featuredapp-walletuserproxy-walletuserproxyallocationwithdraw-8358"></a>
+
+#### Choice `WalletUserProxy_Allocation_Withdraw`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult Allocation_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId Allocation |  |
+| proxyArg | ProxyArg Allocation_Withdraw |  |
+
+<a id="type-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransfer-93002"></a>
+
+#### Choice `WalletUserProxy_BatchTransfer`
+
+Controllers: `getFirstSender transferCalls`
+
+Returns: `WalletUserProxy_BatchTransferResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferCalls | [TransferFactoryCall] | Transfers to execute via their respective transfer factories.<br/><br/>Input holdings are properly threaded through for all instrument-ids.<br/><br/>The sender change is always added back as an additional input to follow-up transfers<br/><br/>for the same instrument-ids.<br/><br/>Note that we accept fully specified calls to factories for maximum flexibility.<br/><br/>Some token admins may actually use different factories for different recipients,<br/><br/>e.g., to implement preapprovals. |
+| optFeaturedAppRightCid | Optional (ContractId FeaturedAppRight) | The featured app right contract of the provider to use on every transfer.<br/><br/>Optional so the batched choice can be used without a featured app right. |
+
+<a id="type-splice-util-featuredapp-walletuserproxy-walletuserproxypublicfetch-18804"></a>
+
+#### Choice `WalletUserProxy_PublicFetch`
+
+Controllers: `actor`
+
+Returns: `WalletUserProxy`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+
+<a id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferfactorytransfer-32457"></a>
+
+#### Choice `WalletUserProxy_TransferFactory_Transfer`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferFactory |  |
+| proxyArg | ProxyArg TransferFactory_Transfer |  |
+
+<a id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionaccept-38416"></a>
+
+#### Choice `WalletUserProxy_TransferInstruction_Accept`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Accept |  |
+
+<a id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionreject-59713"></a>
+
+#### Choice `WalletUserProxy_TransferInstruction_Reject`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Reject |  |
+
+<a id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionwithdraw-40772"></a>
+
+#### Choice `WalletUserProxy_TransferInstruction_Withdraw`
+
+Controllers: `(DA.Internal.Record.getField @"user" proxyArg)`
+
+Returns: `ProxyResult TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferInstruction |  |
+| proxyArg | ProxyArg TransferInstruction_Withdraw |  |

--- a/docs-main/reference/splice-daml-api/splice-util-token-standard-wallet/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-util-token-standard-wallet/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-util-token-standard-wallet docs"
+description: "Reference documentation for splice-util-token-standard-wallet docs modules."
+---
+
+# splice-util-token-standard-wallet docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Util.Token.Wallet.MergeDelegation`](/reference/splice-daml-api/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation) | `Module` | Delegation from users to wallet operators allowing them to merge | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Util.Token.Wallet.MergeDelegation](/reference/splice-daml-api/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation)

--- a/docs-main/reference/splice-daml-api/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation.mdx
+++ b/docs-main/reference/splice-daml-api/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation.mdx
@@ -1,0 +1,483 @@
+---
+title: "Splice.Util.Token.Wallet.MergeDelegation"
+description: "Reference documentation for Daml module Splice.Util.Token.Wallet.MergeDelegation."
+---
+
+<a id="module-splice-util-token-wallet-mergedelegation-69903"></a>
+
+# Splice.Util.Token.Wallet.MergeDelegation
+
+Delegation from users to wallet operators allowing them to merge
+
+their token standard holdings; and optionally transfer tokens from
+
+the operator to the user as part of the merge operation, e.g., for
+
+efficiently implementing extraTransfers.
+
+The main reasons for using this merge delegation infrastructure are:
+
+- keeping the number of holdings low to reduce storage and compute cost
+
+on the validator node hosting them
+
+- batching operations to execute them more efficiently both in terms
+
+of traffic spend and throughput
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmergeresult-21039"></a>
+
+### `data BatchMergeUtility_BatchMergeResult`
+
+Constructors:
+
+<a id="constr-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmergeresult-14556"></a>
+- `BatchMergeUtility_BatchMergeResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| results | [MergeDelegation_MergeResult] | Results of each individual merge delegation call. |
+| operatorChangeMap | InstrumentHoldingMap | Change holdings for the operator after executing extra transfers. |
+
+Instances:
+
+- `instance Eq BatchMergeUtility_BatchMergeResult`
+- `instance Show BatchMergeUtility_BatchMergeResult`
+- `instance GetField operatorChangeMap BatchMergeUtility_BatchMergeResult InstrumentHoldingMap`
+- `instance GetField results BatchMergeUtility_BatchMergeResult [MergeDelegation_MergeResult]`
+- `instance SetField operatorChangeMap BatchMergeUtility_BatchMergeResult InstrumentHoldingMap`
+- `instance SetField results BatchMergeUtility_BatchMergeResult [MergeDelegation_MergeResult]`
+- `instance HasExercise BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult`
+- `instance HasFromAnyChoice BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult`
+- `instance HasToAnyChoice BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult`
+
+<a id="type-splice-util-token-wallet-mergedelegation-featuredapprightcall-44578"></a>
+
+### `data FeaturedAppRightCall`
+
+A call to create featured app markers using a featured app right.
+
+Constructors:
+
+<a id="constr-splice-util-token-wallet-mergedelegation-featuredapprightcall-28365"></a>
+- `FeaturedAppRightCall`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| appRightCid | ContractId FeaturedAppRight |  |
+| beneficiaries | [AppRewardBeneficiary] |  |
+
+Instances:
+
+- `instance Eq FeaturedAppRightCall`
+- `instance Show FeaturedAppRightCall`
+- `instance GetField appRightCid FeaturedAppRightCall (ContractId FeaturedAppRight)`
+- `instance GetField beneficiaries FeaturedAppRightCall [AppRewardBeneficiary]`
+- `instance GetField optFeaturedAppRight MergeDelegation_Merge (Optional FeaturedAppRightCall)`
+- `instance SetField appRightCid FeaturedAppRightCall (ContractId FeaturedAppRight)`
+- `instance SetField beneficiaries FeaturedAppRightCall [AppRewardBeneficiary]`
+- `instance SetField optFeaturedAppRight MergeDelegation_Merge (Optional FeaturedAppRightCall)`
+
+<a id="type-splice-util-token-wallet-mergedelegation-instrumentholdingmap-42719"></a>
+
+### `type InstrumentHoldingMap = Map InstrumentId [ContractId Holding]`
+
+Instances:
+
+- `instance GetField operatorChangeMap BatchMergeUtility_BatchMergeResult InstrumentHoldingMap`
+- `instance SetField operatorChangeMap BatchMergeUtility_BatchMergeResult InstrumentHoldingMap`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationcall-90300"></a>
+
+### `data MergeDelegationCall`
+
+Constructors:
+
+<a id="constr-splice-util-token-wallet-mergedelegation-mergedelegationcall-66961"></a>
+- `MergeDelegationCall`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| delegationCid | ContractId MergeDelegation |  |
+| choiceArg | MergeDelegation_Merge |  |
+
+Instances:
+
+- `instance Eq MergeDelegationCall`
+- `instance Show MergeDelegationCall`
+- `instance GetField choiceArg MergeDelegationCall MergeDelegation_Merge`
+- `instance GetField delegationCid MergeDelegationCall (ContractId MergeDelegation)`
+- `instance GetField mergeCalls BatchMergeUtility_BatchMerge [MergeDelegationCall]`
+- `instance SetField choiceArg MergeDelegationCall MergeDelegation_Merge`
+- `instance SetField delegationCid MergeDelegationCall (ContractId MergeDelegation)`
+- `instance SetField mergeCalls BatchMergeUtility_BatchMerge [MergeDelegationCall]`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalacceptresult-63821"></a>
+
+### `data MergeDelegationProposal_AcceptResult`
+
+Constructors:
+
+<a id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalacceptresult-91086"></a>
+- `MergeDelegationProposal_AcceptResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| mergeDelegationCid | ContractId MergeDelegation |  |
+
+Instances:
+
+- `instance Eq MergeDelegationProposal_AcceptResult`
+- `instance Show MergeDelegationProposal_AcceptResult`
+- `instance GetField mergeDelegationCid MergeDelegationProposal_AcceptResult (ContractId MergeDelegation)`
+- `instance SetField mergeDelegationCid MergeDelegationProposal_AcceptResult (ContractId MergeDelegation)`
+- `instance HasExercise MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult`
+- `instance HasFromAnyChoice MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult`
+- `instance HasToAnyChoice MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalrejectresult-81380"></a>
+
+### `data MergeDelegationProposal_RejectResult`
+
+Dedicated record type to simplify upgrading
+
+Constructors:
+
+<a id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalrejectresult-11455"></a>
+- `MergeDelegationProposal_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | () |  |
+
+Instances:
+
+- `instance Eq MergeDelegationProposal_RejectResult`
+- `instance Show MergeDelegationProposal_RejectResult`
+- `instance GetField result MergeDelegationProposal_RejectResult ()`
+- `instance SetField result MergeDelegationProposal_RejectResult ()`
+- `instance HasExercise MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult`
+- `instance HasFromAnyChoice MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult`
+- `instance HasToAnyChoice MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdrawresult-14389"></a>
+
+### `data MergeDelegationProposal_WithdrawResult`
+
+Dedicated record type to simplify upgrading
+
+Constructors:
+
+<a id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdrawresult-8570"></a>
+- `MergeDelegationProposal_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | () |  |
+
+Instances:
+
+- `instance Eq MergeDelegationProposal_WithdrawResult`
+- `instance Show MergeDelegationProposal_WithdrawResult`
+- `instance GetField result MergeDelegationProposal_WithdrawResult ()`
+- `instance SetField result MergeDelegationProposal_WithdrawResult ()`
+- `instance HasExercise MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult`
+- `instance HasFromAnyChoice MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult`
+- `instance HasToAnyChoice MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationmergeresult-93186"></a>
+
+### `data MergeDelegation_MergeResult`
+
+Constructors:
+
+<a id="constr-splice-util-token-wallet-mergedelegation-mergedelegationmergeresult-31679"></a>
+- `MergeDelegation_MergeResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| optMergeTransferResult | Optional TransferInstructionResult |  |
+| optExtraTransferResult | Optional TransferInstructionResult |  |
+
+Instances:
+
+- `instance Eq MergeDelegation_MergeResult`
+- `instance Show MergeDelegation_MergeResult`
+- `instance GetField optExtraTransferResult MergeDelegation_MergeResult (Optional TransferInstructionResult)`
+- `instance GetField optMergeTransferResult MergeDelegation_MergeResult (Optional TransferInstructionResult)`
+- `instance GetField results BatchMergeUtility_BatchMergeResult [MergeDelegation_MergeResult]`
+- `instance SetField optExtraTransferResult MergeDelegation_MergeResult (Optional TransferInstructionResult)`
+- `instance SetField optMergeTransferResult MergeDelegation_MergeResult (Optional TransferInstructionResult)`
+- `instance SetField results BatchMergeUtility_BatchMergeResult [MergeDelegation_MergeResult]`
+- `instance HasExercise MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult`
+- `instance HasFromAnyChoice MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult`
+- `instance HasToAnyChoice MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationrejectresult-25578"></a>
+
+### `data MergeDelegation_RejectResult`
+
+Dedicated record type to simplify upgrading
+
+Constructors:
+
+<a id="constr-splice-util-token-wallet-mergedelegation-mergedelegationrejectresult-53673"></a>
+- `MergeDelegation_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | () |  |
+
+Instances:
+
+- `instance Eq MergeDelegation_RejectResult`
+- `instance Show MergeDelegation_RejectResult`
+- `instance GetField result MergeDelegation_RejectResult ()`
+- `instance SetField result MergeDelegation_RejectResult ()`
+- `instance HasExercise MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult`
+- `instance HasFromAnyChoice MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult`
+- `instance HasToAnyChoice MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationwithdrawresult-70671"></a>
+
+### `data MergeDelegation_WithdrawResult`
+
+Dedicated record type to simplify upgrading
+
+Constructors:
+
+<a id="constr-splice-util-token-wallet-mergedelegation-mergedelegationwithdrawresult-6896"></a>
+- `MergeDelegation_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| result | () |  |
+
+Instances:
+
+- `instance Eq MergeDelegation_WithdrawResult`
+- `instance Show MergeDelegation_WithdrawResult`
+- `instance GetField result MergeDelegation_WithdrawResult ()`
+- `instance SetField result MergeDelegation_WithdrawResult ()`
+- `instance HasExercise MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult`
+- `instance HasFromAnyChoice MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult`
+- `instance HasToAnyChoice MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult`
+
+<a id="type-splice-util-token-wallet-mergedelegation-transfercall-7536"></a>
+
+### `data TransferCall`
+
+A call to perform a transfer using a transfer factory.
+
+Constructors:
+
+<a id="constr-splice-util-token-wallet-mergedelegation-transfercall-34031"></a>
+- `TransferCall`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| factoryCid | ContractId TransferFactory |  |
+| choiceArg | TransferFactory_Transfer |  |
+
+Instances:
+
+- `instance Eq TransferCall`
+- `instance Show TransferCall`
+- `instance GetField choiceArg TransferCall TransferFactory_Transfer`
+- `instance GetField factoryCid TransferCall (ContractId TransferFactory)`
+- `instance GetField optExtraTransfer MergeDelegation_Merge (Optional TransferCall)`
+- `instance GetField optMergeTransfer MergeDelegation_Merge (Optional TransferCall)`
+- `instance SetField choiceArg TransferCall TransferFactory_Transfer`
+- `instance SetField factoryCid TransferCall (ContractId TransferFactory)`
+- `instance SetField optExtraTransfer MergeDelegation_Merge (Optional TransferCall)`
+- `instance SetField optMergeTransfer MergeDelegation_Merge (Optional TransferCall)`
+
+## Functions
+
+<a id="function-splice-util-token-wallet-mergedelegation-runbatch-68276"></a>
+
+### `runBatch`
+
+```daml
+runBatch : Party -> [MergeDelegationCall] -> InstrumentHoldingMap -> [MergeDelegation_MergeResult] -> Update BatchMergeUtility_BatchMergeResult
+```
+
+Run a batch of token standard transfers.
+
+<a id="function-splice-util-token-wallet-mergedelegation-createactivitymarkerforprovider-74667"></a>
+
+### `createActivityMarkerForProvider`
+
+```daml
+createActivityMarkerForProvider : Party -> FeaturedAppRightCall -> Update ()
+```
+
+<a id="function-splice-util-token-wallet-mergedelegation-checkexpected-33668"></a>
+
+### `checkExpected`
+
+```daml
+checkExpected : (Eq a, Show a) => Text -> a -> a -> Update ()
+```
+
+<a id="function-splice-util-token-wallet-mergedelegation-require-88931"></a>
+
+### `require`
+
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
+
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
+
+## Templates
+
+<a id="type-splice-util-token-wallet-mergedelegation-batchmergeutility-64168"></a>
+
+### Template `BatchMergeUtility`
+
+Utility contract for a operator to execute a batch of merge calls with
+proper threading of the operator's change holdings between the calls that
+involve extra transfers.
+
+Signatories: `operator`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| operator | Party |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `operator`
+
+Returns: `()`
+
+<a id="type-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmerge-8070"></a>
+
+#### Choice `BatchMergeUtility_BatchMerge`
+
+Controllers: `operator`
+
+Returns: `BatchMergeUtility_BatchMergeResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| mergeCalls | [MergeDelegationCall] |  |
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegation-14952"></a>
+
+### Template `MergeDelegation`
+
+The right for a operator like the wallet app operator to merge token
+standard holdings on behalf of a token owner.
+
+Signatories: `owner`, `operator`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| operator | Party | Operator allowed to merge holdings. |
+| owner | Party | Owner delegating their right. |
+| meta | Metadata | Metadata about the delegation, used for extensibility. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `owner`, `operator`
+
+Returns: `()`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationmerge-40083"></a>
+
+#### Choice `MergeDelegation_Merge`
+
+Controllers: `operator`
+
+Returns: `MergeDelegation_MergeResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| optMergeTransfer | Optional TransferCall | The self-transfer to merge holdings for the owner.<br/><br/>Optional to allow for an extra transfer to be executed when the<br/><br/>owner does not yet have any holdings.<br/><br/>At least one of optMergeTransfer or optExtraTransfer must be provided. |
+| optExtraTransfer | Optional TransferCall | An optional extra transfer from the operator to the user to execute<br/><br/>as part of the merge operation. The amount of the self-transfer will be<br/><br/>increased by the amount of the extra transfer, and the new input holdings from the<br/><br/>extra transfer will be added to the self-transfer's input holdings.<br/><br/>These extra transfers can for example be used to efficiently<br/><br/>implement extraTransfers or reward distributions as part of the merge<br/><br/>operation.<br/><br/>Note that extra transfers only work for users that have preapproved<br/><br/>incoming transfers from the operator. Therefore there is no<br/><br/>additional restriction on the merge delegation to let users decide<br/><br/>whether to allow or disallow those transfers as it is already<br/><br/>controlled through the preapproval. |
+| optFeaturedAppRight | Optional FeaturedAppRightCall | The featured app right to use to feature the operator's merging activity. |
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationreject-58487"></a>
+
+#### Choice `MergeDelegation_Reject`
+
+Controllers: `operator`
+
+Returns: `MergeDelegation_RejectResult`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationwithdraw-32286"></a>
+
+#### Choice `MergeDelegation_Withdraw`
+
+Controllers: `owner`
+
+Returns: `MergeDelegation_WithdrawResult`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposal-17546"></a>
+
+### Template `MergeDelegationProposal`
+
+Proposal by the user to setup a merge delegation.
+
+Signatories: `(DA.Internal.Record.getField @"owner" delegation)`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| delegation | MergeDelegation | The delegation to be created if accepted. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `(DA.Internal.Record.getField @"owner" delegation)`
+
+Returns: `()`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalaccept-29492"></a>
+
+#### Choice `MergeDelegationProposal_Accept`
+
+Controllers: `(DA.Internal.Record.getField @"operator" delegation)`
+
+Returns: `MergeDelegationProposal_AcceptResult`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalreject-90901"></a>
+
+#### Choice `MergeDelegationProposal_Reject`
+
+Controllers: `(DA.Internal.Record.getField @"operator" delegation)`
+
+Returns: `MergeDelegationProposal_RejectResult`
+
+<a id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdraw-80248"></a>
+
+#### Choice `MergeDelegationProposal_Withdraw`
+
+Controllers: `(DA.Internal.Record.getField @"owner" delegation)`
+
+Returns: `MergeDelegationProposal_WithdrawResult`

--- a/docs-main/reference/splice-daml-api/splice-util/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-util/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-util docs"
+description: "Reference documentation for splice-util docs modules."
+---
+
+# splice-util docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Util`](/reference/splice-daml-api/splice-util/splice-util) | `Module` | Utility functions shared across all splice apps. | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.Util](/reference/splice-daml-api/splice-util/splice-util)

--- a/docs-main/reference/splice-daml-api/splice-util/splice-util.mdx
+++ b/docs-main/reference/splice-daml-api/splice-util/splice-util.mdx
@@ -1,0 +1,247 @@
+---
+title: "Splice.Util"
+description: "Reference documentation for Daml module Splice.Util."
+---
+
+<a id="module-splice-util-50740"></a>
+
+# Splice.Util
+
+Utility functions shared across all splice apps.
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Typeclasses
+
+<a id="class-splice-util-hascheckedfetch-36555"></a>
+
+### `class (Show t, Eq cgid, Show cgid) => HasCheckedFetch t cgid`
+
+Contracts typically come in groups. For example, all contracts managed by a specific DSO party.
+
+We aim to always fetch with a specific contract group identifier to ensure that we do not mixup
+contracts from different groups.
+
+Note that we are not requiring `HasFetch` here, so that we can use this typeclass also for
+contract groups that are not templates, e.g., interface views.
+
+Methods:
+
+- `contractGroupId : t -> cgid`
+
+<a id="class-splice-util-patchable-41062"></a>
+
+### `class Patchable a`
+
+A type class for patching values. Used in particular for changing only a subset of
+fields in a config value.
+
+Methods:
+
+- `patch : a -> a -> a -> a`
+  For records, `patch new base current` should set all fields in `current` to their value in `new` iff their value was changed
+  in `new` compared to `base`. For other kinds of values that have field-like values
+  (e.g. Maps with keys) the implementation should match the one for records
+  by analogy.
+
+Instances:
+
+- `instance Patchable Decimal`
+- `instance Patchable Int`
+- `instance Patchable Text`
+- `instance (Ord k, Patchable v) => Patchable (Map k v)`
+- `instance Patchable Party`
+- `instance Patchable Time`
+- `instance Patchable a => Patchable (Optional a)`
+- `instance (Patchable a, Ord a) => Patchable (Set a)`
+- `instance Patchable RelTime`
+
+## Functions
+
+<a id="function-splice-util-requirematchingcontract-54053"></a>
+
+### `requireMatchingContract`
+
+```daml
+requireMatchingContract : (Eq t, Show t, HasFetch t) => ContractId t -> t -> Update ()
+```
+
+Require that a contract-id refers to a specific contract.
+
+<a id="function-splice-util-require-11486"></a>
+
+### `require`
+
+```daml
+require : CanAssert m => Text -> Bool -> m ()
+```
+
+Check whether a required condition is true. If it's not, abort the
+transaction with a message saying that the requirement was not met.
+
+<a id="function-splice-util-fetchchecked-58913"></a>
+
+### `fetchChecked`
+
+```daml
+fetchChecked : (HasFetch t, HasCheckedFetch t cgid) => cgid -> ContractId t -> Update t
+```
+
+Fetch a contract that is part of a specific contract group.
+
+The group is typically chosen by the caller to match its own group, or a more specific group.
+
+<a id="function-splice-util-fetchcheckedinterface-8937"></a>
+
+### `fetchCheckedInterface`
+
+```daml
+fetchCheckedInterface : (HasFetch i, HasInterfaceView i v, HasCheckedFetch v cgid) => cgid -> ContractId i -> Update i
+```
+
+Fetch a contract that is part of a specific contract group defined by its interface view.
+
+The group is typically chosen by the caller to match its own group, or a more specific group.
+
+<a id="function-splice-util-fetchandarchive-96960"></a>
+
+### `fetchAndArchive`
+
+```daml
+fetchAndArchive : (HasFetch t, HasCheckedFetch t cgid, HasArchive t) => cgid -> ContractId t -> Update t
+```
+
+Fetch and archive a contract in one go.
+
+Use this when implementing choices that mutate another contract by
+fetching, archiving, and then creating the updated contract.
+
+<a id="function-splice-util-fetchreferencedata-72475"></a>
+
+### `fetchReferenceData`
+
+```daml
+fetchReferenceData : (HasFetch t, HasCheckedFetch t cgid) => cgid -> ContractId t -> Update t
+```
+
+Fetch a contract that serves as reference data.
+
+Use this whenever you need to fetch a contract that you do not intend to mutate.
+
+<a id="function-splice-util-fetchbutarchivelater-86159"></a>
+
+### `fetchButArchiveLater`
+
+```daml
+fetchButArchiveLater : (HasFetch t, HasCheckedFetch t cgid) => cgid -> ContractId t -> Update t
+```
+
+Fetch a contract that is not reference data, and should be archived later in some cases.
+
+Prefer `fetchAndArchive` over this function, as it avoids forgetting to archive the contract.
+
+<a id="function-splice-util-fetchpublicreferencedata-76996"></a>
+
+### `fetchPublicReferenceData`
+
+```daml
+fetchPublicReferenceData : (HasCheckedFetch t cgid, HasExercise t ch t) => cgid -> ContractId t -> ch -> Update t
+```
+
+Fetch a contract that offers a choice anybody to be read as reference data.
+
+<a id="function-splice-util-fetchuncheckedandarchive-65397"></a>
+
+### `fetchUncheckedAndArchive`
+
+```daml
+fetchUncheckedAndArchive : (HasFetch b, HasArchive b) => ContractId b -> Update b
+```
+
+Fetch and archive a contract in one go.
+
+Use this when implementing choices that mutate another contract by
+fetching, archiving, and then creating the updated contract.
+
+<a id="function-splice-util-fetchuncheckedreferencedata-5520"></a>
+
+### `fetchUncheckedReferenceData`
+
+```daml
+fetchUncheckedReferenceData : HasFetch t => ContractId t -> Update t
+```
+
+Fetch a contract that serves as reference data.
+
+Use this whenever you need to fetch a contract that you do not intend to mutate.
+
+<a id="function-splice-util-fetchuncheckedbutarchivelater-82900"></a>
+
+### `fetchUncheckedButArchiveLater`
+
+```daml
+fetchUncheckedButArchiveLater : HasFetch t => ContractId t -> Update t
+```
+
+Fetch a contract that is not reference data, and should be archived later in some cases.
+
+Prefer `fetchAndArchive` over this function, as it avoids forgetting to archive the contract.
+
+<a id="function-splice-util-potentiallyunsafearchive-47027"></a>
+
+### `potentiallyUnsafeArchive`
+
+```daml
+potentiallyUnsafeArchive : HasArchive t => ContractId t -> Update ()
+```
+
+A more appropriately named version of `archive`.
+
+Please justify all its uses, and where possible prefer `fetchAndArchive`
+so that the contract group identifier is surely performed.
+
+<a id="function-splice-util-patchscalar-11117"></a>
+
+### `patchScalar`
+
+```daml
+patchScalar : Eq a => a -> a -> a -> a
+```
+
+<a id="function-splice-util-patchlistasscalar-47719"></a>
+
+### `patchListAsScalar`
+
+```daml
+patchListAsScalar : Eq a => [a] -> [a] -> [a] -> [a]
+```
+
+<a id="function-splice-util-patchlistasset-9274"></a>
+
+### `patchListAsSet`
+
+```daml
+patchListAsSet : (Patchable a, Ord a) => [a] -> [a] -> [a] -> [a]
+```
+
+<a id="function-splice-util-deprecatedchoice-19928"></a>
+
+### `deprecatedChoice`
+
+```daml
+deprecatedChoice : Text -> Text -> Text -> Update a
+```

--- a/docs-main/reference/splice-daml-api/splice-validator-lifecycle/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-validator-lifecycle/index.mdx
@@ -1,0 +1,24 @@
+---
+title: "splice-validator-lifecycle docs"
+description: "Reference documentation for splice-validator-lifecycle docs modules."
+---
+
+# splice-validator-lifecycle docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.ValidatorOnboarding`](/reference/splice-daml-api/splice-validator-lifecycle/splice-validatoronboarding) | `Module` | - | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 1 | 0 | 0 |
+
+## Reference
+
+- [Splice.ValidatorOnboarding](/reference/splice-daml-api/splice-validator-lifecycle/splice-validatoronboarding)

--- a/docs-main/reference/splice-daml-api/splice-validator-lifecycle/splice-validatoronboarding.mdx
+++ b/docs-main/reference/splice-daml-api/splice-validator-lifecycle/splice-validatoronboarding.mdx
@@ -1,0 +1,140 @@
+---
+title: "Splice.ValidatorOnboarding"
+description: "Reference documentation for Daml module Splice.ValidatorOnboarding."
+---
+
+<a id="module-splice-validatoronboarding-49132"></a>
+
+# Splice.ValidatorOnboarding
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-validatoronboarding-validatoronboardingexpireresult-28676"></a>
+
+### `data ValidatorOnboarding_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-validatoronboarding-validatoronboardingexpireresult-66123"></a>
+- `ValidatorOnboarding_ExpireResult`
+
+Instances:
+
+- `instance HasExercise ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult`
+- `instance HasFromAnyChoice ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult`
+- `instance HasToAnyChoice ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult`
+
+<a id="type-splice-validatoronboarding-validatoronboardingmatchresult-68567"></a>
+
+### `data ValidatorOnboarding_MatchResult`
+
+Constructors:
+
+<a id="constr-splice-validatoronboarding-validatoronboardingmatchresult-91618"></a>
+- `ValidatorOnboarding_MatchResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| usedSecret | ContractId UsedSecret |  |
+
+Instances:
+
+- `instance GetField usedSecret ValidatorOnboarding_MatchResult (ContractId UsedSecret)`
+- `instance SetField usedSecret ValidatorOnboarding_MatchResult (ContractId UsedSecret)`
+- `instance HasExercise ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult`
+- `instance HasFromAnyChoice ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult`
+- `instance HasToAnyChoice ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult`
+
+## Templates
+
+<a id="type-splice-validatoronboarding-usedsecret-49603"></a>
+
+### Template `UsedSecret`
+
+Template used by a sponsoring SV node for enforcing that an onboarding secret is used only once.
+
+Signatories: `sv`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party | The SV node that sponsored the onboarding. |
+| secret | Text | An onboarding secret. |
+| validator | Party | The validator that onboarded using the secret. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `sv`
+
+Returns: `()`
+
+<a id="type-splice-validatoronboarding-validatoronboarding-92198"></a>
+
+### Template `ValidatorOnboarding`
+
+Template used by a sponsoring SV node to keep track of the onboarding of a validator candidate.
+We use a secret for authenticating the candidate once he has set up his participant.
+The secret should be unique, contain at least 256-bits of entropy,
+and be communicated to the candidate via a secure off-ledger channel.
+Once the candidate has set up his participants, he contacts the SV node via an API call
+and presents his secret, which triggers the SV node to add him as a validator
+(as a separate on-ledger action for reducing coupling with the DSO governance contracts).
+
+Signatories: `sv`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sv | Party | The SV node sponsoring this onboarding. |
+| candidateSecret | Text | The unique secret given to the candidate. |
+| expiresAt | Time | Can be used by the SV for time-bounding the offer. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `sv`
+
+Returns: `()`
+
+<a id="type-splice-validatoronboarding-validatoronboardingexpire-7877"></a>
+
+#### Choice `ValidatorOnboarding_Expire`
+
+Controllers: `sv`
+
+Returns: `ValidatorOnboarding_ExpireResult`
+
+<a id="type-splice-validatoronboarding-validatoronboardingmatch-2118"></a>
+
+#### Choice `ValidatorOnboarding_Match`
+
+Controllers: `sv`
+
+Returns: `ValidatorOnboarding_MatchResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| providedSecret | Text |  |
+| validator | Party |  |

--- a/docs-main/reference/splice-daml-api/splice-wallet-payments/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-wallet-payments/index.mdx
@@ -1,0 +1,26 @@
+---
+title: "splice-wallet-payments docs"
+description: "Reference documentation for splice-wallet-payments docs modules."
+---
+
+# splice-wallet-payments docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Wallet.Payment`](/reference/splice-daml-api/splice-wallet-payments/splice-wallet-payment) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.Wallet.Subscriptions`](/reference/splice-daml-api/splice-wallet-payments/splice-wallet-subscriptions) | `Module` | - | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 2 | 0 | 0 |
+
+## Reference
+
+- [Splice.Wallet.Payment](/reference/splice-daml-api/splice-wallet-payments/splice-wallet-payment)
+- [Splice.Wallet.Subscriptions](/reference/splice-daml-api/splice-wallet-payments/splice-wallet-subscriptions)

--- a/docs-main/reference/splice-daml-api/splice-wallet-payments/splice-wallet-payment.mdx
+++ b/docs-main/reference/splice-daml-api/splice-wallet-payments/splice-wallet-payment.mdx
@@ -1,0 +1,500 @@
+---
+title: "Splice.Wallet.Payment"
+description: "Reference documentation for Daml module Splice.Wallet.Payment."
+---
+
+<a id="module-splice-wallet-payment-75803"></a>
+
+# Splice.Wallet.Payment
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-wallet-payment-acceptedapppaymentcollectresult-5751"></a>
+
+### `data AcceptedAppPayment_CollectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-acceptedapppaymentcollectresult-53822"></a>
+- `AcceptedAppPayment_CollectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiverAmulets | [(Party, ContractId Amulet)] |  |
+
+Instances:
+
+- `instance GetField receiverAmulets AcceptedAppPayment_CollectResult [(Party, ContractId Amulet)]`
+- `instance SetField receiverAmulets AcceptedAppPayment_CollectResult [(Party, ContractId Amulet)]`
+- `instance HasExercise AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult`
+- `instance HasFromAnyChoice AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult`
+- `instance HasToAnyChoice AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult`
+
+<a id="type-splice-wallet-payment-acceptedapppaymentexpireresult-93793"></a>
+
+### `data AcceptedAppPayment_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-acceptedapppaymentexpireresult-95234"></a>
+- `AcceptedAppPayment_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amulet | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amulet AcceptedAppPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amulet AcceptedAppPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult`
+- `instance HasFromAnyChoice AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult`
+- `instance HasToAnyChoice AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult`
+
+<a id="type-splice-wallet-payment-acceptedapppaymentrejectresult-56853"></a>
+
+### `data AcceptedAppPayment_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-acceptedapppaymentrejectresult-75142"></a>
+- `AcceptedAppPayment_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amulet | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amulet AcceptedAppPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amulet AcceptedAppPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult`
+- `instance HasFromAnyChoice AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult`
+- `instance HasToAnyChoice AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult`
+
+<a id="type-splice-wallet-payment-apppaymentrequestacceptresult-82387"></a>
+
+### `data AppPaymentRequest_AcceptResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-apppaymentrequestacceptresult-79598"></a>
+- `AppPaymentRequest_AcceptResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| acceptedPayment | ContractId AcceptedAppPayment |  |
+| senderChangeAmulet | Optional (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField acceptedPayment AppPaymentRequest_AcceptResult (ContractId AcceptedAppPayment)`
+- `instance GetField senderChangeAmulet AppPaymentRequest_AcceptResult (Optional (ContractId Amulet))`
+- `instance SetField acceptedPayment AppPaymentRequest_AcceptResult (ContractId AcceptedAppPayment)`
+- `instance SetField senderChangeAmulet AppPaymentRequest_AcceptResult (Optional (ContractId Amulet))`
+- `instance HasExercise AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult`
+- `instance HasFromAnyChoice AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult`
+- `instance HasToAnyChoice AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult`
+
+<a id="type-splice-wallet-payment-apppaymentrequestexpireresult-63922"></a>
+
+### `data AppPaymentRequest_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-apppaymentrequestexpireresult-76475"></a>
+- `AppPaymentRequest_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedAppPayment | ContractId TerminatedAppPayment |  |
+
+Instances:
+
+- `instance GetField terminatedAppPayment AppPaymentRequest_ExpireResult (ContractId TerminatedAppPayment)`
+- `instance SetField terminatedAppPayment AppPaymentRequest_ExpireResult (ContractId TerminatedAppPayment)`
+- `instance HasExercise AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult`
+- `instance HasFromAnyChoice AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult`
+- `instance HasToAnyChoice AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult`
+
+<a id="type-splice-wallet-payment-apppaymentrequestrejectresult-75838"></a>
+
+### `data AppPaymentRequest_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-apppaymentrequestrejectresult-65943"></a>
+- `AppPaymentRequest_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedAppPayment | ContractId TerminatedAppPayment |  |
+
+Instances:
+
+- `instance GetField terminatedAppPayment AppPaymentRequest_RejectResult (ContractId TerminatedAppPayment)`
+- `instance SetField terminatedAppPayment AppPaymentRequest_RejectResult (ContractId TerminatedAppPayment)`
+- `instance HasExercise AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult`
+- `instance HasFromAnyChoice AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult`
+- `instance HasToAnyChoice AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult`
+
+<a id="type-splice-wallet-payment-apppaymentrequestwithdrawresult-19567"></a>
+
+### `data AppPaymentRequest_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-apppaymentrequestwithdrawresult-24638"></a>
+- `AppPaymentRequest_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedAppPayment | ContractId TerminatedAppPayment |  |
+
+Instances:
+
+- `instance GetField terminatedAppPayment AppPaymentRequest_WithdrawResult (ContractId TerminatedAppPayment)`
+- `instance SetField terminatedAppPayment AppPaymentRequest_WithdrawResult (ContractId TerminatedAppPayment)`
+- `instance HasExercise AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult`
+- `instance HasFromAnyChoice AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult`
+- `instance HasToAnyChoice AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult`
+
+<a id="type-splice-wallet-payment-paymentamount-12698"></a>
+
+### `data PaymentAmount`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-paymentamount-44729"></a>
+- `PaymentAmount`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amount | Decimal |  |
+| unit | Unit |  |
+
+Instances:
+
+- `instance Eq PaymentAmount`
+- `instance Ord PaymentAmount`
+- `instance Show PaymentAmount`
+- `instance GetField amount PaymentAmount Decimal`
+- `instance GetField amount ReceiverAmount PaymentAmount`
+- `instance GetField paymentAmount SubscriptionPayData PaymentAmount`
+- `instance GetField unit PaymentAmount Unit`
+- `instance SetField amount PaymentAmount Decimal`
+- `instance SetField amount ReceiverAmount PaymentAmount`
+- `instance SetField paymentAmount SubscriptionPayData PaymentAmount`
+- `instance SetField unit PaymentAmount Unit`
+
+<a id="type-splice-wallet-payment-receiveramount-43100"></a>
+
+### `data ReceiverAmount`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-receiveramount-91649"></a>
+- `ReceiverAmount`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| amount | PaymentAmount |  |
+
+Instances:
+
+- `instance Eq ReceiverAmount`
+- `instance Ord ReceiverAmount`
+- `instance Show ReceiverAmount`
+- `instance GetField amount ReceiverAmount PaymentAmount`
+- `instance GetField receiver ReceiverAmount Party`
+- `instance GetField receiverAmounts AppPaymentRequest [ReceiverAmount]`
+- `instance SetField amount ReceiverAmount PaymentAmount`
+- `instance SetField receiver ReceiverAmount Party`
+- `instance SetField receiverAmounts AppPaymentRequest [ReceiverAmount]`
+
+<a id="type-splice-wallet-payment-receiveramulet-61330"></a>
+
+### `data ReceiverAmulet`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-receiveramulet-72427"></a>
+- `ReceiverAmulet`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| lockedAmulet | ContractId LockedAmulet |  |
+
+Instances:
+
+- `instance Eq ReceiverAmulet`
+- `instance Show ReceiverAmulet`
+- `instance GetField lockedAmulet ReceiverAmulet (ContractId LockedAmulet)`
+- `instance GetField receiver ReceiverAmulet Party`
+- `instance SetField lockedAmulet ReceiverAmulet (ContractId LockedAmulet)`
+- `instance SetField receiver ReceiverAmulet Party`
+
+<a id="type-splice-wallet-payment-receiveramuletamount-72096"></a>
+
+### `data ReceiverAmuletAmount`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-receiveramuletamount-97653"></a>
+- `ReceiverAmuletAmount`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| amuletAmount | Decimal |  |
+
+Instances:
+
+- `instance Eq ReceiverAmuletAmount`
+- `instance Ord ReceiverAmuletAmount`
+- `instance Show ReceiverAmuletAmount`
+- `instance GetField amuletAmount ReceiverAmuletAmount Decimal`
+- `instance GetField amuletReceiverAmounts AcceptedAppPayment [ReceiverAmuletAmount]`
+- `instance GetField receiver ReceiverAmuletAmount Party`
+- `instance SetField amuletAmount ReceiverAmuletAmount Decimal`
+- `instance SetField amuletReceiverAmounts AcceptedAppPayment [ReceiverAmuletAmount]`
+- `instance SetField receiver ReceiverAmuletAmount Party`
+
+<a id="type-splice-wallet-payment-unit-67175"></a>
+
+### `data Unit`
+
+Constructors:
+
+<a id="constr-splice-wallet-payment-usdunit-55511"></a>
+- `USDUnit`
+<a id="constr-splice-wallet-payment-amuletunit-84830"></a>
+- `AmuletUnit`
+<a id="constr-splice-wallet-payment-extunit-45462"></a>
+- `ExtUnit`
+Extension constructor to work around the current lack of upgrading for variants in Daml 3.0.
+Will serve as the default value in a containing record in case of an extension.
+
+Instances:
+
+- `instance Eq Unit`
+- `instance Ord Unit`
+- `instance Show Unit`
+- `instance GetField unit PaymentAmount Unit`
+- `instance SetField unit PaymentAmount Unit`
+
+## Functions
+
+<a id="function-splice-wallet-payment-paymentamounttoamulet-10099"></a>
+
+### `paymentAmountToAmulet`
+
+```daml
+paymentAmountToAmulet : Party -> OpenMiningRound -> PaymentAmount -> Update Decimal
+```
+
+<a id="function-splice-wallet-payment-receiveramounttoamuletreceiveramount-72316"></a>
+
+### `receiverAmountToAmuletReceiverAmount`
+
+```daml
+receiverAmountToAmuletReceiverAmount : Party -> OpenMiningRound -> ReceiverAmount -> Update ReceiverAmuletAmount
+```
+
+<a id="function-splice-wallet-payment-apppaymentrequestreceivers-97989"></a>
+
+### `appPaymentRequest_receivers`
+
+```daml
+appPaymentRequest_receivers : AppPaymentRequest -> [Party]
+```
+
+<a id="function-splice-wallet-payment-unzipreceiveramulets-38827"></a>
+
+### `unzipReceiverAmulets`
+
+```daml
+unzipReceiverAmulets : [ReceiverAmulet] -> ([Party], [ContractId LockedAmulet])
+```
+
+<a id="function-splice-wallet-payment-mkreceiveroutput-26465"></a>
+
+### `mkReceiverOutput`
+
+```daml
+mkReceiverOutput : ReceiverAmuletAmount -> TransferOutput
+```
+
+## Templates
+
+<a id="type-splice-wallet-payment-acceptedapppayment-18193"></a>
+
+### Template `AcceptedAppPayment`
+
+Signatories: `sender`, `provider`, `map (\ r -> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| amuletReceiverAmounts | [ReceiverAmuletAmount] |  |
+| provider | Party |  |
+| dso | Party |  |
+| lockedAmulet | ContractId LockedAmulet |  |
+| round | Round | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets. |
+| reference | ContractId AppPaymentRequest | The contract id of the original payment request to correlate it. Note that the contract will no longer be active. |
+
+Choices:
+
+<a id="type-splice-wallet-payment-acceptedapppaymentcollect-62282"></a>
+
+#### Choice `AcceptedAppPayment_Collect`
+
+Controllers: `signatory this`
+
+Returns: `AcceptedAppPayment_CollectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | AppTransferContext |  |
+
+<a id="type-splice-wallet-payment-acceptedapppaymentexpire-51092"></a>
+
+#### Choice `AcceptedAppPayment_Expire`
+
+Controllers: `sender`
+
+Returns: `AcceptedAppPayment_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | AppTransferContext |  |
+
+<a id="type-splice-wallet-payment-acceptedapppaymentreject-83760"></a>
+
+#### Choice `AcceptedAppPayment_Reject`
+
+Controllers: `map (\ r -> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts`
+
+Returns: `AcceptedAppPayment_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | AppTransferContext |  |
+
+#### Choice `Archive`
+
+Controllers: `sender`, `provider`, `map (\ r -> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts`
+
+Returns: `()`
+
+<a id="type-splice-wallet-payment-apppaymentrequest-31524"></a>
+
+### Template `AppPaymentRequest`
+
+Signatories: `sender`, `appPaymentRequest_receivers this`, `provider`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party | The party that should pay. |
+| receiverAmounts | [ReceiverAmount] | Pairs of (party, amount) requesting to be paid. |
+| provider | Party | The app provider; receives usage rewards. |
+| dso | Party | The DSO party of the amulet that should be used to make the payment. |
+| expiresAt | Time | When the payment request expires. |
+| description | Text | Human readable description of the reason / good for which the payment is requested. |
+
+Choices:
+
+<a id="type-splice-wallet-payment-apppaymentrequestaccept-83530"></a>
+
+#### Choice `AppPaymentRequest_Accept`
+
+Controllers: `sender`, `walletProvider`
+
+Returns: `AppPaymentRequest_AcceptResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputs | [TransferInput] |  |
+| context | PaymentTransferContext |  |
+| walletProvider | Party |  |
+
+<a id="type-splice-wallet-payment-apppaymentrequestexpire-10515"></a>
+
+#### Choice `AppPaymentRequest_Expire`
+
+Controllers: `actor`
+
+Returns: `AppPaymentRequest_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+
+<a id="type-splice-wallet-payment-apppaymentrequestreject-66391"></a>
+
+#### Choice `AppPaymentRequest_Reject`
+
+Controllers: `sender`
+
+Returns: `AppPaymentRequest_RejectResult`
+
+<a id="type-splice-wallet-payment-apppaymentrequestwithdraw-31618"></a>
+
+#### Choice `AppPaymentRequest_Withdraw`
+
+Controllers: `appPaymentRequest_receivers this`
+
+Returns: `AppPaymentRequest_WithdrawResult`
+
+#### Choice `Archive`
+
+Controllers: `sender`, `appPaymentRequest_receivers this`, `provider`
+
+Returns: `()`
+
+<a id="type-splice-wallet-payment-terminatedapppayment-49143"></a>
+
+### Template `TerminatedAppPayment`
+
+Instead of just archiving payments (e.g. when the request is accepted) we create an
+TerminatedAppPayment contract. This allows the coordinating workflow to archive its own contracts once the app-payment workflow terminated.
+
+Signatories: `sender`, `provider`, `receivers`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| provider | Party |  |
+| receivers | [Party] |  |
+| reference | ContractId AppPaymentRequest |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `sender`, `provider`, `receivers`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-wallet-payments/splice-wallet-subscriptions.mdx
+++ b/docs-main/reference/splice-daml-api/splice-wallet-payments/splice-wallet-subscriptions.mdx
@@ -1,0 +1,752 @@
+---
+title: "Splice.Wallet.Subscriptions"
+description: "Reference documentation for Daml module Splice.Wallet.Subscriptions."
+---
+
+<a id="module-splice-wallet-subscriptions-81141"></a>
+
+# Splice.Wallet.Subscriptions
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-wallet-subscriptions-subscriptiondata-61040"></a>
+
+### `data SubscriptionData`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptiondata-87477"></a>
+- `SubscriptionData`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party | The party that pays. |
+| receiver | Party | The party that receives payment. |
+| provider | Party | The app provider. |
+| dso | Party |  |
+| description | Text |  |
+
+Instances:
+
+- `instance Eq SubscriptionData`
+- `instance Show SubscriptionData`
+- `instance GetField description SubscriptionData Text`
+- `instance GetField dso SubscriptionData Party`
+- `instance GetField provider SubscriptionData Party`
+- `instance GetField receiver SubscriptionData Party`
+- `instance GetField sender SubscriptionData Party`
+- `instance GetField subscriptionData Subscription SubscriptionData`
+- `instance GetField subscriptionData SubscriptionIdleState SubscriptionData`
+- `instance GetField subscriptionData SubscriptionInitialPayment SubscriptionData`
+- `instance GetField subscriptionData SubscriptionPayment SubscriptionData`
+- `instance GetField subscriptionData SubscriptionRequest SubscriptionData`
+- `instance GetField subscriptionData TerminatedSubscription SubscriptionData`
+- `instance SetField description SubscriptionData Text`
+- `instance SetField dso SubscriptionData Party`
+- `instance SetField provider SubscriptionData Party`
+- `instance SetField receiver SubscriptionData Party`
+- `instance SetField sender SubscriptionData Party`
+- `instance SetField subscriptionData Subscription SubscriptionData`
+- `instance SetField subscriptionData SubscriptionIdleState SubscriptionData`
+- `instance SetField subscriptionData SubscriptionInitialPayment SubscriptionData`
+- `instance SetField subscriptionData SubscriptionPayment SubscriptionData`
+- `instance SetField subscriptionData SubscriptionRequest SubscriptionData`
+- `instance SetField subscriptionData TerminatedSubscription SubscriptionData`
+
+<a id="type-splice-wallet-subscriptions-subscriptionidlestatecancelsubscriptionresult-53096"></a>
+
+### `data SubscriptionIdleState_CancelSubscriptionResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptionidlestatecancelsubscriptionresult-80217"></a>
+- `SubscriptionIdleState_CancelSubscriptionResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
+
+Instances:
+
+- `instance GetField terminatedSubscription SubscriptionIdleState_CancelSubscriptionResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription SubscriptionIdleState_CancelSubscriptionResult (ContractId TerminatedSubscription)`
+- `instance HasExercise SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult`
+- `instance HasFromAnyChoice SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult`
+- `instance HasToAnyChoice SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionidlestateexpiresubscriptionresult-84335"></a>
+
+### `data SubscriptionIdleState_ExpireSubscriptionResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptionidlestateexpiresubscriptionresult-85758"></a>
+- `SubscriptionIdleState_ExpireSubscriptionResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
+
+Instances:
+
+- `instance GetField terminatedSubscription SubscriptionIdleState_ExpireSubscriptionResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription SubscriptionIdleState_ExpireSubscriptionResult (ContractId TerminatedSubscription)`
+- `instance HasExercise SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult`
+- `instance HasFromAnyChoice SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult`
+- `instance HasToAnyChoice SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionidlestatemakepaymentresult-27466"></a>
+
+### `data SubscriptionIdleState_MakePaymentResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptionidlestatemakepaymentresult-79353"></a>
+- `SubscriptionIdleState_MakePaymentResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionPayment | ContractId SubscriptionPayment |  |
+| senderChange | Optional (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField senderChange SubscriptionIdleState_MakePaymentResult (Optional (ContractId Amulet))`
+- `instance GetField subscriptionPayment SubscriptionIdleState_MakePaymentResult (ContractId SubscriptionPayment)`
+- `instance SetField senderChange SubscriptionIdleState_MakePaymentResult (Optional (ContractId Amulet))`
+- `instance SetField subscriptionPayment SubscriptionIdleState_MakePaymentResult (ContractId SubscriptionPayment)`
+- `instance HasExercise SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult`
+- `instance HasFromAnyChoice SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult`
+- `instance HasToAnyChoice SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptioninitialpaymentcollectresult-97286"></a>
+
+### `data SubscriptionInitialPayment_CollectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentcollectresult-66575"></a>
+- `SubscriptionInitialPayment_CollectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscription | ContractId Subscription |  |
+| subscriptionState | ContractId SubscriptionIdleState |  |
+| amulet | ContractId Amulet |  |
+
+Instances:
+
+- `instance GetField amulet SubscriptionInitialPayment_CollectResult (ContractId Amulet)`
+- `instance GetField subscription SubscriptionInitialPayment_CollectResult (ContractId Subscription)`
+- `instance GetField subscriptionState SubscriptionInitialPayment_CollectResult (ContractId SubscriptionIdleState)`
+- `instance SetField amulet SubscriptionInitialPayment_CollectResult (ContractId Amulet)`
+- `instance SetField subscription SubscriptionInitialPayment_CollectResult (ContractId Subscription)`
+- `instance SetField subscriptionState SubscriptionInitialPayment_CollectResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult`
+- `instance HasFromAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult`
+- `instance HasToAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptioninitialpaymentexpireresult-71466"></a>
+
+### `data SubscriptionInitialPayment_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentexpireresult-14633"></a>
+- `SubscriptionInitialPayment_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amuletSum SubscriptionInitialPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum SubscriptionInitialPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult`
+- `instance HasFromAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult`
+- `instance HasToAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptioninitialpaymentrejectresult-97550"></a>
+
+### `data SubscriptionInitialPayment_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentrejectresult-64365"></a>
+- `SubscriptionInitialPayment_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amuletSum SubscriptionInitialPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField amuletSum SubscriptionInitialPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance HasExercise SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult`
+- `instance HasFromAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult`
+- `instance HasToAnyChoice SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionpaydata-96623"></a>
+
+### `data SubscriptionPayData`
+
+Payment-related properties. Expected to be mutated rarely.
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptionpaydata-90180"></a>
+- `SubscriptionPayData`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| paymentAmount | PaymentAmount | What amount of amulet is due on each interval. |
+| paymentInterval | RelTime | At which intervals payments should be made. |
+| paymentDuration | RelTime | The time available to the sender to initiate a payment; they can initiate the payment this much before the end of the current interval. |
+
+Instances:
+
+- `instance Eq SubscriptionPayData`
+- `instance Show SubscriptionPayData`
+- `instance GetField payData SubscriptionIdleState SubscriptionPayData`
+- `instance GetField payData SubscriptionInitialPayment SubscriptionPayData`
+- `instance GetField payData SubscriptionPayment SubscriptionPayData`
+- `instance GetField payData SubscriptionRequest SubscriptionPayData`
+- `instance GetField paymentAmount SubscriptionPayData PaymentAmount`
+- `instance GetField paymentDuration SubscriptionPayData RelTime`
+- `instance GetField paymentInterval SubscriptionPayData RelTime`
+- `instance SetField payData SubscriptionIdleState SubscriptionPayData`
+- `instance SetField payData SubscriptionInitialPayment SubscriptionPayData`
+- `instance SetField payData SubscriptionPayment SubscriptionPayData`
+- `instance SetField payData SubscriptionRequest SubscriptionPayData`
+- `instance SetField paymentAmount SubscriptionPayData PaymentAmount`
+- `instance SetField paymentDuration SubscriptionPayData RelTime`
+- `instance SetField paymentInterval SubscriptionPayData RelTime`
+
+<a id="type-splice-wallet-subscriptions-subscriptionpaymentcollectresult-94269"></a>
+
+### `data SubscriptionPayment_CollectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptionpaymentcollectresult-9234"></a>
+- `SubscriptionPayment_CollectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionState | ContractId SubscriptionIdleState |  |
+| amulet | ContractId Amulet |  |
+
+Instances:
+
+- `instance GetField amulet SubscriptionPayment_CollectResult (ContractId Amulet)`
+- `instance GetField subscriptionState SubscriptionPayment_CollectResult (ContractId SubscriptionIdleState)`
+- `instance SetField amulet SubscriptionPayment_CollectResult (ContractId Amulet)`
+- `instance SetField subscriptionState SubscriptionPayment_CollectResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult`
+- `instance HasFromAnyChoice SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult`
+- `instance HasToAnyChoice SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionpaymentexpireresult-84183"></a>
+
+### `data SubscriptionPayment_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptionpaymentexpireresult-46758"></a>
+- `SubscriptionPayment_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionState | ContractId SubscriptionIdleState |  |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amuletSum SubscriptionPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField subscriptionState SubscriptionPayment_ExpireResult (ContractId SubscriptionIdleState)`
+- `instance SetField amuletSum SubscriptionPayment_ExpireResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField subscriptionState SubscriptionPayment_ExpireResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult`
+- `instance HasFromAnyChoice SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult`
+- `instance HasToAnyChoice SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionpaymentrejectresult-80731"></a>
+
+### `data SubscriptionPayment_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptionpaymentrejectresult-20586"></a>
+- `SubscriptionPayment_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionState | ContractId SubscriptionIdleState |  |
+| amuletSum | AmuletCreateSummary (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField amuletSum SubscriptionPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance GetField subscriptionState SubscriptionPayment_RejectResult (ContractId SubscriptionIdleState)`
+- `instance SetField amuletSum SubscriptionPayment_RejectResult (AmuletCreateSummary (ContractId Amulet))`
+- `instance SetField subscriptionState SubscriptionPayment_RejectResult (ContractId SubscriptionIdleState)`
+- `instance HasExercise SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult`
+- `instance HasFromAnyChoice SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult`
+- `instance HasToAnyChoice SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionrequestacceptandmakepaymentresult-1166"></a>
+
+### `data SubscriptionRequest_AcceptAndMakePaymentResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptionrequestacceptandmakepaymentresult-32571"></a>
+- `SubscriptionRequest_AcceptAndMakePaymentResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionPayment | ContractId SubscriptionInitialPayment |  |
+| senderChange | Optional (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField senderChange SubscriptionRequest_AcceptAndMakePaymentResult (Optional (ContractId Amulet))`
+- `instance GetField subscriptionPayment SubscriptionRequest_AcceptAndMakePaymentResult (ContractId SubscriptionInitialPayment)`
+- `instance SetField senderChange SubscriptionRequest_AcceptAndMakePaymentResult (Optional (ContractId Amulet))`
+- `instance SetField subscriptionPayment SubscriptionRequest_AcceptAndMakePaymentResult (ContractId SubscriptionInitialPayment)`
+- `instance HasExercise SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult`
+- `instance HasFromAnyChoice SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult`
+- `instance HasToAnyChoice SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionrequestrejectresult-11624"></a>
+
+### `data SubscriptionRequest_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptionrequestrejectresult-75381"></a>
+- `SubscriptionRequest_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
+
+Instances:
+
+- `instance GetField terminatedSubscription SubscriptionRequest_RejectResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription SubscriptionRequest_RejectResult (ContractId TerminatedSubscription)`
+- `instance HasExercise SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult`
+- `instance HasFromAnyChoice SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult`
+- `instance HasToAnyChoice SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionrequestwithdrawresult-7225"></a>
+
+### `data SubscriptionRequest_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptionrequestwithdrawresult-40204"></a>
+- `SubscriptionRequest_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
+
+Instances:
+
+- `instance GetField terminatedSubscription SubscriptionRequest_WithdrawResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription SubscriptionRequest_WithdrawResult (ContractId TerminatedSubscription)`
+- `instance HasExercise SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult`
+- `instance HasFromAnyChoice SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult`
+- `instance HasToAnyChoice SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionarchiveresult-60922"></a>
+
+### `data Subscription_ArchiveResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-subscriptions-subscriptionarchiveresult-91207"></a>
+- `Subscription_ArchiveResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
+
+Instances:
+
+- `instance GetField terminatedSubscription Subscription_ArchiveResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription Subscription_ArchiveResult (ContractId TerminatedSubscription)`
+- `instance HasExercise Subscription Subscription_Archive Subscription_ArchiveResult`
+- `instance HasFromAnyChoice Subscription Subscription_Archive Subscription_ArchiveResult`
+- `instance HasToAnyChoice Subscription Subscription_Archive Subscription_ArchiveResult`
+
+## Functions
+
+<a id="function-splice-wallet-subscriptions-subscriptionsignatories-98765"></a>
+
+### `subscriptionSignatories`
+
+```daml
+subscriptionSignatories : SubscriptionData -> [Party]
+```
+
+<a id="function-splice-wallet-subscriptions-paydataisvalid-4217"></a>
+
+### `payDataIsValid`
+
+```daml
+payDataIsValid : SubscriptionPayData -> Bool
+```
+
+<a id="function-splice-wallet-subscriptions-lockandmakechange-61624"></a>
+
+### `lockAndMakeChange`
+
+```daml
+lockAndMakeChange : PaymentTransferContext -> SubscriptionData -> SubscriptionPayData -> [TransferInput] -> Time -> Party -> Update (ContractId LockedAmulet, Optional (ContractId Amulet), Decimal, Round)
+```
+
+<a id="function-splice-wallet-subscriptions-unlockandtransfer-4476"></a>
+
+### `unlockAndTransfer`
+
+```daml
+unlockAndTransfer : AppTransferContext -> SubscriptionData -> Decimal -> ContractId LockedAmulet -> Update (ContractId Amulet)
+```
+
+<a id="function-splice-wallet-subscriptions-mktransferoutput-31673"></a>
+
+### `mkTransferOutput`
+
+```daml
+mkTransferOutput : Party -> Decimal -> TransferOutput
+```
+
+## Templates
+
+<a id="type-splice-wallet-subscriptions-subscription-33404"></a>
+
+### Template `Subscription`
+
+Main subscription object.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionData | SubscriptionData |  |
+| reference | ContractId SubscriptionRequest | Reference to the subscription request, note that the contract will no longer be active so this just acts as a tracking id. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`
+
+<a id="type-splice-wallet-subscriptions-subscriptionarchive-38051"></a>
+
+#### Choice `Subscription_Archive`
+
+Controllers: `signatory this`
+
+Returns: `Subscription_ArchiveResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionidlestate-59870"></a>
+
+### Template `SubscriptionIdleState`
+
+The base state in our subscription flow.
+Here, we are typically waiting for the time for the next payment to arrive.
+If that time has passed, we are waiting for someone to expire the subscription.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscription | ContractId Subscription | The subscription this belongs to. |
+| subscriptionData | SubscriptionData | Copy of the subscription contract for easier access to its field. |
+| payData | SubscriptionPayData | Payment-related properties. |
+| nextPaymentDueAt | Time | After which time the next payment can and should be paid. |
+| reference | ContractId SubscriptionRequest |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`
+
+<a id="type-splice-wallet-subscriptions-subscriptionidlestatecancelsubscription-25061"></a>
+
+#### Choice `SubscriptionIdleState_CancelSubscription`
+
+Controllers: `(DA.Internal.Record.getField @"sender" subscriptionData)`
+
+Returns: `SubscriptionIdleState_CancelSubscriptionResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionidlestateexpiresubscription-50078"></a>
+
+#### Choice `SubscriptionIdleState_ExpireSubscription`
+
+Controllers: `actor`
+
+Returns: `SubscriptionIdleState_ExpireSubscriptionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+
+<a id="type-splice-wallet-subscriptions-subscriptionidlestatemakepayment-62467"></a>
+
+#### Choice `SubscriptionIdleState_MakePayment`
+
+Controllers: `(DA.Internal.Record.getField @"sender" subscriptionData)`, `walletProvider`
+
+Returns: `SubscriptionIdleState_MakePaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputs | [TransferInput] |  |
+| context | PaymentTransferContext |  |
+| walletProvider | Party |  |
+
+<a id="type-splice-wallet-subscriptions-subscriptioninitialpayment-79960"></a>
+
+### Template `SubscriptionInitialPayment`
+
+The initial payment on a subscription.
+Implicitly, this is also the "accept" of the preceding `SubscriptionRequest`.
+Collecting this payments creates the subscription and thereby enables all follow-up payments.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionData | SubscriptionData |  |
+| payData | SubscriptionPayData |  |
+| targetAmount | Decimal | Exact amount in Amulet that the receiver will get. |
+| lockedAmulet | ContractId LockedAmulet |  |
+| round | Round | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets. |
+| reference | ContractId SubscriptionRequest | Reference to the subscription request, note that the contract will no longer be active so this just acts as a tracking id. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`
+
+<a id="type-splice-wallet-subscriptions-subscriptioninitialpaymentcollect-92147"></a>
+
+#### Choice `SubscriptionInitialPayment_Collect`
+
+Controllers: `signatory this`
+
+Returns: `SubscriptionInitialPayment_CollectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferContext | AppTransferContext |  |
+
+<a id="type-splice-wallet-subscriptions-subscriptioninitialpaymentexpire-95363"></a>
+
+#### Choice `SubscriptionInitialPayment_Expire`
+
+Controllers: `actor`
+
+Returns: `SubscriptionInitialPayment_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+| transferContext | AppTransferContext |  |
+
+<a id="type-splice-wallet-subscriptions-subscriptioninitialpaymentreject-61119"></a>
+
+#### Choice `SubscriptionInitialPayment_Reject`
+
+Controllers: `(DA.Internal.Record.getField @"receiver" subscriptionData)`
+
+Returns: `SubscriptionInitialPayment_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferContext | AppTransferContext |  |
+
+<a id="type-splice-wallet-subscriptions-subscriptionpayment-4463"></a>
+
+### Template `SubscriptionPayment`
+
+An in-flight (yet to be collected) payment on an existing subscription.
+Doubles as a "payment in progress" state.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscription | ContractId Subscription | The subscription this belongs to. |
+| subscriptionData | SubscriptionData | Copy of the base subscription properties; for convenience. |
+| payData | SubscriptionPayData | Payment-related properties. |
+| thisPaymentDueAt | Time | After which time the next payment can and should be paid. |
+| targetAmount | Decimal |  |
+| lockedAmulet | ContractId LockedAmulet |  |
+| round | Round | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets. |
+| reference | ContractId SubscriptionRequest |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`
+
+<a id="type-splice-wallet-subscriptions-subscriptionpaymentcollect-45604"></a>
+
+#### Choice `SubscriptionPayment_Collect`
+
+Controllers: `signatory this`
+
+Returns: `SubscriptionPayment_CollectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferContext | AppTransferContext |  |
+
+<a id="type-splice-wallet-subscriptions-subscriptionpaymentexpire-61162"></a>
+
+#### Choice `SubscriptionPayment_Expire`
+
+Controllers: `actor`
+
+Returns: `SubscriptionPayment_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+| transferContext | AppTransferContext |  |
+
+<a id="type-splice-wallet-subscriptions-subscriptionpaymentreject-72046"></a>
+
+#### Choice `SubscriptionPayment_Reject`
+
+Controllers: `(DA.Internal.Record.getField @"receiver" subscriptionData)`
+
+Returns: `SubscriptionPayment_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferContext | AppTransferContext |  |
+
+<a id="type-splice-wallet-subscriptions-subscriptionrequest-40942"></a>
+
+### Template `SubscriptionRequest`
+
+A request for establishing a subscription.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionData | SubscriptionData |  |
+| payData | SubscriptionPayData |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`
+
+<a id="type-splice-wallet-subscriptions-subscriptionrequestacceptandmakepayment-96423"></a>
+
+#### Choice `SubscriptionRequest_AcceptAndMakePayment`
+
+Controllers: `(DA.Internal.Record.getField @"sender" subscriptionData)`, `walletProvider`
+
+Returns: `SubscriptionRequest_AcceptAndMakePaymentResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputs | [TransferInput] |  |
+| context | PaymentTransferContext |  |
+| walletProvider | Party |  |
+
+<a id="type-splice-wallet-subscriptions-subscriptionrequestreject-95001"></a>
+
+#### Choice `SubscriptionRequest_Reject`
+
+Controllers: `(DA.Internal.Record.getField @"sender" subscriptionData)`
+
+Returns: `SubscriptionRequest_RejectResult`
+
+<a id="type-splice-wallet-subscriptions-subscriptionrequestwithdraw-88172"></a>
+
+#### Choice `SubscriptionRequest_Withdraw`
+
+Controllers: `(DA.Internal.Record.getField @"receiver" subscriptionData)`
+
+Returns: `SubscriptionRequest_WithdrawResult`
+
+<a id="type-splice-wallet-subscriptions-terminatedsubscription-20905"></a>
+
+### Template `TerminatedSubscription`
+
+An aborted subscription. Subscriptions should usually be archived together with
+the context contract of the app that makes the subscription, e.g., AnsEntryContext.
+To achieve that, we don't archive subscriptions directly but instead create TerminatedSubscription contracts
+that are then archived as part of the surrounding workflows.
+
+Signatories: `subscriptionSignatories subscriptionData`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| subscriptionData | SubscriptionData |  |
+| reference | ContractId SubscriptionRequest |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `subscriptionSignatories subscriptionData`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-wallet/index.mdx
+++ b/docs-main/reference/splice-daml-api/splice-wallet/index.mdx
@@ -1,0 +1,34 @@
+---
+title: "splice-wallet docs"
+description: "Reference documentation for splice-wallet docs modules."
+---
+
+# splice-wallet docs
+
+This page is generated from versioned Daml docs JSON snapshots.
+
+## Table of Contents
+
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`Splice.Wallet.BuyTrafficRequest`](/reference/splice-daml-api/splice-wallet/splice-wallet-buytrafficrequest) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.Wallet.Install`](/reference/splice-daml-api/splice-wallet/splice-wallet-install) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.Wallet.MintingDelegation`](/reference/splice-daml-api/splice-wallet/splice-wallet-mintingdelegation) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.Wallet.TopUpState`](/reference/splice-daml-api/splice-wallet/splice-wallet-topupstate) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.Wallet.TransferOffer`](/reference/splice-daml-api/splice-wallet/splice-wallet-transferoffer) | `Module` | - | `0.5.18` | - | - | - |
+| [`Splice.Wallet.TransferPreapproval`](/reference/splice-daml-api/splice-wallet/splice-wallet-transferpreapproval) | `Module` | - | `0.5.18` | - | - | - |
+
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `0.5.18` | 6 | 0 | 0 |
+
+## Reference
+
+- [Splice.Wallet.BuyTrafficRequest](/reference/splice-daml-api/splice-wallet/splice-wallet-buytrafficrequest)
+- [Splice.Wallet.Install](/reference/splice-daml-api/splice-wallet/splice-wallet-install)
+- [Splice.Wallet.MintingDelegation](/reference/splice-daml-api/splice-wallet/splice-wallet-mintingdelegation)
+- [Splice.Wallet.TopUpState](/reference/splice-daml-api/splice-wallet/splice-wallet-topupstate)
+- [Splice.Wallet.TransferOffer](/reference/splice-daml-api/splice-wallet/splice-wallet-transferoffer)
+- [Splice.Wallet.TransferPreapproval](/reference/splice-daml-api/splice-wallet/splice-wallet-transferpreapproval)

--- a/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-buytrafficrequest.mdx
+++ b/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-buytrafficrequest.mdx
@@ -1,0 +1,194 @@
+---
+title: "Splice.Wallet.BuyTrafficRequest"
+description: "Reference documentation for Daml module Splice.Wallet.BuyTrafficRequest."
+---
+
+<a id="module-splice-wallet-buytrafficrequest-40881"></a>
+
+# Splice.Wallet.BuyTrafficRequest
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-wallet-buytrafficrequest-buytrafficrequesttrackinginfo-63943"></a>
+
+### `data BuyTrafficRequestTrackingInfo`
+
+Constructors:
+
+<a id="constr-splice-wallet-buytrafficrequest-buytrafficrequesttrackinginfo-4476"></a>
+- `BuyTrafficRequestTrackingInfo`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingId | Text | used to deduplicate requests and query for the status |
+| endUserParty | Party | used in UserWalletTxLogParser's filterByParty |
+
+Instances:
+
+- `instance Eq BuyTrafficRequestTrackingInfo`
+- `instance Show BuyTrafficRequestTrackingInfo`
+- `instance GetField endUserParty BuyTrafficRequestTrackingInfo Party`
+- `instance GetField trackingId BuyTrafficRequestTrackingInfo Text`
+- `instance GetField trackingInfo BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo`
+- `instance GetField trackingInfo BuyTrafficRequest_CompleteResult BuyTrafficRequestTrackingInfo`
+- `instance GetField trackingInfo BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo`
+- `instance GetField trackingInfo WalletAppInstall_BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo`
+- `instance GetField trackingInfo WalletAppInstall_BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo`
+- `instance SetField endUserParty BuyTrafficRequestTrackingInfo Party`
+- `instance SetField trackingId BuyTrafficRequestTrackingInfo Text`
+- `instance SetField trackingInfo BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo`
+- `instance SetField trackingInfo BuyTrafficRequest_CompleteResult BuyTrafficRequestTrackingInfo`
+- `instance SetField trackingInfo BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo`
+
+<a id="type-splice-wallet-buytrafficrequest-buytrafficrequestcancelresult-81241"></a>
+
+### `data BuyTrafficRequest_CancelResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-buytrafficrequest-buytrafficrequestcancelresult-28380"></a>
+- `BuyTrafficRequest_CancelResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | BuyTrafficRequestTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo`
+- `instance SetField trackingInfo BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo`
+- `instance HasExercise BuyTrafficRequest BuyTrafficRequest_Cancel BuyTrafficRequest_CancelResult`
+- `instance HasFromAnyChoice BuyTrafficRequest BuyTrafficRequest_Cancel BuyTrafficRequest_CancelResult`
+- `instance HasToAnyChoice BuyTrafficRequest BuyTrafficRequest_Cancel BuyTrafficRequest_CancelResult`
+
+<a id="type-splice-wallet-buytrafficrequest-buytrafficrequestcompleteresult-44764"></a>
+
+### `data BuyTrafficRequest_CompleteResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-buytrafficrequest-buytrafficrequestcompleteresult-27129"></a>
+- `BuyTrafficRequest_CompleteResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| purchasedTraffic | ContractId MemberTraffic |  |
+| trackingInfo | BuyTrafficRequestTrackingInfo |  |
+| senderChangeAmulet | Optional (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField purchasedTraffic BuyTrafficRequest_CompleteResult (ContractId MemberTraffic)`
+- `instance GetField senderChangeAmulet BuyTrafficRequest_CompleteResult (Optional (ContractId Amulet))`
+- `instance GetField trackingInfo BuyTrafficRequest_CompleteResult BuyTrafficRequestTrackingInfo`
+- `instance SetField purchasedTraffic BuyTrafficRequest_CompleteResult (ContractId MemberTraffic)`
+- `instance SetField senderChangeAmulet BuyTrafficRequest_CompleteResult (Optional (ContractId Amulet))`
+- `instance SetField trackingInfo BuyTrafficRequest_CompleteResult BuyTrafficRequestTrackingInfo`
+- `instance HasExercise BuyTrafficRequest BuyTrafficRequest_Complete BuyTrafficRequest_CompleteResult`
+- `instance HasFromAnyChoice BuyTrafficRequest BuyTrafficRequest_Complete BuyTrafficRequest_CompleteResult`
+- `instance HasToAnyChoice BuyTrafficRequest BuyTrafficRequest_Complete BuyTrafficRequest_CompleteResult`
+
+<a id="type-splice-wallet-buytrafficrequest-buytrafficrequestexpireresult-25706"></a>
+
+### `data BuyTrafficRequest_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-buytrafficrequest-buytrafficrequestexpireresult-5207"></a>
+- `BuyTrafficRequest_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | BuyTrafficRequestTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo`
+- `instance SetField trackingInfo BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo`
+- `instance HasExercise BuyTrafficRequest BuyTrafficRequest_Expire BuyTrafficRequest_ExpireResult`
+- `instance HasFromAnyChoice BuyTrafficRequest BuyTrafficRequest_Expire BuyTrafficRequest_ExpireResult`
+- `instance HasToAnyChoice BuyTrafficRequest BuyTrafficRequest_Expire BuyTrafficRequest_ExpireResult`
+
+## Templates
+
+<a id="type-splice-wallet-buytrafficrequest-buytrafficrequest-65116"></a>
+
+### Template `BuyTrafficRequest`
+
+A request by an end-user to the wallet's automation to buy traffic
+for a sequencer member
+
+Signatories: `endUserParty`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| endUserParty | Party |  |
+| expiresAt | Time | Buy the traffic before this time. |
+| trackingId | Text | Used to deduplicate requests |
+| trafficAmount | Int |  |
+| memberId | Text |  |
+| synchronizerId | Text |  |
+| migrationId | Int |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `endUserParty`
+
+Returns: `()`
+
+<a id="type-splice-wallet-buytrafficrequest-buytrafficrequestcancel-52564"></a>
+
+#### Choice `BuyTrafficRequest_Cancel`
+
+Controllers: `endUserParty`
+
+Returns: `BuyTrafficRequest_CancelResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<a id="type-splice-wallet-buytrafficrequest-buytrafficrequestcomplete-61949"></a>
+
+#### Choice `BuyTrafficRequest_Complete`
+
+Controllers: `endUserParty`, `walletProvider`
+
+Returns: `BuyTrafficRequest_CompleteResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputs | [TransferInput] |  |
+| context | PaymentTransferContext |  |
+| walletProvider | Party |  |
+
+<a id="type-splice-wallet-buytrafficrequest-buytrafficrequestexpire-77595"></a>
+
+#### Choice `BuyTrafficRequest_Expire`
+
+Controllers: `endUserParty`
+
+Returns: `BuyTrafficRequest_ExpireResult`

--- a/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-install.mdx
+++ b/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-install.mdx
@@ -1,0 +1,1008 @@
+---
+title: "Splice.Wallet.Install"
+description: "Reference documentation for Daml module Splice.Wallet.Install."
+---
+
+<a id="module-splice-wallet-install-94326"></a>
+
+# Splice.Wallet.Install
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-wallet-install-amuletoperation-34848"></a>
+
+### `data AmuletOperation`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-coapppayment-62800"></a>
+- `CO_AppPayment (ContractId AppPaymentRequest)`
+<a id="constr-splice-wallet-install-cocompleteacceptedtransfer-10636"></a>
+- `CO_CompleteAcceptedTransfer (ContractId AcceptedTransferOffer)`
+<a id="constr-splice-wallet-install-cosubscriptionacceptandmakeinitialpayment-39374"></a>
+- `CO_SubscriptionAcceptAndMakeInitialPayment (ContractId SubscriptionRequest)`
+<a id="constr-splice-wallet-install-cosubscriptionmakepayment-67209"></a>
+- `CO_SubscriptionMakePayment (ContractId SubscriptionIdleState)`
+<a id="constr-splice-wallet-install-comergetransferinputs-20390"></a>
+- `CO_MergeTransferInputs`
+<a id="constr-splice-wallet-install-cobuymembertraffic-66746"></a>
+- `CO_BuyMemberTraffic`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trafficAmount | Int |  |
+| memberId | Text |  |
+| synchronizerId | Text |  |
+| migrationId | Int |  |
+| minTopupInterval | RelTime |  |
+| topupStateCid | Optional (ContractId ValidatorTopUpState) |  |
+<a id="constr-splice-wallet-install-cocompletebuytrafficrequest-39331"></a>
+- `CO_CompleteBuyTrafficRequest`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trafficRequestCid | ContractId BuyTrafficRequest |  |
+<a id="constr-splice-wallet-install-cotap-54191"></a>
+- `CO_Tap`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| tapAmount | Decimal |  |
+<a id="constr-splice-wallet-install-extamuletoperation-64373"></a>
+- `ExtAmuletOperation`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+<a id="constr-splice-wallet-install-cocreateexternalpartysetupproposal-60911"></a>
+- `CO_CreateExternalPartySetupProposal`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| externalParty | Party |  |
+| preapprovalExpiresAt | Time |  |
+<a id="constr-splice-wallet-install-coaccepttransferpreapprovalproposal-59253"></a>
+- `CO_AcceptTransferPreapprovalProposal`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| preapprovalProposalCid | ContractId TransferPreapprovalProposal |  |
+| expiresAt | Time |  |
+<a id="constr-splice-wallet-install-corenewtransferpreapproval-62183"></a>
+- `CO_RenewTransferPreapproval`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| previousApprovalCid | ContractId TransferPreapproval |  |
+| newExpiresAt | Time |  |
+<a id="constr-splice-wallet-install-cotransferpreapprovalsend-6635"></a>
+- `CO_TransferPreapprovalSend`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferPreapprovalCid | ContractId TransferPreapproval |  |
+| providerFeaturedAppRightCid | Optional (ContractId FeaturedAppRight) |  |
+| amount | Decimal |  |
+| description | Optional Text |  |
+
+Instances:
+
+- `instance Eq AmuletOperation`
+- `instance Show AmuletOperation`
+- `instance GetField amount AmuletOperation Decimal`
+- `instance GetField description AmuletOperation (Optional Text)`
+- `instance GetField dummyUnitField AmuletOperation ()`
+- `instance GetField expiresAt AmuletOperation Time`
+- `instance GetField externalParty AmuletOperation Party`
+- `instance GetField memberId AmuletOperation Text`
+- `instance GetField migrationId AmuletOperation Int`
+- `instance GetField minTopupInterval AmuletOperation RelTime`
+- `instance GetField newExpiresAt AmuletOperation Time`
+- `instance GetField operations WalletAppInstall_ExecuteBatch [AmuletOperation]`
+- `instance GetField preapprovalExpiresAt AmuletOperation Time`
+- `instance GetField preapprovalProposalCid AmuletOperation (ContractId TransferPreapprovalProposal)`
+- `instance GetField previousApprovalCid AmuletOperation (ContractId TransferPreapproval)`
+- `instance GetField providerFeaturedAppRightCid AmuletOperation (Optional (ContractId FeaturedAppRight))`
+- `instance GetField synchronizerId AmuletOperation Text`
+- `instance GetField tapAmount AmuletOperation Decimal`
+- `instance GetField topupStateCid AmuletOperation (Optional (ContractId ValidatorTopUpState))`
+- `instance GetField trafficAmount AmuletOperation Int`
+- `instance GetField trafficRequestCid AmuletOperation (ContractId BuyTrafficRequest)`
+- `instance GetField transferPreapprovalCid AmuletOperation (ContractId TransferPreapproval)`
+- `instance SetField amount AmuletOperation Decimal`
+- `instance SetField description AmuletOperation (Optional Text)`
+- `instance SetField dummyUnitField AmuletOperation ()`
+- `instance SetField expiresAt AmuletOperation Time`
+- `instance SetField externalParty AmuletOperation Party`
+- `instance SetField memberId AmuletOperation Text`
+- `instance SetField migrationId AmuletOperation Int`
+- `instance SetField minTopupInterval AmuletOperation RelTime`
+- `instance SetField newExpiresAt AmuletOperation Time`
+- `instance SetField operations WalletAppInstall_ExecuteBatch [AmuletOperation]`
+- `instance SetField preapprovalExpiresAt AmuletOperation Time`
+- `instance SetField preapprovalProposalCid AmuletOperation (ContractId TransferPreapprovalProposal)`
+- `instance SetField previousApprovalCid AmuletOperation (ContractId TransferPreapproval)`
+- `instance SetField providerFeaturedAppRightCid AmuletOperation (Optional (ContractId FeaturedAppRight))`
+- `instance SetField synchronizerId AmuletOperation Text`
+- `instance SetField tapAmount AmuletOperation Decimal`
+- `instance SetField topupStateCid AmuletOperation (Optional (ContractId ValidatorTopUpState))`
+- `instance SetField trafficAmount AmuletOperation Int`
+- `instance SetField trafficRequestCid AmuletOperation (ContractId BuyTrafficRequest)`
+- `instance SetField transferPreapprovalCid AmuletOperation (ContractId TransferPreapproval)`
+
+<a id="type-splice-wallet-install-amuletoperationoutcome-52121"></a>
+
+### `data AmuletOperationOutcome`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-cooacceptedapppayment-45545"></a>
+- `COO_AcceptedAppPayment (ContractId AcceptedAppPayment)`
+<a id="constr-splice-wallet-install-coocompleteacceptedtransfer-44398"></a>
+- `COO_CompleteAcceptedTransfer (TransferResult, TransferOfferTrackingInfo)`
+<a id="constr-splice-wallet-install-coosubscriptioninitialpayment-16470"></a>
+- `COO_SubscriptionInitialPayment (ContractId SubscriptionInitialPayment)`
+<a id="constr-splice-wallet-install-coosubscriptionpayment-22077"></a>
+- `COO_SubscriptionPayment (ContractId SubscriptionPayment)`
+<a id="constr-splice-wallet-install-coomergetransferinputs-47604"></a>
+- `COO_MergeTransferInputs (Optional (ContractId Amulet))`
+<a id="constr-splice-wallet-install-coobuymembertraffic-30084"></a>
+- `COO_BuyMemberTraffic (ContractId MemberTraffic)`
+<a id="constr-splice-wallet-install-coocompletebuytrafficrequest-58397"></a>
+- `COO_CompleteBuyTrafficRequest (ContractId MemberTraffic, BuyTrafficRequestTrackingInfo)`
+<a id="constr-splice-wallet-install-cootap-14325"></a>
+- `COO_Tap (ContractId Amulet)`
+<a id="constr-splice-wallet-install-cooerror-5538"></a>
+- `COO_Error InvalidTransferReason`
+<a id="constr-splice-wallet-install-extamuletoperationoutcome-44318"></a>
+- `ExtAmuletOperationOutcome`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dummyUnitField | () | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+<a id="constr-splice-wallet-install-coocreateexternalpartysetupproposal-75945"></a>
+- `COO_CreateExternalPartySetupProposal (ContractId ExternalPartySetupProposal)`
+<a id="constr-splice-wallet-install-cooaccepttransferpreapprovalproposal-26799"></a>
+- `COO_AcceptTransferPreapprovalProposal (ContractId TransferPreapproval)`
+<a id="constr-splice-wallet-install-coorenewtransferpreapproval-16241"></a>
+- `COO_RenewTransferPreapproval (ContractId TransferPreapproval)`
+<a id="constr-splice-wallet-install-cootransferpreapprovalsend-96669"></a>
+- `COO_TransferPreapprovalSend (Optional (ContractId Amulet))`
+
+Instances:
+
+- `instance Eq AmuletOperationOutcome`
+- `instance Show AmuletOperationOutcome`
+- `instance GetField dummyUnitField AmuletOperationOutcome ()`
+- `instance GetField outcomes WalletAppInstall_ExecuteBatchResult [AmuletOperationOutcome]`
+- `instance SetField dummyUnitField AmuletOperationOutcome ()`
+- `instance SetField outcomes WalletAppInstall_ExecuteBatchResult [AmuletOperationOutcome]`
+
+<a id="type-splice-wallet-install-executioncontext-4075"></a>
+
+### `data ExecutionContext`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-executioncontext-25706"></a>
+- `ExecutionContext`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| endUser | Party |  |
+| validator | Party |  |
+| paymentContext | PaymentTransferContext |  |
+
+Instances:
+
+- `instance GetField dso ExecutionContext Party`
+- `instance GetField endUser ExecutionContext Party`
+- `instance GetField paymentContext ExecutionContext PaymentTransferContext`
+- `instance GetField validator ExecutionContext Party`
+- `instance SetField dso ExecutionContext Party`
+- `instance SetField endUser ExecutionContext Party`
+- `instance SetField paymentContext ExecutionContext PaymentTransferContext`
+- `instance SetField validator ExecutionContext Party`
+
+<a id="type-splice-wallet-install-walletappinstallacceptedtransferofferabortresult-76594"></a>
+
+### `data WalletAppInstall_AcceptedTransferOffer_AbortResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallacceptedtransferofferabortresult-71839"></a>
+- `WalletAppInstall_AcceptedTransferOffer_AbortResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo WalletAppInstall_AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo`
+- `instance HasExercise WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Abort WalletAppInstall_AcceptedTransferOffer_AbortResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Abort WalletAppInstall_AcceptedTransferOffer_AbortResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Abort WalletAppInstall_AcceptedTransferOffer_AbortResult`
+
+<a id="type-splice-wallet-install-walletappinstallacceptedtransferofferexpireresult-73364"></a>
+
+### `data WalletAppInstall_AcceptedTransferOffer_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallacceptedtransferofferexpireresult-63931"></a>
+- `WalletAppInstall_AcceptedTransferOffer_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo WalletAppInstall_AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance HasExercise WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Expire WalletAppInstall_AcceptedTransferOffer_ExpireResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Expire WalletAppInstall_AcceptedTransferOffer_ExpireResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Expire WalletAppInstall_AcceptedTransferOffer_ExpireResult`
+
+<a id="type-splice-wallet-install-walletappinstallacceptedtransferofferwithdrawresult-30981"></a>
+
+### `data WalletAppInstall_AcceptedTransferOffer_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallacceptedtransferofferwithdrawresult-50854"></a>
+- `WalletAppInstall_AcceptedTransferOffer_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo WalletAppInstall_AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance HasExercise WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Withdraw WalletAppInstall_AcceptedTransferOffer_WithdrawResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Withdraw WalletAppInstall_AcceptedTransferOffer_WithdrawResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Withdraw WalletAppInstall_AcceptedTransferOffer_WithdrawResult`
+
+<a id="type-splice-wallet-install-walletappinstallapppaymentrequestexpireresult-40772"></a>
+
+### `data WalletAppInstall_AppPaymentRequest_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallapppaymentrequestexpireresult-9239"></a>
+- `WalletAppInstall_AppPaymentRequest_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedAppPayment | ContractId TerminatedAppPayment |  |
+
+Instances:
+
+- `instance GetField terminatedAppPayment WalletAppInstall_AppPaymentRequest_ExpireResult (ContractId TerminatedAppPayment)`
+- `instance SetField terminatedAppPayment WalletAppInstall_AppPaymentRequest_ExpireResult (ContractId TerminatedAppPayment)`
+- `instance HasExercise WalletAppInstall WalletAppInstall_AppPaymentRequest_Expire WalletAppInstall_AppPaymentRequest_ExpireResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_AppPaymentRequest_Expire WalletAppInstall_AppPaymentRequest_ExpireResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_AppPaymentRequest_Expire WalletAppInstall_AppPaymentRequest_ExpireResult`
+
+<a id="type-splice-wallet-install-walletappinstallapppaymentrequestrejectresult-13912"></a>
+
+### `data WalletAppInstall_AppPaymentRequest_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallapppaymentrequestrejectresult-2323"></a>
+- `WalletAppInstall_AppPaymentRequest_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedAppPayment | ContractId TerminatedAppPayment |  |
+
+Instances:
+
+- `instance GetField terminatedAppPayment WalletAppInstall_AppPaymentRequest_RejectResult (ContractId TerminatedAppPayment)`
+- `instance SetField terminatedAppPayment WalletAppInstall_AppPaymentRequest_RejectResult (ContractId TerminatedAppPayment)`
+- `instance HasExercise WalletAppInstall WalletAppInstall_AppPaymentRequest_Reject WalletAppInstall_AppPaymentRequest_RejectResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_AppPaymentRequest_Reject WalletAppInstall_AppPaymentRequest_RejectResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_AppPaymentRequest_Reject WalletAppInstall_AppPaymentRequest_RejectResult`
+
+<a id="type-splice-wallet-install-walletappinstallbuytrafficrequestcancelresult-7425"></a>
+
+### `data WalletAppInstall_BuyTrafficRequest_CancelResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallbuytrafficrequestcancelresult-5910"></a>
+- `WalletAppInstall_BuyTrafficRequest_CancelResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | BuyTrafficRequestTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo WalletAppInstall_BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo`
+- `instance HasExercise WalletAppInstall WalletAppInstall_BuyTrafficRequest_Cancel WalletAppInstall_BuyTrafficRequest_CancelResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_BuyTrafficRequest_Cancel WalletAppInstall_BuyTrafficRequest_CancelResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_BuyTrafficRequest_Cancel WalletAppInstall_BuyTrafficRequest_CancelResult`
+
+<a id="type-splice-wallet-install-walletappinstallbuytrafficrequestexpireresult-53806"></a>
+
+### `data WalletAppInstall_BuyTrafficRequest_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallbuytrafficrequestexpireresult-73389"></a>
+- `WalletAppInstall_BuyTrafficRequest_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | BuyTrafficRequestTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo WalletAppInstall_BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo`
+- `instance HasExercise WalletAppInstall WalletAppInstall_BuyTrafficRequest_Expire WalletAppInstall_BuyTrafficRequest_ExpireResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_BuyTrafficRequest_Expire WalletAppInstall_BuyTrafficRequest_ExpireResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_BuyTrafficRequest_Expire WalletAppInstall_BuyTrafficRequest_ExpireResult`
+
+<a id="type-splice-wallet-install-walletappinstallcreatebuytrafficrequestresult-63991"></a>
+
+### `data WalletAppInstall_CreateBuyTrafficRequestResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallcreatebuytrafficrequestresult-84558"></a>
+- `WalletAppInstall_CreateBuyTrafficRequestResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| buyTrafficRequest | ContractId BuyTrafficRequest |  |
+
+Instances:
+
+- `instance GetField buyTrafficRequest WalletAppInstall_CreateBuyTrafficRequestResult (ContractId BuyTrafficRequest)`
+- `instance SetField buyTrafficRequest WalletAppInstall_CreateBuyTrafficRequestResult (ContractId BuyTrafficRequest)`
+- `instance HasExercise WalletAppInstall WalletAppInstall_CreateBuyTrafficRequest WalletAppInstall_CreateBuyTrafficRequestResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_CreateBuyTrafficRequest WalletAppInstall_CreateBuyTrafficRequestResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_CreateBuyTrafficRequest WalletAppInstall_CreateBuyTrafficRequestResult`
+
+<a id="type-splice-wallet-install-walletappinstallcreatetransferofferresult-68160"></a>
+
+### `data WalletAppInstall_CreateTransferOfferResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallcreatetransferofferresult-22589"></a>
+- `WalletAppInstall_CreateTransferOfferResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferOffer | ContractId TransferOffer |  |
+
+Instances:
+
+- `instance GetField transferOffer WalletAppInstall_CreateTransferOfferResult (ContractId TransferOffer)`
+- `instance SetField transferOffer WalletAppInstall_CreateTransferOfferResult (ContractId TransferOffer)`
+- `instance HasExercise WalletAppInstall WalletAppInstall_CreateTransferOffer WalletAppInstall_CreateTransferOfferResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_CreateTransferOffer WalletAppInstall_CreateTransferOfferResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_CreateTransferOffer WalletAppInstall_CreateTransferOfferResult`
+
+<a id="type-splice-wallet-install-walletappinstallexecutebatchresult-15097"></a>
+
+### `data WalletAppInstall_ExecuteBatchResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallexecutebatchresult-44858"></a>
+- `WalletAppInstall_ExecuteBatchResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| endUserName | Text |  |
+| outcomes | [AmuletOperationOutcome] |  |
+| optEndUserParty | Optional Party |  |
+
+Instances:
+
+- `instance Eq WalletAppInstall_ExecuteBatchResult`
+- `instance Show WalletAppInstall_ExecuteBatchResult`
+- `instance GetField endUserName WalletAppInstall_ExecuteBatchResult Text`
+- `instance GetField optEndUserParty WalletAppInstall_ExecuteBatchResult (Optional Party)`
+- `instance GetField outcomes WalletAppInstall_ExecuteBatchResult [AmuletOperationOutcome]`
+- `instance SetField endUserName WalletAppInstall_ExecuteBatchResult Text`
+- `instance SetField optEndUserParty WalletAppInstall_ExecuteBatchResult (Optional Party)`
+- `instance SetField outcomes WalletAppInstall_ExecuteBatchResult [AmuletOperationOutcome]`
+- `instance HasExercise WalletAppInstall WalletAppInstall_ExecuteBatch WalletAppInstall_ExecuteBatchResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_ExecuteBatch WalletAppInstall_ExecuteBatchResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_ExecuteBatch WalletAppInstall_ExecuteBatchResult`
+
+<a id="type-splice-wallet-install-walletappinstallfeaturedapprightscancelresult-9581"></a>
+
+### `data WalletAppInstall_FeaturedAppRights_CancelResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallfeaturedapprightscancelresult-72714"></a>
+- `WalletAppInstall_FeaturedAppRights_CancelResult`
+
+Instances:
+
+- `instance HasExercise WalletAppInstall WalletAppInstall_FeaturedAppRights_Cancel WalletAppInstall_FeaturedAppRights_CancelResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_FeaturedAppRights_Cancel WalletAppInstall_FeaturedAppRights_CancelResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_FeaturedAppRights_Cancel WalletAppInstall_FeaturedAppRights_CancelResult`
+
+<a id="type-splice-wallet-install-walletappinstallfeaturedapprightsselfgrantresult-93142"></a>
+
+### `data WalletAppInstall_FeaturedAppRights_SelfGrantResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallfeaturedapprightsselfgrantresult-62683"></a>
+- `WalletAppInstall_FeaturedAppRights_SelfGrantResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| featuredAppRight | ContractId FeaturedAppRight |  |
+
+Instances:
+
+- `instance GetField featuredAppRight WalletAppInstall_FeaturedAppRights_SelfGrantResult (ContractId FeaturedAppRight)`
+- `instance SetField featuredAppRight WalletAppInstall_FeaturedAppRights_SelfGrantResult (ContractId FeaturedAppRight)`
+- `instance HasExercise WalletAppInstall WalletAppInstall_FeaturedAppRights_SelfGrant WalletAppInstall_FeaturedAppRights_SelfGrantResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_FeaturedAppRights_SelfGrant WalletAppInstall_FeaturedAppRights_SelfGrantResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_FeaturedAppRights_SelfGrant WalletAppInstall_FeaturedAppRights_SelfGrantResult`
+
+<a id="type-splice-wallet-install-walletappinstallsubscriptionidlestatecancelsubscriptionresult-84496"></a>
+
+### `data WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallsubscriptionidlestatecancelsubscriptionresult-61435"></a>
+- `WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
+
+Instances:
+
+- `instance GetField terminatedSubscription WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult (ContractId TerminatedSubscription)`
+- `instance HasExercise WalletAppInstall WalletAppInstall_SubscriptionIdleState_CancelSubscription WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_SubscriptionIdleState_CancelSubscription WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_SubscriptionIdleState_CancelSubscription WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult`
+
+<a id="type-splice-wallet-install-walletappinstallsubscriptionrequestrejectresult-88896"></a>
+
+### `data WalletAppInstall_SubscriptionRequest_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstallsubscriptionrequestrejectresult-60059"></a>
+- `WalletAppInstall_SubscriptionRequest_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| terminatedSubscription | ContractId TerminatedSubscription |  |
+
+Instances:
+
+- `instance GetField terminatedSubscription WalletAppInstall_SubscriptionRequest_RejectResult (ContractId TerminatedSubscription)`
+- `instance SetField terminatedSubscription WalletAppInstall_SubscriptionRequest_RejectResult (ContractId TerminatedSubscription)`
+- `instance HasExercise WalletAppInstall WalletAppInstall_SubscriptionRequest_Reject WalletAppInstall_SubscriptionRequest_RejectResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_SubscriptionRequest_Reject WalletAppInstall_SubscriptionRequest_RejectResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_SubscriptionRequest_Reject WalletAppInstall_SubscriptionRequest_RejectResult`
+
+<a id="type-splice-wallet-install-walletappinstalltransferofferacceptresult-54230"></a>
+
+### `data WalletAppInstall_TransferOffer_AcceptResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstalltransferofferacceptresult-12149"></a>
+- `WalletAppInstall_TransferOffer_AcceptResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| acceptedTransferOffer | ContractId AcceptedTransferOffer |  |
+
+Instances:
+
+- `instance GetField acceptedTransferOffer WalletAppInstall_TransferOffer_AcceptResult (ContractId AcceptedTransferOffer)`
+- `instance SetField acceptedTransferOffer WalletAppInstall_TransferOffer_AcceptResult (ContractId AcceptedTransferOffer)`
+- `instance HasExercise WalletAppInstall WalletAppInstall_TransferOffer_Accept WalletAppInstall_TransferOffer_AcceptResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_TransferOffer_Accept WalletAppInstall_TransferOffer_AcceptResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_TransferOffer_Accept WalletAppInstall_TransferOffer_AcceptResult`
+
+<a id="type-splice-wallet-install-walletappinstalltransferofferexpireresult-53807"></a>
+
+### `data WalletAppInstall_TransferOffer_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstalltransferofferexpireresult-15612"></a>
+- `WalletAppInstall_TransferOffer_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo WalletAppInstall_TransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_TransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance HasExercise WalletAppInstall WalletAppInstall_TransferOffer_Expire WalletAppInstall_TransferOffer_ExpireResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_TransferOffer_Expire WalletAppInstall_TransferOffer_ExpireResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_TransferOffer_Expire WalletAppInstall_TransferOffer_ExpireResult`
+
+<a id="type-splice-wallet-install-walletappinstalltransferofferrejectresult-95787"></a>
+
+### `data WalletAppInstall_TransferOffer_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstalltransferofferrejectresult-23888"></a>
+- `WalletAppInstall_TransferOffer_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo WalletAppInstall_TransferOffer_RejectResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_TransferOffer_RejectResult TransferOfferTrackingInfo`
+- `instance HasExercise WalletAppInstall WalletAppInstall_TransferOffer_Reject WalletAppInstall_TransferOffer_RejectResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_TransferOffer_Reject WalletAppInstall_TransferOffer_RejectResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_TransferOffer_Reject WalletAppInstall_TransferOffer_RejectResult`
+
+<a id="type-splice-wallet-install-walletappinstalltransferofferwithdrawresult-71362"></a>
+
+### `data WalletAppInstall_TransferOffer_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstalltransferofferwithdrawresult-55293"></a>
+- `WalletAppInstall_TransferOffer_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo WalletAppInstall_TransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_TransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance HasExercise WalletAppInstall WalletAppInstall_TransferOffer_Withdraw WalletAppInstall_TransferOffer_WithdrawResult`
+- `instance HasFromAnyChoice WalletAppInstall WalletAppInstall_TransferOffer_Withdraw WalletAppInstall_TransferOffer_WithdrawResult`
+- `instance HasToAnyChoice WalletAppInstall WalletAppInstall_TransferOffer_Withdraw WalletAppInstall_TransferOffer_WithdrawResult`
+
+<a id="type-splice-wallet-install-walletappinstalltransferpreapprovalproposalcreateresult-12514"></a>
+
+### `data WalletAppInstall_TransferPreapprovalProposal_CreateResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-install-walletappinstalltransferpreapprovalproposalcreateresult-3417"></a>
+- `WalletAppInstall_TransferPreapprovalProposal_CreateResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| preapprovalProposalCid | ContractId TransferPreapprovalProposal |  |
+
+Instances:
+
+- `instance GetField preapprovalProposalCid WalletAppInstall_TransferPreapprovalProposal_CreateResult (ContractId TransferPreapprovalProposal)`
+- `instance SetField preapprovalProposalCid WalletAppInstall_TransferPreapprovalProposal_CreateResult (ContractId TransferPreapprovalProposal)`
+
+## Functions
+
+<a id="function-splice-wallet-install-catchall-96802"></a>
+
+### `catchAll`
+
+```daml
+catchAll : Update a -> Update (Either InvalidTransferReason a)
+```
+
+<a id="function-splice-wallet-install-executeamuletoperationrec-79799"></a>
+
+### `executeAmuletOperationRec`
+
+```daml
+executeAmuletOperationRec : ExecutionContext -> [TransferInput] -> [AmuletOperationOutcome] -> [AmuletOperation] -> Update [AmuletOperationOutcome]
+```
+
+<a id="function-splice-wallet-install-mkmergeamuletandrewardstransfer-3655"></a>
+
+### `mkMergeAmuletAndRewardsTransfer`
+
+```daml
+mkMergeAmuletAndRewardsTransfer : Party -> [TransferInput] -> Transfer
+```
+
+<a id="function-splice-wallet-install-unpackcid-65301"></a>
+
+### `unpackCid`
+
+```daml
+unpackCid : AnyValue -> AnyContractId
+```
+
+## Templates
+
+<a id="type-splice-wallet-install-walletappinstall-78445"></a>
+
+### Template `WalletAppInstall`
+
+Signatories: `endUserParty`, `validatorParty`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dsoParty | Party |  |
+| validatorParty | Party |  |
+| endUserName | Text |  |
+| endUserParty | Party |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `endUserParty`, `validatorParty`
+
+Returns: `()`
+
+<a id="type-splice-wallet-install-walletappinstallacceptedtransferofferabort-68763"></a>
+
+#### Choice `WalletAppInstall_AcceptedTransferOffer_Abort`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_AcceptedTransferOffer_AbortResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId AcceptedTransferOffer |  |
+| reason | Text |  |
+
+<a id="type-splice-wallet-install-walletappinstallacceptedtransferofferexpire-57521"></a>
+
+#### Choice `WalletAppInstall_AcceptedTransferOffer_Expire`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_AcceptedTransferOffer_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId AcceptedTransferOffer |  |
+
+<a id="type-splice-wallet-install-walletappinstallacceptedtransferofferwithdraw-52092"></a>
+
+#### Choice `WalletAppInstall_AcceptedTransferOffer_Withdraw`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_AcceptedTransferOffer_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId AcceptedTransferOffer |  |
+| reason | Text |  |
+
+<a id="type-splice-wallet-install-walletappinstallallocationfactoryallocate-87859"></a>
+
+#### Choice `WalletAppInstall_AllocationFactory_Allocate`
+
+Controllers: `validatorParty`
+
+Returns: `AllocationInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationFactory | ContractId AllocationFactory |  |
+| allocateArg | AllocationFactory_Allocate |  |
+
+<a id="type-splice-wallet-install-walletappinstallallocationwithdraw-36167"></a>
+
+#### Choice `WalletAppInstall_Allocation_Withdraw`
+
+Controllers: `validatorParty`
+
+Returns: `Allocation_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| allocationCid | ContractId Allocation |  |
+| withdrawArg | Allocation_Withdraw |  |
+
+<a id="type-splice-wallet-install-walletappinstallapppaymentrequestexpire-63657"></a>
+
+#### Choice `WalletAppInstall_AppPaymentRequest_Expire`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_AppPaymentRequest_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId AppPaymentRequest |  |
+
+<a id="type-splice-wallet-install-walletappinstallapppaymentrequestreject-30597"></a>
+
+#### Choice `WalletAppInstall_AppPaymentRequest_Reject`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_AppPaymentRequest_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId AppPaymentRequest |  |
+
+<a id="type-splice-wallet-install-walletappinstallbuytrafficrequestcancel-57332"></a>
+
+#### Choice `WalletAppInstall_BuyTrafficRequest_Cancel`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_BuyTrafficRequest_CancelResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requestCid | ContractId BuyTrafficRequest |  |
+| reason | Text |  |
+
+<a id="type-splice-wallet-install-walletappinstallbuytrafficrequestexpire-56287"></a>
+
+#### Choice `WalletAppInstall_BuyTrafficRequest_Expire`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_BuyTrafficRequest_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| requestCid | ContractId BuyTrafficRequest |  |
+
+<a id="type-splice-wallet-install-walletappinstallcreatebuytrafficrequest-33718"></a>
+
+#### Choice `WalletAppInstall_CreateBuyTrafficRequest`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_CreateBuyTrafficRequestResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| memberId | Text |  |
+| synchronizerId | Text |  |
+| migrationId | Int |  |
+| trafficAmount | Int |  |
+| expiresAt | Time |  |
+| trackingId | Text |  |
+
+<a id="type-splice-wallet-install-walletappinstallcreatetransferoffer-6821"></a>
+
+#### Choice `WalletAppInstall_CreateTransferOffer`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_CreateTransferOfferResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| amount | PaymentAmount |  |
+| description | Text |  |
+| expiresAt | Time |  |
+| trackingId | Text |  |
+
+<a id="type-splice-wallet-install-walletappinstallexecutebatch-90628"></a>
+
+#### Choice `WalletAppInstall_ExecuteBatch`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_ExecuteBatchResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| operations | [AmuletOperation] |  |
+
+<a id="type-splice-wallet-install-walletappinstallfeaturedapprightscancel-92504"></a>
+
+#### Choice `WalletAppInstall_FeaturedAppRights_Cancel`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_FeaturedAppRights_CancelResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId FeaturedAppRight |  |
+
+<a id="type-splice-wallet-install-walletappinstallfeaturedapprightsselfgrant-7751"></a>
+
+#### Choice `WalletAppInstall_FeaturedAppRights_SelfGrant`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_FeaturedAppRights_SelfGrantResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| amuletRulesCid | ContractId AmuletRules |  |
+
+<a id="type-splice-wallet-install-walletappinstallsubscriptionidlestatecancelsubscription-97037"></a>
+
+#### Choice `WalletAppInstall_SubscriptionIdleState_CancelSubscription`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId SubscriptionIdleState |  |
+
+<a id="type-splice-wallet-install-walletappinstallsubscriptionrequestreject-94073"></a>
+
+#### Choice `WalletAppInstall_SubscriptionRequest_Reject`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_SubscriptionRequest_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId SubscriptionRequest |  |
+
+<a id="type-splice-wallet-install-walletappinstalltransferfactorytransfer-23966"></a>
+
+#### Choice `WalletAppInstall_TransferFactory_Transfer`
+
+Controllers: `validatorParty`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferFactoryCid | ContractId TransferFactory |  |
+| transferArg | TransferFactory_Transfer |  |
+
+<a id="type-splice-wallet-install-walletappinstalltransferinstructionaccept-23051"></a>
+
+#### Choice `WalletAppInstall_TransferInstruction_Accept`
+
+Controllers: `validatorParty`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferInstructionCid | ContractId TransferInstruction |  |
+| acceptArg | TransferInstruction_Accept |  |
+
+<a id="type-splice-wallet-install-walletappinstalltransferinstructionreject-1446"></a>
+
+#### Choice `WalletAppInstall_TransferInstruction_Reject`
+
+Controllers: `validatorParty`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferInstructionCid | ContractId TransferInstruction |  |
+| rejectArg | TransferInstruction_Reject |  |
+
+<a id="type-splice-wallet-install-walletappinstalltransferinstructionwithdraw-1151"></a>
+
+#### Choice `WalletAppInstall_TransferInstruction_Withdraw`
+
+Controllers: `validatorParty`
+
+Returns: `TransferInstructionResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferInstructionCid | ContractId TransferInstruction |  |
+| withdrawArg | TransferInstruction_Withdraw |  |
+
+<a id="type-splice-wallet-install-walletappinstalltransferofferaccept-7295"></a>
+
+#### Choice `WalletAppInstall_TransferOffer_Accept`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_TransferOffer_AcceptResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferOffer |  |
+
+<a id="type-splice-wallet-install-walletappinstalltransferofferexpire-5606"></a>
+
+#### Choice `WalletAppInstall_TransferOffer_Expire`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_TransferOffer_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferOffer |  |
+
+<a id="type-splice-wallet-install-walletappinstalltransferofferreject-96746"></a>
+
+#### Choice `WalletAppInstall_TransferOffer_Reject`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_TransferOffer_RejectResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferOffer |  |
+
+<a id="type-splice-wallet-install-walletappinstalltransferofferwithdraw-19519"></a>
+
+#### Choice `WalletAppInstall_TransferOffer_Withdraw`
+
+Controllers: `validatorParty`
+
+Returns: `WalletAppInstall_TransferOffer_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| cid | ContractId TransferOffer |  |
+| reason | Text |  |

--- a/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-mintingdelegation.mdx
+++ b/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-mintingdelegation.mdx
@@ -1,0 +1,253 @@
+---
+title: "Splice.Wallet.MintingDelegation"
+description: "Reference documentation for Daml module Splice.Wallet.MintingDelegation."
+---
+
+<a id="module-splice-wallet-mintingdelegation-95009"></a>
+
+# Splice.Wallet.MintingDelegation
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationproposalacceptresult-95133"></a>
+
+### `data MintingDelegationProposal_AcceptResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-mintingdelegation-mintingdelegationproposalacceptresult-35064"></a>
+- `MintingDelegationProposal_AcceptResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| mintingDelegationCid | ContractId MintingDelegation |  |
+
+Instances:
+
+- `instance Eq MintingDelegationProposal_AcceptResult`
+- `instance Show MintingDelegationProposal_AcceptResult`
+- `instance GetField mintingDelegationCid MintingDelegationProposal_AcceptResult (ContractId MintingDelegation)`
+- `instance SetField mintingDelegationCid MintingDelegationProposal_AcceptResult (ContractId MintingDelegation)`
+- `instance HasExercise MintingDelegationProposal MintingDelegationProposal_Accept MintingDelegationProposal_AcceptResult`
+- `instance HasFromAnyChoice MintingDelegationProposal MintingDelegationProposal_Accept MintingDelegationProposal_AcceptResult`
+- `instance HasToAnyChoice MintingDelegationProposal MintingDelegationProposal_Accept MintingDelegationProposal_AcceptResult`
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationproposalrejectresult-38748"></a>
+
+### `data MintingDelegationProposal_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-mintingdelegation-mintingdelegationproposalrejectresult-9461"></a>
+- `MintingDelegationProposal_RejectResult`
+(no fields)
+
+Instances:
+
+- `instance Eq MintingDelegationProposal_RejectResult`
+- `instance Show MintingDelegationProposal_RejectResult`
+- `instance HasExercise MintingDelegationProposal MintingDelegationProposal_Reject MintingDelegationProposal_RejectResult`
+- `instance HasFromAnyChoice MintingDelegationProposal MintingDelegationProposal_Reject MintingDelegationProposal_RejectResult`
+- `instance HasToAnyChoice MintingDelegationProposal MintingDelegationProposal_Reject MintingDelegationProposal_RejectResult`
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationproposalwithdrawresult-74809"></a>
+
+### `data MintingDelegationProposal_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-mintingdelegation-mintingdelegationproposalwithdrawresult-928"></a>
+- `MintingDelegationProposal_WithdrawResult`
+(no fields)
+
+Instances:
+
+- `instance Eq MintingDelegationProposal_WithdrawResult`
+- `instance Show MintingDelegationProposal_WithdrawResult`
+- `instance HasExercise MintingDelegationProposal MintingDelegationProposal_Withdraw MintingDelegationProposal_WithdrawResult`
+- `instance HasFromAnyChoice MintingDelegationProposal MintingDelegationProposal_Withdraw MintingDelegationProposal_WithdrawResult`
+- `instance HasToAnyChoice MintingDelegationProposal MintingDelegationProposal_Withdraw MintingDelegationProposal_WithdrawResult`
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationmintresult-4933"></a>
+
+### `data MintingDelegation_MintResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-mintingdelegation-mintingdelegationmintresult-18172"></a>
+- `MintingDelegation_MintResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferResult | TransferResult |  |
+
+Instances:
+
+- `instance Eq MintingDelegation_MintResult`
+- `instance Show MintingDelegation_MintResult`
+- `instance GetField transferResult MintingDelegation_MintResult TransferResult`
+- `instance SetField transferResult MintingDelegation_MintResult TransferResult`
+- `instance HasExercise MintingDelegation MintingDelegation_Mint MintingDelegation_MintResult`
+- `instance HasFromAnyChoice MintingDelegation MintingDelegation_Mint MintingDelegation_MintResult`
+- `instance HasToAnyChoice MintingDelegation MintingDelegation_Mint MintingDelegation_MintResult`
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationrejectresult-12270"></a>
+
+### `data MintingDelegation_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-mintingdelegation-mintingdelegationrejectresult-24691"></a>
+- `MintingDelegation_RejectResult`
+(no fields)
+
+Instances:
+
+- `instance Eq MintingDelegation_RejectResult`
+- `instance Show MintingDelegation_RejectResult`
+- `instance HasExercise MintingDelegation MintingDelegation_Reject MintingDelegation_RejectResult`
+- `instance HasFromAnyChoice MintingDelegation MintingDelegation_Reject MintingDelegation_RejectResult`
+- `instance HasToAnyChoice MintingDelegation MintingDelegation_Reject MintingDelegation_RejectResult`
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationwithdrawresult-83199"></a>
+
+### `data MintingDelegation_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-mintingdelegation-mintingdelegationwithdrawresult-61082"></a>
+- `MintingDelegation_WithdrawResult`
+(no fields)
+
+Instances:
+
+- `instance Eq MintingDelegation_WithdrawResult`
+- `instance Show MintingDelegation_WithdrawResult`
+- `instance HasExercise MintingDelegation MintingDelegation_Withdraw MintingDelegation_WithdrawResult`
+- `instance HasFromAnyChoice MintingDelegation MintingDelegation_Withdraw MintingDelegation_WithdrawResult`
+- `instance HasToAnyChoice MintingDelegation MintingDelegation_Withdraw MintingDelegation_WithdrawResult`
+
+## Templates
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegation-65428"></a>
+
+### Template `MintingDelegation`
+
+The right allowing the delegate to mint rewards on behalf of the beneficiary.
+
+Signatories: `beneficiary`, `delegate`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| beneficiary | Party | The party on whose behalf minting is performed. |
+| delegate | Party | The party authorized to perform minting operations. |
+| dso | Party | Expected DSO party. |
+| expiresAt | Time | The time after which this delegation is no longer valid. |
+| amuletMergeLimit | Int | The number of amulet contracts to keep after auto-merging; i.e.,<br/><br/>auto-merge contracts once there are strictly more than this number of contracts.<br/><br/>This is a suggestion to the delegate and is not enforced in daml |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `beneficiary`, `delegate`
+
+Returns: `()`
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationmint-91388"></a>
+
+#### Choice `MintingDelegation_Mint`
+
+Controllers: `delegate`
+
+Returns: `MintingDelegation_MintResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputs | [TransferInput] | The inputs to the transfer, like the validator liveness activity records owned by the beneficiary. |
+| context | PaymentTransferContext | The transfer context including amulet rules. |
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationreject-13031"></a>
+
+#### Choice `MintingDelegation_Reject`
+
+Controllers: `delegate`
+
+Returns: `MintingDelegation_RejectResult`
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationwithdraw-75826"></a>
+
+#### Choice `MintingDelegation_Withdraw`
+
+Controllers: `beneficiary`
+
+Returns: `MintingDelegation_WithdrawResult`
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationproposal-50922"></a>
+
+### Template `MintingDelegationProposal`
+
+Proposal by the user to setup a minting delegation.
+
+Signatories: `(DA.Internal.Record.getField @"beneficiary" delegation)`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| delegation | MintingDelegation | The delegation to be created if accepted. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `(DA.Internal.Record.getField @"beneficiary" delegation)`
+
+Returns: `()`
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationproposalaccept-24656"></a>
+
+#### Choice `MintingDelegationProposal_Accept`
+
+Controllers: `(DA.Internal.Record.getField @"delegate" delegation)`
+
+Returns: `MintingDelegationProposal_AcceptResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| existingDelegationCid | Optional (ContractId MintingDelegation) | Optional existing delegation to archive while creating the new one.<br/><br/>Useful for changing the parameters of the delegation. |
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationproposalreject-13601"></a>
+
+#### Choice `MintingDelegationProposal_Reject`
+
+Controllers: `(DA.Internal.Record.getField @"delegate" delegation)`
+
+Returns: `MintingDelegationProposal_RejectResult`
+
+<a id="type-splice-wallet-mintingdelegation-mintingdelegationproposalwithdraw-3376"></a>
+
+#### Choice `MintingDelegationProposal_Withdraw`
+
+Controllers: `(DA.Internal.Record.getField @"beneficiary" delegation)`
+
+Returns: `MintingDelegationProposal_WithdrawResult`

--- a/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-topupstate.mdx
+++ b/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-topupstate.mdx
@@ -1,0 +1,67 @@
+---
+title: "Splice.Wallet.TopUpState"
+description: "Reference documentation for Daml module Splice.Wallet.TopUpState."
+---
+
+<a id="module-splice-wallet-topupstate-18603"></a>
+
+# Splice.Wallet.TopUpState
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Functions
+
+<a id="function-splice-wallet-topupstate-initialvalidatortopupstate-90212"></a>
+
+### `initialValidatorTopUpState`
+
+```daml
+initialValidatorTopUpState : Party -> Party -> Text -> Text -> ValidatorTopUpState
+```
+
+## Templates
+
+<a id="type-splice-wallet-topupstate-validatortopupstate-56541"></a>
+
+### Template `ValidatorTopUpState`
+
+The state of a given top-up loop.
+
+Records the last time when this validator purchased traffic for this sequencer member in order to:
+1. allow for crash fault tolerant deduplication of traffic purchases
+2. allow enforcing a rate limit to prevent the validator from spending too much on traffic purchases.
+
+Signatories: `validator`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| dso | Party |  |
+| validator | Party | The validator operator purchasing traffic for the given sequencer member |
+| memberId | Text | The id of the sequencer member (participant or mediator) for which traffic has been purchased |
+| synchronizerId | Text | The id of the synchronizer for which this contract tracks purchased extra traffic |
+| migrationId | Int | The migration id of the synchronizer for which this contract tracks purchased extra traffic |
+| lastPurchasedAt | Time | Time when the traffic was last purchased by the validator for the given sequencer member |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `validator`
+
+Returns: `()`

--- a/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-transferoffer.mdx
+++ b/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-transferoffer.mdx
@@ -1,0 +1,398 @@
+---
+title: "Splice.Wallet.TransferOffer"
+description: "Reference documentation for Daml module Splice.Wallet.TransferOffer."
+---
+
+<a id="module-splice-wallet-transferoffer-28108"></a>
+
+# Splice.Wallet.TransferOffer
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-wallet-transferoffer-acceptedtransferofferabortresult-19853"></a>
+
+### `data AcceptedTransferOffer_AbortResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-transferoffer-acceptedtransferofferabortresult-99882"></a>
+- `AcceptedTransferOffer_AbortResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo`
+- `instance HasExercise AcceptedTransferOffer AcceptedTransferOffer_Abort AcceptedTransferOffer_AbortResult`
+- `instance HasFromAnyChoice AcceptedTransferOffer AcceptedTransferOffer_Abort AcceptedTransferOffer_AbortResult`
+- `instance HasToAnyChoice AcceptedTransferOffer AcceptedTransferOffer_Abort AcceptedTransferOffer_AbortResult`
+
+<a id="type-splice-wallet-transferoffer-acceptedtransferoffercompleteresult-69887"></a>
+
+### `data AcceptedTransferOffer_CompleteResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-transferoffer-acceptedtransferoffercompleteresult-43306"></a>
+- `AcceptedTransferOffer_CompleteResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferResult | TransferResult |  |
+| trackingInfo | TransferOfferTrackingInfo |  |
+| senderChangeAmulet | Optional (ContractId Amulet) |  |
+
+Instances:
+
+- `instance GetField senderChangeAmulet AcceptedTransferOffer_CompleteResult (Optional (ContractId Amulet))`
+- `instance GetField trackingInfo AcceptedTransferOffer_CompleteResult TransferOfferTrackingInfo`
+- `instance GetField transferResult AcceptedTransferOffer_CompleteResult TransferResult`
+- `instance SetField senderChangeAmulet AcceptedTransferOffer_CompleteResult (Optional (ContractId Amulet))`
+- `instance SetField trackingInfo AcceptedTransferOffer_CompleteResult TransferOfferTrackingInfo`
+- `instance SetField transferResult AcceptedTransferOffer_CompleteResult TransferResult`
+- `instance HasExercise AcceptedTransferOffer AcceptedTransferOffer_Complete AcceptedTransferOffer_CompleteResult`
+- `instance HasFromAnyChoice AcceptedTransferOffer AcceptedTransferOffer_Complete AcceptedTransferOffer_CompleteResult`
+- `instance HasToAnyChoice AcceptedTransferOffer AcceptedTransferOffer_Complete AcceptedTransferOffer_CompleteResult`
+
+<a id="type-splice-wallet-transferoffer-acceptedtransferofferexpireresult-60205"></a>
+
+### `data AcceptedTransferOffer_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-transferoffer-acceptedtransferofferexpireresult-67584"></a>
+- `AcceptedTransferOffer_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance HasExercise AcceptedTransferOffer AcceptedTransferOffer_Expire AcceptedTransferOffer_ExpireResult`
+- `instance HasFromAnyChoice AcceptedTransferOffer AcceptedTransferOffer_Expire AcceptedTransferOffer_ExpireResult`
+- `instance HasToAnyChoice AcceptedTransferOffer AcceptedTransferOffer_Expire AcceptedTransferOffer_ExpireResult`
+
+<a id="type-splice-wallet-transferoffer-acceptedtransferofferwithdrawresult-79292"></a>
+
+### `data AcceptedTransferOffer_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-transferoffer-acceptedtransferofferwithdrawresult-34065"></a>
+- `AcceptedTransferOffer_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance HasExercise AcceptedTransferOffer AcceptedTransferOffer_Withdraw AcceptedTransferOffer_WithdrawResult`
+- `instance HasFromAnyChoice AcceptedTransferOffer AcceptedTransferOffer_Withdraw AcceptedTransferOffer_WithdrawResult`
+- `instance HasToAnyChoice AcceptedTransferOffer AcceptedTransferOffer_Withdraw AcceptedTransferOffer_WithdrawResult`
+
+<a id="type-splice-wallet-transferoffer-transferoffertrackinginfo-52959"></a>
+
+### `data TransferOfferTrackingInfo`
+
+Constructors:
+
+<a id="constr-splice-wallet-transferoffer-transferoffertrackinginfo-29420"></a>
+- `TransferOfferTrackingInfo`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingId | Text |  |
+| sender | Party |  |
+| receiver | Party |  |
+
+Instances:
+
+- `instance Eq TransferOfferTrackingInfo`
+- `instance Show TransferOfferTrackingInfo`
+- `instance GetField receiver TransferOfferTrackingInfo Party`
+- `instance GetField sender TransferOfferTrackingInfo Party`
+- `instance GetField trackingId TransferOfferTrackingInfo Text`
+- `instance GetField trackingInfo WalletAppInstall_AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo WalletAppInstall_AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo WalletAppInstall_AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo WalletAppInstall_TransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo WalletAppInstall_TransferOffer_RejectResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo WalletAppInstall_TransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo AcceptedTransferOffer_CompleteResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo TransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo TransferOffer_RejectResult TransferOfferTrackingInfo`
+- `instance GetField trackingInfo TransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance SetField receiver TransferOfferTrackingInfo Party`
+- `instance SetField sender TransferOfferTrackingInfo Party`
+- `instance SetField trackingId TransferOfferTrackingInfo Text`
+- `instance SetField trackingInfo WalletAppInstall_AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_TransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_TransferOffer_RejectResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo WalletAppInstall_TransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo AcceptedTransferOffer_CompleteResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo TransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo TransferOffer_RejectResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo TransferOffer_WithdrawResult TransferOfferTrackingInfo`
+
+<a id="type-splice-wallet-transferoffer-transferofferacceptresult-62459"></a>
+
+### `data TransferOffer_AcceptResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-transferoffer-transferofferacceptresult-68938"></a>
+- `TransferOffer_AcceptResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| acceptedTransferOffer | ContractId AcceptedTransferOffer |  |
+
+Instances:
+
+- `instance GetField acceptedTransferOffer TransferOffer_AcceptResult (ContractId AcceptedTransferOffer)`
+- `instance SetField acceptedTransferOffer TransferOffer_AcceptResult (ContractId AcceptedTransferOffer)`
+- `instance HasExercise TransferOffer TransferOffer_Accept TransferOffer_AcceptResult`
+- `instance HasFromAnyChoice TransferOffer TransferOffer_Accept TransferOffer_AcceptResult`
+- `instance HasToAnyChoice TransferOffer TransferOffer_Accept TransferOffer_AcceptResult`
+
+<a id="type-splice-wallet-transferoffer-transferofferexpireresult-84418"></a>
+
+### `data TransferOffer_ExpireResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-transferoffer-transferofferexpireresult-36631"></a>
+- `TransferOffer_ExpireResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo TransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo TransferOffer_ExpireResult TransferOfferTrackingInfo`
+- `instance HasExercise TransferOffer TransferOffer_Expire TransferOffer_ExpireResult`
+- `instance HasFromAnyChoice TransferOffer TransferOffer_Expire TransferOffer_ExpireResult`
+- `instance HasToAnyChoice TransferOffer TransferOffer_Expire TransferOffer_ExpireResult`
+
+<a id="type-splice-wallet-transferoffer-transferofferrejectresult-40046"></a>
+
+### `data TransferOffer_RejectResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-transferoffer-transferofferrejectresult-28795"></a>
+- `TransferOffer_RejectResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo TransferOffer_RejectResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo TransferOffer_RejectResult TransferOfferTrackingInfo`
+- `instance HasExercise TransferOffer TransferOffer_Reject TransferOffer_RejectResult`
+- `instance HasFromAnyChoice TransferOffer TransferOffer_Reject TransferOffer_RejectResult`
+- `instance HasToAnyChoice TransferOffer TransferOffer_Reject TransferOffer_RejectResult`
+
+<a id="type-splice-wallet-transferoffer-transferofferwithdrawresult-27711"></a>
+
+### `data TransferOffer_WithdrawResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-transferoffer-transferofferwithdrawresult-1170"></a>
+- `TransferOffer_WithdrawResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| trackingInfo | TransferOfferTrackingInfo |  |
+
+Instances:
+
+- `instance GetField trackingInfo TransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance SetField trackingInfo TransferOffer_WithdrawResult TransferOfferTrackingInfo`
+- `instance HasExercise TransferOffer TransferOffer_Withdraw TransferOffer_WithdrawResult`
+- `instance HasFromAnyChoice TransferOffer TransferOffer_Withdraw TransferOffer_WithdrawResult`
+- `instance HasToAnyChoice TransferOffer TransferOffer_Withdraw TransferOffer_WithdrawResult`
+
+## Templates
+
+<a id="type-splice-wallet-transferoffer-acceptedtransferoffer-37657"></a>
+
+### Template `AcceptedTransferOffer`
+
+Signatories: `sender`, `receiver`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| receiver | Party |  |
+| dso | Party |  |
+| amount | PaymentAmount |  |
+| expiresAt | Time |  |
+| trackingId | Text |  |
+
+Choices:
+
+<a id="type-splice-wallet-transferoffer-acceptedtransferofferabort-66868"></a>
+
+#### Choice `AcceptedTransferOffer_Abort`
+
+Controllers: `sender`
+
+Returns: `AcceptedTransferOffer_AbortResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+<a id="type-splice-wallet-transferoffer-acceptedtransferoffercomplete-88466"></a>
+
+#### Choice `AcceptedTransferOffer_Complete`
+
+Controllers: `sender`, `walletProvider`
+
+Returns: `AcceptedTransferOffer_CompleteResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| inputs | [TransferInput] |  |
+| transferContext | PaymentTransferContext |  |
+| walletProvider | Party |  |
+
+<a id="type-splice-wallet-transferoffer-acceptedtransferofferexpire-98344"></a>
+
+#### Choice `AcceptedTransferOffer_Expire`
+
+Controllers: `actor`
+
+Returns: `AcceptedTransferOffer_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+
+<a id="type-splice-wallet-transferoffer-acceptedtransferofferwithdraw-26317"></a>
+
+#### Choice `AcceptedTransferOffer_Withdraw`
+
+Controllers: `receiver`
+
+Returns: `AcceptedTransferOffer_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |
+
+#### Choice `Archive`
+
+Controllers: `sender`, `receiver`
+
+Returns: `()`
+
+<a id="type-splice-wallet-transferoffer-transferoffer-51604"></a>
+
+### Template `TransferOffer`
+
+Signatories: `sender`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| sender | Party |  |
+| receiver | Party |  |
+| dso | Party |  |
+| amount | PaymentAmount |  |
+| description | Text |  |
+| expiresAt | Time |  |
+| trackingId | Text |  |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `sender`
+
+Returns: `()`
+
+<a id="type-splice-wallet-transferoffer-transferofferaccept-78794"></a>
+
+#### Choice `TransferOffer_Accept`
+
+Controllers: `receiver`
+
+Returns: `TransferOffer_AcceptResult`
+
+<a id="type-splice-wallet-transferoffer-transferofferexpire-75051"></a>
+
+#### Choice `TransferOffer_Expire`
+
+Controllers: `actor`
+
+Returns: `TransferOffer_ExpireResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| actor | Party |  |
+
+<a id="type-splice-wallet-transferoffer-transferofferreject-41375"></a>
+
+#### Choice `TransferOffer_Reject`
+
+Controllers: `receiver`
+
+Returns: `TransferOffer_RejectResult`
+
+<a id="type-splice-wallet-transferoffer-transferofferwithdraw-41986"></a>
+
+#### Choice `TransferOffer_Withdraw`
+
+Controllers: `sender`
+
+Returns: `TransferOffer_WithdrawResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| reason | Text |  |

--- a/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-transferpreapproval.mdx
+++ b/docs-main/reference/splice-daml-api/splice-wallet/splice-wallet-transferpreapproval.mdx
@@ -1,0 +1,92 @@
+---
+title: "Splice.Wallet.TransferPreapproval"
+description: "Reference documentation for Daml module Splice.Wallet.TransferPreapproval."
+---
+
+<a id="module-splice-wallet-transferpreapproval-41862"></a>
+
+# Splice.Wallet.TransferPreapproval
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `0.5.18`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Data Types
+
+<a id="type-splice-wallet-transferpreapproval-transferpreapprovalproposalacceptresult-56845"></a>
+
+### `data TransferPreapprovalProposal_AcceptResult`
+
+Constructors:
+
+<a id="constr-splice-wallet-transferpreapproval-transferpreapprovalproposalacceptresult-12116"></a>
+- `TransferPreapprovalProposal_AcceptResult`
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| transferPreapprovalCid | ContractId TransferPreapproval |  |
+| transferResult | TransferResult |  |
+| amuletPaid | Decimal |  |
+
+Instances:
+
+- `instance GetField amuletPaid TransferPreapprovalProposal_AcceptResult Decimal`
+- `instance GetField transferPreapprovalCid TransferPreapprovalProposal_AcceptResult (ContractId TransferPreapproval)`
+- `instance GetField transferResult TransferPreapprovalProposal_AcceptResult TransferResult`
+- `instance SetField amuletPaid TransferPreapprovalProposal_AcceptResult Decimal`
+- `instance SetField transferPreapprovalCid TransferPreapprovalProposal_AcceptResult (ContractId TransferPreapproval)`
+- `instance SetField transferResult TransferPreapprovalProposal_AcceptResult TransferResult`
+- `instance HasExercise TransferPreapprovalProposal TransferPreapprovalProposal_Accept TransferPreapprovalProposal_AcceptResult`
+- `instance HasFromAnyChoice TransferPreapprovalProposal TransferPreapprovalProposal_Accept TransferPreapprovalProposal_AcceptResult`
+- `instance HasToAnyChoice TransferPreapprovalProposal TransferPreapprovalProposal_Accept TransferPreapprovalProposal_AcceptResult`
+
+## Templates
+
+<a id="type-splice-wallet-transferpreapproval-transferpreapprovalproposal-39002"></a>
+
+### Template `TransferPreapprovalProposal`
+
+Signatories: `receiver`
+
+Payload:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| receiver | Party |  |
+| provider | Party |  |
+| expectedDso | Optional Party | The DSO party that the receiver expects to bet set on the transfer preapproval.<br/><br/>Must be set. It is only optional due to being introduced as part of a smart-contract upgrade. |
+
+Choices:
+
+#### Choice `Archive`
+
+Controllers: `receiver`
+
+Returns: `()`
+
+<a id="type-splice-wallet-transferpreapproval-transferpreapprovalproposalaccept-6548"></a>
+
+#### Choice `TransferPreapprovalProposal_Accept`
+
+Controllers: `provider`
+
+Returns: `TransferPreapprovalProposal_AcceptResult`
+
+Arguments:
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| context | PaymentTransferContext |  |
+| inputs | [TransferInput] |  |
+| expiresAt | Time |  |

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "generate:splice-scan-openapi-reference": "python3 scripts/generate_splice_scan_openapi_reference.py",
     "generate:splice-validator-openapi-reference": "python3 scripts/generate_splice_validator_openapi_reference.py",
     "generate:splice-token-standard-openapi-reference": "python3 scripts/generate_splice_token_standard_openapi_reference.py",
+    "generate:splice-daml-api-reference": "python3 scripts/generate_splice_daml_api_reference.py",
     "generate:typescript-bindings-reference": "python3 scripts/generate_typescript_bindings_reference.py"
   },
   "dependencies": {

--- a/scripts/generate_all_reference_docs.py
+++ b/scripts/generate_all_reference_docs.py
@@ -21,6 +21,7 @@ SCRIPT_PATHS = [
     REPO_ROOT / "scripts" / "generate_splice_scan_openapi_reference.py",
     REPO_ROOT / "scripts" / "generate_splice_validator_openapi_reference.py",
     REPO_ROOT / "scripts" / "generate_splice_token_standard_openapi_reference.py",
+    REPO_ROOT / "scripts" / "generate_splice_daml_api_reference.py",
     REPO_ROOT / "scripts" / "generate_typescript_bindings_reference.py",
 ]
 

--- a/scripts/generate_splice_daml_api_reference.py
+++ b/scripts/generate_splice_daml_api_reference.py
@@ -1,0 +1,697 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import splice_openapi_release_bundles
+
+
+DEFAULT_SOURCE_CONFIG = REPO_ROOT / "config" / "x2mdx" / "splice-daml-api" / "source-artifacts.json"
+DEFAULT_CACHE_DIR = REPO_ROOT / ".internal" / "cache" / "x2mdx" / "splice-daml-api"
+DEFAULT_MANIFEST_ROOT = REPO_ROOT / ".internal" / "generated" / "x2mdx" / "splice-daml-api"
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "docs-main" / "reference" / "splice-daml-api"
+DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
+
+
+@dataclass(frozen=True)
+class PackageInfo:
+    family: str
+    package_name: str
+    package_id: str
+    package_root: Path
+    exposed_modules: list[str]
+    depends: list[str]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the Splice Daml API reference from published splice-node release-bundle DARs."
+    )
+    parser.add_argument("--source-config", default=str(DEFAULT_SOURCE_CONFIG))
+    parser.add_argument("--cache-dir", default=str(DEFAULT_CACHE_DIR))
+    parser.add_argument("--manifest-root", default=str(DEFAULT_MANIFEST_ROOT))
+    parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT))
+    parser.add_argument("--docs-json", default=str(DEFAULT_DOCS_JSON))
+    parser.add_argument("--nav-dropdown", default="API Reference")
+    parser.add_argument("--family", action="append", help="Family name to generate. Repeat to limit generation.")
+    parser.add_argument("--version", action="append", help="Release version to include. Repeat to limit generation.")
+    parser.add_argument("--publish-version", help="Release version whose docs should be published.")
+    parser.add_argument("--force-refresh", action="store_true", help="Re-download and re-extract release bundles.")
+    parser.add_argument("--force-regenerate", action="store_true", help="Regenerate Daml docs JSON and MDX output.")
+    parser.add_argument(
+        "--source-name",
+        default="Published Splice Daml docs JSON generated from release DAR artifacts",
+        help="Source label embedded in generated content.",
+    )
+    parser.add_argument(
+        "--version-filter",
+        default="published splice-node release bundles",
+        help="Version-filter label embedded in generated content.",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def configured_sections(source_config: dict[str, Any]) -> list[dict[str, Any]]:
+    sections = source_config.get("sections")
+    if not isinstance(sections, list) or not sections:
+        raise ValueError("Source config must define a non-empty `sections` list")
+    output: list[dict[str, Any]] = []
+    for section in sections:
+        if not isinstance(section, dict):
+            raise ValueError("Each section must be an object")
+        group = section.get("group")
+        description = section.get("description")
+        families = section.get("families")
+        if not isinstance(group, str) or not group:
+            raise ValueError("Each section must define a non-empty string `group`")
+        if description is not None and not isinstance(description, str):
+            raise ValueError("Section `description` must be a string when present")
+        if not isinstance(families, list) or not families or not all(isinstance(item, str) and item for item in families):
+            raise ValueError(f"Section {group!r} must define a non-empty string list `families`")
+        output.append({"group": group, "description": description or "", "families": families})
+    return output
+
+
+def blocked_live_families(source_config: dict[str, Any]) -> dict[str, str]:
+    payload = source_config.get("blocked_live_families") or []
+    if not isinstance(payload, list):
+        raise ValueError("blocked_live_families must be a list when present")
+    blocked: dict[str, str] = {}
+    for item in payload:
+        if not isinstance(item, dict):
+            raise ValueError("Each blocked_live_families entry must be an object")
+        name = item.get("name")
+        reason = item.get("reason")
+        if not isinstance(name, str) or not name:
+            raise ValueError("Each blocked_live_families entry needs a non-empty `name`")
+        if not isinstance(reason, str) or not reason:
+            raise ValueError(f"Blocked family {name!r} needs a non-empty `reason`")
+        blocked[name] = reason
+    return blocked
+
+
+def configured_families(source_config: dict[str, Any]) -> list[str]:
+    sections = configured_sections(source_config)
+    families: list[str] = []
+    seen: set[str] = set()
+    for section in sections:
+        for family in section["families"]:
+            if family in seen:
+                raise ValueError(f"Duplicate family configured: {family}")
+            seen.add(family)
+            families.append(family)
+    return families
+
+
+def docs_json_page_ref(path: Path, docs_json_path: Path) -> str:
+    relative = path.resolve().relative_to(docs_json_path.resolve().parent)
+    if relative.suffix != ".mdx":
+        raise ValueError(f"Expected MDX file under docs root, got: {path}")
+    return relative.with_suffix("").as_posix()
+
+
+def docs_route(path: Path, docs_json_path: Path) -> str:
+    page_ref = docs_json_page_ref(path, docs_json_path)
+    if page_ref.endswith("/index"):
+        page_ref = page_ref[: -len("/index")]
+    return f"/{page_ref}"
+
+
+def read_mdx_title(path: Path) -> str:
+    in_frontmatter = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line == "---":
+            if in_frontmatter:
+                break
+            in_frontmatter = True
+            continue
+        if not in_frontmatter:
+            continue
+        if line.startswith("title: "):
+            return line.split(":", 1)[1].strip().strip('"')
+    raise ValueError(f"Missing title frontmatter in {path}")
+
+
+def live_families_from_archive(archive_path: Path) -> set[str]:
+    pattern = re.compile(r".*/docs/html/app_dev/api/([^/]+)/index\.html$")
+    families: set[str] = set()
+    with tarfile.open(archive_path, "r:gz") as handle:
+        for member in handle.getmembers():
+            if not member.isfile():
+                continue
+            match = pattern.fullmatch(member.name)
+            if match:
+                families.add(match.group(1))
+    if not families:
+        raise ValueError(f"No app_dev/api families found in {archive_path}")
+    return families
+
+
+def dar_members_from_archive(archive_path: Path) -> dict[str, str]:
+    current_pattern = re.compile(r".*/dars/([^/]+)-current\.dar$")
+    fallback_pattern = re.compile(r".*/dars/([^/]+?)-[0-9].*\.dar$")
+    members: dict[str, tuple[int, str]] = {}
+    with tarfile.open(archive_path, "r:gz") as handle:
+        for member in handle.getmembers():
+            if not member.isfile() or not member.name.endswith(".dar") or "/dars/" not in member.name:
+                continue
+            filename = Path(member.name).name
+            current_match = current_pattern.fullmatch(member.name)
+            if current_match:
+                family = current_match.group(1)
+                priority = 1
+            else:
+                fallback_match = fallback_pattern.fullmatch(member.name)
+                if fallback_match is None:
+                    continue
+                family = fallback_match.group(1)
+                priority = 0
+            previous = members.get(family)
+            if previous is None or priority > previous[0]:
+                members[family] = (priority, member.name)
+    return {family: member_name for family, (_priority, member_name) in members.items()}
+
+
+def extract_dar(
+    *,
+    archive_path: Path,
+    dar_member_name: str,
+    output_dir: Path,
+    force_refresh: bool,
+) -> Path:
+    if output_dir.exists() and not force_refresh and any(output_dir.rglob("*.daml")):
+        return output_dir
+
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="splice-dar-") as temp_dir:
+        temp_dar = Path(temp_dir) / "bundle.dar"
+        with tarfile.open(archive_path, "r:gz") as handle:
+            member = handle.getmember(dar_member_name)
+            extracted = handle.extractfile(member)
+            if extracted is None:
+                raise FileNotFoundError(f"Failed to extract {dar_member_name} from {archive_path}")
+            temp_dar.write_bytes(extracted.read())
+        with zipfile.ZipFile(temp_dar) as dar_zip:
+            dar_zip.extractall(output_dir)
+    return output_dir
+
+
+def package_info(*, family: str, extract_dir: Path) -> PackageInfo:
+    package_root = next(
+        (path for path in sorted(extract_dir.iterdir()) if path.is_dir() and path.name != "META-INF"),
+        None,
+    )
+    if package_root is None:
+        raise FileNotFoundError(f"Could not find extracted package root in {extract_dir}")
+
+    conf_path = next((package_root / "data").glob("*.conf"), None)
+    if conf_path is None:
+        raise FileNotFoundError(f"Missing package conf in {package_root / 'data'}")
+
+    fields: dict[str, str] = {}
+    for line in conf_path.read_text(encoding="utf-8").splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        fields[key.strip()] = value.strip()
+
+    package_id = fields.get("id")
+    if not package_id:
+        raise ValueError(f"Missing package id in {conf_path}")
+    package_name = fields.get("name")
+    if not package_name:
+        raise ValueError(f"Missing package name in {conf_path}")
+    exposed_modules = [item for item in fields.get("exposed-modules", "").split() if item]
+    if not exposed_modules:
+        raise ValueError(f"Missing exposed modules in {conf_path}")
+    depends = [item for item in fields.get("depends", "").split() if item]
+    return PackageInfo(
+        family=family,
+        package_name=package_name,
+        package_id=package_id,
+        package_root=package_root,
+        exposed_modules=exposed_modules,
+        depends=depends,
+    )
+
+
+def module_source_paths(info: PackageInfo) -> list[str]:
+    source_paths: list[str] = []
+    for module_name in info.exposed_modules:
+        relative_path = Path(*module_name.split(".")).with_suffix(".daml")
+        source_path = info.package_root / relative_path
+        if not source_path.exists():
+            raise FileNotFoundError(f"Missing source file for module {module_name}: {source_path}")
+        source_paths.append(str(relative_path))
+    return source_paths
+
+
+def dependency_include_dirs(
+    *,
+    info: PackageInfo,
+    package_index: dict[str, PackageInfo],
+) -> list[Path]:
+    include_dirs: list[Path] = []
+    seen_ids: set[str] = set()
+    package_name_index = {package.package_name: package for package in package_index.values()}
+
+    def resolve_dependency(package_id: str) -> PackageInfo | None:
+        exact = package_index.get(package_id)
+        if exact is not None:
+            return exact
+        candidates = [
+            package
+            for package_name, package in package_name_index.items()
+            if package_id == package_name or package_id.startswith(f"{package_name}-")
+        ]
+        if not candidates:
+            return None
+        candidates.sort(key=lambda package: len(package.package_name), reverse=True)
+        return candidates[0]
+
+    def visit(package_id: str) -> None:
+        if package_id in seen_ids:
+            return
+        seen_ids.add(package_id)
+        dependency = resolve_dependency(package_id)
+        if dependency is None:
+            return
+        include_dirs.append(dependency.package_root)
+        for nested in dependency.depends:
+            visit(nested)
+
+    for dependency_id in info.depends:
+        visit(dependency_id)
+    return include_dirs
+
+
+def generate_daml_json(
+    *,
+    info: PackageInfo,
+    include_dirs: list[Path],
+    output_json: Path,
+    force_regenerate: bool,
+) -> Path:
+    if output_json.exists() and not force_regenerate:
+        print(f"Using cached Daml docs JSON: {output_json}")
+        return output_json
+
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    command = ["daml", "damlc", "docs"]
+    for include_dir in include_dirs:
+        command.extend(["--include", str(include_dir)])
+    command.extend(
+        [
+            "--include-modules",
+            ",".join(info.exposed_modules),
+            "--format",
+            "json",
+            "--output",
+            str(output_json),
+            *module_source_paths(info),
+        ]
+    )
+    print("Running:", " ".join(command))
+    subprocess.run(command, cwd=str(info.package_root), check=True)
+    return output_json
+
+
+def write_manifest(
+    *,
+    manifest_path: Path,
+    source_name: str,
+    publish_version: str,
+    versions: list[dict[str, str]],
+) -> Path:
+    manifest = {
+        "source": source_name,
+        "publish_version": publish_version,
+        "versions": versions,
+    }
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote manifest: {manifest_path}")
+    return manifest_path
+
+
+def run_x2mdx(
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    publish_version: str,
+    overview_title: str,
+    source_name: str,
+    version_filter: str,
+    docs_json_path: Path,
+) -> None:
+    shutil.rmtree(output_dir, ignore_errors=True)
+    route_prefix = docs_route(output_dir / "index.mdx", docs_json_path)
+    command = [
+        "x2mdx",
+        "daml-json",
+        "build-api-pages-from-manifest",
+        "--manifest",
+        str(manifest_path),
+        "--output-dir",
+        str(output_dir),
+        "--publish-version",
+        publish_version,
+        "--overview-title",
+        overview_title,
+        "--source-name",
+        source_name,
+        "--version-filter",
+        version_filter,
+        "--link-prefix",
+        route_prefix,
+    ]
+    print("Running:", " ".join(command))
+    subprocess.run(command, cwd=str(REPO_ROOT), check=True)
+
+
+def family_group(*, family_dir: Path, docs_json_path: Path) -> dict[str, Any]:
+    index_path = family_dir / "index.mdx"
+    if not index_path.exists():
+        raise FileNotFoundError(f"Missing generated family index: {index_path}")
+    index_title = read_mdx_title(index_path)
+    page_entries = []
+    for page in sorted(family_dir.glob("*.mdx")):
+        title = read_mdx_title(page)
+        page_entries.append((0 if page.name == "index.mdx" else 1, title.lower(), docs_json_page_ref(page, docs_json_path)))
+    page_entries.sort()
+    return {
+        "title": index_title,
+        "route": docs_route(index_path, docs_json_path),
+        "group": {
+            "group": index_title,
+            "pages": [page_ref for _sort, _title, page_ref in page_entries],
+        },
+    }
+
+
+def ensure_group_path(items: list[Any], group_path: list[str], *, top_level_insert_after_group: str | None) -> list[Any]:
+    current_pages = items
+    top_level_items = items
+    for depth, label in enumerate(group_path):
+        group = next((item for item in current_pages if isinstance(item, dict) and item.get("group") == label), None)
+        if group is None:
+            group = {"group": label, "pages": []}
+            if depth == 0 and top_level_insert_after_group:
+                inserted = False
+                for index, item in enumerate(top_level_items):
+                    if isinstance(item, dict) and item.get("group") == top_level_insert_after_group:
+                        top_level_items.insert(index + 1, group)
+                        inserted = True
+                        break
+                if not inserted:
+                    top_level_items.append(group)
+            else:
+                current_pages.append(group)
+        pages = group.get("pages")
+        if not isinstance(pages, list):
+            pages = []
+            group["pages"] = pages
+        current_pages = pages
+    return current_pages
+
+
+def write_overview_page(
+    *,
+    output_root: Path,
+    docs_json_path: Path,
+    overview_title: str,
+    publish_version: str,
+    sections: list[dict[str, Any]],
+    generated_groups: dict[str, dict[str, Any]],
+    blocked: dict[str, str],
+) -> Path:
+    lines = [
+        "---",
+        f'title: "{overview_title}"',
+        'description: "Generated package reference pages for the published Splice Daml API DAR artifacts"',
+        "---",
+        "",
+        (
+            "These pages mirror the live `docs.sync.global/app_dev/api/` Daml surface wherever the published "
+            f"`{publish_version}_splice-node.tar.gz` bundle provides a corresponding DAR artifact."
+        ),
+        "",
+        "## Coverage",
+        f"- Generated family pages from published DARs: {len(generated_groups)}",
+        f"- Live families blocked by missing release DARs: {len(blocked)}",
+        "",
+        "## Reference",
+    ]
+
+    for section in sections:
+        lines.append(f"### {section['group']}")
+        if section["description"]:
+            lines.append(section["description"])
+        lines.append("")
+        for family in section["families"]:
+            group = generated_groups.get(family)
+            if group is None:
+                continue
+            lines.append(f"- [{group['title']}]({group['route']})")
+        lines.append("")
+
+    if blocked:
+        lines.extend(["## Artifact gaps", ""])
+        for family, reason in blocked.items():
+            live_url = f"https://docs.sync.global/app_dev/api/{family}/index.html"
+            lines.append(f"- `{family}`: {reason} Live page: {live_url}")
+        lines.append("")
+
+    output_root.mkdir(parents=True, exist_ok=True)
+    overview_path = output_root / "index.mdx"
+    overview_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    return overview_path
+
+
+def update_docs_navigation(
+    *,
+    docs_json_path: Path,
+    dropdown_label: str,
+    parent_groups: list[str],
+    top_level_insert_after_group: str | None,
+    nav_group_label: str,
+    output_root: Path,
+    sections: list[dict[str, Any]],
+    generated_groups: dict[str, dict[str, Any]],
+) -> None:
+    docs = load_json(docs_json_path)
+    dropdowns = docs.get("navigation", {}).get("dropdowns")
+    if not isinstance(dropdowns, list):
+        raise ValueError(f"docs.json navigation.dropdowns must be a list: {docs_json_path}")
+    dropdown = next((item for item in dropdowns if isinstance(item, dict) and item.get("dropdown") == dropdown_label), None)
+    if dropdown is None:
+        raise ValueError(f"Dropdown not found in docs.json: {dropdown_label}")
+    pages = dropdown.get("pages")
+    if not isinstance(pages, list):
+        raise ValueError(f"Dropdown does not expose a pages list: {dropdown_label}")
+
+    target_pages = ensure_group_path(
+        pages,
+        parent_groups,
+        top_level_insert_after_group=top_level_insert_after_group,
+    )
+    target_pages[:] = [
+        item
+        for item in target_pages
+        if not (isinstance(item, dict) and item.get("group") == nav_group_label)
+    ]
+
+    group_pages: list[Any] = [docs_json_page_ref(output_root / "index.mdx", docs_json_path)]
+    for section in sections:
+        section_groups = [
+            generated_groups[family]["group"]
+            for family in section["families"]
+            if family in generated_groups
+        ]
+        if section_groups:
+            group_pages.append({"group": section["group"], "pages": section_groups})
+
+    target_pages.append({"group": nav_group_label, "pages": group_pages})
+    docs_json_path.write_text(json.dumps(docs, indent=2) + "\n", encoding="utf-8")
+    print(f"Updated docs navigation: {docs_json_path}")
+
+
+def main() -> int:
+    args = parse_args()
+    source_config = load_json(Path(args.source_config).resolve())
+    sections = configured_sections(source_config)
+    blocked = blocked_live_families(source_config)
+    configured = configured_families(source_config)
+    include_families = set(args.family or configured)
+    unknown_families = include_families.difference(configured)
+    if unknown_families:
+        raise ValueError(f"Unknown family selection: {sorted(unknown_families)}")
+
+    releases = splice_openapi_release_bundles.selected_releases(
+        source_config=source_config,
+        include_versions=set(args.version) if args.version else None,
+    )
+    publish_version = args.publish_version or str(source_config.get("publish_version") or releases[-1]["version"])
+    release_by_version = {release["version"]: release for release in releases}
+    if publish_version not in release_by_version:
+        raise ValueError(f"Publish version {publish_version!r} was not selected")
+    publish_release = release_by_version[publish_version]
+
+    cache_dir = Path(args.cache_dir).resolve()
+    manifest_root = Path(args.manifest_root).resolve()
+    output_root = Path(args.output_root).resolve()
+    docs_json_path = Path(args.docs_json).resolve()
+
+    publish_archive = splice_openapi_release_bundles.ensure_archive(
+        cache_dir=cache_dir,
+        release=publish_release,
+        force_refresh=args.force_refresh,
+    )
+    live_families = live_families_from_archive(publish_archive)
+    covered_families = set(configured).union(blocked)
+    missing_live = sorted(live_families.difference(covered_families))
+    extra_covered = sorted(covered_families.difference(live_families))
+    if missing_live or extra_covered:
+        problems = []
+        if missing_live:
+            problems.append(f"uncovered live families: {missing_live}")
+        if extra_covered:
+            problems.append(f"configured families not present on live docs surface: {extra_covered}")
+        raise ValueError("; ".join(problems))
+
+    publish_dars = dar_members_from_archive(publish_archive)
+    for family in configured:
+        if family not in publish_dars:
+            raise ValueError(f"Configured family {family!r} has no DAR in publish release {publish_version}")
+    for family in blocked:
+        if family in publish_dars:
+            raise ValueError(f"Blocked family {family!r} unexpectedly has a DAR in publish release {publish_version}")
+
+    package_info_by_version: dict[str, dict[str, PackageInfo]] = {}
+    package_info_by_id: dict[str, dict[str, PackageInfo]] = {}
+    for release in releases:
+        archive = splice_openapi_release_bundles.ensure_archive(
+            cache_dir=cache_dir,
+            release=release,
+            force_refresh=args.force_refresh,
+        )
+        dar_members = dar_members_from_archive(archive)
+        family_infos: dict[str, PackageInfo] = {}
+        id_index: dict[str, PackageInfo] = {}
+        for family in configured:
+            member_name = dar_members.get(family)
+            if member_name is None:
+                continue
+            extract_dir = extract_dar(
+                archive_path=archive,
+                dar_member_name=member_name,
+                output_dir=cache_dir / "extracted" / release["version"] / family,
+                force_refresh=args.force_refresh,
+            )
+            info = package_info(family=family, extract_dir=extract_dir)
+            family_infos[family] = info
+            id_index[info.package_id] = info
+        package_info_by_version[release["version"]] = family_infos
+        package_info_by_id[release["version"]] = id_index
+
+    generated_groups: dict[str, dict[str, Any]] = {}
+    for family in configured:
+        if family not in include_families:
+            continue
+
+        manifest_versions: list[dict[str, str]] = []
+        for release in releases:
+            info = package_info_by_version[release["version"]].get(family)
+            if info is None:
+                continue
+            output_json = generate_daml_json(
+                info=info,
+                include_dirs=dependency_include_dirs(
+                    info=info,
+                    package_index=package_info_by_id[release["version"]],
+                ),
+                output_json=cache_dir / "json" / release["version"] / f"{family}.json",
+                force_regenerate=args.force_regenerate,
+            )
+            manifest_versions.append(
+                {
+                    "version": release["version"],
+                    "json_path": str(output_json.resolve()),
+                }
+            )
+
+        if not manifest_versions:
+            raise ValueError(f"No generated JSON versions available for {family}")
+
+        manifest_path = write_manifest(
+            manifest_path=manifest_root / family / "manifest.json",
+            source_name=args.source_name,
+            publish_version=publish_version,
+            versions=manifest_versions,
+        )
+        family_output_dir = output_root / family
+        run_x2mdx(
+            manifest_path=manifest_path,
+            output_dir=family_output_dir,
+            publish_version=publish_version,
+            overview_title=f"{family} docs",
+            source_name=args.source_name,
+            version_filter=args.version_filter,
+            docs_json_path=docs_json_path,
+        )
+        generated_groups[family] = family_group(family_dir=family_output_dir, docs_json_path=docs_json_path)
+
+    overview_path = write_overview_page(
+        output_root=output_root,
+        docs_json_path=docs_json_path,
+        overview_title=str(source_config.get("overview_title") or "Splice Daml APIs"),
+        publish_version=publish_version,
+        sections=sections,
+        generated_groups=generated_groups,
+        blocked=blocked,
+    )
+    print(f"Wrote overview page: {overview_path}")
+
+    update_docs_navigation(
+        docs_json_path=docs_json_path,
+        dropdown_label=args.nav_dropdown,
+        parent_groups=list(source_config.get("nav_parent_groups") or []),
+        top_level_insert_after_group=source_config.get("top_level_insert_after_group")
+        if isinstance(source_config.get("top_level_insert_after_group"), str)
+        else None,
+        nav_group_label=str(source_config.get("nav_group_label") or "Daml APIs"),
+        output_root=output_root,
+        sections=sections,
+        generated_groups=generated_groups,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a docs-side generator for the Splice Daml API surface from published `*_splice-node.tar.gz` release bundles
- generate the 20 live DAR-backed Splice Daml API families under `API Reference -> Splice APIs -> Daml APIs`
- record the one remaining live artifact gap (`splice-token-standard-test`) on the overview page because the published bundle does not ship a matching DAR

## Validation
- `direnv exec /Users/danielporter/control/.worktrees/docs-splice-daml-api-reference python3 -m py_compile scripts/generate_splice_daml_api_reference.py`
- `direnv exec /Users/danielporter/control/.worktrees/docs-splice-daml-api-reference python3 scripts/generate_splice_daml_api_reference.py`
- `direnv exec /Users/danielporter/control/.worktrees/docs-splice-daml-api-reference python3 scripts/generate_all_reference_docs.py --dry-run`
- `direnv exec /Users/danielporter/control/.worktrees/docs-splice-daml-api-reference npm run generate:all-reference-docs -- --dry-run`
- compared generated family/module counts against the published docs HTML inside `0.5.18_splice-node.tar.gz`: 20 generated families, 1 blocked live family, no mismatches