### PR TITLE
Fix MDX code fences on broken docs pages

### DIFF
--- a/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
+++ b/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
@@ -1166,8 +1166,10 @@ These storage mixins can be used with any of the node configurations. All the re
 
 The mixins work by defining a shared variable, which can be referenced by any node configuration
 
-    storage = ${_shared.storage}
-    storage.parameters.databaseName = "canton_participant"
+```hocon
+storage = ${_shared.storage}
+storage.parameters.databaseName = "canton_participant"
+```
 
 If you ever see the following error: `Could not resolve substitution to a value: ${_shared.storage}`, then you forgot to add the persistence mixin configuration file.
 
@@ -1346,4 +1348,3 @@ If desired, you can run many nodes in the same process. This is convenient for t
 ```
 
 {/* COPIED_END */}
-

--- a/docs-main/global-synchronizer/production-operations/party-management.mdx
+++ b/docs-main/global-synchronizer/production-operations/party-management.mdx
@@ -1415,16 +1415,18 @@ However, in some cases you might not run this from a Canton console (for example
 
 lexicographic ordering on namespaces:
 
-    def compute_decentralized_namespace(owners):
-        builder = hashlib.sha256()
-        # hash purpose prefix
-        builder.update((37).to_bytes(4))
-        for owner in sorted(owners):
-            # namespace length
-            builder.update(len(owner).to_bytes(4))
-            builder.update(owner.encode("utf-8"))
-        # 1220 is the Canton prefix for sha256 hashes
-        return f"1220{builder.hexdigest()}"
+```python
+def compute_decentralized_namespace(owners):
+    builder = hashlib.sha256()
+    # hash purpose prefix
+    builder.update((37).to_bytes(4))
+    for owner in sorted(owners):
+        # namespace length
+        builder.update(len(owner).to_bytes(4))
+        builder.update(owner.encode("utf-8"))
+    # 1220 is the Canton prefix for sha256 hashes
+    return f"1220{builder.hexdigest()}"
+```
 
 {/* COPIED_END */}
 


### PR DESCRIPTION
## Fixed pages

- [Party Management](https://docs.canton.network/global-synchronizer/production-operations/party-management)
- [Canton Getting Started Tutorial](https://docs.canton.network/global-synchronizer/canton-console/getting-started-tutorial)

## Summary

- Fence the decentralized namespace Python example on the Party Management page.
- Fence the HOCON storage mixin example on the Canton Getting Started Tutorial page.
- Prevent MDX from evaluating code sample placeholders as JavaScript expressions during render.

## Root cause

Two copied examples were represented as indented code blocks. Mintlify/MDX compiled parts of those examples as paragraph text with embedded expressions:

- `f"1220{builder.hexdigest()}"` tried to read a JavaScript `builder` variable.
- `storage = ${_shared.storage}` tried to read a JavaScript `_shared` variable.

Both runtime errors prevented the page content from rendering, leaving the affected pages with no code blocks visible.

## Validation

- Reproduced in running Chromium against `https://docs.canton.network/global-synchronizer/production-operations/party-management`; console reported `ReferenceError: builder is not defined`, and the rendered page had zero code blocks.
- Reproduced in running Chromium against `https://docs.canton.network/global-synchronizer/canton-console/getting-started-tutorial`; console reported `ReferenceError: _shared is not defined`, and the rendered page had zero code blocks.
- Ran focused `@mdx-js/mdx` compile checks confirming the affected examples now compile as `language-python` and `language-hocon` fenced code blocks.
- Earlier attempted `mintlify validate` and `mintlify dev --no-open`; both remained on their progress spinner without diagnostics, so they were stopped.
