### PR TITLE
Close Daml Standard Library parity gaps

### DIFF
--- a/docs-main/appdev/reference/daml-standard-library/da-action-state-class.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-action-state-class.mdx
@@ -9,6 +9,22 @@ description: "Reference documentation for Daml module DA.Action.State.Class."
 
 DA.Action.State.Class
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Typeclasses
 
 <a id="class-da-action-state-class-actionstate-80467"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-action-state.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-action-state.mdx
@@ -9,6 +9,22 @@ description: "Reference documentation for Daml module DA.Action.State."
 
 DA.Action.State
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-action-state-type-state-76783"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-action.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-action.mdx
@@ -9,6 +9,22 @@ description: "Reference documentation for Daml module DA.Action."
 
 Action
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-action-when-35467"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-assert.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-assert.mdx
@@ -7,6 +7,22 @@ description: "Reference documentation for Daml module DA.Assert."
 
 # DA.Assert
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-assert-asserteq-7135"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-bifunctor.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-bifunctor.mdx
@@ -7,6 +7,22 @@ description: "Reference documentation for Daml module DA.Bifunctor."
 
 # DA.Bifunctor
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Typeclasses
 
 <a id="class-da-bifunctor-bifunctor-68312"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-crypto-text.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-crypto-text.mdx
@@ -11,9 +11,21 @@ Functions for working with Crypto builtins.
 
 For example, as used to implement CCTP functionality.
 
-## Notices
+## Module Snapshot
 
-- Warnings: `2`
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Alpha (experimental).
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `2`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
 
 <Warning>
 DA.Crypto.Text is an alpha feature. It can change without notice.

--- a/docs-main/appdev/reference/daml-standard-library/da-date.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-date.mdx
@@ -13,6 +13,22 @@ The bounds for Date are 0001-01-01T00:00:00.000000Z and
 
 9999-12-31T23:59:59.999999Z.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-date-types-dayofweek-18120"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-either.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-either.mdx
@@ -17,6 +17,22 @@ an error value and the `Right` constructor is used to hold a correct
 
 value (mnemonic: "right" also means correct).
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-either-lefts-59601"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-exception.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-exception.mdx
@@ -11,10 +11,21 @@ Exception handling in Daml.
 
 DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions
 
-## Notices
+## Module Snapshot
 
-- Deprecations: `2`
-- Deprecated since: `3.4.9`
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Deprecated.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `2`
+Deprecated since: `3.4.11`
+</Card>
+</CardGroup>
 
 <Warning>
 Exceptions are deprecated, prefer `failWithStatus`, and avoid using catch.

--- a/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
@@ -9,6 +9,22 @@ description: "Reference documentation for Daml module DA.Fail."
 
 Fail, for FailureStatus
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-internal-fail-types-failurecategory-97811"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-foldable.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-foldable.mdx
@@ -19,6 +19,22 @@ import DA.Foldable qualified as F
 
 ```
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Typeclasses
 
 <a id="class-da-foldable-foldable-25994"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-functor.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-functor.mdx
@@ -9,6 +9,22 @@ description: "Reference documentation for Daml module DA.Functor."
 
 The `Functor` class is used for types that can be mapped over.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-functor-dollargt-48161"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-internal-interface-anyview-types.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-internal-interface-anyview-types.mdx
@@ -7,6 +7,22 @@ description: "Reference documentation for Daml module DA.Internal.Interface.AnyV
 
 # DA.Internal.Interface.AnyView.Types
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-internal-interface-anyview-types-anyview-16883"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-internal-interface-anyview.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-internal-interface-anyview.mdx
@@ -7,6 +7,22 @@ description: "Reference documentation for Daml module DA.Internal.Interface.AnyV
 
 # DA.Internal.Interface.AnyView
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Typeclasses
 
 <a id="class-da-internal-interface-anyview-hasfromanyview-30108"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-list-builtinorder.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-list-builtinorder.mdx
@@ -29,6 +29,22 @@ pass in values that cannot be compared, e.g., functions. The
 
 implementation of those instances is not used.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-list-builtinorder-dedup-38418"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-list-total.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-list-total.mdx
@@ -7,6 +7,22 @@ description: "Reference documentation for Daml module DA.List.Total."
 
 # DA.List.Total
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-list-total-head-26095"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-list.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-list.mdx
@@ -9,6 +9,22 @@ description: "Reference documentation for Daml module DA.List."
 
 List
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-list-sort-96399"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-logic.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-logic.mdx
@@ -9,6 +9,22 @@ description: "Reference documentation for Daml module DA.Logic."
 
 Logic -  Propositional calculus.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-logic-types-formula-34794"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-map.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-map.mdx
@@ -57,6 +57,22 @@ default `Ord` instances, and `Set k` assuming `k` has a
 
 default `Ord` instance.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-map-fromlist-23400"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-math.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-math.mdx
@@ -17,6 +17,22 @@ by the Daml runtime so they are not performant. Their use is not advised in perf
 
 contexts.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-math-starstar-89123"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-monoid.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-monoid.mdx
@@ -7,6 +7,22 @@ description: "Reference documentation for Daml module DA.Monoid."
 
 # DA.Monoid
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-monoid-types-all-38142"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-nonempty-types.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-nonempty-types.mdx
@@ -11,6 +11,22 @@ This module contains the type for non-empty lists so we can give it a stable pac
 
 This is reexported from DA.NonEmpty so you should never need to import this module.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-nonempty-types-nonempty-16010"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-nonempty.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-nonempty.mdx
@@ -23,6 +23,22 @@ import qualified DA.NonEmpty as NE
 
 ```
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-nonempty-cons-63704"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-numeric.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-numeric.mdx
@@ -7,6 +7,22 @@ description: "Reference documentation for Daml module DA.Numeric."
 
 # DA.Numeric
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-numeric-roundingmode-53864"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-optional.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-optional.mdx
@@ -23,6 +23,22 @@ action, where all errors are represented by `None`. A richer
 
 error action can be built using the `Either` type.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-optional-fromsome-59859"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-record.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-record.mdx
