### PR TITLE
Add Splice Wallet API (Internal) Mintlify OpenAPI source

### DIFF
--- a/config/mintlify-openapi/splice-openapi/source-artifacts.json
+++ b/config/mintlify-openapi/splice-openapi/source-artifacts.json
@@ -12,7 +12,8 @@
   "enabled_nav_specs": [
     "scan.yaml",
     "scan-stream-server.yaml",
-    "wallet-external.yaml"
+    "wallet-external.yaml",
+    "wallet-internal.yaml"
   ],
   "legacy_cleanup_paths": [
     "reference/splice-scan-openapi"

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1406,6 +1406,13 @@
                       "source": "openapi/splice/validator/wallet-external.yaml",
                       "directory": "reference/splice-wallet-api-external"
                     }
+                  },
+                  {
+                    "group": "Wallet API (Internal)",
+                    "openapi": {
+                      "source": "openapi/splice/validator/wallet-internal.yaml",
+                      "directory": "reference/splice-wallet-api-internal"
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
Adds the published Splice OpenAPI source `openapi/splice/validator/wallet-internal.yaml` and wires it into `docs-main/docs.json` under `API Reference -> Splice APIs` using Mintlify's native OpenAPI renderer.

Scope intentionally stays to one OpenAPI source file and its nav entry so Mintlify behavior can be reviewed independently of the other Splice specs.

Preview page: https://cantonfoundation-splice-wallet-api-internal-openapi.mintlify.io/reference/splice-wallet-api-internal
