### PR TITLE
Render Splice Scan API with Mintlify OpenAPI

### DIFF
--- a/config/mintlify-openapi/splice-openapi/source-artifacts.json
+++ b/config/mintlify-openapi/splice-openapi/source-artifacts.json
@@ -9,7 +9,9 @@
   "top_level_group_label": "Splice APIs",
   "insert_after_group": "Wallet Kernel",
   "managed_openapi_root": "openapi/splice",
-  "enabled_nav_specs": [],
+  "enabled_nav_specs": [
+    "scan.yaml"
+  ],
   "families": [
     {
       "group": "Scan APIs",

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1312,18 +1312,6 @@
             ]
           },
           {
-            "group": "Splice APIs",
-            "pages": [
-              {
-                "group": "Scan APIs",
-                "pages": [
-                  "reference/splice-scan-openapi/scan-yaml",
-                  "reference/splice-scan-openapi/scan-stream-server-yaml"
-                ]
-              }
-            ]
-          },
-          {
             "group": "Daml Standard Library",
             "pages": [
               "appdev/reference/daml-standard-library/index",
@@ -1384,6 +1372,23 @@
             "group": "Daml TypeScript Bindings",
             "pages": [
               "reference/typescript"
+            ]
+          },
+          {
+            "group": "Splice APIs",
+            "pages": [
+              {
+                "group": "Scan APIs",
+                "pages": [
+                  {
+                    "group": "Scan API",
+                    "openapi": {
+                      "source": "openapi/splice/scan/scan.yaml",
+                      "directory": "reference/splice-scan-api"
+                    }
+                  }
+                ]
+              }
             ]
           }
         ]


### PR DESCRIPTION
Adds the published Splice OpenAPI source `openapi/splice/scan/scan.yaml` and wires it into `docs-main/docs.json` under `API Reference -> Splice APIs` using Mintlify's native OpenAPI renderer.

Scope intentionally stays to one OpenAPI source file and its nav entry so Mintlify behavior can be reviewed independently of the other Splice specs.

Preview page: https://cantonfoundation-splice-scan-api-openapi.mintlify.io/reference/splice-scan-api
