### PR TITLE
Harden docs wrappers against local x2mdx

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ mintlify dev
 
 ### Run all generated reference docs
 
-Load the repo's `direnv` / `nix` shell first, then rerun all generated reference-doc wrappers in one command:
+Load the repo's `direnv` / `nix` shell first, then rerun all generated reference-doc wrappers in one command. The wrappers also re-exec through the docs repo shell themselves, so they do not pick up a local `x2mdx` checkout from ambient `PATH`:
 
 ```bash
 direnv allow
@@ -77,7 +77,7 @@ Use `--dry-run` to print the exact per-step commands without executing them.
 ### Generate the JSON API reference
 
 This repo includes a checked-in source config plus regenerated local Ledger API OpenAPI snapshots under `config/x2mdx/ledger-api/`.
-The generator script refreshes those local `openapi.yaml` snapshots from configured Canton release bundles, rewrites the local manifest, and then regenerates the page and `docs.json` update with the GitHub-pinned `x2mdx`:
+The generator script refreshes those local `openapi.yaml` snapshots from configured Canton release bundles, rewrites the local manifest, and then regenerates the page and `docs.json` update through the docs repo `direnv` / `nix` shell:
 
 ```bash
 python3 scripts/generate_json_api_reference.py
@@ -99,7 +99,7 @@ The generated page is placed directly under the top-level `API Reference` dropdo
 ### Generate the JSON API AsyncAPI reference
 
 This repo also includes a checked-in source config for the Ledger API AsyncAPI bundle inputs under `config/x2mdx/ledger-api-asyncapi/source-artifacts.json`.
-The generator script downloads the configured Canton release bundles, extracts `asyncapi.yaml` into `.internal/cache/x2mdx/ledger-api-asyncapi/`, writes a local x2mdx manifest into `.internal/generated/x2mdx/ledger-api-asyncapi/manifest.json`, and then renders the MDX page with the GitHub-pinned `x2mdx`.
+The generator script downloads the configured Canton release bundles, extracts `asyncapi.yaml` into `.internal/cache/x2mdx/ledger-api-asyncapi/`, writes a local x2mdx manifest into `.internal/generated/x2mdx/ledger-api-asyncapi/manifest.json`, and then renders the MDX page through the docs repo `direnv` / `nix` shell.
 
 Run:
 
@@ -123,7 +123,7 @@ The generated page is placed directly under the top-level `API Reference` dropdo
 ### Generate the Ledger bindings API reference
 
 This repo also includes a checked-in source config for the published Java/Scala bindings Javadoc/Scaladoc jars at `config/x2mdx/ledger-bindings/source-artifacts.json`.
-The generator script downloads those jars into `.internal/cache/x2mdx/ledger-bindings/`, writes a local x2mdx manifest into `.internal/generated/x2mdx/ledger-bindings/manifest.json`, and then renders the MDX pages with the GitHub-pinned `x2mdx`.
+The generator script downloads those jars into `.internal/cache/x2mdx/ledger-bindings/`, writes a local x2mdx manifest into `.internal/generated/x2mdx/ledger-bindings/manifest.json`, and then renders the MDX pages through the docs repo `direnv` / `nix` shell.
 
 Run:
 
@@ -149,7 +149,7 @@ The generated nav is added under the top-level `API Reference` dropdown as `Ledg
 ### Generate the Daml Standard Library reference
 
 This repo also includes a checked-in source config for versioned Daml Standard Library docs JSON generation at `config/x2mdx/daml-standard-library/source-artifacts.json`.
-The generator script uses local SDK artifacts via `dpm` or `daml` to build cached docs JSON snapshots under `.internal/cache/x2mdx/daml-standard-library/`, writes a local x2mdx manifest into `.internal/generated/x2mdx/daml-standard-library/manifest.json`, and then renders MDX pages with the GitHub-pinned `x2mdx`.
+The generator script uses local SDK artifacts via `dpm` or `daml` to build cached docs JSON snapshots under `.internal/cache/x2mdx/daml-standard-library/`, writes a local x2mdx manifest into `.internal/generated/x2mdx/daml-standard-library/manifest.json`, and then renders MDX pages through the docs repo `direnv` / `nix` shell.
 
 Run:
 
@@ -173,7 +173,7 @@ The generated nav is added under the top-level `API Reference` dropdown as `Daml
 ### Generate the Canton protobuf history reference
 
 This repo also includes a checked-in source config for Canton release-bundle protobuf inputs at `config/x2mdx/protobuf-history/source-artifacts.json`.
