### PR TITLE
Add Splice Transfer Instruction API Mintlify OpenAPI source

### DIFF
--- a/config/mintlify-openapi/splice-openapi/source-artifacts.json
+++ b/config/mintlify-openapi/splice-openapi/source-artifacts.json
@@ -17,7 +17,8 @@
     "validator-internal.yaml",
     "ans-external.yaml",
     "scan-proxy.yaml",
-    "token-metadata-v1.yaml"
+    "token-metadata-v1.yaml",
+    "transfer-instruction-v1.yaml"
   ],
   "legacy_cleanup_paths": [
     "reference/splice-scan-openapi"

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1446,6 +1446,13 @@
                       "source": "openapi/splice/token-standard/token-metadata-v1.yaml",
                       "directory": "reference/splice-token-metadata-service"
                     }
+                  },
+                  {
+                    "group": "Transfer Instruction API",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/transfer-instruction-v1.yaml",
+                      "directory": "reference/splice-transfer-instruction-api"
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
Adds the published Splice OpenAPI source `openapi/splice/token-standard/transfer-instruction-v1.yaml` and wires it into `docs-main/docs.json` under `API Reference -> Splice APIs` using Mintlify's native OpenAPI renderer.

Scope intentionally stays to one OpenAPI source file and its nav entry so Mintlify behavior can be reviewed independently of the other Splice specs.

Preview page: https://cantonfoundation-splice-transfer-instruction-openapi.mintlify.io/reference/splice-transfer-instruction-api
