### PR TITLE
Fix Mintlify-blocking MDX parse errors

### DIFF
--- a/docs-main/appdev/modules/m4-backend-dev.mdx
+++ b/docs-main/appdev/modules/m4-backend-dev.mdx
@@ -687,60 +687,109 @@ The bound `B` should be at most the configured maximum deduplication duration. O
 Error handling is needed when the status code of the command submission RPC call or in the completion event is not `OK`. The following table lists appropriate reactions by status code (written as `STATUS_CODE`) and error code (written in capital letters with a link to the error code documentation). Fields in the error metadata are written as `field` in lowercase letters.
 
 <table>
-<caption>Command deduplication error handling with known processing time bound</caption>
-<colgroup>
-<col style="width: 16%" />
-<col style="width: 83%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Error condition</th>
-<th>Reaction</th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td><p><code>DEADLINE_EXCEEDED</code></p></td>
-<td><p>Consider the submission lost.</p>
-<p>Retry from <code class="interpreted-text" role="ref">Step 2 &lt;dedup-bounded-step-offset&gt;</code>, obtaining the completion offset <code>OFF1</code>, and possibly increase the timeout.</p></td>
-</tr>
-<tr class="even">
-<td>Application crashed</td>
-<td>Retry from <code class="interpreted-text" role="ref">Step 2 &lt;dedup-bounded-step-offset&gt;</code>, obtaining the completion offset <code>OFF1</code>.</td>
-</tr>
-<tr class="odd">
-<td><code>ALREADY_EXISTS</code> / <code class="interpreted-text" role="brokenref">DUPLICATE_COMMAND &lt;error_code_DUPLICATE_COMMAND&gt;</code></td>
-<td>The change ID has already been accepted by the ledger within the reported deduplication period. The optional field <code>completion_offset</code> contains the precise offset. The optional field <code>existing_submission_id</code> contains the submission ID of the successful submission. Report success for the ledger change.</td>
-</tr>
-<tr class="even">
-<td></td>
-<td></td>
-</tr>
-<tr class="odd">
-<td><p><code>FAILED_PRECONDITION</code> / <code class="interpreted-text" role="brokenref">PARTICIPANT_PRUNED_DATA_ACCESSED &lt;error_code_PARTICIPANT_PRUNED_DATA_ACCESSED&gt;</code></p></td>
-<td><p>The specified deduplication offset has been pruned by the participant. <code>earliest_offset</code> contains the last pruned offset.</p>
-<blockquote>
-<p>Use the <code class="interpreted-text" role="ref">Command Completion Service &lt;command-completion-service&gt;</code> by asking for the <code class="interpreted-text" role="subsiteref">completions &lt;com.daml.ledger.api.v2.CompletionStreamRequest&gt;</code>, starting from the last pruned offset by setting <code class="interpreted-text" role="subsiteref">offset &lt;com.daml.ledger.api.v2.CompletionStreamRequest.begin_exclusive&gt;</code> to the value of <code>earliest_offset</code>, and use the first received <code class="interpreted-text" role="subsiteref">completion offset &lt;com.daml.ledger.api.v2.Completion.offset&gt;</code> or <code class="interpreted-text" role="subsiteref">checkpoint offset &lt;com.daml.ledger.api.v2.OffsetCheckpoint.offset&gt;</code> as a deduplication offset.</p>
-</blockquote></td>
-</tr>
-<tr class="even">
-<td></td>
-<td></td>
-</tr>
-<tr class="odd">
-<td><code>ABORTED</code> / other error codes</td>
-<td>Wait a bit and retry from <code class="interpreted-text" role="ref">Step 2 &lt;dedup-bounded-step-offset&gt;</code>, obtaining the completion offset <code>OFF1</code>.</td>
-</tr>
-<tr class="even">
-<td><p>other error conditions</p></td>
-<td><p>Use background knowledge about the business workflow and the current ledger state to decide whether earlier submissions might still get accepted.</p>
-<ul>
-<li>If you conclude that it cannot be accepted any more, stop retrying and report that the ledger change failed.</li>
-<li>Otherwise, retry from <code class="interpreted-text" role="ref">Step 2 &lt;dedup-bounded-step-offset&gt;</code>, obtaining a completion offset <code>OFF1</code>, or give up without knowing for sure that the ledger change will not happen.</li>
-</ul>
-<p>For example, if the ledger change only creates a contract instance of a template, you can never be sure, as any outstanding submission might still be accepted on the ledger. In particular, you must not draw any conclusions from not having received a <code class="interpreted-text" role="brokenref">SUBMISSION_ALREADY_IN_FLIGHT &lt;error_code_SUBMISSION_ALREADY_IN_FLIGHT&gt;</code> error, because the outstanding submission may be queued somewhere and will reach the relevant processing point only later.</p></td>
-</tr>
-</tbody>
+  <caption>Command deduplication error handling with known processing time bound</caption>
+  <colgroup>
+    <col style={{ width: "16%" }} />
+    <col style={{ width: "83%" }} />
+  </colgroup>
+  <thead>
+    <tr className="header">
+      <th>Error condition</th>
+      <th>Reaction</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr className="odd">
+      <td>
+        <code>DEADLINE_EXCEEDED</code>
+      </td>
+      <td>
+        <p>Consider the submission lost.</p>
+        <p>
+          Retry from <code>Step 2 &lt;dedup-bounded-step-offset&gt;</code>, obtaining the
+          completion offset <code>OFF1</code>, and possibly increase the timeout.
+        </p>
+      </td>
+    </tr>
+    <tr className="even">
+      <td>Application crashed</td>
+      <td>
+        Retry from <code>Step 2 &lt;dedup-bounded-step-offset&gt;</code>, obtaining the
+        completion offset <code>OFF1</code>.
+      </td>
+    </tr>
+    <tr className="odd">
+      <td>
+        <code>ALREADY_EXISTS</code> / <code>DUPLICATE_COMMAND &lt;error_code_DUPLICATE_COMMAND&gt;</code>
+      </td>
+      <td>
+        The change ID has already been accepted by the ledger within the reported deduplication
+        period. The optional field <code>completion_offset</code> contains the precise offset. The
+        optional field <code>existing_submission_id</code> contains the submission ID of the
+        successful submission. Report success for the ledger change.
+      </td>
+    </tr>
+    <tr className="odd">
+      <td>
+        <code>FAILED_PRECONDITION</code> /{" "}
+        <code>PARTICIPANT_PRUNED_DATA_ACCESSED &lt;error_code_PARTICIPANT_PRUNED_DATA_ACCESSED&gt;</code>
+      </td>
+      <td>
+        <p>
+          The specified deduplication offset has been pruned by the participant.{" "}
+          <code>earliest_offset</code> contains the last pruned offset.
+        </p>
+        <p>
+          Use the <code>Command Completion Service &lt;command-completion-service&gt;</code> by
+          asking for the{" "}
+          <code>completions &lt;com.daml.ledger.api.v2.CompletionStreamRequest&gt;</code>,
+          starting from the last pruned offset by setting{" "}
+          <code>offset &lt;com.daml.ledger.api.v2.CompletionStreamRequest.begin_exclusive&gt;</code>{" "}
+          to the value of <code>earliest_offset</code>, and use the first received{" "}
+          <code>completion offset &lt;com.daml.ledger.api.v2.Completion.offset&gt;</code> or{" "}
+          <code>checkpoint offset &lt;com.daml.ledger.api.v2.OffsetCheckpoint.offset&gt;</code> as
+          a deduplication offset.
+        </p>
+      </td>
+    </tr>
+    <tr className="odd">
+      <td>
+        <code>ABORTED</code> / other error codes
+      </td>
+      <td>
+        Wait a bit and retry from <code>Step 2 &lt;dedup-bounded-step-offset&gt;</code>,
+        obtaining the completion offset <code>OFF1</code>.
+      </td>
+    </tr>
+    <tr className="even">
+      <td>Other error conditions</td>
+      <td>
+        <p>
+          Use background knowledge about the business workflow and the current ledger state to
+          decide whether earlier submissions might still get accepted.
+        </p>
+        <ul>
+          <li>
+            If you conclude that it cannot be accepted any more, stop retrying and report that the
+            ledger change failed.
+          </li>
+          <li>
+            Otherwise, retry from <code>Step 2 &lt;dedup-bounded-step-offset&gt;</code>, obtaining
+            a completion offset <code>OFF1</code>, or give up without knowing for sure that the
+            ledger change will not happen.
+          </li>
+        </ul>
+        <p>
+          For example, if the ledger change only creates a contract instance of a template, you can
+          never be sure, as any outstanding submission might still be accepted on the ledger. In
+          particular, you must not draw any conclusions from not having received a{" "}
+          <code>SUBMISSION_ALREADY_IN_FLIGHT &lt;error_code_SUBMISSION_ALREADY_IN_FLIGHT&gt;</code>{" "}
+          error, because the outstanding submission may be queued somewhere and will reach the
+          relevant processing point only later.
+        </p>
+      </td>
+    </tr>
+  </tbody>
 </table>
 
 Command deduplication error handling with known processing time bound
