### PR TITLE
Add Splice Token Metadata Service Mintlify OpenAPI source

### DIFF
--- a/config/mintlify-openapi/splice-openapi/source-artifacts.json
+++ b/config/mintlify-openapi/splice-openapi/source-artifacts.json
@@ -16,7 +16,8 @@
     "wallet-internal.yaml",
     "validator-internal.yaml",
     "ans-external.yaml",
-    "scan-proxy.yaml"
+    "scan-proxy.yaml",
+    "token-metadata-v1.yaml"
   ],
   "legacy_cleanup_paths": [
     "reference/splice-scan-openapi"

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1436,6 +1436,18 @@
                     }
                   }
                 ]
+              },
+              {
+                "group": "Token Standard APIs",
+                "pages": [
+                  {
+                    "group": "Token Metadata Service",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/token-metadata-v1.yaml",
+                      "directory": "reference/splice-token-metadata-service"
+                    }
+                  }
+                ]
               }
             ]
           }


### PR DESCRIPTION
Adds the published Splice OpenAPI source `openapi/splice/token-standard/token-metadata-v1.yaml` and wires it into `docs-main/docs.json` under `API Reference -> Splice APIs` using Mintlify's native OpenAPI renderer.

Scope intentionally stays to one OpenAPI source file and its nav entry so Mintlify behavior can be reviewed independently of the other Splice specs.

Preview page: https://cantonfoundation-splice-token-metadata-openapi.mintlify.io/reference/splice-token-metadata-service
