### PR TITLE
Add Splice ANS API Mintlify OpenAPI source

### DIFF
--- a/config/mintlify-openapi/splice-openapi/source-artifacts.json
+++ b/config/mintlify-openapi/splice-openapi/source-artifacts.json
@@ -14,7 +14,8 @@
     "scan-stream-server.yaml",
     "wallet-external.yaml",
     "wallet-internal.yaml",
-    "validator-internal.yaml"
+    "validator-internal.yaml",
+    "ans-external.yaml"
   ],
   "legacy_cleanup_paths": [
     "reference/splice-scan-openapi"

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1420,6 +1420,13 @@
                       "source": "openapi/splice/validator/validator-internal.yaml",
                       "directory": "reference/splice-validator-api-internal"
                     }
+                  },
+                  {
+                    "group": "ANS API",
+                    "openapi": {
+                      "source": "openapi/splice/validator/ans-external.yaml",
+                      "directory": "reference/splice-ans-api"
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
Adds the published Splice OpenAPI source `openapi/splice/validator/ans-external.yaml` and wires it into `docs-main/docs.json` under `API Reference -> Splice APIs` using Mintlify's native OpenAPI renderer.

Scope intentionally stays to one OpenAPI source file and its nav entry so Mintlify behavior can be reviewed independently of the other Splice specs.

Preview page: https://cantonfoundation-splice-ans-api-openapi.mintlify.io/reference/splice-ans-api