@@ -11,6 +11,22 @@ Exports the record machinery necessary to allow one to annotate
 
 code that is polymorphic in the underlying record type.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-internal-record-hasfield-59910"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-semigroup.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-semigroup.mdx
@@ -7,6 +7,22 @@ description: "Reference documentation for Daml module DA.Semigroup."
 
 # DA.Semigroup
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-semigroup-types-max-52699"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-set.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-set.mdx
@@ -57,6 +57,22 @@ default `Ord` instances, and `Set k` assuming `k` has a
 
 default `Ord` instance.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-set-types-set-90436"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-stack.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-stack.mdx
@@ -7,6 +7,22 @@ description: "Reference documentation for Daml module DA.Stack."
 
 # DA.Stack
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-stack-types-srcloc-15887"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-text.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-text.mdx
@@ -9,6 +9,22 @@ description: "Reference documentation for Daml module DA.Text."
 
 Functions for working with Text.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-text-explode-24206"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-textmap.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-textmap.mdx
@@ -13,6 +13,22 @@ collection of key/value pairs such that, each possible key appears
 
 at most once in the collection.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-textmap-fromlist-19033"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-time.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-time.mdx
@@ -17,6 +17,22 @@ The bounds for Time are 0001-01-01T00:00:00.000000Z and
 
 9999-12-31T23:59:59.999999Z.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-time-types-reltime-23082"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-traversable.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-traversable.mdx
