### PR TITLE
Add Splice Scan Proxy API Mintlify OpenAPI source

### DIFF
--- a/config/mintlify-openapi/splice-openapi/source-artifacts.json
+++ b/config/mintlify-openapi/splice-openapi/source-artifacts.json
@@ -15,7 +15,8 @@
     "wallet-external.yaml",
     "wallet-internal.yaml",
     "validator-internal.yaml",
-    "ans-external.yaml"
+    "ans-external.yaml",
+    "scan-proxy.yaml"
   ],
   "legacy_cleanup_paths": [
     "reference/splice-scan-openapi"

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1427,6 +1427,13 @@
                       "source": "openapi/splice/validator/ans-external.yaml",
                       "directory": "reference/splice-ans-api"
                     }
+                  },
+                  {
+                    "group": "Scan Proxy API",
+                    "openapi": {
+                      "source": "openapi/splice/validator/scan-proxy.yaml",
+                      "directory": "reference/splice-scan-proxy-api"
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
Adds the published Splice OpenAPI source `openapi/splice/validator/scan-proxy.yaml` and wires it into `docs-main/docs.json` under `API Reference -> Splice APIs` using Mintlify's native OpenAPI renderer.

Scope intentionally stays to one OpenAPI source file and its nav entry so Mintlify behavior can be reviewed independently of the other Splice specs.

Preview page: https://cantonfoundation-splice-scan-proxy-api-openapi.mintlify.io/reference/splice-scan-proxy-api