@@ -770,23 +819,19 @@ Finding a good bound `B` on the processing time is hard, and there may still be 
 
 2.  Obtain a recent offset `OFF0` on the completion stream and remember across crashes that you use `OFF0` with the chosen command ID. There are several ways to do so:
 
-```text
-\- Use the State Service by asking for the current ledger end.
+- Use the State Service by asking for the current ledger end.
 
-> <Note>
-```
->
-    > >
-    > Note
-    >
-    >
-</Note>
-    >
-    > 
-    >
-    > Some ledger implementations reject deduplication offsets that do not identify a command completion visible to the submitting parties with the error code id INVALID_DEDUPLICATION_PERIOD. In general, the ledger end need not identify a command completion that is visible to the submitting parties. When running on such a ledger, use the Command Service approach described next.
+  <Note>
+    Some ledger implementations reject deduplication offsets that do not identify a command
+    completion visible to the submitting parties with the error code id
+    <code> INVALID_DEDUPLICATION_PERIOD</code>. In general, the ledger end need not identify a
+    command completion that is visible to the submitting parties. When running on such a ledger,
+    use the Command Service approach described next.
+  </Note>
 
-    - Use the Command Service to obtain a recent offset by repeatedly submitting a dummy command, e.g., a Create-And-Exercise command of some single-signatory template with the Archive choice, until you get a successful response. The response contains the completion offset.
+- Use the Command Service to obtain a recent offset by repeatedly submitting a dummy command, e.g.,
+  a Create-And-Exercise command of some single-signatory template with the Archive choice, until
+  you get a successful response. The response contains the completion offset.
 
 3.  When you use the Command Completion Service:
 

