### PR TITLE
Add Splice Allocation Instruction API Mintlify OpenAPI source

### DIFF
--- a/config/mintlify-openapi/splice-openapi/source-artifacts.json
+++ b/config/mintlify-openapi/splice-openapi/source-artifacts.json
@@ -19,7 +19,8 @@
     "scan-proxy.yaml",
     "token-metadata-v1.yaml",
     "transfer-instruction-v1.yaml",
-    "allocation-v1.yaml"
+    "allocation-v1.yaml",
+    "allocation-instruction-v1.yaml"
   ],
   "legacy_cleanup_paths": [
     "reference/splice-scan-openapi"

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1460,6 +1460,13 @@
                       "source": "openapi/splice/token-standard/allocation-v1.yaml",
                       "directory": "reference/splice-allocation-api"
                     }
+                  },
+                  {
+                    "group": "Allocation Instruction API",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/allocation-instruction-v1.yaml",
+                      "directory": "reference/splice-allocation-instruction-api"
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
Adds the published Splice OpenAPI source `openapi/splice/token-standard/allocation-instruction-v1.yaml` and wires it into `docs-main/docs.json` under `API Reference -> Splice APIs` using Mintlify's native OpenAPI renderer.

Scope intentionally stays to one OpenAPI source file and its nav entry so Mintlify behavior can be reviewed independently of the other Splice specs.

Preview page: https://cantonfoundation-splice-allocation-instruction-openapi.mintlify.io/reference/splice-allocation-instruction-api
