### PR TITLE
Add PQS SQL reference to Ledger API nav

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -873,6 +873,7 @@
           {
             "group": "Ledger API",
             "pages": [
+              "appdev/reference/pqs-sql-reference",
               {
                 "group": "AsyncAPI",
                 "pages": [


### PR DESCRIPTION
## Summary
- Add the existing PQS SQL Reference page as a duplicate link under API Reference -> Ledger API.

## Validation
- Not run per request; preview validation pending.