### PR TITLE
Add Splice Wallet API (External) Mintlify OpenAPI source

### DIFF
--- a/config/mintlify-openapi/splice-openapi/source-artifacts.json
+++ b/config/mintlify-openapi/splice-openapi/source-artifacts.json
@@ -11,7 +11,8 @@
   "managed_openapi_root": "openapi/splice",
   "enabled_nav_specs": [
     "scan.yaml",
-    "scan-stream-server.yaml"
+    "scan-stream-server.yaml",
+    "wallet-external.yaml"
   ],
   "legacy_cleanup_paths": [
     "reference/splice-scan-openapi"

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1396,6 +1396,18 @@
                     }
                   }
                 ]
+              },
+              {
+                "group": "Validator APIs",
+                "pages": [
+                  {
+                    "group": "Wallet API (External)",
+                    "openapi": {
+                      "source": "openapi/splice/validator/wallet-external.yaml",
+                      "directory": "reference/splice-wallet-api-external"
+                    }
+                  }
+                ]
               }
             ]
           }


### PR DESCRIPTION
Adds the published Splice OpenAPI source `openapi/splice/validator/wallet-external.yaml` and wires it into `docs-main/docs.json` under `API Reference -> Splice APIs` using Mintlify's native OpenAPI renderer.

Scope intentionally stays to one OpenAPI source file and its nav entry so Mintlify behavior can be reviewed independently of the other Splice specs.

Preview page: https://cantonfoundation-splice-wallet-api-external-openapi.mintlify.io/reference/splice-wallet-api-external