-The generator script discovers stable Canton versions from the source repo tags, downloads the matching `canton-open-source-<version>.tar.gz` bundles from `canton.io/releases`, extracts the published `protobuf/` tree under `.internal/cache/x2mdx/protobuf-history/`, compiles local descriptor images with `grpc_tools.protoc`, writes a local x2mdx manifest into `.internal/generated/x2mdx/protobuf-history/manifest.json`, and then renders MDX pages with the GitHub-pinned `x2mdx`.
+The generator script discovers stable Canton versions from the source repo tags, downloads the matching `canton-open-source-<version>.tar.gz` bundles from `canton.io/releases`, extracts the published `protobuf/` tree under `.internal/cache/x2mdx/protobuf-history/`, compiles local descriptor images with `grpc_tools.protoc`, writes a local x2mdx manifest into `.internal/generated/x2mdx/protobuf-history/manifest.json`, and then renders MDX pages through the docs repo `direnv` / `nix` shell.
 
 Run:
 
@@ -221,7 +221,7 @@ The generated nav is added under the top-level `Reference` dropdown as `gRPC Led
 ### Generate the TypeScript bindings reference
 
 This repo also includes a checked-in source config for published `@daml/types` npm artifacts at `config/x2mdx/typescript-bindings/source-artifacts.json`.
-The generator script downloads the configured tarballs into `.internal/cache/x2mdx/typescript-bindings/`, installs local package dependencies, renders TypeDoc JSON into `.internal/generated/x2mdx/typescript-bindings/`, writes a local x2mdx manifest, and then rewrites the checked-in Mintlify page with the GitHub-pinned `x2mdx`.
+The generator script downloads the configured tarballs into `.internal/cache/x2mdx/typescript-bindings/`, installs local package dependencies, renders TypeDoc JSON into `.internal/generated/x2mdx/typescript-bindings/`, writes a local x2mdx manifest, and then rewrites the checked-in Mintlify page through the docs repo `direnv` / `nix` shell.
 
 Run:
 
@@ -245,7 +245,7 @@ The generator also adds that page under the top-level `API Reference` dropdown a
 ### Generate the Wallet Gateway JSON-RPC reference
 
 This repo also includes a checked-in source config for versioned Wallet Gateway OpenRPC specs from `hyperledger-labs/splice-wallet-kernel` at `config/x2mdx/wallet-gateway-openrpc/source-artifacts.json`.
-The generator script discovers versions from GitHub releases filtered to the `@canton-network/wallet-gateway-remote@` release stream, clones or fetches a cached bare repo under `.internal/cache/x2mdx/wallet-gateway-openrpc/`, materializes local versioned OpenRPC JSON files from the matching tag snapshots, writes a local x2mdx manifest into `.internal/generated/x2mdx/wallet-gateway-openrpc/manifest.json`, and then renders MDX pages with the GitHub-pinned `x2mdx`.
+The generator script discovers versions from GitHub releases filtered to the `@canton-network/wallet-gateway-remote@` release stream, clones or fetches a cached bare repo under `.internal/cache/x2mdx/wallet-gateway-openrpc/`, materializes local versioned OpenRPC JSON files from the matching tag snapshots, writes a local x2mdx manifest into `.internal/generated/x2mdx/wallet-gateway-openrpc/manifest.json`, and then renders MDX pages through the docs repo `direnv` / `nix` shell.
 
 Run:
 
@@ -262,7 +262,7 @@ npm run generate:wallet-gateway-openrpc-reference
 ### Generate the Splice Scan OpenAPI reference
 
 This repo also includes a checked-in source config for the published decentralized-canton-sync OpenAPI bundle at `config/x2mdx/splice-scan-openapi/source-artifacts.json`.
-The generator script discovers matching stable releases through the GitHub releases API, downloads `*_openapi.tar.gz` bundle assets into `.internal/cache/x2mdx/splice-openapi/`, materializes all bundled YAML files into local versioned fixtures for `$ref` resolution, writes a local x2mdx manifest into `.internal/generated/x2mdx/splice-scan-openapi/manifest.json`, and then renders the checked-in Mintlify pages with the GitHub-pinned `x2mdx`.
+The generator script discovers matching stable releases through the GitHub releases API, downloads `*_openapi.tar.gz` bundle assets into `.internal/cache/x2mdx/splice-openapi/`, materializes all bundled YAML files into local versioned fixtures for `$ref` resolution, writes a local x2mdx manifest into `.internal/generated/x2mdx/splice-scan-openapi/manifest.json`, and then renders the checked-in Mintlify pages through the docs repo `direnv` / `nix` shell.
 
 Run:
 

--- a/docs-main/reference/scala/com-digitalasset-canton-version.mdx
+++ b/docs-main/reference/scala/com-digitalasset-canton-version.mdx
@@ -18,7 +18,7 @@ description: "Generated package reference page from local Javadoc/Scaladoc snaps
 | [`HandshakeError`](#type-com-digitalasset-canton-version-handshakeerror) | 🟢 `v3.4` | Trait for errors that are returned to clients when handshake fails. |
 | [`HandshakeErrors`](#type-com-digitalasset-canton-version-handshakeerrors) | 🟢 `v3.4` | - |
 | [`HasProtocolVersionedWrapper`](#type-com-digitalasset-canton-version-hasprotocolversionedwrapper) | 🟢 `v3.4` | Trait for classes that can be serialized by using ProtoBuf. See... |
-| [`HasRepresentativeProtocolVersion`](#type-com-digitalasset-canton-version-hasrepresentativeprotocolversion) | 🟢 `v3.4` | We have a correspondence &#123;Proto version&#125; &lt;-&gt; &#123;[protocol version]&#125;... |
+| [`HasRepresentativeProtocolVersion`](#type-com-digitalasset-canton-version-hasrepresentativeprotocolversion) | 🟢 `v3.4` | We have a correspondence {Proto version} &lt;-&gt; {[protocol version]}... |
 | [`HasToByteString`](#type-com-digitalasset-canton-version-hastobytestring) | 🟢 `v3.4` | Trait for classes that can be serialized to a... |
 | [`HasVersionedMessageCompanion`](#type-com-digitalasset-canton-version-hasversionedmessagecompanion) | 🟢 `v3.4` | Traits for the companion objects of classes that implement... |
 | [`HasVersionedMessageCompanionCommon`](#type-com-digitalasset-canton-version-hasversionedmessagecompanioncommon) | 🟢 `v3.4` | Proto versions that are supported by fromProtoVersioned... |
@@ -3303,7 +3303,7 @@ trait HasRepresentativeProtocolVersion extends AnyRef
 
 **Summary**
 
-We have a correspondence &#123;Proto version&#125; &lt;-&gt; &#123;[protocol version]&#125;: each proto version correspond to a list of consecutive protocol versions. The representative is one instance of this list, usually the smallest value. In other words, the Proto versions induce an equivalence relation on the list of protocol version, thus use of representative.
+We have a correspondence {Proto version} &lt;-&gt; {[protocol version]}: each proto version correspond to a list of consecutive protocol versions. The representative is one instance of this list, usually the smallest value. In other words, the Proto versions induce an equivalence relation on the list of protocol version, thus use of representative.
 
 **Members**
 

--- a/scripts/docs_env.py
+++ b/scripts/docs_env.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+
+DIRENV_ENV_MARKER = "DIGITAL_ASSET_DOCS_DIRENV"
+
+
+def repo_direnv_command(repo_root: Path, *args: str) -> list[str]:
+    return ["direnv", "exec", str(repo_root), *args]
+
+
+def ensure_repo_direnv(*, repo_root: Path, script_path: Path, argv: Sequence[str]) -> None:
+    if os.environ.get(DIRENV_ENV_MARKER) == "1":
+        return
+
+    env = os.environ.copy()
+    env[DIRENV_ENV_MARKER] = "1"
+    command = repo_direnv_command(repo_root, "python3", str(script_path), *argv)
+    raise SystemExit(subprocess.run(command, check=False, env=env).returncode)

--- a/scripts/generate_all_reference_docs.py
+++ b/scripts/generate_all_reference_docs.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from docs_env import ensure_repo_direnv, repo_direnv_command
 import reference_nav
 
 
@@ -110,10 +111,14 @@ def scratch_docs_json_path(job: ScriptJob) -> Path:
 
 
 def build_command(job: ScriptJob) -> list[str]:
-    command = [sys.executable, str(job.script_path)]
-    command.extend(job.extra_args)
-    command.extend(["--docs-json", str(scratch_docs_json_path(job))])
-    return command
+    return repo_direnv_command(
+        REPO_ROOT,
+        "python3",
+        str(job.script_path),
+        *job.extra_args,
+        "--docs-json",
+        str(scratch_docs_json_path(job)),
+    )
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -280,6 +285,7 @@ def consolidate_docs_json() -> None:
 
 
 def main() -> int:
+    ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
     args = parse_args()
     total = len(SCRIPT_JOBS)
     running_processes: list[tuple[ScriptJob, subprocess.Popen[bytes]]] = []

--- a/scripts/generate_canton_protobuf_history.py
+++ b/scripts/generate_canton_protobuf_history.py
@@ -17,6 +17,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from docs_env import ensure_repo_direnv, repo_direnv_command
 import reference_nav
 
 
@@ -370,6 +371,7 @@ def sync_output_tree(*, source_dir: Path, target_dir: Path) -> None:
 
 
 def main() -> int:
+    ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
     repo_config = source_config.get("repo") if isinstance(source_config.get("repo"), dict) else {}
@@ -442,7 +444,8 @@ def main() -> int:
         else:
             version_filter = f"stable Canton release bundles >= {min_version}"
 
-    command = [
+    command = repo_direnv_command(
+        REPO_ROOT,
         "x2mdx",
         "protobuf",
         "build-api-pages-from-manifest",
@@ -454,7 +457,7 @@ def main() -> int:
         args.source_name,
         "--version-filter",
         version_filter,
-    ]
+    )
     print("Running:", " ".join(command))
     completed = subprocess.run(command, cwd=REPO_ROOT)
     if completed.returncode != 0:

--- a/scripts/generate_daml_standard_library_reference.py
+++ b/scripts/generate_daml_standard_library_reference.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from docs_env import ensure_repo_direnv, repo_direnv_command
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CACHE_ROOT = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser() / "x2mdx"
@@ -221,6 +222,7 @@ def update_docs_navigation(
 
 
 def main() -> int:
+    ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
     configured_versions = source_config.get("versions")
@@ -252,7 +254,8 @@ def main() -> int:
         manifest_path=Path(args.manifest_out).resolve(),
         versions=selected_versions,
     )
-    command = [
+    command = repo_direnv_command(
+        REPO_ROOT,
         "x2mdx",
         "daml-json",
         "build-api-pages-from-manifest",
@@ -268,7 +271,7 @@ def main() -> int:
         args.version_filter,
         "--link-prefix",
         docs_route_prefix(Path(args.output_dir).resolve(), Path(args.docs_json).resolve()),
-    ]
+    )
     for version in args.version or []:
         command.extend(["--version", version])
     print("Running:", " ".join(command))

--- a/scripts/generate_grpc_ledger_api_reference.py
+++ b/scripts/generate_grpc_ledger_api_reference.py
@@ -11,8 +11,10 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from docs_env import ensure_repo_direnv
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 

--- a/scripts/generate_json_api_asyncapi_reference.py
+++ b/scripts/generate_json_api_asyncapi_reference.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from docs_env import ensure_repo_direnv, repo_direnv_command
 from ledger_api_release_bundles import (
     bundle_url,
     load_json,
@@ -254,7 +255,8 @@ def normalize_nav_group_into_pages(*, docs_json_path: Path, dropdown_label: str,
 
 def build_command(args: argparse.Namespace, manifest_path: Path, publish_version: str, versions: list[str]) -> list[str]:
     nav_groups = args.nav_group if args.nav_group is not None else [DEFAULT_NAV_GROUP]
-    command = [
+    command = repo_direnv_command(
+        REPO_ROOT,
         "x2mdx",
         "asyncapi",
         "build-api-pages-from-manifest",
@@ -278,7 +280,7 @@ def build_command(args: argparse.Namespace, manifest_path: Path, publish_version
         args.page_title,
         "--page-description",
         args.page_description,
-    ]
+    )
     for nav_group in nav_groups:
         command.extend(["--nav-group", nav_group])
     for version in versions:
@@ -296,6 +298,7 @@ def remove_legacy_output(*, output_file: Path) -> None:
 
 
 def main() -> int:
+    ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
     selected_version_entries = selected_versions(source_config, set(args.version) if args.version else None)

--- a/scripts/generate_json_api_reference.py
+++ b/scripts/generate_json_api_reference.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from docs_env import ensure_repo_direnv, repo_direnv_command
 from ledger_api_release_bundles import (
     bundle_url,
     load_json,
@@ -111,7 +112,8 @@ def build_command(args: argparse.Namespace) -> list[str]:
     nav_groups = args.nav_group if args.nav_group is not None else [DEFAULT_NAV_GROUP]
     versions = args.version or DEFAULT_SNAPSHOT_VERSIONS
 
-    command = [
+    command = repo_direnv_command(
+        REPO_ROOT,
         "x2mdx",
         "openapi",
         "build-api-pages-from-manifest",
@@ -131,7 +133,7 @@ def build_command(args: argparse.Namespace) -> list[str]:
         args.source_name,
         "--version-filter",
         args.version_filter,
-    ]
+    )
 
     for version in versions:
         command.extend(["--version", version])
@@ -312,6 +314,7 @@ def write_manifest(
 
 
 def main() -> int:
+    ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
     include_versions = set(args.version) if args.version else None

--- a/scripts/generate_ledger_bindings_api_reference.py
+++ b/scripts/generate_ledger_bindings_api_reference.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+from docs_env import ensure_repo_direnv, repo_direnv_command
 import reference_nav
 
 
@@ -480,7 +481,8 @@ def build_manifest(
 def build_command(args: argparse.Namespace, manifest_path: Path) -> list[str]:
     render_overview_file = DEFAULT_RENDER_ROOT / "ledger-api-jvm-bindings.mdx"
     render_details_dir = DEFAULT_RENDER_ROOT / "details"
-    command = [
+    command = repo_direnv_command(
+        REPO_ROOT,
         "x2mdx",
         "jvm-docs",
         "build-api-pages-from-manifest",
@@ -496,7 +498,7 @@ def build_command(args: argparse.Namespace, manifest_path: Path) -> list[str]:
         args.source_name,
         "--version-filter",
         args.version_filter,
-    ]
+    )
     for version in args.version or []:
         command.extend(["--version", version])
     return command
@@ -864,6 +866,7 @@ def publish_rendered_pages(
 
 
 def main() -> int:
+    ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
     include_versions = set(args.version) if args.version else None

--- a/scripts/generate_splice_scan_openapi_reference.py
+++ b/scripts/generate_splice_scan_openapi_reference.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from pathlib import Path
 
+from docs_env import ensure_repo_direnv
 from splice_openapi_release_bundles import render_reference
 
 
@@ -45,6 +47,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> int:
+    ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
     args = parse_args()
     include_versions = set(args.version) if args.version else None
     version_filter = args.version_filter

--- a/scripts/generate_typescript_bindings_reference.py
+++ b/scripts/generate_typescript_bindings_reference.py
@@ -12,6 +12,7 @@ import tarfile
 from pathlib import Path
 from typing import Any
 
+from docs_env import ensure_repo_direnv, repo_direnv_command
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CACHE_ROOT = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser() / "x2mdx"
@@ -266,6 +267,7 @@ def write_manifest(
 
 
 def main() -> int:
+    ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
     configured_versions = source_config.get("versions")
@@ -299,7 +301,8 @@ def main() -> int:
         publish_version=publish_version,
     )
 
-    command = [
+    command = repo_direnv_command(
+        REPO_ROOT,
         "x2mdx",
         "typedoc",
         "build-api-pages-from-manifest",
@@ -317,7 +320,7 @@ def main() -> int:
         args.page_title,
         "--page-description",
         args.page_description,
-    ]
+    )
     for version in args.version or []:
         command.extend(["--version", version])
     print("Running:", " ".join(command))

--- a/scripts/generate_wallet_gateway_openrpc_reference.py
+++ b/scripts/generate_wallet_gateway_openrpc_reference.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from docs_env import ensure_repo_direnv, repo_direnv_command
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CACHE_ROOT = Path(os.environ.get("XDG_CACHE_HOME", "~/.cache")).expanduser() / "x2mdx"
@@ -282,6 +283,7 @@ def write_manifest(
 
 
 def main() -> int:
+    ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
     include_versions = set(args.version) if args.version else None
@@ -334,7 +336,8 @@ def main() -> int:
     )
 
     fixture_root = REPO_ROOT
-    command = [
+    command = repo_direnv_command(
+        REPO_ROOT,
         "x2mdx",
         "openrpc",
         "build-api-pages-from-manifest",
@@ -354,7 +357,7 @@ def main() -> int:
         args.source_name,
         "--version-filter",
         args.version_filter or f"{tag_prefix} GitHub releases",
-    ]
+    )
     for version in args.version or []:
         command.extend(["--version", version])
     print("Running:", " ".join(command))

--- a/scripts/splice_openapi_release_bundles.py
+++ b/scripts/splice_openapi_release_bundles.py
@@ -13,6 +13,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from docs_env import repo_direnv_command
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -421,7 +422,8 @@ def build_command(
         raise ValueError("source_path_prefix must be a non-empty string")
     spec_filename = spec_page["filename"]
 
-    command = [
+    command = repo_direnv_command(
+        REPO_ROOT,
         "x2mdx",
         "openapi",
         "build-api-pages-from-manifest",
@@ -435,7 +437,7 @@ def build_command(
         source_name,
         "--version-filter",
         version_filter,
-    ]
+    )
     command.extend(["--include-spec-pattern", rf"^{re.escape(spec_filename)}$"])
     for mapping in source_config.get("canonical_paths", []):
         command.extend(["--canonical-path", mapping])


### PR DESCRIPTION
## Summary
- add a shared `scripts/docs_env.py` helper so the reference-doc wrappers re-exec through the `digital-asset/docs` `direnv`/Nix shell
- route every `x2mdx` subprocess call through that same docs-shell environment instead of relying on ambient `PATH`
- update the README wording to document the new invariant and keep the one regenerated JVM page drift from the current pinned generator

## Testing
- `python3 -m compileall scripts`
- `direnv exec /Users/danielporter/control/.worktrees/docs-no-local-x2mdx python3 /Users/danielporter/control/.worktrees/docs-no-local-x2mdx/scripts/generate_all_reference_docs.py`
- `python3 /Users/danielporter/control/.worktrees/docs-no-local-x2mdx/scripts/generate_json_api_reference.py --help`
- `python3 /Users/danielporter/control/.worktrees/docs-no-local-x2mdx/scripts/generate_grpc_ledger_api_reference.py --help`
- `rg -n "/Users/danielporter/control/x2mdx|direnv exec .*control/x2mdx|\.venv/bin/x2mdx" /Users/danielporter/control/.worktrees/docs-no-local-x2mdx` (no matches)
