### PR TITLE
Add Splice Validator API (Internal) Mintlify OpenAPI source

### DIFF
--- a/config/mintlify-openapi/splice-openapi/source-artifacts.json
+++ b/config/mintlify-openapi/splice-openapi/source-artifacts.json
@@ -13,7 +13,8 @@
     "scan.yaml",
     "scan-stream-server.yaml",
     "wallet-external.yaml",
-    "wallet-internal.yaml"
+    "wallet-internal.yaml",
+    "validator-internal.yaml"
   ],
   "legacy_cleanup_paths": [
     "reference/splice-scan-openapi"

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1413,6 +1413,13 @@
                       "source": "openapi/splice/validator/wallet-internal.yaml",
                       "directory": "reference/splice-wallet-api-internal"
                     }
+                  },
+                  {
+                    "group": "Validator API (Internal)",
+                    "openapi": {
+                      "source": "openapi/splice/validator/validator-internal.yaml",
+                      "directory": "reference/splice-validator-api-internal"
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
Adds the published Splice OpenAPI source `openapi/splice/validator/validator-internal.yaml` and wires it into `docs-main/docs.json` under `API Reference -> Splice APIs` using Mintlify's native OpenAPI renderer.

Scope intentionally stays to one OpenAPI source file and its nav entry so Mintlify behavior can be reviewed independently of the other Splice specs.

Preview page: https://cantonfoundation-splice-validator-api-internal-openapi.mintlify.io/reference/splice-validator-api-internal
