### PR TITLE
Pin docs nixpkgs for reproducible shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This repository uses a dual-license model:
 ### Direnv + Nix workflow
 
 This repo includes `.envrc` and `shell.nix` for a reproducible local toolchain.
+The Nix package set is pinned by `nix/nixpkgs.src.json`.
 
 Required:
 - `direnv`

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,7 @@
+let
+  spec = builtins.fromJSON (builtins.readFile ./nixpkgs.src.json);
+in
+  import (builtins.fetchTarball {
+    url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
+    sha256 = spec.sha256;
+  }) {}

--- a/nix/nixpkgs.src.json
+++ b/nix/nixpkgs.src.json
@@ -1,0 +1,6 @@
+{
+  "owner": "NixOS",
+  "repo": "nixpkgs",
+  "rev": "8edf06bea5bcbee082df1b7369ff973b91618b8d",
+  "sha256": "0zwkwkiifcbzsmfn932nkgvhaj91n3hqg05fqss8s79bdwk6w35i"
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import ./nix/nixpkgs.nix }:
 
 let
   pythonBase = pkgs.python311;


### PR DESCRIPTION
## Summary
- Pin the docs Nix package set locally instead of importing ambient `<nixpkgs>`
- Add `nix/nixpkgs.src.json` plus `nix/nixpkgs.nix` and keep caller-provided `pkgs` overrides working
- Document the pin in the README direnv/Nix workflow note

## Testing
- `env -u NIX_PATH nix-instantiate --eval -E 'let pkgs = import ./nix/nixpkgs.nix; in pkgs.python311Packages.protobuf.version'` -> `"5.28.3"`\n- `env -u NIX_PATH nix-shell --run 'x2mdx list-formats'`\n- `direnv allow . && direnv exec . x2mdx list-formats`\n\nNo generated reference docs were rerun; this only changes the developer shell inputs.