### PR TITLE
Add Splice Allocation API Mintlify OpenAPI source

### DIFF
--- a/config/mintlify-openapi/splice-openapi/source-artifacts.json
+++ b/config/mintlify-openapi/splice-openapi/source-artifacts.json
@@ -18,7 +18,8 @@
     "ans-external.yaml",
     "scan-proxy.yaml",
     "token-metadata-v1.yaml",
-    "transfer-instruction-v1.yaml"
+    "transfer-instruction-v1.yaml",
+    "allocation-v1.yaml"
   ],
   "legacy_cleanup_paths": [
     "reference/splice-scan-openapi"

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1453,6 +1453,13 @@
                       "source": "openapi/splice/token-standard/transfer-instruction-v1.yaml",
                       "directory": "reference/splice-transfer-instruction-api"
                     }
+                  },
+                  {
+                    "group": "Allocation API",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/allocation-v1.yaml",
+                      "directory": "reference/splice-allocation-api"
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
Adds the published Splice OpenAPI source `openapi/splice/token-standard/allocation-v1.yaml` and wires it into `docs-main/docs.json` under `API Reference -> Splice APIs` using Mintlify's native OpenAPI renderer.

Scope intentionally stays to one OpenAPI source file and its nav entry so Mintlify behavior can be reviewed independently of the other Splice specs.

Preview page: https://cantonfoundation-splice-allocation-api-openapi.mintlify.io/reference/splice-allocation-api