--- a/docs-main/appdev/reference/daml-lf-reference.mdx
+++ b/docs-main/appdev/reference/daml-lf-reference.mdx
@@ -176,34 +176,32 @@ Daml-LF values are represented as JSON values in the JSON Ledger API. This repre
 </tr>
 <tr className="odd">
 <td>`Variant`</td>
-<td><p>.. code-block:</p>
-
-```text
-{
- "tag": "&lt;constructor_name&gt;",
- "value": "&lt;variant_value&gt;"
-}
-```
+<td>
+<code>
+&#123;<br />
+&nbsp;&nbsp;"tag": "&lt;constructor_name&gt;",<br />
+&nbsp;&nbsp;"value": "&lt;variant_value&gt;"<br />
+&#125;
+</code>
 </td>
-<td><p>.. code-block:</p>
-
-```text
-data Location
-  = InHand
-  ; InAccount Account
-    deriving (Eq, Show)
-```
-
-
-```text
-{
- "tag": "InAccount",
-     "value": {
-         "number": "CH-1234567890",
-         "bank": { }
-     }
-}
-```
+<td>
+<code>
+data Location<br />
+&nbsp;&nbsp;= InHand<br />
+&nbsp;&nbsp;; InAccount Account<br />
+&nbsp;&nbsp;&nbsp;&nbsp;deriving (Eq, Show)
+</code>
+<br />
+<br />
+<code>
+&#123;<br />
+&nbsp;&nbsp;"tag": "InAccount",<br />
+&nbsp;&nbsp;"value": &#123;<br />
+&nbsp;&nbsp;&nbsp;&nbsp;"number": "CH-1234567890",<br />
+&nbsp;&nbsp;&nbsp;&nbsp;"bank": &#123; &#125;<br />
+&nbsp;&nbsp;&#125;<br />
+&#125;
+</code>
 </td>
 </tr>
 <tr className="even">


### PR DESCRIPTION
## Summary
- fix malformed MDX/JSX in the imported command-deduplication table in `m4-backend-dev`
- rewrite the Daml LF `Variant` table row so it is valid MDX inside HTML table cells
- unblock Mintlify parsing for the current `main` content set

## Validation
- targeted `@mdx-js/mdx` compile check passes for every file Mintlify had flagged during preview debugging
- local `mintlify validate` no longer surfaced parser errors before the local timeout cap