@@ -19,6 +19,22 @@ import DA.Traversable   qualified as F
 
 ```
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Typeclasses
 
 <a id="class-da-traversable-traversable-18144"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-tuple.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-tuple.mdx
@@ -9,6 +9,22 @@ description: "Reference documentation for Daml module DA.Tuple."
 
 Tuple - Ubiquitous functions of tuples.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Functions
 
 <a id="function-da-tuple-first-48871"></a>

--- a/docs-main/appdev/reference/daml-standard-library/da-validation.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-validation.mdx
@@ -9,6 +9,22 @@ description: "Reference documentation for Daml module DA.Validation."
 
 `Validation` type and associated functions.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-validation-types-validation-39644"></a>

--- a/docs-main/appdev/reference/daml-standard-library/ghc-show-text.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/ghc-show-text.mdx
@@ -1,0 +1,34 @@
+---
+title: "GHC.Show.Text"
+description: "Reference documentation for Daml module GHC.Show.Text."
+---
+
+<a id="module-ghc-show-text-13336"></a>
+
+# GHC.Show.Text
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Functions
+
+<a id="function-ghc-show-text-showsprectext-69636"></a>
+
+### `showsPrecText`
+
+```daml
+showsPrecText : Int -> Text -> ShowS
+```

--- a/docs-main/appdev/reference/daml-standard-library/ghc-tuple-check.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/ghc-tuple-check.mdx
@@ -1,0 +1,34 @@
+---
+title: "GHC.Tuple.Check"
+description: "Reference documentation for Daml module GHC.Tuple.Check."
+---
+
+<a id="module-ghc-tuple-check-92032"></a>
+
+# GHC.Tuple.Check
+
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
+## Functions
+
+<a id="function-ghc-tuple-check-userwrittentuple-58630"></a>
+
+### `userWrittenTuple`
+
+```daml
+userWrittenTuple : a -> a
+```

--- a/docs-main/appdev/reference/daml-standard-library/index.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/index.mdx
@@ -7,52 +7,92 @@ description: "Reference documentation for Daml Standard Library modules."
 
 This page is generated from versioned Daml docs JSON snapshots.
 
-## Source
-
-- Source name: `Published Daml Standard Library docs JSON from local SDK artifacts`
-- Version filter: `characterization fixture versions`
-- Publish version: `3.4.11`
-- Versions analyzed: `3.4.10, 3.4.11`
-
 ## Table of Contents
 
-🟢 Active Since  🟠 Deprecated  🔴 Removed
+| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
+| --- | --- | --- | --- | --- | --- | --- |
+| [`DA.Action`](/appdev/reference/daml-standard-library/da-action) | `Module` | Action | `3.4.11` | - | - | - |
+| [`DA.Action.State`](/appdev/reference/daml-standard-library/da-action-state) | `Module` | DA.Action.State | `3.4.11` | - | - | - |
+| [`DA.Action.State.Class`](/appdev/reference/daml-standard-library/da-action-state-class) | `Module` | DA.Action.State.Class | `3.4.11` | - | - | - |
+| [`DA.Assert`](/appdev/reference/daml-standard-library/da-assert) | `Module` | - | `3.4.11` | - | - | - |
+| [`DA.Bifunctor`](/appdev/reference/daml-standard-library/da-bifunctor) | `Module` | - | `3.4.11` | - | - | - |
+| [`DA.Crypto.Text`](/appdev/reference/daml-standard-library/da-crypto-text) | `Module` | Functions for working with Crypto builtins. | `3.4.11` | - | - | - |
+| [`DA.Date`](/appdev/reference/daml-standard-library/da-date) | `Module` | This module provides a set of functions to manipulate Date values. | `3.4.11` | - | - | - |
+| [`DA.Either`](/appdev/reference/daml-standard-library/da-either) | `Module` | The Either type represents values with two possibilities. | `3.4.11` | - | - | - |
+| [`DA.Exception`](/appdev/reference/daml-standard-library/da-exception) | `Module` | Exception handling in Daml. | `3.4.11` | - | `3.4.11` | - |
+| [`DA.Fail`](/appdev/reference/daml-standard-library/da-fail) | `Module` | Fail, for FailureStatus | `3.4.11` | - | - | - |
+| [`DA.Foldable`](/appdev/reference/daml-standard-library/da-foldable) | `Module` | Class of data structures that can be folded to a summary value. | `3.4.11` | - | - | - |
+| [`DA.Functor`](/appdev/reference/daml-standard-library/da-functor) | `Module` | The Functor class is used for types that can be mapped over. | `3.4.11` | - | - | - |
+| [`DA.Internal.Interface.AnyView`](/appdev/reference/daml-standard-library/da-internal-interface-anyview) | `Module` | - | `3.4.11` | - | - | - |
+| [`DA.Internal.Interface.AnyView.Types`](/appdev/reference/daml-standard-library/da-internal-interface-anyview-types) | `Module` | - | `3.4.11` | - | - | - |
+| [`DA.List`](/appdev/reference/daml-standard-library/da-list) | `Module` | List | `3.4.11` | - | - | - |
+| [`DA.List.BuiltinOrder`](/appdev/reference/daml-standard-library/da-list-builtinorder) | `Module` | Note: This is only supported in Daml-LF 1.11 or later. | `3.4.11` | - | - | - |
+| [`DA.List.Total`](/appdev/reference/daml-standard-library/da-list-total) | `Module` | - | `3.4.11` | - | - | - |
+| [`DA.Logic`](/appdev/reference/daml-standard-library/da-logic) | `Module` | Logic - Propositional calculus. | `3.4.11` | - | - | - |
+| [`DA.Map`](/appdev/reference/daml-standard-library/da-map) | `Module` | Note: This is only supported in Daml-LF 1.11 or later. | `3.4.11` | - | - | - |
+| [`DA.Math`](/appdev/reference/daml-standard-library/da-math) | `Module` | Math - Utility Math functions for Decimal | `3.4.11` | - | - | - |
+| [`DA.Monoid`](/appdev/reference/daml-standard-library/da-monoid) | `Module` | - | `3.4.11` | - | - | - |
+| [`DA.NonEmpty`](/appdev/reference/daml-standard-library/da-nonempty) | `Module` | Type and functions for non-empty lists. This module re-exports many functions with | `3.4.11` | - | - | - |
+| [`DA.NonEmpty.Types`](/appdev/reference/daml-standard-library/da-nonempty-types) | `Module` | This module contains the type for non-empty lists so we can give it a stable package id. | `3.4.11` | - | - | - |
+| [`DA.Numeric`](/appdev/reference/daml-standard-library/da-numeric) | `Module` | - | `3.4.11` | - | - | - |
+| [`DA.Optional`](/appdev/reference/daml-standard-library/da-optional) | `Module` | The Optional type encapsulates an optional value. A value of type | `3.4.11` | - | - | - |
+| [`DA.Record`](/appdev/reference/daml-standard-library/da-record) | `Module` | Exports the record machinery necessary to allow one to annotate | `3.4.11` | - | - | - |
+| [`DA.Semigroup`](/appdev/reference/daml-standard-library/da-semigroup) | `Module` | - | `3.4.11` | - | - | - |
+| [`DA.Set`](/appdev/reference/daml-standard-library/da-set) | `Module` | Note: This is only supported in Daml-LF 1.11 or later. | `3.4.11` | - | - | - |
+| [`DA.Stack`](/appdev/reference/daml-standard-library/da-stack) | `Module` | - | `3.4.11` | - | - | - |
+| [`DA.Text`](/appdev/reference/daml-standard-library/da-text) | `Module` | Functions for working with Text. | `3.4.11` | - | - | - |
+| [`DA.TextMap`](/appdev/reference/daml-standard-library/da-textmap) | `Module` | TextMap - A map is an associative array data type composed of a | `3.4.11` | - | - | - |
+| [`DA.Time`](/appdev/reference/daml-standard-library/da-time) | `Module` | This module provides a set of functions to manipulate Time values. | `3.4.11` | - | - | - |
+| [`DA.Traversable`](/appdev/reference/daml-standard-library/da-traversable) | `Module` | Class of data structures that can be traversed from left to right, performing an action on each element. | `3.4.11` | - | - | - |
+| [`DA.Tuple`](/appdev/reference/daml-standard-library/da-tuple) | `Module` | Tuple - Ubiquitous functions of tuples. | `3.4.11` | - | - | - |
+| [`DA.Validation`](/appdev/reference/daml-standard-library/da-validation) | `Module` | Validation type and associated functions. | `3.4.11` | - | - | - |
+| [`GHC.Show.Text`](/appdev/reference/daml-standard-library/ghc-show-text) | `Module` | - | `3.4.11` | - | - | - |
+| [`GHC.Tuple.Check`](/appdev/reference/daml-standard-library/ghc-tuple-check) | `Module` | - | `3.4.11` | - | - | - |
+| [`Prelude`](/appdev/reference/daml-standard-library/prelude) | `Module` | The pieces that make up the Daml language. | `3.4.11` | - | - | - |
 
-| NAME | STATUS | SUMMARY |
-| --- | --- | --- |
-| [DA.Action](/appdev/reference/daml-standard-library/da-action) | 🟢 `v3.4` | Action |
-| [DA.Action.State](/appdev/reference/daml-standard-library/da-action-state) | 🟢 `v3.4` | DA.Action.State |
-| [DA.Action.State.Class](/appdev/reference/daml-standard-library/da-action-state-class) | 🟢 `v3.4` | DA.Action.State.Class |
-| [DA.Assert](/appdev/reference/daml-standard-library/da-assert) | 🟢 `v3.4` | - |
-| [DA.Bifunctor](/appdev/reference/daml-standard-library/da-bifunctor) | 🟢 `v3.4` | - |
-| [DA.Crypto.Text](/appdev/reference/daml-standard-library/da-crypto-text) | 🟢 `v3.4` | Functions for working with Crypto builtins. For example, as used to implement CCTP functionality. |
-| [DA.Date](/appdev/reference/daml-standard-library/da-date) | 🟢 `v3.4` | This module provides a set of functions to manipulate Date values. The bounds for Date are 0001-01-01T00:00:00.000000... |
-| [DA.Either](/appdev/reference/daml-standard-library/da-either) | 🟢 `v3.4` | The `Either` type represents values with two possibilities. It is sometimes used to represent a value which is either... |
-| [DA.Exception](/appdev/reference/daml-standard-library/da-exception) | 🟢 `v3.4` 🟠 `v3.4` | Exception handling in Daml. DEPRECATED: Use `failWithStatus` and `FailureStatus` over Daml Exceptions |
-| [DA.Fail](/appdev/reference/daml-standard-library/da-fail) | 🟢 `v3.4` | Fail, for FailureStatus |
-| [DA.Foldable](/appdev/reference/daml-standard-library/da-foldable) | 🟢 `v3.4` | Class of data structures that can be folded to a summary value. It's a good idea to import this module qualified to a... |
-| [DA.Functor](/appdev/reference/daml-standard-library/da-functor) | 🟢 `v3.4` | The `Functor` class is used for types that can be mapped over. |
-| [DA.Internal.Interface.AnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview) | 🟢 `v3.4` | - |
-| [DA.Internal.Interface.AnyView.Types](/appdev/reference/daml-standard-library/da-internal-interface-anyview-types) | 🟢 `v3.4` | - |
-| [DA.List](/appdev/reference/daml-standard-library/da-list) | 🟢 `v3.4` | List |
-| [DA.List.BuiltinOrder](/appdev/reference/daml-standard-library/da-list-builtinorder) | 🟢 `v3.4` | Note: This is only supported in Daml-LF 1.11 or later. This module provides variants of other standard library functi... |
-| [DA.List.Total](/appdev/reference/daml-standard-library/da-list-total) | 🟢 `v3.4` | - |
-| [DA.Logic](/appdev/reference/daml-standard-library/da-logic) | 🟢 `v3.4` | Logic - Propositional calculus. |
-| [DA.Map](/appdev/reference/daml-standard-library/da-map) | 🟢 `v3.4` | Note: This is only supported in Daml-LF 1.11 or later. This module exports the generic map type `Map k v` and associa... |
-| [DA.Math](/appdev/reference/daml-standard-library/da-math) | 🟢 `v3.4` | Math - Utility Math functions for `Decimal` The this library is designed to give good precision, typically giving 9 c... |
-| [DA.Monoid](/appdev/reference/daml-standard-library/da-monoid) | 🟢 `v3.4` | - |
-| [DA.NonEmpty](/appdev/reference/daml-standard-library/da-nonempty) | 🟢 `v3.4` | Type and functions for non-empty lists. This module re-exports many functions with the same name as prelude list func... |
-| [DA.NonEmpty.Types](/appdev/reference/daml-standard-library/da-nonempty-types) | 🟢 `v3.4` | This module contains the type for non-empty lists so we can give it a stable package id. This is reexported from DA.N... |
-| [DA.Numeric](/appdev/reference/daml-standard-library/da-numeric) | 🟢 `v3.4` | - |
-| [DA.Optional](/appdev/reference/daml-standard-library/da-optional) | 🟢 `v3.4` | The `Optional` type encapsulates an optional value. A value of type `Optional a` either contains a value of type `a`... |
-| [DA.Record](/appdev/reference/daml-standard-library/da-record) | 🟢 `v3.4` | Exports the record machinery necessary to allow one to annotate code that is polymorphic in the underlying record type. |
-| [DA.Semigroup](/appdev/reference/daml-standard-library/da-semigroup) | 🟢 `v3.4` | - |
-| [DA.Set](/appdev/reference/daml-standard-library/da-set) | 🟢 `v3.4` | Note: This is only supported in Daml-LF 1.11 or later. This module exports the generic set type `Set k` and associate... |
-| [DA.Stack](/appdev/reference/daml-standard-library/da-stack) | 🟢 `v3.4` | - |
-| [DA.Text](/appdev/reference/daml-standard-library/da-text) | 🟢 `v3.4` | Functions for working with Text. |
-| [DA.TextMap](/appdev/reference/daml-standard-library/da-textmap) | 🟢 `v3.4` | TextMap - A map is an associative array data type composed of a collection of key/value pairs such that, each possibl... |
-| [DA.Time](/appdev/reference/daml-standard-library/da-time) | 🟢 `v3.4` | This module provides a set of functions to manipulate Time values. The `Time` type represents a specific datetime in... |
-| [DA.Traversable](/appdev/reference/daml-standard-library/da-traversable) | 🟢 `v3.4` | Class of data structures that can be traversed from left to right, performing an action on each element. You typicall... |
-| [DA.Tuple](/appdev/reference/daml-standard-library/da-tuple) | 🟢 `v3.4` | Tuple - Ubiquitous functions of tuples. |
-| [DA.Validation](/appdev/reference/daml-standard-library/da-validation) | 🟢 `v3.4` | `Validation` type and associated functions. |
-| [Prelude](/appdev/reference/daml-standard-library/prelude) | 🟢 `v3.4` | The pieces that make up the Daml language. |
+## Version Change Summary
+
+| Version | Added | Changed | Removed |
+| --- | --- | --- | --- |
+| `3.4.11` | 38 | 0 | 0 |
+
+## Reference
+
+- [DA.Action](/appdev/reference/daml-standard-library/da-action)
+- [DA.Action.State](/appdev/reference/daml-standard-library/da-action-state)
+- [DA.Action.State.Class](/appdev/reference/daml-standard-library/da-action-state-class)
+- [DA.Assert](/appdev/reference/daml-standard-library/da-assert)
+- [DA.Bifunctor](/appdev/reference/daml-standard-library/da-bifunctor)
+- [DA.Crypto.Text](/appdev/reference/daml-standard-library/da-crypto-text)
+- [DA.Date](/appdev/reference/daml-standard-library/da-date)
+- [DA.Either](/appdev/reference/daml-standard-library/da-either)
+- [DA.Exception](/appdev/reference/daml-standard-library/da-exception)
+- [DA.Fail](/appdev/reference/daml-standard-library/da-fail)
+- [DA.Foldable](/appdev/reference/daml-standard-library/da-foldable)
+- [DA.Functor](/appdev/reference/daml-standard-library/da-functor)
+- [DA.Internal.Interface.AnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview)
+- [DA.Internal.Interface.AnyView.Types](/appdev/reference/daml-standard-library/da-internal-interface-anyview-types)
+- [DA.List](/appdev/reference/daml-standard-library/da-list)
+- [DA.List.BuiltinOrder](/appdev/reference/daml-standard-library/da-list-builtinorder)
+- [DA.List.Total](/appdev/reference/daml-standard-library/da-list-total)
+- [DA.Logic](/appdev/reference/daml-standard-library/da-logic)
+- [DA.Map](/appdev/reference/daml-standard-library/da-map)
+- [DA.Math](/appdev/reference/daml-standard-library/da-math)
+- [DA.Monoid](/appdev/reference/daml-standard-library/da-monoid)
+- [DA.NonEmpty](/appdev/reference/daml-standard-library/da-nonempty)
+- [DA.NonEmpty.Types](/appdev/reference/daml-standard-library/da-nonempty-types)
+- [DA.Numeric](/appdev/reference/daml-standard-library/da-numeric)
+- [DA.Optional](/appdev/reference/daml-standard-library/da-optional)
+- [DA.Record](/appdev/reference/daml-standard-library/da-record)
+- [DA.Semigroup](/appdev/reference/daml-standard-library/da-semigroup)
+- [DA.Set](/appdev/reference/daml-standard-library/da-set)
+- [DA.Stack](/appdev/reference/daml-standard-library/da-stack)
+- [DA.Text](/appdev/reference/daml-standard-library/da-text)
+- [DA.TextMap](/appdev/reference/daml-standard-library/da-textmap)
+- [DA.Time](/appdev/reference/daml-standard-library/da-time)
+- [DA.Traversable](/appdev/reference/daml-standard-library/da-traversable)
+- [DA.Tuple](/appdev/reference/daml-standard-library/da-tuple)
+- [DA.Validation](/appdev/reference/daml-standard-library/da-validation)
+- [GHC.Show.Text](/appdev/reference/daml-standard-library/ghc-show-text)
+- [GHC.Tuple.Check](/appdev/reference/daml-standard-library/ghc-tuple-check)
+- [Prelude](/appdev/reference/daml-standard-library/prelude)

--- a/docs-main/appdev/reference/daml-standard-library/prelude.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/prelude.mdx
@@ -9,6 +9,22 @@ description: "Reference documentation for Daml module Prelude."
 
 The pieces that make up the Daml language.
 
+## Module Snapshot
+
+<CardGroup cols={2}>
+<Card title="Lifecycle">
+Stable.
+</Card>
+<Card title="Notices">
+Status: `active`
+Introduced in: `3.4.11`
+Removed in: `-`
+Warnings: `0`
+Deprecations: `0`
+Deprecated since: `-`
+</Card>
+</CardGroup>
+
 ## Data Types
 
 <a id="type-da-internal-any-anychoice-86490"></a>

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1266,53 +1266,6 @@
             ]
           },
           {
-            "group": "Daml Standard Library",
-            "pages": [
-              "appdev/reference/daml-standard-library/index",
-              {
-                "group": "Modules",
-                "pages": [
-                  "appdev/reference/daml-standard-library/da-action",
-                  "appdev/reference/daml-standard-library/da-action-state",
-                  "appdev/reference/daml-standard-library/da-action-state-class",
-                  "appdev/reference/daml-standard-library/da-assert",
-                  "appdev/reference/daml-standard-library/da-bifunctor",
-                  "appdev/reference/daml-standard-library/da-crypto-text",
-                  "appdev/reference/daml-standard-library/da-date",
-                  "appdev/reference/daml-standard-library/da-either",
-                  "appdev/reference/daml-standard-library/da-exception",
-                  "appdev/reference/daml-standard-library/da-fail",
-                  "appdev/reference/daml-standard-library/da-foldable",
-                  "appdev/reference/daml-standard-library/da-functor",
-                  "appdev/reference/daml-standard-library/da-internal-interface-anyview",
-                  "appdev/reference/daml-standard-library/da-internal-interface-anyview-types",
-                  "appdev/reference/daml-standard-library/da-list",
-                  "appdev/reference/daml-standard-library/da-list-builtinorder",
-                  "appdev/reference/daml-standard-library/da-list-total",
-                  "appdev/reference/daml-standard-library/da-logic",
-                  "appdev/reference/daml-standard-library/da-map",
-                  "appdev/reference/daml-standard-library/da-math",
-                  "appdev/reference/daml-standard-library/da-monoid",
-                  "appdev/reference/daml-standard-library/da-nonempty",
-                  "appdev/reference/daml-standard-library/da-nonempty-types",
-                  "appdev/reference/daml-standard-library/da-numeric",
-                  "appdev/reference/daml-standard-library/da-optional",
-                  "appdev/reference/daml-standard-library/da-record",
-                  "appdev/reference/daml-standard-library/da-semigroup",
-                  "appdev/reference/daml-standard-library/da-set",
-                  "appdev/reference/daml-standard-library/da-stack",
-                  "appdev/reference/daml-standard-library/da-text",
-                  "appdev/reference/daml-standard-library/da-textmap",
-                  "appdev/reference/daml-standard-library/da-time",
-                  "appdev/reference/daml-standard-library/da-traversable",
-                  "appdev/reference/daml-standard-library/da-tuple",
-                  "appdev/reference/daml-standard-library/da-validation",
-                  "appdev/reference/daml-standard-library/prelude"
-                ]
-              }
-            ]
-          },
-          {
             "group": "Wallet Kernel",
             "pages": [
               "reference/wallet-gateway-json-rpc/index",
@@ -1549,6 +1502,55 @@
                       }
                     ]
                   }
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Daml Standard Library",
+            "pages": [
+              "appdev/reference/daml-standard-library/index",
+              {
+                "group": "Modules",
+                "pages": [
+                  "appdev/reference/daml-standard-library/da-action",
+                  "appdev/reference/daml-standard-library/da-action-state",
+                  "appdev/reference/daml-standard-library/da-action-state-class",
+                  "appdev/reference/daml-standard-library/da-assert",
+                  "appdev/reference/daml-standard-library/da-bifunctor",
+                  "appdev/reference/daml-standard-library/da-crypto-text",
+                  "appdev/reference/daml-standard-library/da-date",
+                  "appdev/reference/daml-standard-library/da-either",
+                  "appdev/reference/daml-standard-library/da-exception",
+                  "appdev/reference/daml-standard-library/da-fail",
+                  "appdev/reference/daml-standard-library/da-foldable",
+                  "appdev/reference/daml-standard-library/da-functor",
+                  "appdev/reference/daml-standard-library/da-internal-interface-anyview",
+                  "appdev/reference/daml-standard-library/da-internal-interface-anyview-types",
+                  "appdev/reference/daml-standard-library/da-list",
+                  "appdev/reference/daml-standard-library/da-list-builtinorder",
+                  "appdev/reference/daml-standard-library/da-list-total",
+                  "appdev/reference/daml-standard-library/da-logic",
+                  "appdev/reference/daml-standard-library/da-map",
+                  "appdev/reference/daml-standard-library/da-math",
+                  "appdev/reference/daml-standard-library/da-monoid",
+                  "appdev/reference/daml-standard-library/da-nonempty",
+                  "appdev/reference/daml-standard-library/da-nonempty-types",
+                  "appdev/reference/daml-standard-library/da-numeric",
+                  "appdev/reference/daml-standard-library/da-optional",
+                  "appdev/reference/daml-standard-library/da-record",
+                  "appdev/reference/daml-standard-library/da-semigroup",
+                  "appdev/reference/daml-standard-library/da-set",
+                  "appdev/reference/daml-standard-library/da-stack",
+                  "appdev/reference/daml-standard-library/da-text",
+                  "appdev/reference/daml-standard-library/da-textmap",
+                  "appdev/reference/daml-standard-library/da-time",
+                  "appdev/reference/daml-standard-library/da-traversable",
+                  "appdev/reference/daml-standard-library/da-tuple",
+                  "appdev/reference/daml-standard-library/da-validation",
+                  "appdev/reference/daml-standard-library/ghc-show-text",
+                  "appdev/reference/daml-standard-library/ghc-tuple-check",
+                  "appdev/reference/daml-standard-library/prelude"
                 ]
               }
             ]

--- a/scripts/generate_daml_standard_library_json.sh
+++ b/scripts/generate_daml_standard_library_json.sh
@@ -285,6 +285,12 @@ if [[ ! -d "$TARGET_ROOT" ]]; then
   exit 1
 fi
 
+TMP_BASE="${TMPDIR:-/tmp}"
+if [[ ! -d "$TMP_BASE" ]]; then
+  TMP_BASE="/tmp"
+fi
+export TMPDIR="$TMP_BASE"
+
 resolve_stdlib_src_root() {
   local candidate
   candidate="$TARGET_ROOT/daml-stdlib-$SDK_VERSION"
@@ -360,7 +366,7 @@ case "$PACKAGE_SET" in
     ;;
   base)
     STDLIB_SRC_ROOT="$(resolve_stdlib_src_root)"
-    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/daml-base-json.XXXXXX")"
+    TMP_DIR="$(mktemp -d "$TMP_BASE/daml-base-json.XXXXXX")"
     trap 'rm -rf "$TMP_DIR"' EXIT
     PRIM_JSON="$TMP_DIR/daml-prim.json"
     STDLIB_JSON="$TMP_DIR/daml-stdlib.json"

--- a/scripts/generate_daml_standard_library_reference.py
+++ b/scripts/generate_daml_standard_library_reference.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -218,6 +217,45 @@ def update_docs_navigation(
     return docs_json_path
 
 
+def render_daml_pages(
+    *,
+    manifest_path: Path,
+    output_dir: Path,
+    publish_version: str,
+    source_name: str,
+    version_filter: str,
+    link_prefix: str,
+) -> None:
+    from x2mdx.daml_json.lifecycle import build_daml_doc_report_from_sources
+    from x2mdx.daml_json.snapshots import load_daml_doc_sources
+    from x2mdx.daml_json import render as daml_render
+    from x2mdx.render import write_pages
+
+    sources = load_daml_doc_sources(manifest_path)
+    report = build_daml_doc_report_from_sources(
+        sources,
+        source_name=source_name,
+        version_filter=version_filter,
+        publish_version=publish_version,
+    )
+
+    # The shared renderer excludes these two small helper modules by default.
+    # Keep the override local to the stdlib wrapper so the docs surface can match
+    # the live published standard-library inventory without changing x2mdx itself.
+    original_exclusions = daml_render.EXCLUDED_MODULE_NAMES
+    daml_render.EXCLUDED_MODULE_NAMES = frozenset()
+    try:
+        output_root, pages = daml_render.build_pages(
+            report,
+            output_dir=output_dir,
+            overview_title=GROUP_LABEL,
+            link_prefix=link_prefix,
+        )
+    finally:
+        daml_render.EXCLUDED_MODULE_NAMES = original_exclusions
+    write_pages(pages, output_root)
+
+
 def main() -> int:
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
@@ -250,29 +288,14 @@ def main() -> int:
         manifest_path=Path(args.manifest_out).resolve(),
         versions=selected_versions,
     )
-    command = [
-        "x2mdx",
-        "daml-json",
-        "build-api-pages-from-manifest",
-        "--manifest",
-        str(manifest_path),
-        "--output-dir",
-        str(Path(args.output_dir).resolve()),
-        "--publish-version",
-        str(publish_version),
-        "--source-name",
-        args.source_name,
-        "--version-filter",
-        args.version_filter,
-        "--link-prefix",
-        docs_route_prefix(Path(args.output_dir).resolve(), Path(args.docs_json).resolve()),
-    ]
-    for version in args.version or []:
-        command.extend(["--version", version])
-    print("Running:", " ".join(command))
-    completed = subprocess.run(command, cwd=REPO_ROOT)
-    if completed.returncode != 0:
-        return completed.returncode
+    render_daml_pages(
+        manifest_path=manifest_path,
+        output_dir=Path(args.output_dir).resolve(),
+        publish_version=str(publish_version),
+        source_name=args.source_name,
+        version_filter=args.version_filter,
+        link_prefix=docs_route_prefix(Path(args.output_dir).resolve(), Path(args.docs_json).resolve()),
+    )
 
     update_docs_navigation(
         docs_json_path=Path(args.docs_json).resolve(),


### PR DESCRIPTION
## Summary
- fix the docs-side stdlib harness to run reliably inside the repo-local Nix shell
- render the two live GHC helper modules from existing SDK artifact JSON without modifying x2mdx
- refresh the checked-in standard-library pages and nav

## Validation
- direnv exec /Users/danielporter/control/.worktrees/docs-daml-stdlib-gap-closure python3 -m py_compile scripts/generate_daml_standard_library_reference.py
- direnv exec /Users/danielporter/control/.worktrees/docs-daml-stdlib-gap-closure python3 scripts/generate_daml_standard_library_reference.py --version 3.4.11 --publish-version 3.4.11
- direnv exec /Users/danielporter/control/.worktrees/docs-daml-stdlib-gap-closure python3 scripts/generate_all_reference_docs.py --dry-run
- direnv exec /Users/danielporter/control/.worktrees/docs-daml-stdlib-gap-closure npm run generate:all-reference-docs -- --dry-run

## Remaining gap
- `DA.ContractKeys` is still tracked separately because the current 3.5 artifact-backed stdlib materialization path does not yet build cleanly docs-side without further harness work.