### PR TITLE
Fix stdlib tempdir handling

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,12 @@
+# Preserve the caller's TMPDIR state because some nix shells replace it with
+# a temp directory path that no longer exists after activation.
+old_tmpdir="${TMPDIR-}"
+old_tmpdir_was_set="${TMPDIR+x}"
+
 use nix
+
+if [ -n "${old_tmpdir_was_set}" ]; then
+  export TMPDIR="$old_tmpdir"
+else
+  unset TMPDIR
+fi


### PR DESCRIPTION
## What changed

- sanitize `TMPDIR` in `scripts/generate_daml_standard_library_json.sh` before creating temp directories or invoking downstream docs generation
- fall back to `/tmp`, then `PWD`, when the inherited temp parent does not exist

## Why

`generate_all_reference_docs.py` started failing in the Daml Standard Library step after `fd6f6bf` because the stdlib helper trusted the Nix-shell `TMPDIR`. In this environment that can point at a removed `/private/tmp/nix-shell-*` directory, which breaks both the initial `mktemp` call and later transient files that `dpm damlc docs` writes.
