### PR TITLE
Batch remaining Splice OpenAPI sources

### DIFF
--- a/config/mintlify-openapi/splice-openapi/source-artifacts.json
+++ b/config/mintlify-openapi/splice-openapi/source-artifacts.json
@@ -10,7 +10,15 @@
   "insert_after_group": "Wallet Kernel",
   "managed_openapi_root": "openapi/splice",
   "enabled_nav_specs": [
-    "scan.yaml"
+    "scan.yaml",
+    "scan-stream-server.yaml",
+    "wallet-external.yaml",
+    "ans-external.yaml",
+    "scan-proxy.yaml",
+    "token-metadata-v1.yaml",
+    "transfer-instruction-v1.yaml",
+    "allocation-v1.yaml",
+    "allocation-instruction-v1.yaml"
   ],
   "legacy_cleanup_paths": [
     "reference/splice-scan-openapi"

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1387,6 +1387,72 @@
                       "source": "openapi/splice/scan/scan.yaml",
                       "directory": "reference/splice-scan-api"
                     }
+                  },
+                  {
+                    "group": "Scan Streaming API",
+                    "openapi": {
+                      "source": "openapi/splice/scan/scan-stream-server.yaml",
+                      "directory": "reference/splice-scan-streaming-api"
+                    }
+                  }
+                ]
+              },
+              {
+                "group": "Validator APIs",
+                "pages": [
+                  {
+                    "group": "Wallet API (External)",
+                    "openapi": {
+                      "source": "openapi/splice/validator/wallet-external.yaml",
+                      "directory": "reference/splice-wallet-api-external"
+                    }
+                  },
+                  {
+                    "group": "ANS API",
+                    "openapi": {
+                      "source": "openapi/splice/validator/ans-external.yaml",
+                      "directory": "reference/splice-ans-api"
+                    }
+                  },
+                  {
+                    "group": "Scan Proxy API",
+                    "openapi": {
+                      "source": "openapi/splice/validator/scan-proxy.yaml",
+                      "directory": "reference/splice-scan-proxy-api"
+                    }
+                  }
+                ]
+              },
+              {
+                "group": "Token Standard APIs",
+                "pages": [
+                  {
+                    "group": "Token Metadata Service",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/token-metadata-v1.yaml",
+                      "directory": "reference/splice-token-metadata-service"
+                    }
+                  },
+                  {
+                    "group": "Transfer Instruction API",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/transfer-instruction-v1.yaml",
+                      "directory": "reference/splice-transfer-instruction-api"
+                    }
+                  },
+                  {
+                    "group": "Allocation API",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/allocation-v1.yaml",
+                      "directory": "reference/splice-allocation-api"
+                    }
+                  },
+                  {
+                    "group": "Allocation Instruction API",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/allocation-instruction-v1.yaml",
+                      "directory": "reference/splice-allocation-instruction-api"
+                    }
                   }
                 ]
               }


### PR DESCRIPTION
## Summary

[Preview here.](https://cantonfoundation-splice-selected-openapi-batch.mintlify.io/reference/splice-scan-api/common/get-readyz)

Batch the selected Splice Mintlify-native OpenAPI surfaces into one review branch on top of current `main`.

Included from the existing Splice PR set:
- `#230` Scan Streaming API
- `#231` Wallet API (External)
- `#234` ANS API
- `#235` Scan Proxy API
- `#236` Token Metadata Service
- `#237` Transfer Instruction API
- `#238` Allocation API
- `#239` Allocation Instruction API