### PR TITLE
Restore generated docs

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -884,6 +884,13 @@
             "pages": [
               "appdev/reference/pqs-sql-reference",
               {
+                "group": "OpenAPI",
+                "openapi": {
+                  "source": "openapi/json-ledger-api/openapi.yaml",
+                  "directory": "reference/json-api-reference"
+                }
+              },
+              {
                 "group": "AsyncAPI",
                 "pages": [
                   "reference/json-api-asyncapi-reference/index",
@@ -942,9 +949,65 @@
                     "group": "Packages",
                     "pages": [
                       "reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandservice/submitandwait",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandsubmissionservice/submit",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/contractservice/getcontract",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/getpackage",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/getpackagestatus",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/listpackages",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/listvettedpackages",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getactivecontracts",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getledgerend",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/updateservice/getupdatebyid",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/updateservice/getupdates",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion",
                       "reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-admin",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid",
                       "reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission",
                       "reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-testing",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-testing/timeservice/gettime",
+                      "reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-testing/timeservice/settime",
                       "reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive-transaction-v1"
                     ]
                   }
@@ -8211,6 +8274,89 @@
                   "reference/wallet-gateway-json-rpc/operations/user-api/setprimarywallet",
                   "reference/wallet-gateway-json-rpc/operations/user-api/sign",
                   "reference/wallet-gateway-json-rpc/operations/user-api/syncwallets"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Splice APIs",
+            "pages": [
+              {
+                "group": "Scan APIs",
+                "pages": [
+                  {
+                    "group": "Scan API",
+                    "openapi": {
+                      "source": "openapi/splice/scan/scan.yaml",
+                      "directory": "reference/splice-scan-api"
+                    }
+                  },
+                  {
+                    "group": "Scan Streaming API",
+                    "openapi": {
+                      "source": "openapi/splice/scan/scan-stream-server.yaml",
+                      "directory": "reference/splice-scan-streaming-api"
+                    }
+                  }
+                ]
+              },
+              {
+                "group": "Validator APIs",
+                "pages": [
+                  {
+                    "group": "Wallet API (External)",
+                    "openapi": {
+                      "source": "openapi/splice/validator/wallet-external.yaml",
+                      "directory": "reference/splice-wallet-api-external"
+                    }
+                  },
+                  {
+                    "group": "ANS API",
+                    "openapi": {
+                      "source": "openapi/splice/validator/ans-external.yaml",
+                      "directory": "reference/splice-ans-api"
+                    }
+                  },
+                  {
+                    "group": "Scan Proxy API",
+                    "openapi": {
+                      "source": "openapi/splice/validator/scan-proxy.yaml",
+                      "directory": "reference/splice-scan-proxy-api"
+                    }
+                  }
+                ]
+              },
+              {
+                "group": "Token Standard APIs",
+                "pages": [
+                  {
+                    "group": "Token Metadata Service",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/token-metadata-v1.yaml",
+                      "directory": "reference/splice-token-metadata-service"
+                    }
+                  },
+                  {
+                    "group": "Transfer Instruction API",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/transfer-instruction-v1.yaml",
+                      "directory": "reference/splice-transfer-instruction-api"
+                    }
+                  },
+                  {
+                    "group": "Allocation API",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/allocation-v1.yaml",
+                      "directory": "reference/splice-allocation-api"
+                    }
+                  },
+                  {
+                    "group": "Allocation Instruction API",
+                    "openapi": {
+                      "source": "openapi/splice/token-standard/allocation-instruction-v1.yaml",
+                      "directory": "reference/splice-allocation-instruction-api"
+                    }
+                  }
                 ]
               }
             ]

--- a/docs-main/openapi/json-ledger-api/openapi.yaml
+++ b/docs-main/openapi/json-ledger-api/openapi.yaml
@@ -1,8437 +1,8437 @@
-openapi: 3.0.3
-info:
-  title: JSON Ledger API HTTP endpoints
-  version: 3.5.0-SNAPSHOT
-  description: |-
-    This specification version fixes the API inconsistencies where certain fields marked as required in the spec are in fact optional.
-    If you use code generation tool based on this file, you might need to adjust the existing application code to handle those fields as optional.
-    If you do not want to change your client code, continue using the OpenAPI specification for the latest Canton 3.4 patch release.
-    MINIMUM_CANTON_VERSION=3.5.0
-paths:
-  /v2/commands/submit-and-wait:
-    post:
-      description: |-
-        Submits a single composite command and waits for its result.
-        Propagates the gRPC error of failed submissions including Daml interpretation errors.
-      operationId: postV2CommandsSubmit-and-wait
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/JsCommands'
-        required: true
-      responses:
-        '200':
-          description: ''
+  openapi: 3.0.3
+  info:
+    title: JSON Ledger API HTTP endpoints
+    version: 3.5.0-SNAPSHOT
+    description: |-
+      This specification version fixes the API inconsistencies where certain fields marked as required in the spec are in fact optional.
+      If you use code generation tool based on this file, you might need to adjust the existing application code to handle those fields as optional.
+      If you do not want to change your client code, continue using the OpenAPI specification for the latest Canton 3.4 patch release.
+      MINIMUM_CANTON_VERSION=3.5.0
+  paths:
+    /v2/commands/submit-and-wait:
+      post:
+        description: |-
+          Submits a single composite command and waits for its result.
+          Propagates the gRPC error of failed submissions including Daml interpretation errors.
+        operationId: postV2CommandsSubmit-and-wait
+        requestBody:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubmitAndWaitResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/commands/submit-and-wait-for-transaction:
-    post:
-      description: |-
-        Submits a single composite command, waits for its result, and returns the transaction.
-        Propagates the gRPC error of failed submissions including Daml interpretation errors.
-      operationId: postV2CommandsSubmit-and-wait-for-transaction
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/JsSubmitAndWaitForTransactionRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsSubmitAndWaitForTransactionResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
+                $ref: '#/components/schemas/JsCommands'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SubmitAndWaitResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/submit-and-wait-for-transaction:
+      post:
+        description: |-
+          Submits a single composite command, waits for its result, and returns the transaction.
+          Propagates the gRPC error of failed submissions including Daml interpretation errors.
+        operationId: postV2CommandsSubmit-and-wait-for-transaction
+        requestBody:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/commands/submit-and-wait-for-reassignment:
-    post:
-      description: |-
-        Submits a single composite reassignment command, waits for its result, and returns the reassignment.
-        Propagates the gRPC error of failed submission.
-      operationId: postV2CommandsSubmit-and-wait-for-reassignment
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SubmitAndWaitForReassignmentRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
+                $ref: '#/components/schemas/JsSubmitAndWaitForTransactionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsSubmitAndWaitForTransactionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/submit-and-wait-for-reassignment:
+      post:
+        description: |-
+          Submits a single composite reassignment command, waits for its result, and returns the reassignment.
+          Propagates the gRPC error of failed submission.
+        operationId: postV2CommandsSubmit-and-wait-for-reassignment
+        requestBody:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsSubmitAndWaitForReassignmentResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/commands/submit-and-wait-for-transaction-tree:
-    post:
-      description: Submit a batch of commands and wait for the transaction trees response.
-        Provided for backwards compatibility, it will be removed in the Canton version
-        3.5.0, use submit-and-wait-for-transaction instead.
-      operationId: postV2CommandsSubmit-and-wait-for-transaction-tree
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/JsCommands'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsSubmitAndWaitForTransactionTreeResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
+                $ref: '#/components/schemas/SubmitAndWaitForReassignmentRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsSubmitAndWaitForReassignmentResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/submit-and-wait-for-transaction-tree:
+      post:
+        description: Submit a batch of commands and wait for the transaction trees response.
+          Provided for backwards compatibility, it will be removed in the Canton version
+          3.5.0, use submit-and-wait-for-transaction instead.
+        operationId: postV2CommandsSubmit-and-wait-for-transaction-tree
+        requestBody:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsCantonError'
-      deprecated: true
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/commands/async/submit:
-    post:
-      description: Submit a single composite command.
-      operationId: postV2CommandsAsyncSubmit
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/JsCommands'
-        required: true
-      responses:
-        '200':
-          description: ''
+                $ref: '#/components/schemas/JsCommands'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsSubmitAndWaitForTransactionTreeResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/async/submit:
+      post:
+        description: Submit a single composite command.
+        operationId: postV2CommandsAsyncSubmit
+        requestBody:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubmitResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/commands/async/submit-reassignment:
-    post:
-      description: Submit a single reassignment.
-      operationId: postV2CommandsAsyncSubmit-reassignment
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SubmitReassignmentRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SubmitReassignmentResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
+                $ref: '#/components/schemas/JsCommands'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SubmitResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/async/submit-reassignment:
+      post:
+        description: Submit a single reassignment.
+        operationId: postV2CommandsAsyncSubmit-reassignment
+        requestBody:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/commands/completions:
-    post:
-      description: |-
-        Query completions list (blocking call)
+                $ref: '#/components/schemas/SubmitReassignmentRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/SubmitReassignmentResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/commands/completions:
+      post:
+        description: |-
+          Query completions list (blocking call)
 
-        Subscribe to command completion events.
-        Notice: This endpoint should be used for small results set.
-        When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
-        there will be an error (`413 Content Too Large`) returned.
-        Increasing this limit may lead to performance issues and high memory consumption.
-        Consider using websockets (asyncapi) for better efficiency with larger results.
-      operationId: postV2CommandsCompletions
-      parameters:
-      - name: limit
-        in: query
-        description: maximum number of elements to return, this param is ignored if
-          is bigger than server setting
-        required: false
-        schema:
-          type: integer
-          format: int64
-      - name: stream_idle_timeout_ms
-        in: query
-        description: timeout to complete and send result if no new elements are received
-          (for open ended streams)
-        required: false
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CompletionStreamRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
+          Subscribe to command completion events.
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2CommandsCompletions
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CompletionStreamResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body, Invalid value for:
-            query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/events/events-by-contract-id:
-    post:
-      description: |-
-        Get the create and the consuming exercise event for the contract with the provided ID.
-        No events will be returned for contracts that have been pruned because they
-        have already been archived before the latest pruning offset.
-        If the contract cannot be found for the request, or all the contract-events are filtered, a CONTRACT_EVENTS_NOT_FOUND error will be raised.
-      operationId: postV2EventsEvents-by-contract-id
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetEventsByContractIdRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsGetEventsByContractIdResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
+                $ref: '#/components/schemas/CompletionStreamRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/CompletionStreamResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/events/events-by-contract-id:
+      post:
+        description: |-
+          Get the create and the consuming exercise event for the contract with the provided ID.
+          No events will be returned for contracts that have been pruned because they
+          have already been archived before the latest pruning offset.
+          If the contract cannot be found for the request, or all the contract-events are filtered, a CONTRACT_EVENTS_NOT_FOUND error will be raised.
+        operationId: postV2EventsEvents-by-contract-id
+        requestBody:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/version:
-    get:
-      description: Read the Ledger API version
-      operationId: getV2Version
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetLedgerApiVersionResponse'
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/dars/validate:
-    post:
-      description: |-
-        Validates the DAR and checks the upgrade compatibility of the DAR's packages
-        with the set of the already vetted packages on the target vetting synchronizer.
-        See ValidateDarFileRequest for details regarding the target vetting synchronizer.
+                $ref: '#/components/schemas/GetEventsByContractIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetEventsByContractIdResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/version:
+      get:
+        description: Read the Ledger API version
+        operationId: getV2Version
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetLedgerApiVersionResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/dars/validate:
+      post:
+        description: |-
+          Validates the DAR and checks the upgrade compatibility of the DAR's packages
+          with the set of the already vetted packages on the target vetting synchronizer.
+          See ValidateDarFileRequest for details regarding the target vetting synchronizer.
 
-        The operation has no effect on the state of the participant or the Canton ledger:
-        the DAR payload and its packages are not persisted neither are the packages vetted.
-      operationId: postV2DarsValidate
-      parameters:
-      - name: synchronizerId
-        in: query
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/octet-stream:
-            schema:
-              type: string
-              format: binary
-        required: true
-      responses:
-        '200':
-          description: ''
-        '400':
-          description: 'Invalid value, Invalid value for: body, Invalid value for:
-            query parameter synchronizerId'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/dars:
-    post:
-      description: Upload a DAR to the participant node
-      operationId: postV2Dars
-      parameters:
-      - name: vetAllPackages
-        in: query
-        required: false
-        schema:
-          type: boolean
-      - name: synchronizerId
-        in: query
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/octet-stream:
-            schema:
-              type: string
-              format: binary
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UploadDarFileResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body, Invalid value for:
-            query parameter vetAllPackages, Invalid value for: query parameter synchronizerId'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/packages:
-    get:
-      description: Returns the identifiers of all supported packages.
-      operationId: getV2Packages
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListPackagesResponse'
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    post:
-      description: |-
-        Behaves the same as /dars. This endpoint will be deprecated and removed in a future release.
-        Upload a DAR file to the participant.
-
-        If vetting is enabled in the request, the DAR is checked for upgrade compatibility
-        with the set of the already vetted packages on the target vetting synchronizer
-        See UploadDarFileRequest for details regarding vetting and the target vetting synchronizer.
-      operationId: postV2Packages
-      parameters:
-      - name: vetAllPackages
-        in: query
-        required: false
-        schema:
-          type: boolean
-      - name: synchronizerId
-        in: query
-        required: false
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/octet-stream:
-            schema:
-              type: string
-              format: binary
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UploadDarFileResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body, Invalid value for:
-            query parameter vetAllPackages, Invalid value for: query parameter synchronizerId'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/packages/{package-id}:
-    get:
-      description: Returns the contents of a single package.
-      operationId: getV2PackagesPackage-id
-      parameters:
-      - name: package-id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
-          headers:
-            Canton-Package-Hash:
-              required: true
-              schema:
-                type: string
+          The operation has no effect on the state of the participant or the Canton ledger:
+          the DAR payload and its packages are not persisted neither are the packages vetted.
+        operationId: postV2DarsValidate
+        parameters:
+        - name: synchronizerId
+          in: query
+          required: false
+          schema:
+            type: string
+        requestBody:
           content:
             application/octet-stream:
               schema:
                 type: string
                 format: binary
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/packages/{package-id}/status:
-    get:
-      description: Returns the status of a single package.
-      operationId: getV2PackagesPackage-idStatus
-      parameters:
-      - name: package-id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetPackageStatusResponse'
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/package-vetting:
-    get:
-      description: |-
-        Lists which participant node vetted what packages on which synchronizer.
-        This endpoint (GET /package-vetting) is deprecated and will be removed in a future release. Please use POST /package-vetting/list instead.
-      operationId: getV2Package-vetting
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ListVettedPackagesRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListVettedPackagesResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      deprecated: true
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    post:
-      description: |-
-        Update the vetted packages of this participant
-        This endpoint (POST /package-vetting) is deprecated and will be removed in a future release. Please use POST /package-vetting/update instead.
-      operationId: postV2Package-vetting
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateVettedPackagesRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpdateVettedPackagesResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      deprecated: true
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/package-vetting/list:
-    post:
-      description: |-
-        Lists which participant node vetted what packages on which synchronizer.
-        Can be called by any authenticated user.
-      operationId: postV2Package-vettingList
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ListVettedPackagesRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListVettedPackagesResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/package-vetting/update:
-    post:
-      description: Update the vetted packages of this participant
-      operationId: postV2Package-vettingUpdate
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateVettedPackagesRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpdateVettedPackagesResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/parties:
-    get:
-      description: |-
-        List the parties known by the participant.
-        The list returned contains parties whose ledger access is facilitated by
-        the participant and the ones maintained elsewhere.
-      operationId: getV2Parties
-      parameters:
-      - name: identity-provider-id
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: filter-party
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: pageSize
-        in: query
-        description: maximum number of elements in a returned page
-        required: false
-        schema:
-          type: integer
-          format: int32
-      - name: pageToken
-        in: query
-        description: token - to continue results from a given page, leave empty to
-          start from the beginning of the list, obtain token from the result of previous
-          page
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListKnownPartiesResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: query parameter identity-provider-id,
-            Invalid value for: query parameter filter-party, Invalid value for: query
-            parameter pageSize, Invalid value for: query parameter pageToken'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    post:
-      description: |-
-        Allocates a new party on a ledger and adds it to the set managed by the participant.
-        Caller specifies a party identifier suggestion, the actual identifier
-        allocated might be different and is implementation specific.
-        Caller can specify party metadata that is stored locally on the participant.
-        This call may:
-
-        - Succeed, in which case the actual allocated identifier is visible in
-          the response.
-        - Respond with a gRPC error
-
-        daml-on-kv-ledger: suggestion's uniqueness is checked by the validators in
-        the consensus layer and call rejected if the identifier is already present.
-        canton: completely different globally unique identifier is allocated.
-        Behind the scenes calls to an internal protocol are made. As that protocol
-        is richer than the surface protocol, the arguments take implicit values
-        The party identifier suggestion must be a valid party name. Party names are required to be non-empty US-ASCII strings built from letters, digits, space,
-        colon, minus and underscore limited to 255 chars
-      operationId: postV2Parties
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AllocatePartyRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AllocatePartyResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/parties/external/allocate:
-    post:
-      description: |-
-        Alpha 3.3: Endpoint to allocate a new external party on a synchronizer
-
-        Expected to be stable in 3.5
-
-        The external party must be hosted (at least) on this node with either confirmation or observation permissions
-        It can optionally be hosted on other nodes (then called a multi-hosted party).
-        If hosted on additional nodes, explicit authorization of the hosting relationship must be performed on those nodes
-        before the party can be used.
-        Decentralized namespaces are supported but must be provided fully authorized by their owners.
-        The individual owner namespace transactions can be submitted in the same call (fully authorized as well).
-        In the simple case of a non-multi hosted, non-decentralized party, the RPC will return once the party is
-        effectively allocated and ready to use, similarly to the AllocateParty behavior.
-        For more complex scenarios applications may need to query the party status explicitly (only through the admin API as of now).
-      operationId: postV2PartiesExternalAllocate
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AllocateExternalPartyRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AllocateExternalPartyResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/parties/participant-id:
-    get:
-      description: |-
-        Return the identifier of the participant.
-        All horizontally scaled replicas should return the same id.
-        daml-on-kv-ledger: returns an identifier supplied on command line at launch time
-        canton: returns globally unique identifier of the participant
-      operationId: getV2PartiesParticipant-id
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetParticipantIdResponse'
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/parties/{party}:
-    get:
-      description: |-
-        Get the party details of the given parties. Only known parties will be
-        returned in the list.
-      operationId: getV2PartiesParty
-      parameters:
-      - name: party
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: identity-provider-id
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: parties
-        in: query
-        required: false
-        schema:
-          type: array
-          items:
+          required: true
+        responses:
+          '200':
+            description: ''
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter synchronizerId'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/dars:
+      post:
+        description: Upload a DAR to the participant node
+        operationId: postV2Dars
+        parameters:
+        - name: vetAllPackages
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: synchronizerId
+          in: query
+          required: false
+          schema:
             type: string
-      responses:
-        '200':
-          description: ''
+        requestBody:
           content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetPartiesResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: query parameter identity-provider-id,
-            Invalid value for: query parameter parties'
-          content:
-            text/plain:
+            application/octet-stream:
               schema:
                 type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    patch:
-      description: |-
-        Update selected modifiable participant-local attributes of a party details resource.
-        Can update the participant's local information for local parties.
-      operationId: patchV2PartiesParty
-      parameters:
-      - name: party
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdatePartyDetailsRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpdatePartyDetailsResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/parties/external/generate-topology:
-    post:
-      description: |-
-        Alpha 3.3: Convenience endpoint to generate topology transactions for external signing
+                format: binary
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UploadDarFileResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter vetAllPackages, Invalid value for: query parameter synchronizerId'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/packages:
+      get:
+        description: Returns the identifiers of all supported packages.
+        operationId: getV2Packages
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListPackagesResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: |-
+          Behaves the same as /dars. This endpoint will be deprecated and removed in a future release.
+          Upload a DAR file to the participant.
 
-        Expected to be stable in 3.5
-
-        You may use this endpoint to generate the common external topology transactions
-        which can be signed externally and uploaded as part of the allocate party process
-
-        Note that this request will create a normal namespace using the same key for the
-        identity as for signing. More elaborate schemes such as multi-signature
-        or decentralized parties require you to construct the topology transactions yourself.
-      operationId: postV2PartiesExternalGenerate-topology
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GenerateExternalPartyTopologyRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GenerateExternalPartyTopologyResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/state/active-contracts:
-    post:
-      description: |-
-        Query active contracts list (blocking call).
-        Querying active contracts is an expensive operation and if possible should not be repeated often.
-        Consider querying active contracts initially (for a given offset)
-        and then repeatedly call one of `/v2/updates/...`endpoints  to get subsequent modifications.
-        You can also use websockets to get updates with better performance.
-
-        Returns a stream of the snapshot of the active contracts and incomplete (un)assignments at a ledger offset.
-        Once the stream of GetActiveContractsResponses completes,
-        the client SHOULD begin streaming updates from the update service,
-        starting at the GetActiveContractsRequest.active_at_offset specified in this request.
-        Clients SHOULD NOT assume that the set of active contracts they receive reflects the state at the ledger end.
-
-        Notice: This endpoint should be used for small results set.
-        When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
-        there will be an error (`413 Content Too Large`) returned.
-        Increasing this limit may lead to performance issues and high memory consumption.
-        Consider using websockets (asyncapi) for better efficiency with larger results.
-      operationId: postV2StateActive-contracts
-      parameters:
-      - name: limit
-        in: query
-        description: maximum number of elements to return, this param is ignored if
-          is bigger than server setting
-        required: false
-        schema:
-          type: integer
-          format: int64
-      - name: stream_idle_timeout_ms
-        in: query
-        description: timeout to complete and send result if no new elements are received
-          (for open ended streams)
-        required: false
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetActiveContractsRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/JsGetActiveContractsResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body, Invalid value for:
-            query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/state/connected-synchronizers:
-    get:
-      description: Get the list of connected synchronizers at the time of the query.
-      operationId: getV2StateConnected-synchronizers
-      parameters:
-      - name: party
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: participantId
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: identityProviderId
-        in: query
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetConnectedSynchronizersResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: query parameter party, Invalid
-            value for: query parameter participantId, Invalid value for: query parameter
-            identityProviderId'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/state/ledger-end:
-    get:
-      description: |-
-        Get the current ledger end.
-        Subscriptions started with the returned offset will serve events after this RPC was called.
-      operationId: getV2StateLedger-end
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetLedgerEndResponse'
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/state/latest-pruned-offsets:
-    get:
-      description: Get the latest successfully pruned ledger offsets
-      operationId: getV2StateLatest-pruned-offsets
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetLatestPrunedOffsetsResponse'
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/updates:
-    post:
-      description: |-
-        Read the ledger's filtered update stream for the specified contents and filters.
-        It returns the event types in accordance with the stream contents selected. Also the selection criteria
-        for individual events depends on the transaction shape chosen.
-
-        - ACS delta: a requesting party must be a stakeholder of an event for it to be included.
-        - ledger effects: a requesting party must be a witness of an event for it to be included.
-        Notice: This endpoint should be used for small results set.
-        When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
-        there will be an error (`413 Content Too Large`) returned.
-        Increasing this limit may lead to performance issues and high memory consumption.
-        Consider using websockets (asyncapi) for better efficiency with larger results.
-      operationId: postV2Updates
-      parameters:
-      - name: limit
-        in: query
-        description: maximum number of elements to return, this param is ignored if
-          is bigger than server setting
-        required: false
-        schema:
-          type: integer
-          format: int64
-      - name: stream_idle_timeout_ms
-        in: query
-        description: timeout to complete and send result if no new elements are received
-          (for open ended streams)
-        required: false
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetUpdatesRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/JsGetUpdatesResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body, Invalid value for:
-            query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/updates/flats:
-    post:
-      description: |-
-        Query flat transactions update list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.
-        Notice: This endpoint should be used for small results set.
-        When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
-        there will be an error (`413 Content Too Large`) returned.
-        Increasing this limit may lead to performance issues and high memory consumption.
-        Consider using websockets (asyncapi) for better efficiency with larger results.
-      operationId: postV2UpdatesFlats
-      parameters:
-      - name: limit
-        in: query
-        description: maximum number of elements to return, this param is ignored if
-          is bigger than server setting
-        required: false
-        schema:
-          type: integer
-          format: int64
-      - name: stream_idle_timeout_ms
-        in: query
-        description: timeout to complete and send result if no new elements are received
-          (for open ended streams)
-        required: false
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetUpdatesRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/JsGetUpdatesResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body, Invalid value for:
-            query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      deprecated: true
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/updates/trees:
-    post:
-      description: |-
-        Query update transactions tree list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.
-        Notice: This endpoint should be used for small results set.
-        When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
-        there will be an error (`413 Content Too Large`) returned.
-        Increasing this limit may lead to performance issues and high memory consumption.
-        Consider using websockets (asyncapi) for better efficiency with larger results.
-      operationId: postV2UpdatesTrees
-      parameters:
-      - name: limit
-        in: query
-        description: maximum number of elements to return, this param is ignored if
-          is bigger than server setting
-        required: false
-        schema:
-          type: integer
-          format: int64
-      - name: stream_idle_timeout_ms
-        in: query
-        description: timeout to complete and send result if no new elements are received
-          (for open ended streams)
-        required: false
-        schema:
-          type: integer
-          format: int64
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetUpdatesRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/JsGetUpdateTreesResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body, Invalid value for:
-            query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      deprecated: true
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/updates/transaction-tree-by-offset/{offset}:
-    get:
-      description: Get transaction tree by offset. Provided for backwards compatibility,
-        it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset
-        instead.
-      operationId: getV2UpdatesTransaction-tree-by-offsetOffset
-      parameters:
-      - name: offset
-        in: path
-        required: true
-        schema:
-          type: integer
-          format: int64
-      - name: parties
-        in: query
-        required: false
-        schema:
-          type: array
-          items:
+          If vetting is enabled in the request, the DAR is checked for upgrade compatibility
+          with the set of the already vetted packages on the target vetting synchronizer
+          See UploadDarFileRequest for details regarding vetting and the target vetting synchronizer.
+        operationId: postV2Packages
+        parameters:
+        - name: vetAllPackages
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: synchronizerId
+          in: query
+          required: false
+          schema:
             type: string
-      responses:
-        '200':
-          description: ''
+        requestBody:
           content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsGetTransactionTreeResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: path parameter offset, Invalid
-            value for: query parameter parties'
-          content:
-            text/plain:
+            application/octet-stream:
               schema:
                 type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      deprecated: true
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/updates/transaction-by-offset:
-    post:
-      description: Get transaction by offset. Provided for backwards compatibility,
-        it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset
-        instead.
-      operationId: postV2UpdatesTransaction-by-offset
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetTransactionByOffsetRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsGetTransactionResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      deprecated: true
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/updates/update-by-offset:
-    post:
-      description: |-
-        Lookup an update by its offset.
-        If there is no update with this offset, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
-      operationId: postV2UpdatesUpdate-by-offset
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetUpdateByOffsetRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsGetUpdateResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/updates/transaction-by-id:
-    post:
-      description: Get transaction by id. Provided for backwards compatibility, it
-        will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.
-      operationId: postV2UpdatesTransaction-by-id
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetTransactionByIdRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsGetTransactionResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      deprecated: true
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/updates/update-by-id:
-    post:
-      description: |-
-        Lookup an update by its ID.
-        If there is no update with this ID, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
-      operationId: postV2UpdatesUpdate-by-id
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetUpdateByIdRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsGetUpdateResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/updates/transaction-tree-by-id/{update-id}:
-    get:
-      description: Get transaction tree by id. Provided for backwards compatibility,
-        it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id
-        instead.
-      operationId: getV2UpdatesTransaction-tree-by-idUpdate-id
-      parameters:
-      - name: update-id
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: parties
-        in: query
-        required: false
-        schema:
-          type: array
-          items:
+                format: binary
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UploadDarFileResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter vetAllPackages, Invalid value for: query parameter synchronizerId'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/packages/{package-id}:
+      get:
+        description: Returns the contents of a single package.
+        operationId: getV2PackagesPackage-id
+        parameters:
+        - name: package-id
+          in: path
+          required: true
+          schema:
             type: string
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsGetTransactionTreeResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: query parameter parties'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      deprecated: true
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/users:
-    get:
-      description: List all existing users.
-      operationId: getV2Users
-      parameters:
-      - name: pageSize
-        in: query
-        description: maximum number of elements in a returned page
-        required: false
-        schema:
-          type: integer
-          format: int32
-      - name: pageToken
-        in: query
-        description: token - to continue results from a given page, leave empty to
-          start from the beginning of the list, obtain token from the result of previous
-          page
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListUsersResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: query parameter pageSize,
-            Invalid value for: query parameter pageToken'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    post:
-      description: Create a new user.
-      operationId: postV2Users
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateUserRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreateUserResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/users/{user-id}:
-    get:
-      description: Get the user data of a specific user or the authenticated user.
-      operationId: getV2UsersUser-id
-      parameters:
-      - name: user-id
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: identity-provider-id
-        in: query
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetUserResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: query parameter identity-provider-id'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    delete:
-      description: Delete an existing user and all its rights.
-      operationId: deleteV2UsersUser-id
-      parameters:
-      - name: user-id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                type: object
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    patch:
-      description: Update selected modifiable attribute of a user resource described
-        by the ``User`` message.
-      operationId: patchV2UsersUser-id
-      parameters:
-      - name: user-id
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateUserRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpdateUserResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/authenticated-user:
-    get:
-      description: Get the user data of the current authenticated user.
-      operationId: getV2Authenticated-user
-      parameters:
-      - name: identity-provider-id
-        in: query
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetUserResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: query parameter identity-provider-id'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/users/{user-id}/rights:
-    get:
-      description: List the set of all rights granted to a user.
-      operationId: getV2UsersUser-idRights
-      parameters:
-      - name: user-id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListUserRightsResponse'
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    post:
-      description: |-
-        Grant rights to a user.
-        Granting rights does not affect the resource version of the corresponding user.
-      operationId: postV2UsersUser-idRights
-      parameters:
-      - name: user-id
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GrantUserRightsRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GrantUserRightsResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    patch:
-      description: |-
-        Revoke rights from a user.
-        Revoking rights does not affect the resource version of the corresponding user.
-      operationId: patchV2UsersUser-idRights
-      parameters:
-      - name: user-id
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RevokeUserRightsRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RevokeUserRightsResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/users/{user-id}/identity-provider-id:
-    patch:
-      description: Update the assignment of a user from one IDP to another.
-      operationId: patchV2UsersUser-idIdentity-provider-id
-      parameters:
-      - name: user-id
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateUserIdentityProviderIdRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpdateUserIdentityProviderIdResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/idps:
-    get:
-      description: List all existing identity provider configurations.
-      operationId: getV2Idps
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListIdentityProviderConfigsResponse'
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    post:
-      description: |-
-        Create a new identity provider configuration.
-        The request will fail if the maximum allowed number of separate configurations is reached.
-      operationId: postV2Idps
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateIdentityProviderConfigRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreateIdentityProviderConfigResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/idps/{idp-id}:
-    get:
-      description: Get the identity provider configuration data by id.
-      operationId: getV2IdpsIdp-id
-      parameters:
-      - name: idp-id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetIdentityProviderConfigResponse'
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    delete:
-      description: Delete an existing identity provider configuration.
-      operationId: deleteV2IdpsIdp-id
-      parameters:
-      - name: idp-id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeleteIdentityProviderConfigResponse'
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-    patch:
-      description: |-
-        Update selected modifiable attribute of an identity provider config resource described
-        by the ``IdentityProviderConfig`` message.
-      operationId: patchV2IdpsIdp-id
-      parameters:
-      - name: idp-id
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateIdentityProviderConfigRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpdateIdentityProviderConfigResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/interactive-submission/prepare:
-    post:
-      description: Requires `readAs` scope for the submitting party when LAPI User
-        authorization is enabled
-      operationId: postV2Interactive-submissionPrepare
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/JsPrepareSubmissionRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsPrepareSubmissionResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/interactive-submission/execute:
-    post:
-      description: |-
-        Execute a prepared submission _asynchronously_ on the ledger.
-        Requires a signature of the transaction from the submitting external party.
-      operationId: postV2Interactive-submissionExecute
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/JsExecuteSubmissionRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ExecuteSubmissionResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/interactive-submission/executeAndWait:
-    post:
-      description: |-
-        Similar to ExecuteSubmission but _synchronously_ wait for the completion of the transaction
-        IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest.
-        A malicious node could make a successfully committed request appeared failed and vice versa
-      operationId: postV2Interactive-submissionExecuteandwait
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/JsExecuteSubmissionAndWaitRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ExecuteSubmissionAndWaitResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/interactive-submission/executeAndWaitForTransaction:
-    post:
-      description: |-
-        Similar to ExecuteSubmissionAndWait but additionally returns the transaction
-        IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest.
-        A malicious node could make a successfully committed request appear as failed and vice versa
-      operationId: postV2Interactive-submissionExecuteandwaitfortransaction
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/JsExecuteSubmissionAndWaitForTransactionRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsExecuteSubmissionAndWaitForTransactionResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/interactive-submission/preferred-package-version:
-    get:
-      description: |-
-        A preferred package is the highest-versioned package for a provided package-name
-        that is vetted by all the participants hosting the provided parties.
-
-        Ledger API clients should use this endpoint for constructing command submissions
-        that are compatible with the provided preferred package, by making informed decisions on:
-        - which are the compatible packages that can be used to create contracts
-        - which contract or exercise choice argument version can be used in the command
-        - which choices can be executed on a template or interface of a contract
-
-        Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.
-
-        Provided for backwards compatibility, it will be removed in the Canton version 3.4.0
-      operationId: getV2Interactive-submissionPreferred-package-version
-      parameters:
-      - name: parties
-        in: query
-        required: false
-        schema:
-          type: array
-          items:
+        responses:
+          '200':
+            description: ''
+            headers:
+              Canton-Package-Hash:
+                required: true
+                schema:
+                  type: string
+            content:
+              application/octet-stream:
+                schema:
+                  type: string
+                  format: binary
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/packages/{package-id}/status:
+      get:
+        description: Returns the status of a single package.
+        operationId: getV2PackagesPackage-idStatus
+        parameters:
+        - name: package-id
+          in: path
+          required: true
+          schema:
             type: string
-      - name: package-name
-        in: query
-        required: true
-        schema:
-          type: string
-      - name: vetting_valid_at
-        in: query
-        required: false
-        schema:
-          type: string
-          format: date-time
-      - name: synchronizer-id
-        in: query
-        required: false
-        schema:
-          type: string
-      responses:
-        '200':
-          description: ''
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPackageStatusResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/package-vetting:
+      get:
+        description: |-
+          Lists which participant node vetted what packages on which synchronizer.
+          This endpoint (GET /package-vetting) is deprecated and will be removed in a future release. Please use POST /package-vetting/list instead.
+        operationId: getV2Package-vetting
+        requestBody:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetPreferredPackageVersionResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: query parameter parties,
-            Invalid value for: query parameter package-name, Invalid value for: query
-            parameter vetting_valid_at, Invalid value for: query parameter synchronizer-id'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/interactive-submission/preferred-packages:
-    post:
-      description: |-
-        Compute the preferred packages for the vetting requirements in the request.
-        A preferred package is the highest-versioned package for a provided package-name
-        that is vetted by all the participants hosting the provided parties.
-
-        Ledger API clients should use this endpoint for constructing command submissions
-        that are compatible with the provided preferred packages, by making informed decisions on:
-        - which are the compatible packages that can be used to create contracts
-        - which contract or exercise choice argument version can be used in the command
-        - which choices can be executed on a template or interface of a contract
-
-        If the package preferences could not be computed due to no selection satisfying the requirements,
-        a `FAILED_PRECONDITION` error will be returned.
-
-        Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.
-
-        Experimental API: this endpoint is not guaranteed to provide backwards compatibility in future releases
-      operationId: postV2Interactive-submissionPreferred-packages
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetPreferredPackagesRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
+                $ref: '#/components/schemas/ListVettedPackagesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListVettedPackagesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: |-
+          Update the vetted packages of this participant
+          This endpoint (POST /package-vetting) is deprecated and will be removed in a future release. Please use POST /package-vetting/update instead.
+        operationId: postV2Package-vetting
+        requestBody:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetPreferredPackagesResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /livez:
-    get:
-      description: Checks if the service is alive
-      operationId: getLivez
-      responses:
-        '200':
-          description: 'OK: service is alive'
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /readyz:
-    get:
-      description: Checks if the service is ready to serve requests
-      operationId: getReadyz
-      responses:
-        '200':
-          description: 'OK: readiness message'
-          content:
-            text/plain:
-              schema:
-                type: string
-        '400':
-          description: Invalid value
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
+                $ref: '#/components/schemas/UpdateVettedPackagesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateVettedPackagesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/package-vetting/list:
+      post:
+        description: |-
+          Lists which participant node vetted what packages on which synchronizer.
+          Can be called by any authenticated user.
+        operationId: postV2Package-vettingList
+        requestBody:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-  /v2/contracts/contract-by-id:
-    post:
-      description: |-
-        Looking up contract data by contract ID.
-        This endpoint is experimental / alpha, therefore no backwards compatibility is guaranteed.
-        This endpoint must not be used to look up contracts which entered the participant via party replication
-        or repair service.
-      operationId: postV2ContractsContract-by-id
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/GetContractRequest'
-        required: true
-      responses:
-        '200':
-          description: ''
+                $ref: '#/components/schemas/ListVettedPackagesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListVettedPackagesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/package-vetting/update:
+      post:
+        description: Update the vetted packages of this participant
+        operationId: postV2Package-vettingUpdate
+        requestBody:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetContractResponse'
-        '400':
-          description: 'Invalid value, Invalid value for: body'
-          content:
-            text/plain:
-              schema:
-                type: string
-        default:
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JsCantonError'
-      security:
-      - httpAuth: []
-      - apiKeyAuth: []
-components:
-  schemas:
-    AllocateExternalPartyRequest:
-      title: AllocateExternalPartyRequest
-      description: |-
-        Required authorization:
-          ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id) OR IsAuthenticatedUser(user_id)``
-      type: object
-      required:
-      - synchronizer
-      - onboardingTransactions
-      properties:
-        synchronizer:
-          description: |-
-            TODO(#27670) support synchronizer aliases
-            Synchronizer ID on which to onboard the party
-
-            Required
-          type: string
-        onboardingTransactions:
-          description: |-
-            TopologyTransactions to onboard the external party
-            Can contain:
-            - A namespace for the party.
-            This can be either a single NamespaceDelegation,
-            or DecentralizedNamespaceDefinition along with its authorized namespace owners in the form of NamespaceDelegations.
-            May be provided, if so it must be fully authorized by the signatures in this request combined with the existing topology state.
-            - A PartyToParticipant to register the hosting relationship of the party, and the party's signing keys and threshold.
-            Must be provided.
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/SignedTransaction'
-        multiHashSignatures:
-          description: |-
-            Optional signatures of the combined hash of all onboarding_transactions
-            This may be used instead of providing signatures on each individual transaction
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Signature'
-        identityProviderId:
-          description: |-
-            The id of the ``Identity Provider``
-            If not set, assume the party is managed by the default identity provider.
-
-            Optional
-          type: string
-        waitForAllocation:
-          description: |-
-            When true, this RPC will attempt to wait for the party to be allocated on the synchronizer before returning.
-            When false, the allocation will happen asynchronously.
-            This is a best effort only as this synchronization is only possible for non decentralized parties (single hosting node).
-            For decentralized parties, this flag is ignored.
-            Defaults to true.
-
-            Optional
-          type: boolean
-        userId:
-          description: |-
-            The user who will get the act_as rights to the newly allocated party.
-            If set to an empty string (the default), no user will get rights to the party.
-
-            Optional
-          type: string
-    AllocateExternalPartyResponse:
-      title: AllocateExternalPartyResponse
-      type: object
-      required:
-      - partyId
-      properties:
-        partyId:
-          description: |-
-            The allocated party id
-
-            Required
-          type: string
-    AllocatePartyRequest:
-      title: AllocatePartyRequest
-      description: |-
-        Required authorization:
-          ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id) OR IsAuthenticatedUser(user_id)``
-      type: object
-      properties:
-        partyIdHint:
-          description: |-
-            A hint to the participant which party ID to allocate. It can be
-            ignored.
-            Must be a valid PartyIdString (as described in ``value.proto``).
-
-            Optional
-          type: string
-        localMetadata:
-          $ref: '#/components/schemas/ObjectMeta'
-          description: |-
-            Formerly "display_name"
-            Participant-local metadata to be stored in the ``PartyDetails`` of this newly allocated party.
-
-            Optional
-        identityProviderId:
-          description: |-
-            The id of the ``Identity Provider``
-            If not set, assume the party is managed by the default identity provider or party is not hosted by the participant.
-
-            Optional
-          type: string
-        synchronizerId:
-          description: |-
-            The synchronizer, on which the party should be allocated.
-            For backwards compatibility, this field may be omitted, if the participant is connected to only one synchronizer.
-            Otherwise a synchronizer must be specified.
-
-            Optional
-          type: string
-        userId:
-          description: |-
-            The user who will get the act_as rights to the newly allocated party.
-            If set to an empty string (the default), no user will get rights to the party.
-
-            Optional
-          type: string
-    AllocatePartyResponse:
-      title: AllocatePartyResponse
-      type: object
-      required:
-      - partyDetails
-      properties:
-        partyDetails:
-          $ref: '#/components/schemas/PartyDetails'
-          description: |-
-            The allocated party details
-
-            Required
-    ArchivedEvent:
-      title: ArchivedEvent
-      description: Records that a contract has been archived, and choices may no longer
-        be exercised on it.
-      type: object
-      required:
-      - offset
-      - nodeId
-      - contractId
-      - templateId
-      - packageName
-      - witnessParties
-      properties:
-        offset:
-          description: |-
-            The offset of origin.
-            Offsets are managed by the participant nodes.
-            Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
-            It is a valid absolute offset (positive integer)
-
-            Required
-          type: integer
-          format: int64
-        nodeId:
-          description: |-
-            The position of this event in the originating transaction or reassignment.
-            Node IDs are not necessarily equal across participants,
-            as these may see different projections/parts of transactions.
-            Must be valid node ID (non-negative integer)
-
-            Required
-          type: integer
-          format: int32
-        contractId:
-          description: |-
-            The ID of the archived contract.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        templateId:
-          description: |-
-            Identifies the template that defines the choice that archived the contract.
-            This template's package-id may differ from the target contract's package-id
-            if the target contract has been upgraded or downgraded.
-
-            The identifier uses the package-id reference format.
-
-            Required
-          type: string
-        witnessParties:
-          description: |-
-            The parties that are notified of this event. For an ``ArchivedEvent``,
-            these are the intersection of the stakeholders of the contract in
-            question and the parties specified in the ``TransactionFilter``. The
-            stakeholders are the union of the signatories and the observers of
-            the contract.
-            Each one of its elements must be a valid PartyIdString (as described
-            in ``value.proto``).
-
-            Required: must be non-empty
-          type: array
-          items:
+                $ref: '#/components/schemas/UpdateVettedPackagesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateVettedPackagesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties:
+      get:
+        description: |-
+          List the parties known by the participant.
+          The list returned contains parties whose ledger access is facilitated by
+          the participant and the ones maintained elsewhere.
+        operationId: getV2Parties
+        parameters:
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
             type: string
-        packageName:
-          description: |-
-            The package name of the contract.
-
-            Required
-          type: string
-        implementedInterfaces:
-          description: |-
-            The interfaces implemented by the target template that have been
-            matched from the interface filter query.
-            Populated only in case interface filters with include_interface_view set.
-
-            If defined, the identifier uses the package-id reference format.
-
-            Optional: can be empty
-          type: array
-          items:
+        - name: filter-party
+          in: query
+          required: false
+          schema:
             type: string
-    AssignCommand:
-      title: AssignCommand
-      description: Assign a contract
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/AssignCommand1'
-    AssignCommand1:
-      title: AssignCommand
-      description: Assign a contract
-      type: object
-      required:
-      - reassignmentId
-      - source
-      - target
-      properties:
-        reassignmentId:
-          description: |-
-            The ID from the unassigned event to be completed by this assignment.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        source:
-          description: |-
-            The ID of the source synchronizer
-            Must be a valid synchronizer id
-
-            Required
-          type: string
-        target:
-          description: |-
-            The ID of the target synchronizer
-            Must be a valid synchronizer id
-
-            Required
-          type: string
-    CanActAs:
-      title: CanActAs
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/CanActAs1'
-    CanActAs1:
-      title: CanActAs
-      type: object
-      required:
-      - party
-      properties:
-        party:
-          description: |-
-            The right to authorize commands for this party.
-
-            Required
-          type: string
-    CanExecuteAs:
-      title: CanExecuteAs
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/CanExecuteAs1'
-    CanExecuteAs1:
-      title: CanExecuteAs
-      type: object
-      required:
-      - party
-      properties:
-        party:
-          description: |-
-            The right to prepare and execute submissions as this party.
-            This right does not entitle the user to perform any reads.
-            If reading is required, a separate ReadAs right must be added.
-            Right to execute as a party is also implicitly contained in the CanActAs right.
-
-            Required
-          type: string
-    CanExecuteAsAnyParty:
-      title: CanExecuteAsAnyParty
-      description: |-
-        The rights of a user to prepare and execute transactions as any party.
-        Its utility is predominantly for users that perform interactive submissions
-        on behalf of many parties.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/CanExecuteAsAnyParty1'
-    CanExecuteAsAnyParty1:
-      title: CanExecuteAsAnyParty
-      description: |-
-        The rights of a user to prepare and execute transactions as any party.
-        Its utility is predominantly for users that perform interactive submissions
-        on behalf of many parties.
-      type: object
-    CanReadAs:
-      title: CanReadAs
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/CanReadAs1'
-    CanReadAs1:
-      title: CanReadAs
-      type: object
-      required:
-      - party
-      properties:
-        party:
-          description: |-
-            The right to read ledger data visible to this party.
-
-            Required
-          type: string
-    CanReadAsAnyParty:
-      title: CanReadAsAnyParty
-      description: |-
-        The rights of a participant's super reader. Its utility is predominantly for
-        feeding external tools, such as PQS, continually without the need to change subscriptions
-        as new parties pop in and out of existence.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/CanReadAsAnyParty1'
-    CanReadAsAnyParty1:
-      title: CanReadAsAnyParty
-      description: |-
-        The rights of a participant's super reader. Its utility is predominantly for
-        feeding external tools, such as PQS, continually without the need to change subscriptions
-        as new parties pop in and out of existence.
-      type: object
-    Command:
-      title: Command
-      description: A command can either create a new contract or exercise a choice
-        on an existing contract.
-      oneOf:
-      - type: object
-        required:
-        - CreateAndExerciseCommand
-        properties:
-          CreateAndExerciseCommand:
-            $ref: '#/components/schemas/CreateAndExerciseCommand'
-      - type: object
-        required:
-        - CreateCommand
-        properties:
-          CreateCommand:
-            $ref: '#/components/schemas/CreateCommand'
-      - type: object
-        required:
-        - ExerciseByKeyCommand
-        properties:
-          ExerciseByKeyCommand:
-            $ref: '#/components/schemas/ExerciseByKeyCommand'
-      - type: object
-        required:
-        - ExerciseCommand
-        properties:
-          ExerciseCommand:
-            $ref: '#/components/schemas/ExerciseCommand'
-    Command1:
-      title: Command
-      description: A command can either create a new contract or exercise a choice
-        on an existing contract.
-      oneOf:
-      - type: object
-        required:
-        - AssignCommand
-        properties:
-          AssignCommand:
-            $ref: '#/components/schemas/AssignCommand'
-      - type: object
-        required:
-        - Empty
-        properties:
-          Empty:
-            $ref: '#/components/schemas/Empty2'
-      - type: object
-        required:
-        - UnassignCommand
-        properties:
-          UnassignCommand:
-            $ref: '#/components/schemas/UnassignCommand'
-    Completion:
-      title: Completion
-      description: 'A completion represents the status of a submitted command on the
-        ledger: it can be successful or failed.'
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/Completion1'
-    Completion1:
-      title: Completion
-      description: 'A completion represents the status of a submitted command on the
-        ledger: it can be successful or failed.'
-      type: object
-      required:
-      - commandId
-      - userId
-      - offset
-      - actAs
-      - synchronizerTime
-      properties:
-        commandId:
-          description: |-
-            The ID of the succeeded or failed command.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        status:
-          $ref: '#/components/schemas/JsStatus'
-          description: |-
-            Identifies the exact type of the error.
-            It uses the same format of conveying error details as it is used for the RPC responses of the APIs.
-
-            Optional
-        updateId:
-          description: |-
-            The update_id of the transaction or reassignment that resulted from the command with command_id.
-
-            Only set for successfully executed commands.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Optional
-          type: string
-        userId:
-          description: |-
-            The user-id that was used for the submission, as described in ``commands.proto``.
-            Must be a valid UserIdString (as described in ``value.proto``).
-
-            Required
-          type: string
-        actAs:
-          description: |-
-            The set of parties on whose behalf the commands were executed.
-            Contains the ``act_as`` parties from ``commands.proto``
-            filtered to the requesting parties in CompletionStreamRequest.
-            The order of the parties need not be the same as in the submission.
-            Each element must be a valid PartyIdString (as described in ``value.proto``).
-
-            Required: must be non-empty
-          type: array
-          items:
-            type: string
-        submissionId:
-          description: |-
-            The submission ID this completion refers to, as described in ``commands.proto``.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Optional
-          type: string
-        deduplicationPeriod:
-          $ref: '#/components/schemas/DeduplicationPeriod1'
-        traceContext:
-          $ref: '#/components/schemas/TraceContext'
-          description: |-
-            The Ledger API trace context
-
-            The trace context transported in this message corresponds to the trace context supplied
-            by the client application in a HTTP2 header of the original command submission.
-            We typically use a header to transfer this type of information. Here we use message
-            body, because it is used in gRPC streams which do not support per message headers.
-            This field will be populated with the trace context contained in the original submission.
-            If that was not provided, a unique ledger-api-server generated trace context will be used
-            instead.
-
-            Optional
-        offset:
-          description: |-
-            May be used in a subsequent CompletionStreamRequest to resume the consumption of this stream at a later time.
-            Must be a valid absolute offset (positive integer).
-
-            Required
-          type: integer
-          format: int64
-        synchronizerTime:
-          $ref: '#/components/schemas/SynchronizerTime'
-          description: |-
-            The synchronizer along with its record time.
-            The synchronizer id provided, in case of
-
-            - successful/failed transactions: identifies the synchronizer of the transaction
-            - for successful/failed unassign commands: identifies the source synchronizer
-            - for successful/failed assign commands: identifies the target synchronizer
-
-            Required
-        paidTrafficCost:
-          description: |-
-            The traffic cost paid by this participant node for the confirmation request
-            for the submitted command.
-
-            Commands whose execution is rejected before their corresponding
-            confirmation request is ordered by the synchronizer will report a paid
-            traffic cost of zero.
-            If a confirmation request is ordered for a command, but the request fails
-            (e.g., due to contention with a concurrent contract archival), the traffic
-            cost is paid and reported on the failed completion for the request.
-
-            If you want to correlate the traffic cost of a successful completion
-            with the transaction that resulted from the command, you can use the
-            ``offset`` field to retrieve the transaction using
-            ``UpdateService.GetUpdateByOffset`` on the same participant node; or alternatively use the ``update_id``
-            field to retrieve the transaction using ``UpdateService.GetUpdateById`` on any participant node
-            that sees the transaction.
-
-            Note: for completions processed before the participant started serving
-            traffic cost on the Ledger API, this field will be set to zero.
-            Additionally, the total cost incurred by the submitting node for the submission of the transaction may be greater
-            than the reported cost, for example if retries were issued due to failed submissions to the synchronizer.
-            The cost reported here is the one paid for ordering the confirmation request.
-
-            Optional
-          type: integer
-          format: int64
-    CompletionResponse:
-      title: CompletionResponse
-      description: Required
-      oneOf:
-      - type: object
-        required:
-        - Completion
-        properties:
-          Completion:
-            $ref: '#/components/schemas/Completion'
-      - type: object
-        required:
-        - Empty
-        properties:
-          Empty:
-            $ref: '#/components/schemas/Empty4'
-      - type: object
-        required:
-        - OffsetCheckpoint
-        properties:
-          OffsetCheckpoint:
-            $ref: '#/components/schemas/OffsetCheckpoint'
-    CompletionStreamRequest:
-      title: CompletionStreamRequest
-      type: object
-      required:
-      - parties
-      properties:
-        userId:
-          description: |-
-            Only completions of commands submitted with the same user_id will be visible in the stream.
-            Must be a valid UserIdString (as described in ``value.proto``).
-
-            Required unless authentication is used with a user token.
-            In that case, the token's user-id will be used for the request's user_id.
-
-            Optional
-          type: string
-        parties:
-          description: |-
-            Non-empty list of parties whose data should be included.
-            The stream shows only completions of commands for which at least one of the ``act_as`` parties is in the given set of parties.
-            Must be a valid PartyIdString (as described in ``value.proto``).
-
-            Required: must be non-empty
-          type: array
-          items:
-            type: string
-        beginExclusive:
-          description: |-
-            This optional field indicates the minimum offset for completions. This can be used to resume an earlier completion stream.
-            If not set the ledger uses the ledger begin offset instead.
-            If specified, it must be a valid absolute offset (positive integer) or zero (ledger begin offset).
-            If the ledger has been pruned, this parameter must be specified and greater than the pruning offset.
-
-            Optional
-          type: integer
-          format: int64
-    CompletionStreamResponse:
-      title: CompletionStreamResponse
-      type: object
-      properties:
-        completionResponse:
-          $ref: '#/components/schemas/CompletionResponse'
-    ConnectedSynchronizer:
-      title: ConnectedSynchronizer
-      type: object
-      required:
-      - synchronizerAlias
-      - synchronizerId
-      properties:
-        synchronizerAlias:
-          description: |-
-            The alias of the synchronizer
-
-            Required
-          type: string
-        synchronizerId:
-          description: |-
-            The ID of the synchronizer
-
-            Required
-          type: string
-        permission:
-          description: |-
-            The permission on the synchronizer
-            Set if a party was used in the request, otherwise unspecified.
-
-            Optional
-          type: string
-          enum:
-          - PARTICIPANT_PERMISSION_UNSPECIFIED
-          - PARTICIPANT_PERMISSION_SUBMISSION
-          - PARTICIPANT_PERMISSION_CONFIRMATION
-          - PARTICIPANT_PERMISSION_OBSERVATION
-    CostEstimation:
-      title: CostEstimation
-      description: |-
-        Estimation of the cost of submitting the prepared transaction
-        The estimation is done against the synchronizer chosen during preparation of the transaction
-        (or the one explicitly requested).
-        The cost of re-assigning contracts to another synchronizer when necessary is not included in the estimation.
-      type: object
-      required:
-      - confirmationRequestTrafficCostEstimation
-      - confirmationResponseTrafficCostEstimation
-      - totalTrafficCostEstimation
-      - estimationTimestamp
-      properties:
-        estimationTimestamp:
-          description: |-
-            Timestamp at which the estimation was made
-
-            Required
-          type: string
-        confirmationRequestTrafficCostEstimation:
-          description: |-
-            Estimated traffic cost of the confirmation request associated with the transaction
-
-            Required
-          type: integer
-          format: int64
-        confirmationResponseTrafficCostEstimation:
-          description: |-
-            Estimated traffic cost of the confirmation response associated with the transaction
-            This field can also be used as an indication of the cost that other potential confirming nodes
-            of the party will incur to approve or reject the transaction
-
-            Required
-          type: integer
-          format: int64
-        totalTrafficCostEstimation:
-          description: |-
-            Sum of the fields above
-
-            Required
-          type: integer
-          format: int64
-    CostEstimationHints:
-      title: CostEstimationHints
-      description: Hints to improve cost estimation precision of a prepared transaction
-      type: object
-      properties:
-        disabled:
-          description: |-
-            Disable cost estimation
-            Default (not set) is false
-
-            Optional
-          type: boolean
-        expectedSignatures:
-          description: |-
-            Details on the keys that will be used to sign the transaction (how many and of which type).
-            Signature size impacts the cost of the transaction.
-            If empty, the signature sizes will be approximated with threshold-many signatures (where threshold is defined
-            in the PartyToParticipant of the external party), using keys in the order they are registered.
-            Empty list is equivalent to not providing this field
-
-            Optional: can be empty
-          type: array
-          items:
-            type: string
-            enum:
-            - SIGNING_ALGORITHM_SPEC_UNSPECIFIED
-            - SIGNING_ALGORITHM_SPEC_ED25519
-            - SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256
-            - SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384
-    CreateAndExerciseCommand:
-      title: CreateAndExerciseCommand
-      description: Create a contract and exercise a choice on it in the same transaction.
-      type: object
-      required:
-      - templateId
-      - createArguments
-      - choice
-      - choiceArgument
-      properties:
-        templateId:
-          description: |-
-            The template of the contract the client wants to create.
-            Both package-name and package-id reference identifier formats for the template-id are supported.
-            Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
-
-            Required
-          type: string
-        createArguments:
-          description: |-
-            The arguments required for creating a contract from this template.
-
-            Required
-        choice:
-          description: |-
-            The name of the choice the client wants to exercise.
-            Must be a valid NameString (as described in ``value.proto``).
-
-            Required
-          type: string
-        choiceArgument:
-          description: |-
-            The argument for this choice.
-
-            Required
-    CreateCommand:
-      title: CreateCommand
-      description: Create a new contract instance based on a template.
-      type: object
-      required:
-      - templateId
-      - createArguments
-      properties:
-        templateId:
-          description: |-
-            The template of contract the client wants to create.
-            Both package-name and package-id reference identifier formats for the template-id are supported.
-            Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
-
-            Required
-          type: string
-        createArguments:
-          description: |-
-            The arguments required for creating a contract from this template.
-
-            Required
-    CreateIdentityProviderConfigRequest:
-      title: CreateIdentityProviderConfigRequest
-      type: object
-      required:
-      - identityProviderConfig
-      properties:
-        identityProviderConfig:
-          $ref: '#/components/schemas/IdentityProviderConfig'
-          description: Required
-    CreateIdentityProviderConfigResponse:
-      title: CreateIdentityProviderConfigResponse
-      type: object
-      required:
-      - identityProviderConfig
-      properties:
-        identityProviderConfig:
-          $ref: '#/components/schemas/IdentityProviderConfig'
-          description: Required
-    CreateUserRequest:
-      title: CreateUserRequest
-      description: |2-
-         RPC requests and responses
-        ///////////////////////////
-         Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(user.identity_provider_id)``
-      type: object
-      required:
-      - user
-      properties:
-        user:
-          $ref: '#/components/schemas/User'
-          description: |-
-            The user to create.
-
-            Required
-        rights:
-          description: |-
-            The rights to be assigned to the user upon creation,
-            which SHOULD include appropriate rights for the ``user.primary_party``.
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Right'
-    CreateUserResponse:
-      title: CreateUserResponse
-      type: object
-      required:
-      - user
-      properties:
-        user:
-          $ref: '#/components/schemas/User'
-          description: |-
-            Created user.
-
-            Required
-    CreatedEvent:
-      title: CreatedEvent
-      description: Records that a contract has been created, and choices may now be
-        exercised on it.
-      type: object
-      required:
-      - offset
-      - nodeId
-      - contractId
-      - templateId
-      - createdAt
-      - packageName
-      - representativePackageId
-      - acsDelta
-      - createArgument
-      - witnessParties
-      - signatories
-      properties:
-        offset:
-          description: |-
-            The offset of origin, which has contextual meaning, please see description at messages that include a CreatedEvent.
-            Offsets are managed by the participant nodes.
-            Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
-            It is a valid absolute offset (positive integer)
-
-            Required
-          type: integer
-          format: int64
-        nodeId:
-          description: |-
-            The position of this event in the originating transaction or reassignment.
-            The origin has contextual meaning, please see description at messages that include a CreatedEvent.
-            Node IDs are not necessarily equal across participants,
-            as these may see different projections/parts of transactions.
-            Must be valid node ID (non-negative integer)
-
-            Required
-          type: integer
-          format: int32
-        contractId:
-          description: |-
-            The ID of the created contract.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        templateId:
-          description: |-
-            The template of the created contract.
-            The identifier uses the package-id reference format.
-
-            Required
-          type: string
-        contractKey:
-          description: |-
-            The key of the created contract.
-            This will be set if and only if ``template_id`` defines a contract key.
-
-            Optional
-        contractKeyHash:
-          description: |-
-            The hash of contract_key.
-            This will be set if and only if ``template_id`` defines a contract key.
-
-            Optional: can be empty
-          type: string
-        createArgument:
-          description: |-
-            The arguments that have been used to create the contract.
-
-            Required
-        createdEventBlob:
-          description: |-
-            Opaque representation of contract create event payload intended for forwarding
-            to an API server as a contract disclosed as part of a command
-            submission.
-
-            Optional: can be empty
-          type: string
-        interfaceViews:
-          description: |-
-            Interface views specified in the transaction filter.
-            Includes an ``InterfaceView`` for each interface for which there is a ``InterfaceFilter`` with
-
-            - its party in the ``witness_parties`` of this event,
-            - and which is implemented by the template of this event,
-            - and which has ``include_interface_view`` set.
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/JsInterfaceView'
-        witnessParties:
-          description: |-
-            The parties that are notified of this event. When a ``CreatedEvent``
-            is returned as part of a transaction tree or ledger-effects transaction, this will include all
-            the parties specified in the ``TransactionFilter`` that are witnesses  of the event
-            (the stakeholders of the contract and all informees of all the ancestors
-            of this create action that this participant knows about).
-            If served as part of a ACS delta transaction those will
-            be limited to all parties specified in the ``TransactionFilter`` that
-            are stakeholders of the contract (i.e. either signatories or observers).
-            If the ``CreatedEvent`` is returned as part of an AssignedEvent,
-            ActiveContract or IncompleteUnassigned (so the event is related to
-            an assignment or unassignment): this will include all parties of the
-            ``TransactionFilter`` that are stakeholders of the contract.
-
-            The behavior of reading create events visible to parties not hosted
-            on the participant node serving the Ledger API is undefined. Concretely,
-            there is neither a guarantee that the participant node will serve all their
-            create events on the ACS stream, nor is there a guarantee that matching archive
-            events are delivered for such create events.
-
-            For most clients this is not a problem, as they only read events for parties
-            that are hosted on the participant node. If you need to read events
-            for parties that may not be hosted at all times on the participant node,
-            subscribe to the ``TopologyEvent``s for that party by setting a corresponding
-            ``UpdateFormat``.  Using these events, query the ACS as-of an offset where the
-            party is hosted on the participant node, and ignore create events at offsets
-            where the party is not hosted on the participant node.
-
-            Required: must be non-empty
-          type: array
-          items:
-            type: string
-        signatories:
-          description: |-
-            The signatories for this contract as specified by the template.
-
-            Required: must be non-empty
-          type: array
-          items:
-            type: string
-        observers:
-          description: |-
-            The observers for this contract as specified explicitly by the template or implicitly as choice controllers.
-            This field never contains parties that are signatories.
-
-            Optional: can be empty
-          type: array
-          items:
-            type: string
-        createdAt:
-          description: |-
-            Ledger effective time of the transaction that created the contract.
-
-            Required
-          type: string
-        packageName:
-          description: |-
-            The package name of the created contract.
-
-            Required
-          type: string
-        representativePackageId:
-          description: |-
-            A package-id present in the participant package store that typechecks the contract's argument.
-            This may differ from the package-id of the template used to create the contract.
-            For contracts created before Canton 3.4, this field matches the contract's creation package-id.
-
-            NOTE: Experimental, server internal concept, not for client consumption. Subject to change without notice.
-
-            Required
-          type: string
-        acsDelta:
-          description: |-
-            Whether this event would be part of respective ACS_DELTA shaped stream,
-            and should therefore considered when tracking contract activeness on the client-side.
-
-            Required
-          type: boolean
-    CreatedTreeEvent:
-      title: CreatedTreeEvent
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/CreatedEvent'
-    CumulativeFilter:
-      title: CumulativeFilter
-      description: |-
-        A filter that matches all contracts that are either an instance of one of
-        the ``template_filters`` or that match one of the ``interface_filters``.
-      type: object
-      properties:
-        identifierFilter:
-          $ref: '#/components/schemas/IdentifierFilter'
-    DeduplicationDuration:
-      title: DeduplicationDuration
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/Duration'
-    DeduplicationDuration1:
-      title: DeduplicationDuration
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/Duration'
-    DeduplicationDuration2:
-      title: DeduplicationDuration
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/Duration'
-    DeduplicationOffset:
-      title: DeduplicationOffset
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          type: integer
-          format: int64
-    DeduplicationOffset1:
-      title: DeduplicationOffset
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          type: integer
-          format: int64
-    DeduplicationOffset2:
-      title: DeduplicationOffset
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          type: integer
-          format: int64
-    DeduplicationPeriod:
-      title: DeduplicationPeriod
-      description: |-
-        Specifies the deduplication period for the change ID.
-        If omitted, the participant will assume the configured maximum deduplication time.
-
-        Optional
-      oneOf:
-      - type: object
-        required:
-        - DeduplicationDuration
-        properties:
-          DeduplicationDuration:
-            $ref: '#/components/schemas/DeduplicationDuration'
-      - type: object
-        required:
-        - DeduplicationOffset
-        properties:
-          DeduplicationOffset:
-            $ref: '#/components/schemas/DeduplicationOffset'
-      - type: object
-        required:
-        - Empty
-        properties:
-          Empty:
-            $ref: '#/components/schemas/Empty'
-    DeduplicationPeriod1:
-      title: DeduplicationPeriod
-      description: |-
-        The actual deduplication window used for the submission, which is derived from
-        ``Commands.deduplication_period``. The ledger may convert the deduplication period into other
-        descriptions and extend the period in implementation-specified ways.
-
-        Used to audit the deduplication guarantee described in ``commands.proto``.
-
-        The deduplication guarantee applies even if the completion omits this field.
-
-        Optional
-      oneOf:
-      - type: object
-        required:
-        - DeduplicationDuration
-        properties:
-          DeduplicationDuration:
-            $ref: '#/components/schemas/DeduplicationDuration1'
-      - type: object
-        required:
-        - DeduplicationOffset
-        properties:
-          DeduplicationOffset:
-            $ref: '#/components/schemas/DeduplicationOffset1'
-      - type: object
-        required:
-        - Empty
-        properties:
-          Empty:
-            $ref: '#/components/schemas/Empty3'
-    DeduplicationPeriod2:
-      title: DeduplicationPeriod
-      oneOf:
-      - type: object
-        required:
-        - DeduplicationDuration
-        properties:
-          DeduplicationDuration:
-            $ref: '#/components/schemas/DeduplicationDuration2'
-      - type: object
-        required:
-        - DeduplicationOffset
-        properties:
-          DeduplicationOffset:
-            $ref: '#/components/schemas/DeduplicationOffset2'
-      - type: object
-        required:
-        - Empty
-        properties:
-          Empty:
-            $ref: '#/components/schemas/Empty10'
-    DeleteIdentityProviderConfigResponse:
-      title: DeleteIdentityProviderConfigResponse
-      description: Does not (yet) contain any data.
-      type: object
-    DisclosedContract:
-      title: DisclosedContract
-      description: |-
-        An additional contract that is used to resolve
-        contract & contract key lookups.
-      type: object
-      required:
-      - createdEventBlob
-      properties:
-        templateId:
-          description: |-
-            The template id of the contract.
-            The identifier uses the package-id reference format.
-
-            If provided, used to validate the template id of the contract serialized in the created_event_blob.
-
-            Optional
-          type: string
-        contractId:
-          description: |-
-            The contract id
-
-            If provided, used to validate the contract id of the contract serialized in the created_event_blob.
-
-            Optional
-          type: string
-        createdEventBlob:
-          description: |-
-            Opaque byte string containing the complete payload required by the Daml engine
-            to reconstruct a contract not known to the receiving participant.
-
-            Required: must be non-empty
-          type: string
-        synchronizerId:
-          description: |-
-            The ID of the synchronizer where the contract is currently assigned
-
-            Optional
-          type: string
-    Duration:
-      title: Duration
-      type: object
-      required:
-      - seconds
-      - nanos
-      properties:
-        seconds:
-          type: integer
-          format: int64
-        nanos:
-          type: integer
-          format: int32
-        unknownFields:
-          $ref: '#/components/schemas/UnknownFieldSet'
-          description: This field is automatically added as part of protobuf to json
-            mapping
-    Empty:
-      title: Empty
-      type: object
-    Empty1:
-      title: Empty
-      type: object
-    Empty10:
-      title: Empty
-      type: object
-    Empty2:
-      title: Empty
-      type: object
-    Empty3:
-      title: Empty
-      type: object
-    Empty4:
-      title: Empty
-      type: object
-    Empty5:
-      title: Empty
-      type: object
-    Empty6:
-      title: Empty
-      type: object
-    Empty7:
-      title: Empty
-      type: object
-    Empty8:
-      title: Empty
-      type: object
-    Empty9:
-      title: Empty
-      type: object
-    Event:
-      title: Event
-      description: |-
-        Events in transactions can have two primary shapes:
-
-        - ACS delta: events can be CreatedEvent or ArchivedEvent
-        - ledger effects: events can be CreatedEvent or ExercisedEvent
-
-        In the update service the events are restricted to the events
-        visible for the parties specified in the transaction filter. Each
-        event message type below contains a ``witness_parties`` field which
-        indicates the subset of the requested parties that can see the event
-        in question.
-      oneOf:
-      - type: object
-        required:
-        - ArchivedEvent
-        properties:
-          ArchivedEvent:
-            $ref: '#/components/schemas/ArchivedEvent'
-      - type: object
-        required:
-        - CreatedEvent
-        properties:
-          CreatedEvent:
-            $ref: '#/components/schemas/CreatedEvent'
-      - type: object
-        required:
-        - ExercisedEvent
-        properties:
-          ExercisedEvent:
-            $ref: '#/components/schemas/ExercisedEvent'
-    EventFormat:
-      title: EventFormat
-      description: |-
-        A format for events which defines both which events should be included
-        and what data should be computed and included for them.
-
-        Note that some of the filtering behavior depends on the `TransactionShape`,
-        which is expected to be specified alongside usages of `EventFormat`.
-      type: object
-      properties:
-        filtersByParty:
-          $ref: '#/components/schemas/Map_Filters'
-          description: |-
-            Each key must be a valid PartyIdString (as described in ``value.proto``).
-            The interpretation of the filter depends on the transaction-shape being filtered:
-
-            1. For **ledger-effects** create and exercise events are returned, for which the witnesses include at least one of
-               the listed parties and match the per-party filter.
-            2. For **transaction and active-contract-set streams** create and archive events are returned for all contracts whose
-               stakeholders include at least one of the listed parties and match the per-party filter.
-
-            Optional: can be empty
-        filtersForAnyParty:
-          $ref: '#/components/schemas/Filters'
-          description: |-
-            Wildcard filters that apply to all the parties existing on the participant. The interpretation of the filters is the same
-            with the per-party filter as described above.
-
-            Optional
-        verbose:
-          description: |-
-            If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
-            In particular, setting the verbose flag to true triggers the ledger to include labels for record fields.
-
-            Optional
-          type: boolean
-    ExecuteSubmissionAndWaitResponse:
-      title: ExecuteSubmissionAndWaitResponse
-      type: object
-      required:
-      - updateId
-      - completionOffset
-      properties:
-        updateId:
-          description: |-
-            The id of the transaction that resulted from the submitted command.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        completionOffset:
-          description: |-
-            The details of the offset field are described in ``community/ledger-api/README.md``.
-
-            Required
-          type: integer
-          format: int64
-    ExecuteSubmissionResponse:
-      title: ExecuteSubmissionResponse
-      type: object
-    ExerciseByKeyCommand:
-      title: ExerciseByKeyCommand
-      description: Exercise a choice on an existing contract specified by its key.
-      type: object
-      required:
-      - templateId
-      - contractKey
-      - choice
-      - choiceArgument
-      properties:
-        templateId:
-          description: |-
-            The template of contract the client wants to exercise.
-            Both package-name and package-id reference identifier formats for the template-id are supported.
-            Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
-
-            Required
-          type: string
-        contractKey:
-          description: |-
-            The key of the contract the client wants to exercise upon.
-
-            Required
-        choice:
-          description: |-
-            The name of the choice the client wants to exercise.
-            Must be a valid NameString (as described in ``value.proto``)
-
-            Required
-          type: string
-        choiceArgument:
-          description: |-
-            The argument for this choice.
-
-            Required
-    ExerciseCommand:
-      title: ExerciseCommand
-      description: Exercise a choice on an existing contract.
-      type: object
-      required:
-      - templateId
-      - contractId
-      - choice
-      - choiceArgument
-      properties:
-        templateId:
-          description: |-
-            The template or interface of the contract the client wants to exercise.
-            Both package-name and package-id reference identifier formats for the template-id are supported.
-            Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
-            To exercise a choice on an interface, specify the interface identifier in the template_id field.
-
-            Required
-          type: string
-        contractId:
-          description: |-
-            The ID of the contract the client wants to exercise upon.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        choice:
-          description: |-
-            The name of the choice the client wants to exercise.
-            Must be a valid NameString (as described in ``value.proto``)
-
-            Required
-          type: string
-        choiceArgument:
-          description: |-
-            The argument for this choice.
-
-            Required
-    ExercisedEvent:
-      title: ExercisedEvent
-      description: Records that a choice has been exercised on a target contract.
-      type: object
-      required:
-      - offset
-      - nodeId
-      - contractId
-      - templateId
-      - choice
-      - choiceArgument
-      - consuming
-      - lastDescendantNodeId
-      - packageName
-      - acsDelta
-      - actingParties
-      - witnessParties
-      properties:
-        offset:
-          description: |-
-            The offset of origin.
-            Offsets are managed by the participant nodes.
-            Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
-            It is a valid absolute offset (positive integer)
-
-            Required
-          type: integer
-          format: int64
-        nodeId:
-          description: |-
-            The position of this event in the originating transaction or reassignment.
-            Node IDs are not necessarily equal across participants,
-            as these may see different projections/parts of transactions.
-            Must be valid node ID (non-negative integer)
-
-            Required
-          type: integer
-          format: int32
-        contractId:
-          description: |-
-            The ID of the target contract.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        templateId:
-          description: |-
-            Identifies the template that defines the executed choice.
-            This template's package-id may differ from the target contract's package-id
-            if the target contract has been upgraded or downgraded.
-
-            The identifier uses the package-id reference format.
-
-            Required
-          type: string
-        interfaceId:
-          description: |-
-            The interface where the choice is defined, if inherited.
-            If defined, the identifier uses the package-id reference format.
-
-            Optional
-          type: string
-        choice:
-          description: |-
-            The choice that was exercised on the target contract.
-            Must be a valid NameString (as described in ``value.proto``).
-
-            Required
-          type: string
-        choiceArgument:
-          description: |-
-            The argument of the exercised choice.
-
-            Required
-        actingParties:
-          description: |-
-            The parties that exercised the choice.
-            Each element must be a valid PartyIdString (as described in ``value.proto``).
-
-            Required: must be non-empty
-          type: array
-          items:
-            type: string
-        consuming:
-          description: |-
-            If true, the target contract may no longer be exercised.
-
-            Required
-          type: boolean
-        witnessParties:
-          description: |-
-            The parties that are notified of this event. The witnesses of an exercise
-            node will depend on whether the exercise was consuming or not.
-            If consuming, the witnesses are the union of the stakeholders,
-            the actors and all informees of all the ancestors of this event this
-            participant knows about.
-            If not consuming, the witnesses are the union of the signatories,
-            the actors and all informees of all the ancestors of this event this
-            participant knows about.
-            In both cases the witnesses are limited to the querying parties, or not
-            limited in case anyParty filters are used.
-            Note that the actors might not necessarily be observers
-            and thus stakeholders. This is the case when the controllers of a
-            choice are specified using "flexible controllers", using the
-            ``choice ... controller`` syntax, and said controllers are not
-            explicitly marked as observers.
-            Each element must be a valid PartyIdString (as described in ``value.proto``).
-
-            Required: must be non-empty
-          type: array
-          items:
-            type: string
-        lastDescendantNodeId:
-          description: |-
-            Specifies the upper boundary of the node ids of the events in the same transaction that appeared as a result of
-            this ``ExercisedEvent``. This allows unambiguous identification of all the members of the subtree rooted at this
-            node. A full subtree can be constructed when all descendant nodes are present in the stream. If nodes are heavily
-            filtered, it is only possible to determine if a node is in a consequent subtree or not.
-
-            Required
-          type: integer
-          format: int32
-        exerciseResult:
-          description: |-
-            The result of exercising the choice.
-
-            Optional
-        packageName:
-          description: |-
-            The package name of the contract.
-
-            Required
-          type: string
-        implementedInterfaces:
-          description: |-
-            If the event is consuming, the interfaces implemented by the target template that have been
-            matched from the interface filter query.
-            Populated only in case interface filters with include_interface_view set.
-
-            The identifier uses the package-id reference format.
-
-            Optional: can be empty
-          type: array
-          items:
-            type: string
-        acsDelta:
-          description: |-
-            Whether this event would be part of respective ACS_DELTA shaped stream,
-            and should therefore considered when tracking contract activeness on the client-side.
-
-            Required
-          type: boolean
-    ExercisedTreeEvent:
-      title: ExercisedTreeEvent
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/ExercisedEvent'
-    ExperimentalCommandInspectionService:
-      title: ExperimentalCommandInspectionService
-      description: Whether the Ledger API supports command inspection service
-      type: object
-      required:
-      - supported
-      properties:
-        supported:
-          description: Required
-          type: boolean
-    ExperimentalFeatures:
-      title: ExperimentalFeatures
-      description: See the feature message definitions for descriptions.
-      type: object
-      properties:
-        staticTime:
-          $ref: '#/components/schemas/ExperimentalStaticTime'
-          description: Optional
-        commandInspectionService:
-          $ref: '#/components/schemas/ExperimentalCommandInspectionService'
-          description: Optional
-    ExperimentalStaticTime:
-      title: ExperimentalStaticTime
-      description: Ledger is in the static time mode and exposes a time service.
-      type: object
-      required:
-      - supported
-      properties:
-        supported:
-          description: Required
-          type: boolean
-    FeaturesDescriptor:
-      title: FeaturesDescriptor
-      type: object
-      required:
-      - experimental
-      - userManagement
-      - partyManagement
-      - offsetCheckpoint
-      - packageFeature
-      properties:
-        experimental:
-          $ref: '#/components/schemas/ExperimentalFeatures'
-          description: |-
-            Features under development or features that are used
-            for ledger implementation testing purposes only.
-
-            Daml applications SHOULD not depend on these in production.
-
-            Required
-        userManagement:
-          $ref: '#/components/schemas/UserManagementFeature'
-          description: |-
-            If set, then the Ledger API server supports user management.
-            It is recommended that clients query this field to gracefully adjust their behavior for
-            ledgers that do not support user management.
-
-            Required
-        partyManagement:
-          $ref: '#/components/schemas/PartyManagementFeature'
-          description: |-
-            If set, then the Ledger API server supports party management configurability.
-            It is recommended that clients query this field to gracefully adjust their behavior to
-            maximum party page size.
-
-            Required
-        offsetCheckpoint:
-          $ref: '#/components/schemas/OffsetCheckpointFeature'
-          description: |-
-            It contains the timeouts related to the periodic offset checkpoint emission
-
-            Required
-        packageFeature:
-          $ref: '#/components/schemas/PackageFeature'
-          description: |-
-            If set, then the Ledger API server supports package listing
-            configurability. It is recommended that clients query this field to
-            gracefully adjust their behavior to maximum package listing page size.
-
-            Required
-    Field:
-      title: Field
-      type: object
-      properties:
-        varint:
-          type: array
-          items:
-            type: integer
-            format: int64
-        fixed64:
-          type: array
-          items:
-            type: integer
-            format: int64
-        fixed32:
-          type: array
-          items:
+        - name: pageSize
+          in: query
+          description: maximum number of elements in a returned page
+          required: false
+          schema:
             type: integer
             format: int32
-        lengthDelimited:
-          type: array
-          items:
+        - name: pageToken
+          in: query
+          description: token - to continue results from a given page, leave empty to
+            start from the beginning of the list, obtain token from the result of previous
+            page
+          required: false
+          schema:
             type: string
-    FieldMask:
-      title: FieldMask
-      type: object
-      required:
-      - unknownFields
-      properties:
-        paths:
-          type: array
-          items:
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListKnownPartiesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter identity-provider-id,
+              Invalid value for: query parameter filter-party, Invalid value for: query
+              parameter pageSize, Invalid value for: query parameter pageToken'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: |-
+          Allocates a new party on a ledger and adds it to the set managed by the participant.
+          Caller specifies a party identifier suggestion, the actual identifier
+          allocated might be different and is implementation specific.
+          Caller can specify party metadata that is stored locally on the participant.
+          This call may:
+
+          - Succeed, in which case the actual allocated identifier is visible in
+            the response.
+          - Respond with a gRPC error
+
+          daml-on-kv-ledger: suggestion's uniqueness is checked by the validators in
+          the consensus layer and call rejected if the identifier is already present.
+          canton: completely different globally unique identifier is allocated.
+          Behind the scenes calls to an internal protocol are made. As that protocol
+          is richer than the surface protocol, the arguments take implicit values
+          The party identifier suggestion must be a valid party name. Party names are required to be non-empty US-ASCII strings built from letters, digits, space,
+          colon, minus and underscore limited to 255 chars
+        operationId: postV2Parties
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocatePartyRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/AllocatePartyResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/external/allocate:
+      post:
+        description: |-
+          Alpha 3.3: Endpoint to allocate a new external party on a synchronizer
+
+          Expected to be stable in 3.5
+
+          The external party must be hosted (at least) on this node with either confirmation or observation permissions
+          It can optionally be hosted on other nodes (then called a multi-hosted party).
+          If hosted on additional nodes, explicit authorization of the hosting relationship must be performed on those nodes
+          before the party can be used.
+          Decentralized namespaces are supported but must be provided fully authorized by their owners.
+          The individual owner namespace transactions can be submitted in the same call (fully authorized as well).
+          In the simple case of a non-multi hosted, non-decentralized party, the RPC will return once the party is
+          effectively allocated and ready to use, similarly to the AllocateParty behavior.
+          For more complex scenarios applications may need to query the party status explicitly (only through the admin API as of now).
+        operationId: postV2PartiesExternalAllocate
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllocateExternalPartyRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/AllocateExternalPartyResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/participant-id:
+      get:
+        description: |-
+          Return the identifier of the participant.
+          All horizontally scaled replicas should return the same id.
+          daml-on-kv-ledger: returns an identifier supplied on command line at launch time
+          canton: returns globally unique identifier of the participant
+        operationId: getV2PartiesParticipant-id
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetParticipantIdResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/{party}:
+      get:
+        description: |-
+          Get the party details of the given parties. Only known parties will be
+          returned in the list.
+        operationId: getV2PartiesParty
+        parameters:
+        - name: party
+          in: path
+          required: true
+          schema:
             type: string
-        unknownFields:
-          $ref: '#/components/schemas/UnknownFieldSet'
-    Filters:
-      title: Filters
-      description: The union of a set of template filters, interface filters, or a
-        wildcard.
-      type: object
-      properties:
-        cumulative:
-          description: |-
-            Every filter in the cumulative list expands the scope of the resulting stream. Each interface,
-            template or wildcard filter means additional events that will match the query.
-            The impact of include_interface_view and include_created_event_blob fields in the filters will
-            also be accumulated.
-            A template or an interface SHOULD NOT appear twice in the accumulative field.
-            A wildcard filter SHOULD NOT be defined more than once in the accumulative field.
-            If no ``CumulativeFilter`` defined, the default of a single ``WildcardFilter`` with
-            include_created_event_blob unset is used.
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/CumulativeFilter'
-    GenerateExternalPartyTopologyRequest:
-      title: GenerateExternalPartyTopologyRequest
-      type: object
-      required:
-      - synchronizer
-      - partyHint
-      - publicKey
-      properties:
-        synchronizer:
-          description: |-
-            Synchronizer-id for which we are building this request.
-            TODO(#27670) support synchronizer aliases
-
-            Required
-          type: string
-        partyHint:
-          description: |-
-            The actual party id will be constructed from this hint and a fingerprint of the public key
-
-            Required
-          type: string
-        publicKey:
-          $ref: '#/components/schemas/SigningPublicKey'
-          description: |-
-            Public key
-
-            Required
-        localParticipantObservationOnly:
-          description: |-
-            If true, then the local participant will only be observing, not confirming. Default false.
-
-            Optional
-          type: boolean
-        otherConfirmingParticipantUids:
-          description: |-
-            Other participant ids which should be confirming for this party
-
-            Optional: can be empty
-          type: array
-          items:
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
             type: string
-        confirmationThreshold:
-          description: |-
-            Confirmation threshold >= 1 for the party. Defaults to all available confirmers (or if set to 0).
-
-            Optional
-          type: integer
-          format: int32
-        observingParticipantUids:
-          description: |-
-            Other observing participant ids for this party
-
-            Optional: can be empty
-          type: array
-          items:
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPartiesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter identity-provider-id,
+              Invalid value for: query parameter parties'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: |-
+          Update selected modifiable participant-local attributes of a party details resource.
+          Can update the participant's local information for local parties.
+        operationId: patchV2PartiesParty
+        parameters:
+        - name: party
+          in: path
+          required: true
+          schema:
             type: string
-    GenerateExternalPartyTopologyResponse:
-      title: GenerateExternalPartyTopologyResponse
-      description: Response message with topology transactions and the multi-hash
-        to be signed.
-      type: object
-      required:
-      - partyId
-      - publicKeyFingerprint
-      - multiHash
-      - topologyTransactions
-      properties:
-        partyId:
-          description: |-
-            The generated party id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdatePartyDetailsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdatePartyDetailsResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/parties/external/generate-topology:
+      post:
+        description: |-
+          Alpha 3.3: Convenience endpoint to generate topology transactions for external signing
 
-            Required
-          type: string
-        publicKeyFingerprint:
-          description: |-
-            The fingerprint of the supplied public key
+          Expected to be stable in 3.5
 
-            Required
-          type: string
-        topologyTransactions:
-          description: |-
-            The serialized topology transactions which need to be signed and submitted as part of the allocate party process
-            Note that the serialization includes the versioning information. Therefore, the transaction here is serialized
-            as an `UntypedVersionedMessage` which in turn contains the serialized `TopologyTransaction` in the version
-            supported by the synchronizer.
+          You may use this endpoint to generate the common external topology transactions
+          which can be signed externally and uploaded as part of the allocate party process
 
-            Required: must be non-empty
-          type: array
-          items:
+          Note that this request will create a normal namespace using the same key for the
+          identity as for signing. More elaborate schemes such as multi-signature
+          or decentralized parties require you to construct the topology transactions yourself.
+        operationId: postV2PartiesExternalGenerate-topology
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateExternalPartyTopologyRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GenerateExternalPartyTopologyResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/active-contracts:
+      post:
+        description: |-
+          Query active contracts list (blocking call).
+          Querying active contracts is an expensive operation and if possible should not be repeated often.
+          Consider querying active contracts initially (for a given offset)
+          and then repeatedly call one of `/v2/updates/...`endpoints  to get subsequent modifications.
+          You can also use websockets to get updates with better performance.
+
+          Returns a stream of the snapshot of the active contracts and incomplete (un)assignments at a ledger offset.
+          Once the stream of GetActiveContractsResponses completes,
+          the client SHOULD begin streaming updates from the update service,
+          starting at the GetActiveContractsRequest.active_at_offset specified in this request.
+          Clients SHOULD NOT assume that the set of active contracts they receive reflects the state at the ledger end.
+
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2StateActive-contracts
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetActiveContractsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetActiveContractsResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/connected-synchronizers:
+      get:
+        description: Get the list of connected synchronizers at the time of the query.
+        operationId: getV2StateConnected-synchronizers
+        parameters:
+        - name: party
+          in: query
+          required: false
+          schema:
             type: string
-        multiHash:
-          description: |-
-            the multi-hash which may be signed instead of each individual transaction
-
-            Required: must be non-empty
-          type: string
-    GetActiveContractsRequest:
-      title: GetActiveContractsRequest
-      description: |-
-        If the given offset is different than the ledger end, and there are (un)assignments in-flight at the given offset,
-        the snapshot may fail with "FAILED_PRECONDITION/PARTICIPANT_PRUNED_DATA_ACCESSED".
-        Note that it is ok to request acs snapshots for party migration with offsets other than ledger end, because party
-        migration is not concerned with incomplete (un)assignments.
-      type: object
-      required:
-      - activeAtOffset
-      properties:
-        filter:
-          $ref: '#/components/schemas/TransactionFilter'
-          description: |-
-            Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
-            Templates to include in the served snapshot, per party.
-            Optional, if specified event_format must be unset, if not specified event_format must be set.
-        verbose:
-          description: |-
-            Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
-            If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
-            In particular, setting the verbose flag to true triggers the ledger to include labels for record fields.
-            Optional, if specified event_format must be unset.
-          type: boolean
-        activeAtOffset:
-          description: |-
-            The offset at which the snapshot of the active contracts will be computed.
-            Must be no greater than the current ledger end offset.
-            Must be greater than or equal to the last pruning offset.
-            Must be a valid absolute offset (positive integer) or ledger begin offset (zero).
-            If zero, the empty set will be returned.
-
-            Required
-          type: integer
-          format: int64
-        eventFormat:
-          $ref: '#/components/schemas/EventFormat'
-          description: |-
-            Format of the contract_entries in the result. In case of CreatedEvent the presentation will be of
-            TRANSACTION_SHAPE_ACS_DELTA.
-            Optional for backwards compatibility, defaults to an EventFormat where:
-
-            - filters_by_party is the filter.filters_by_party from this request
-            - filters_for_any_party is the filter.filters_for_any_party from this request
-            - verbose is the verbose field from this request
-        streamContinuationToken:
-          description: |-
-            Opaque representation of a continuation token defining a position in the active contracts snapshot.
-            The prefix of the active contracts snapshot will be omitted up to and including the element from which
-            the continuation token was read.
-            To reuse the continuation token from a `GetActiveContractsPageResponse`:
-
-            - subsequent request must be executed on the same participant with the same version of canton,
-            - subsequent request must have the same active_at_offset,
-            - subsequent request must have the same event_format
-            - and the participant must not have been pruned after the active_at_offset.
-
-            If not specified, the whole active contracts snapshot will be returned.
-
-            Optional: can be empty
-          type: string
-    GetConnectedSynchronizersResponse:
-      title: GetConnectedSynchronizersResponse
-      type: object
-      properties:
-        connectedSynchronizers:
-          description: 'Optional: can be empty'
-          type: array
-          items:
-            $ref: '#/components/schemas/ConnectedSynchronizer'
-    GetContractRequest:
-      title: GetContractRequest
-      type: object
-      required:
-      - contractId
-      properties:
-        contractId:
-          description: |-
-            The ID of the contract.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        queryingParties:
-          description: |-
-            The list of querying parties
-            The stakeholders of the referenced contract must have an intersection with any of these parties
-            to return the result.
-            If no querying_parties specified, all possible contracts could be returned.
-
-            Optional: can be empty
-          type: array
-          items:
+        - name: participantId
+          in: query
+          required: false
+          schema:
             type: string
-    GetContractResponse:
-      title: GetContractResponse
-      type: object
-      required:
-      - createdEvent
-      properties:
-        createdEvent:
-          $ref: '#/components/schemas/CreatedEvent'
-          description: |-
-            The representative_package_id will be always set to the contract package ID, therefore this endpoint should
-            not be used to lookup contract which entered the participant via party replication or repair service.
-            The witnesses field will contain only the querying_parties which are also stakeholders of the contract as well.
-            The following fields of the created event cannot be populated, so those should not be used / parsed:
+        - name: identityProviderId
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetConnectedSynchronizersResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter party, Invalid
+              value for: query parameter participantId, Invalid value for: query parameter
+              identityProviderId'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/ledger-end:
+      get:
+        description: |-
+          Get the current ledger end.
+          Subscriptions started with the returned offset will serve events after this RPC was called.
+        operationId: getV2StateLedger-end
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetLedgerEndResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/state/latest-pruned-offsets:
+      get:
+        description: Get the latest successfully pruned ledger offsets
+        operationId: getV2StateLatest-pruned-offsets
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetLatestPrunedOffsetsResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates:
+      post:
+        description: |-
+          Read the ledger's filtered update stream for the specified contents and filters.
+          It returns the event types in accordance with the stream contents selected. Also the selection criteria
+          for individual events depends on the transaction shape chosen.
 
-            - offset
-            - node_id
-            - created_event_blob
-            - interface_views
-            - acs_delta
+          - ACS delta: a requesting party must be a stakeholder of an event for it to be included.
+          - ledger effects: a requesting party must be a witness of an event for it to be included.
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2Updates
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdatesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetUpdatesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/flats:
+      post:
+        description: |-
+          Query flat transactions update list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2UpdatesFlats
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdatesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetUpdatesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/trees:
+      post:
+        description: |-
+          Query update transactions tree list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead.
+          Notice: This endpoint should be used for small results set.
+          When number of results exceeded node configuration limit (`http-list-max-elements-limit`)
+          there will be an error (`413 Content Too Large`) returned.
+          Increasing this limit may lead to performance issues and high memory consumption.
+          Consider using websockets (asyncapi) for better efficiency with larger results.
+        operationId: postV2UpdatesTrees
+        parameters:
+        - name: limit
+          in: query
+          description: maximum number of elements to return, this param is ignored if
+            is bigger than server setting
+          required: false
+          schema:
+            type: integer
+            format: int64
+        - name: stream_idle_timeout_ms
+          in: query
+          description: timeout to complete and send result if no new elements are received
+            (for open ended streams)
+          required: false
+          schema:
+            type: integer
+            format: int64
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdatesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/JsGetUpdateTreesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body, Invalid value for:
+              query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-tree-by-offset/{offset}:
+      get:
+        description: Get transaction tree by offset. Provided for backwards compatibility,
+          it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset
+          instead.
+        operationId: getV2UpdatesTransaction-tree-by-offsetOffset
+        parameters:
+        - name: offset
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionTreeResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: path parameter offset, Invalid
+              value for: query parameter parties'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-by-offset:
+      post:
+        description: Get transaction by offset. Provided for backwards compatibility,
+          it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset
+          instead.
+        operationId: postV2UpdatesTransaction-by-offset
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTransactionByOffsetRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/update-by-offset:
+      post:
+        description: |-
+          Lookup an update by its offset.
+          If there is no update with this offset, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
+        operationId: postV2UpdatesUpdate-by-offset
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdateByOffsetRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetUpdateResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-by-id:
+      post:
+        description: Get transaction by id. Provided for backwards compatibility, it
+          will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.
+        operationId: postV2UpdatesTransaction-by-id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTransactionByIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/update-by-id:
+      post:
+        description: |-
+          Lookup an update by its ID.
+          If there is no update with this ID, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
+        operationId: postV2UpdatesUpdate-by-id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUpdateByIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetUpdateResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/updates/transaction-tree-by-id/{update-id}:
+      get:
+        description: Get transaction tree by id. Provided for backwards compatibility,
+          it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id
+          instead.
+        operationId: getV2UpdatesTransaction-tree-by-idUpdate-id
+        parameters:
+        - name: update-id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsGetTransactionTreeResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter parties'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        deprecated: true
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users:
+      get:
+        description: List all existing users.
+        operationId: getV2Users
+        parameters:
+        - name: pageSize
+          in: query
+          description: maximum number of elements in a returned page
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - name: pageToken
+          in: query
+          description: token - to continue results from a given page, leave empty to
+            start from the beginning of the list, obtain token from the result of previous
+            page
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListUsersResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter pageSize,
+              Invalid value for: query parameter pageToken'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: Create a new user.
+        operationId: postV2Users
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateUserRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/CreateUserResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users/{user-id}:
+      get:
+        description: Get the user data of a specific user or the authenticated user.
+        operationId: getV2UsersUser-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetUserResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter identity-provider-id'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      delete:
+        description: Delete an existing user and all its rights.
+        operationId: deleteV2UsersUser-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  type: object
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: Update selected modifiable attribute of a user resource described
+          by the ``User`` message.
+        operationId: patchV2UsersUser-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateUserRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateUserResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/authenticated-user:
+      get:
+        description: Get the user data of the current authenticated user.
+        operationId: getV2Authenticated-user
+        parameters:
+        - name: identity-provider-id
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetUserResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter identity-provider-id'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users/{user-id}/rights:
+      get:
+        description: List the set of all rights granted to a user.
+        operationId: getV2UsersUser-idRights
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListUserRightsResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: |-
+          Grant rights to a user.
+          Granting rights does not affect the resource version of the corresponding user.
+        operationId: postV2UsersUser-idRights
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GrantUserRightsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GrantUserRightsResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: |-
+          Revoke rights from a user.
+          Revoking rights does not affect the resource version of the corresponding user.
+        operationId: patchV2UsersUser-idRights
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevokeUserRightsRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/RevokeUserRightsResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/users/{user-id}/identity-provider-id:
+      patch:
+        description: Update the assignment of a user from one IDP to another.
+        operationId: patchV2UsersUser-idIdentity-provider-id
+        parameters:
+        - name: user-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateUserIdentityProviderIdRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateUserIdentityProviderIdResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/idps:
+      get:
+        description: List all existing identity provider configurations.
+        operationId: getV2Idps
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ListIdentityProviderConfigsResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      post:
+        description: |-
+          Create a new identity provider configuration.
+          The request will fail if the maximum allowed number of separate configurations is reached.
+        operationId: postV2Idps
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateIdentityProviderConfigRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/CreateIdentityProviderConfigResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/idps/{idp-id}:
+      get:
+        description: Get the identity provider configuration data by id.
+        operationId: getV2IdpsIdp-id
+        parameters:
+        - name: idp-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetIdentityProviderConfigResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      delete:
+        description: Delete an existing identity provider configuration.
+        operationId: deleteV2IdpsIdp-id
+        parameters:
+        - name: idp-id
+          in: path
+          required: true
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/DeleteIdentityProviderConfigResponse'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+      patch:
+        description: |-
+          Update selected modifiable attribute of an identity provider config resource described
+          by the ``IdentityProviderConfig`` message.
+        operationId: patchV2IdpsIdp-id
+        parameters:
+        - name: idp-id
+          in: path
+          required: true
+          schema:
+            type: string
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateIdentityProviderConfigRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/UpdateIdentityProviderConfigResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/prepare:
+      post:
+        description: Requires `readAs` scope for the submitting party when LAPI User
+          authorization is enabled
+        operationId: postV2Interactive-submissionPrepare
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsPrepareSubmissionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsPrepareSubmissionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/execute:
+      post:
+        description: |-
+          Execute a prepared submission _asynchronously_ on the ledger.
+          Requires a signature of the transaction from the submitting external party.
+        operationId: postV2Interactive-submissionExecute
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsExecuteSubmissionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ExecuteSubmissionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/executeAndWait:
+      post:
+        description: |-
+          Similar to ExecuteSubmission but _synchronously_ wait for the completion of the transaction
+          IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest.
+          A malicious node could make a successfully committed request appeared failed and vice versa
+        operationId: postV2Interactive-submissionExecuteandwait
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsExecuteSubmissionAndWaitRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/ExecuteSubmissionAndWaitResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/executeAndWaitForTransaction:
+      post:
+        description: |-
+          Similar to ExecuteSubmissionAndWait but additionally returns the transaction
+          IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest.
+          A malicious node could make a successfully committed request appear as failed and vice versa
+        operationId: postV2Interactive-submissionExecuteandwaitfortransaction
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsExecuteSubmissionAndWaitForTransactionRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsExecuteSubmissionAndWaitForTransactionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/preferred-package-version:
+      get:
+        description: |-
+          A preferred package is the highest-versioned package for a provided package-name
+          that is vetted by all the participants hosting the provided parties.
 
-            Required
-    GetEventsByContractIdRequest:
-      title: GetEventsByContractIdRequest
-      type: object
-      required:
-      - contractId
-      - eventFormat
-      properties:
-        contractId:
-          description: |-
-            The contract id being queried.
+          Ledger API clients should use this endpoint for constructing command submissions
+          that are compatible with the provided preferred package, by making informed decisions on:
+          - which are the compatible packages that can be used to create contracts
+          - which contract or exercise choice argument version can be used in the command
+          - which choices can be executed on a template or interface of a contract
 
-            Required
-          type: string
-        eventFormat:
-          $ref: '#/components/schemas/EventFormat'
-          description: |-
-            Format of the events in the result, the presentation will be of TRANSACTION_SHAPE_ACS_DELTA.
+          Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.
 
-            Required
-    GetIdentityProviderConfigResponse:
-      title: GetIdentityProviderConfigResponse
-      type: object
-      required:
-      - identityProviderConfig
-      properties:
-        identityProviderConfig:
-          $ref: '#/components/schemas/IdentityProviderConfig'
-          description: Required
-    GetLatestPrunedOffsetsResponse:
-      title: GetLatestPrunedOffsetsResponse
-      type: object
-      properties:
-        participantPrunedUpToInclusive:
-          description: |-
-            It will always be a non-negative integer.
-            If positive, the absolute offset up to which the ledger has been pruned,
-            disregarding the state of all divulged contracts pruning.
-            If zero, the ledger has not been pruned yet.
+          Provided for backwards compatibility, it will be removed in the Canton version 3.4.0
+        operationId: getV2Interactive-submissionPreferred-package-version
+        parameters:
+        - name: parties
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: package-name
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: vetting_valid_at
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: synchronizer-id
+          in: query
+          required: false
+          schema:
+            type: string
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPreferredPackageVersionResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: query parameter parties,
+              Invalid value for: query parameter package-name, Invalid value for: query
+              parameter vetting_valid_at, Invalid value for: query parameter synchronizer-id'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/interactive-submission/preferred-packages:
+      post:
+        description: |-
+          Compute the preferred packages for the vetting requirements in the request.
+          A preferred package is the highest-versioned package for a provided package-name
+          that is vetted by all the participants hosting the provided parties.
 
-            Optional
-          type: integer
-          format: int64
-        allDivulgedContractsPrunedUpToInclusive:
-          description: |-
-            It will always be a non-negative integer.
-            If positive, the absolute offset up to which all divulged events have been pruned on the ledger.
-            It can be at or before the ``participant_pruned_up_to_inclusive`` offset.
-            For more details about all divulged events pruning,
-            see ``PruneRequest.prune_all_divulged_contracts`` in ``participant_pruning_service.proto``.
-            If zero, the divulged events have not been pruned yet.
+          Ledger API clients should use this endpoint for constructing command submissions
+          that are compatible with the provided preferred packages, by making informed decisions on:
+          - which are the compatible packages that can be used to create contracts
+          - which contract or exercise choice argument version can be used in the command
+          - which choices can be executed on a template or interface of a contract
 
-            Optional
-          type: integer
-          format: int64
-    GetLedgerApiVersionResponse:
-      title: GetLedgerApiVersionResponse
-      type: object
-      required:
-      - version
-      - features
-      properties:
-        version:
-          description: |-
-            The version of the ledger API.
+          If the package preferences could not be computed due to no selection satisfying the requirements,
+          a `FAILED_PRECONDITION` error will be returned.
 
-            Required
-          type: string
-        features:
-          $ref: '#/components/schemas/FeaturesDescriptor'
-          description: |-
-            The features supported by this Ledger API endpoint.
+          Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.
 
-            Daml applications CAN use the feature descriptor on top of
-            version constraints on the Ledger API version to determine
-            whether a given Ledger API endpoint supports the features
-            required to run the application.
+          Experimental API: this endpoint is not guaranteed to provide backwards compatibility in future releases
+        operationId: postV2Interactive-submissionPreferred-packages
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPreferredPackagesRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetPreferredPackagesResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /livez:
+      get:
+        description: Checks if the service is alive
+        operationId: getLivez
+        responses:
+          '200':
+            description: 'OK: service is alive'
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /readyz:
+      get:
+        description: Checks if the service is ready to serve requests
+        operationId: getReadyz
+        responses:
+          '200':
+            description: 'OK: readiness message'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          '400':
+            description: Invalid value
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+    /v2/contracts/contract-by-id:
+      post:
+        description: |-
+          Looking up contract data by contract ID.
+          This endpoint is experimental / alpha, therefore no backwards compatibility is guaranteed.
+          This endpoint must not be used to look up contracts which entered the participant via party replication
+          or repair service.
+        operationId: postV2ContractsContract-by-id
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetContractRequest'
+          required: true
+        responses:
+          '200':
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/GetContractResponse'
+          '400':
+            description: 'Invalid value, Invalid value for: body'
+            content:
+              text/plain:
+                schema:
+                  type: string
+          default:
+            description: ''
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/JsCantonError'
+        security:
+        - httpAuth: []
+        - apiKeyAuth: []
+  components:
+    schemas:
+      AllocateExternalPartyRequest:
+        title: AllocateExternalPartyRequest
+        description: |-
+          Required authorization:
+            ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id) OR IsAuthenticatedUser(user_id)``
+        type: object
+        required:
+        - synchronizer
+        - onboardingTransactions
+        properties:
+          synchronizer:
+            description: |-
+              TODO(#27670) support synchronizer aliases
+              Synchronizer ID on which to onboard the party
 
-            See the feature descriptions themselves for the relation between
-            Ledger API versions and feature presence.
+              Required
+            type: string
+          onboardingTransactions:
+            description: |-
+              TopologyTransactions to onboard the external party
+              Can contain:
+              - A namespace for the party.
+              This can be either a single NamespaceDelegation,
+              or DecentralizedNamespaceDefinition along with its authorized namespace owners in the form of NamespaceDelegations.
+              May be provided, if so it must be fully authorized by the signatures in this request combined with the existing topology state.
+              - A PartyToParticipant to register the hosting relationship of the party, and the party's signing keys and threshold.
+              Must be provided.
 
-            Required
-    GetLedgerEndResponse:
-      title: GetLedgerEndResponse
-      type: object
-      properties:
-        offset:
-          description: |-
-            It will always be a non-negative integer.
-            If zero, the participant view of the ledger is empty.
-            If positive, the absolute offset of the ledger as viewed by the participant.
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/SignedTransaction'
+          multiHashSignatures:
+            description: |-
+              Optional signatures of the combined hash of all onboarding_transactions
+              This may be used instead of providing signatures on each individual transaction
 
-            Optional
-          type: integer
-          format: int64
-    GetPackageStatusResponse:
-      title: GetPackageStatusResponse
-      type: object
-      required:
-      - packageStatus
-      properties:
-        packageStatus:
-          description: |-
-            The status of the package.
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Signature'
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the party is managed by the default identity provider.
 
-            Required
-          type: string
-          enum:
-          - PACKAGE_STATUS_UNSPECIFIED
-          - PACKAGE_STATUS_REGISTERED
-    GetParticipantIdResponse:
-      title: GetParticipantIdResponse
-      type: object
-      required:
-      - participantId
-      properties:
-        participantId:
-          description: |-
-            Identifier of the participant, which SHOULD be globally unique.
-            Must be a valid LedgerString (as describe in ``value.proto``).
+              Optional
+            type: string
+          waitForAllocation:
+            description: |-
+              When true, this RPC will attempt to wait for the party to be allocated on the synchronizer before returning.
+              When false, the allocation will happen asynchronously.
+              This is a best effort only as this synchronization is only possible for non decentralized parties (single hosting node).
+              For decentralized parties, this flag is ignored.
+              Defaults to true.
 
-            Required
-          type: string
-    GetPartiesResponse:
-      title: GetPartiesResponse
-      type: object
-      required:
-      - partyDetails
-      properties:
-        partyDetails:
-          description: |-
-            The details of the requested Daml parties by the participant, if known.
-            The party details may not be in the same order as requested.
+              Optional
+            type: boolean
+          userId:
+            description: |-
+              The user who will get the act_as rights to the newly allocated party.
+              If set to an empty string (the default), no user will get rights to the party.
 
-            Required: must be non-empty
-          type: array
-          items:
+              Optional
+            type: string
+      AllocateExternalPartyResponse:
+        title: AllocateExternalPartyResponse
+        type: object
+        required:
+        - partyId
+        properties:
+          partyId:
+            description: |-
+              The allocated party id
+
+              Required
+            type: string
+      AllocatePartyRequest:
+        title: AllocatePartyRequest
+        description: |-
+          Required authorization:
+            ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id) OR IsAuthenticatedUser(user_id)``
+        type: object
+        properties:
+          partyIdHint:
+            description: |-
+              A hint to the participant which party ID to allocate. It can be
+              ignored.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          localMetadata:
+            $ref: '#/components/schemas/ObjectMeta'
+            description: |-
+              Formerly "display_name"
+              Participant-local metadata to be stored in the ``PartyDetails`` of this newly allocated party.
+
+              Optional
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the party is managed by the default identity provider or party is not hosted by the participant.
+
+              Optional
+            type: string
+          synchronizerId:
+            description: |-
+              The synchronizer, on which the party should be allocated.
+              For backwards compatibility, this field may be omitted, if the participant is connected to only one synchronizer.
+              Otherwise a synchronizer must be specified.
+
+              Optional
+            type: string
+          userId:
+            description: |-
+              The user who will get the act_as rights to the newly allocated party.
+              If set to an empty string (the default), no user will get rights to the party.
+
+              Optional
+            type: string
+      AllocatePartyResponse:
+        title: AllocatePartyResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
             $ref: '#/components/schemas/PartyDetails'
-    GetPreferredPackageVersionResponse:
-      title: GetPreferredPackageVersionResponse
-      type: object
-      properties:
-        packagePreference:
-          $ref: '#/components/schemas/PackagePreference'
-          description: |-
-            Not populated when no preferred package is found
+            description: |-
+              The allocated party details
 
-            Optional
-    GetPreferredPackagesRequest:
-      title: GetPreferredPackagesRequest
-      type: object
-      required:
-      - packageVettingRequirements
-      properties:
-        packageVettingRequirements:
-          description: |-
-            The package-name vetting requirements for which the preferred packages should be resolved.
+              Required
+      ArchivedEvent:
+        title: ArchivedEvent
+        description: Records that a contract has been archived, and choices may no longer
+          be exercised on it.
+        type: object
+        required:
+        - offset
+        - nodeId
+        - contractId
+        - templateId
+        - packageName
+        - witnessParties
+        properties:
+          offset:
+            description: |-
+              The offset of origin.
+              Offsets are managed by the participant nodes.
+              Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
+              It is a valid absolute offset (positive integer)
 
-            Generally it is enough to provide the requirements for the intended command's root package-names.
-            Additional package-name requirements can be provided when additional Daml transaction informees need to use
-            package dependencies of the command's root packages.
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating transaction or reassignment.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of transactions.
+              Must be valid node ID (non-negative integer)
 
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/PackageVettingRequirement'
-        synchronizerId:
-          description: |-
-            The synchronizer whose vetting state should be used for resolving this query.
-            If not specified, the vetting states of all synchronizers to which the participant is connected are used.
+              Required
+            type: integer
+            format: int32
+          contractId:
+            description: |-
+              The ID of the archived contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
 
-            Optional
-          type: string
-        vettingValidAt:
-          description: |-
-            The timestamp at which the package vetting validity should be computed
-            on the latest topology snapshot as seen by the participant.
-            If not provided, the participant's current clock time is used.
-
-            Optional
-          type: string
-    GetPreferredPackagesResponse:
-      title: GetPreferredPackagesResponse
-      type: object
-      required:
-      - synchronizerId
-      - packageReferences
-      properties:
-        packageReferences:
-          description: |-
-            The package references of the preferred packages.
-            Must contain one package reference for each requested package-name.
-
-            If you build command submissions whose content depends on the returned
-            preferred packages, then we recommend submitting the preferred package-ids
-            in the ``package_id_selection_preference`` of the command submission to
-            avoid race conditions with concurrent changes of the on-ledger package vetting state.
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/PackageReference'
-        synchronizerId:
-          description: |-
-            The synchronizer for which the package preferences are computed.
-            If the synchronizer_id was specified in the request, then it matches the request synchronizer_id.
-
-            Required
-          type: string
-    GetTransactionByIdRequest:
-      title: GetTransactionByIdRequest
-      description: Provided for backwards compatibility, it will be removed in the
-        Canton version 3.5.0.
-      type: object
-      required:
-      - updateId
-      properties:
-        updateId:
-          description: |-
-            The ID of a particular transaction.
-            Must be a valid LedgerString (as described in ``value.proto``).
-            Required
-          type: string
-        requestingParties:
-          description: |-
-            Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
-            The parties whose events the client expects to see.
-            Events that are not visible for the parties in this collection will not be present in the response.
-            Each element must be a valid PartyIdString (as described in ``value.proto``).
-            Optional for backwards compatibility for GetTransactionById request: if defined transaction_format must be
-            unset (falling back to defaults).
-          type: array
-          items:
+              Required
             type: string
-        transactionFormat:
-          $ref: '#/components/schemas/TransactionFormat'
-          description: |-
-            Optional for GetTransactionById request for backwards compatibility: defaults to a transaction_format, where:
+          templateId:
+            description: |-
+              Identifies the template that defines the choice that archived the contract.
+              This template's package-id may differ from the target contract's package-id
+              if the target contract has been upgraded or downgraded.
 
-            - event_format.filters_by_party will have template-wildcard filters for all the requesting_parties
-            - event_format.filters_for_any_party is unset
-            - event_format.verbose = true
-            - transaction_shape = TRANSACTION_SHAPE_ACS_DELTA
-    GetTransactionByOffsetRequest:
-      title: GetTransactionByOffsetRequest
-      description: Provided for backwards compatibility, it will be removed in the
-        Canton version 3.5.0.
-      type: object
-      required:
-      - offset
-      properties:
-        offset:
-          description: |-
-            The offset of the transaction being looked up.
-            Must be a valid absolute offset (positive integer).
-            Required
-          type: integer
-          format: int64
-        requestingParties:
-          description: |-
-            Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
-            The parties whose events the client expects to see.
-            Events that are not visible for the parties in this collection will not be present in the response.
-            Each element must be a valid PartyIdString (as described in ``value.proto``).
-            Optional for backwards compatibility for GetTransactionByOffset request: if defined transaction_format must be
-            unset (falling back to defaults).
-          type: array
-          items:
+              The identifier uses the package-id reference format.
+
+              Required
             type: string
-        transactionFormat:
-          $ref: '#/components/schemas/TransactionFormat'
-          description: |-
-            Optional for GetTransactionByOffset request for backwards compatibility: defaults to a TransactionFormat, where:
+          witnessParties:
+            description: |-
+              The parties that are notified of this event. For an ``ArchivedEvent``,
+              these are the intersection of the stakeholders of the contract in
+              question and the parties specified in the ``TransactionFilter``. The
+              stakeholders are the union of the signatories and the observers of
+              the contract.
+              Each one of its elements must be a valid PartyIdString (as described
+              in ``value.proto``).
 
-            - event_format.filters_by_party will have template-wildcard filters for all the requesting_parties
-            - event_format.filters_for_any_party is unset
-            - event_format.verbose = true
-            - transaction_shape = TRANSACTION_SHAPE_ACS_DELTA
-    GetUpdateByIdRequest:
-      title: GetUpdateByIdRequest
-      type: object
-      required:
-      - updateId
-      - updateFormat
-      properties:
-        updateId:
-          description: |-
-            The ID of a particular update.
-            Must be a valid LedgerString (as described in ``value.proto``).
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          packageName:
+            description: |-
+              The package name of the contract.
 
-            Required
-          type: string
-        updateFormat:
-          $ref: '#/components/schemas/UpdateFormat'
-          description: |-
-            The format for the update.
-
-            Required
-    GetUpdateByOffsetRequest:
-      title: GetUpdateByOffsetRequest
-      type: object
-      required:
-      - offset
-      - updateFormat
-      properties:
-        offset:
-          description: |-
-            The offset of the update being looked up.
-            Must be a valid absolute offset (positive integer).
-
-            Required
-          type: integer
-          format: int64
-        updateFormat:
-          $ref: '#/components/schemas/UpdateFormat'
-          description: |-
-            The format for the update.
-
-            Required
-    GetUpdatesRequest:
-      title: GetUpdatesRequest
-      type: object
-      required:
-      - beginExclusive
-      properties:
-        beginExclusive:
-          description: |-
-            Exclusive lower bound offset of the requested ledger section (non-negative integer).
-            The response will only contain transactions whose offset is strictly greater than this.
-            If set to zero, the lower bound is set to the beginning of the ledger.
-            If the participant has been pruned, this parameter must be greater or equal than the pruning offset.
-            Required
-          type: integer
-          format: int64
-        endInclusive:
-          description: |-
-            Inclusive higher bound offset of the requested ledger section.
-            If specified the response will only contain transactions whose offset is less than or equal to this.
-            If not specified,
-
-            - the descending_order must not be selected,
-            - the stream will not terminate.
-
-            Optional
-          type: integer
-          format: int64
-        filter:
-          $ref: '#/components/schemas/TransactionFilter'
-          description: |-
-            Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
-            Requesting parties with template filters.
-            Template filters must be empty for GetUpdateTrees requests.
-            Optional for backwards compatibility, if defined update_format must be unset
-        verbose:
-          description: |-
-            Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
-            If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
-            In particular, setting the verbose flag to true triggers the ledger to include labels, record and variant type ids
-            for record fields.
-            Optional for backwards compatibility, if defined update_format must be unset
-          type: boolean
-        updateFormat:
-          $ref: '#/components/schemas/UpdateFormat'
-          description: |-
-            Must be unset for GetUpdateTrees request.
-            Optional for backwards compatibility for GetUpdates request: defaults to an UpdateFormat where:
-
-            - include_transactions.event_format.filters_by_party = the filter.filters_by_party on this request
-            - include_transactions.event_format.filters_for_any_party = the filter.filters_for_any_party on this request
-            - include_transactions.event_format.verbose = the same flag specified on this request
-            - include_transactions.transaction_shape = TRANSACTION_SHAPE_ACS_DELTA
-            - include_reassignments.filter = the same filter specified on this request
-            - include_reassignments.verbose = the same flag specified on this request
-            - include_topology_events.include_participant_authorization_events.parties = all the parties specified in filter
-        descendingOrder:
-          description: |-
-            If set, the stream will populate the elements in descending order.
-
-            Optional
-          type: boolean
-    GetUserResponse:
-      title: GetUserResponse
-      type: object
-      required:
-      - user
-      properties:
-        user:
-          $ref: '#/components/schemas/User'
-          description: |-
-            Retrieved user.
-
-            Required
-    GrantUserRightsRequest:
-      title: GrantUserRightsRequest
-      description: |-
-        Add the rights to the set of rights granted to the user.
-
-        Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id)``
-      type: object
-      required:
-      - userId
-      properties:
-        userId:
-          description: |-
-            The user to whom to grant rights.
-
-            Required
-          type: string
-        rights:
-          description: |-
-            The rights to grant.
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Right'
-        identityProviderId:
-          description: |-
-            The id of the ``Identity Provider``
-            If not set, assume the user is managed by the default identity provider.
-
-            Optional
-          type: string
-    GrantUserRightsResponse:
-      title: GrantUserRightsResponse
-      type: object
-      properties:
-        newlyGrantedRights:
-          description: |-
-            The rights that were newly granted by the request.
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Right'
-    IdentifierFilter:
-      title: IdentifierFilter
-      description: Required
-      oneOf:
-      - type: object
-        required:
-        - Empty
-        properties:
-          Empty:
-            $ref: '#/components/schemas/Empty1'
-      - type: object
-        required:
-        - InterfaceFilter
-        properties:
-          InterfaceFilter:
-            $ref: '#/components/schemas/InterfaceFilter'
-      - type: object
-        required:
-        - TemplateFilter
-        properties:
-          TemplateFilter:
-            $ref: '#/components/schemas/TemplateFilter'
-      - type: object
-        required:
-        - WildcardFilter
-        properties:
-          WildcardFilter:
-            $ref: '#/components/schemas/WildcardFilter'
-    IdentityProviderAdmin:
-      title: IdentityProviderAdmin
-      description: |-
-        The right to administer the identity provider that the user is assigned to.
-        It means, being able to manage users and parties that are also assigned
-        to the same identity provider.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/IdentityProviderAdmin1'
-    IdentityProviderAdmin1:
-      title: IdentityProviderAdmin
-      description: |-
-        The right to administer the identity provider that the user is assigned to.
-        It means, being able to manage users and parties that are also assigned
-        to the same identity provider.
-      type: object
-    IdentityProviderConfig:
-      title: IdentityProviderConfig
-      type: object
-      required:
-      - identityProviderId
-      - issuer
-      - jwksUrl
-      properties:
-        identityProviderId:
-          description: |-
-            The identity provider identifier
-            Must be a valid LedgerString (as describe in ``value.proto``).
-
-            Required
-          type: string
-        isDeactivated:
-          description: |-
-            When set, the callers using JWT tokens issued by this identity provider are denied all access
-            to the Ledger API.
-            Modifiable
-
-            Optional
-          type: boolean
-        issuer:
-          description: |-
-            Specifies the issuer of the JWT token.
-            The issuer value is a case sensitive URL using the https scheme that contains scheme, host,
-            and optionally, port number and path components and no query or fragment components.
-            Modifiable
-
-            Can be left empty when used in `UpdateIdentityProviderConfigRequest` if the issuer is not being updated.
-
-            Required
-          type: string
-        jwksUrl:
-          description: |-
-            The JWKS (JSON Web Key Set) URL.
-            The Ledger API uses JWKs (JSON Web Keys) from the provided URL to verify that the JWT has been
-            signed with the loaded JWK. Only RS256 (RSA Signature with SHA-256) signing algorithm is supported.
-            Modifiable
-
-            Required
-          type: string
-        audience:
-          description: |-
-            Specifies the audience of the JWT token.
-            When set, the callers using JWT tokens issued by this identity provider are allowed to get an access
-            only if the "aud" claim includes the string specified here
-            Modifiable
-
-            Optional
-          type: string
-    InterfaceFilter:
-      title: InterfaceFilter
-      description: This filter matches contracts that implement a specific interface.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/InterfaceFilter1'
-    InterfaceFilter1:
-      title: InterfaceFilter
-      description: This filter matches contracts that implement a specific interface.
-      type: object
-      required:
-      - interfaceId
-      properties:
-        interfaceId:
-          description: |-
-            The interface that a matching contract must implement.
-            The ``interface_id`` needs to be valid: corresponding interface should be defined in
-            one of the available packages at the time of the query.
-            Both package-name and package-id reference formats for the identifier are supported.
-            Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
-
-            Required
-          type: string
-        includeInterfaceView:
-          description: |-
-            Whether to include the interface view on the contract in the returned ``CreatedEvent``.
-            Use this to access contract data in a uniform manner in your API client.
-
-            Optional
-          type: boolean
-        includeCreatedEventBlob:
-          description: |-
-            Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
-            Use this to access the contract create event payload in your API client
-            for submitting it as a disclosed contract with future commands.
-
-            Optional
-          type: boolean
-    JsActiveContract:
-      title: JsActiveContract
-      type: object
-      required:
-      - createdEvent
-      - synchronizerId
-      - reassignmentCounter
-      properties:
-        createdEvent:
-          $ref: '#/components/schemas/CreatedEvent'
-          description: |-
-            The event as it appeared in the context of its last update (i.e. daml transaction or
-            reassignment). In particular, the last offset, node_id pair is preserved.
-            The last update is the most recent update created or assigned this contract on synchronizer_id synchronizer.
-            The offset of the CreatedEvent might point to an already pruned update, therefore it cannot necessarily be used
-            for lookups.
-
-            Required
-        synchronizerId:
-          description: |-
-            A valid synchronizer id
-
-            Required
-          type: string
-        reassignmentCounter:
-          description: |-
-            Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
-            with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
-            equals zero.
-            This field will be the reassignment_counter of the latest observable activation event on this synchronizer, which is
-            before the active_at_offset.
-
-            Required
-          type: integer
-          format: int64
-    JsArchived:
-      title: JsArchived
-      type: object
-      required:
-      - archivedEvent
-      - synchronizerId
-      properties:
-        archivedEvent:
-          $ref: '#/components/schemas/ArchivedEvent'
-          description: Required
-        synchronizerId:
-          description: |-
-            The synchronizer which sequenced the archival of the contract
-
-            Required
-          type: string
-    JsAssignedEvent:
-      title: JsAssignedEvent
-      description: Records that a contract has been assigned, and it can be used on
-        the target synchronizer.
-      type: object
-      required:
-      - source
-      - target
-      - reassignmentId
-      - reassignmentCounter
-      - createdEvent
-      properties:
-        source:
-          description: |-
-            The ID of the source synchronizer.
-            Must be a valid synchronizer id.
-
-            Required
-          type: string
-        target:
-          description: |-
-            The ID of the target synchronizer.
-            Must be a valid synchronizer id.
-
-            Required
-          type: string
-        reassignmentId:
-          description: |-
-            The ID from the unassigned event.
-            For correlation capabilities.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        submitter:
-          description: |-
-            Party on whose behalf the assign command was executed.
-            Empty if the assignment happened offline via the repair service.
-            Must be a valid PartyIdString (as described in ``value.proto``).
-
-            Optional
-          type: string
-        reassignmentCounter:
-          description: |-
-            Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
-            with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
-            equals zero.
-
-            Required
-          type: integer
-          format: int64
-        createdEvent:
-          $ref: '#/components/schemas/CreatedEvent'
-          description: |-
-            The offset of this event refers to the offset of the assignment,
-            while the node_id is the index of within the batch.
-
-            Required
-    JsAssignmentEvent:
-      title: JsAssignmentEvent
-      type: object
-      required:
-      - source
-      - target
-      - reassignmentId
-      - submitter
-      - reassignmentCounter
-      - createdEvent
-      properties:
-        source:
-          type: string
-        target:
-          type: string
-        reassignmentId:
-          type: string
-        submitter:
-          type: string
-        reassignmentCounter:
-          type: integer
-          format: int64
-        createdEvent:
-          $ref: '#/components/schemas/CreatedEvent'
-    JsCantonError:
-      title: JsCantonError
-      type: object
-      required:
-      - code
-      - cause
-      - context
-      - errorCategory
-      properties:
-        code:
-          type: string
-        cause:
-          type: string
-        correlationId:
-          type: string
-        traceId:
-          type: string
-        context:
-          $ref: '#/components/schemas/Map_String'
-        resources:
-          type: array
-          items:
-            $ref: '#/components/schemas/Tuple2_String_String'
-        errorCategory:
-          type: integer
-          format: int32
-        grpcCodeValue:
-          type: integer
-          format: int32
-        retryInfo:
-          type: string
-        definiteAnswer:
-          type: boolean
-    JsCommands:
-      title: JsCommands
-      description: A composite command that groups multiple commands together.
-      type: object
-      required:
-      - commandId
-      - commands
-      - actAs
-      properties:
-        commands:
-          description: |-
-            Individual elements of this atomic command. Must be non-empty.
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Command'
-        commandId:
-          description: |-
-            Uniquely identifies the command.
-            The triple (user_id, act_as, command_id) constitutes the change ID for the intended ledger change,
-            where act_as is interpreted as a set of party names.
-            The change ID can be used for matching the intended ledger changes with all their completions.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        actAs:
-          description: |-
-            Set of parties on whose behalf the command should be executed.
-            If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
-            to act on behalf of each of the given parties.
-            Each element must be a valid PartyIdString (as described in ``value.proto``).
-
-            Required: must be non-empty
-          type: array
-          items:
+              Required
             type: string
-        userId:
-          description: |-
-            Uniquely identifies the participant user that issued the command.
-            Must be a valid UserIdString (as described in ``value.proto``).
-            Required unless authentication is used with a user token.
-            In that case, the token's user-id will be used for the request's user_id.
+          implementedInterfaces:
+            description: |-
+              The interfaces implemented by the target template that have been
+              matched from the interface filter query.
+              Populated only in case interface filters with include_interface_view set.
 
-            Optional
-          type: string
-        readAs:
-          description: |-
-            Set of parties on whose behalf (in addition to all parties listed in ``act_as``) contracts can be retrieved.
-            This affects Daml operations such as ``fetch``, ``fetchByKey``, ``lookupByKey``, ``exercise``, and ``exerciseByKey``.
-            Note: A participant node of a Daml network can host multiple parties. Each contract present on the participant
-            node is only visible to a subset of these parties. A command can only use contracts that are visible to at least
-            one of the parties in ``act_as`` or ``read_as``. This visibility check is independent from the Daml authorization
-            rules for fetch operations.
-            If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
-            to read contract data on behalf of each of the given parties.
+              If defined, the identifier uses the package-id reference format.
 
-            Optional: can be empty
-          type: array
-          items:
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      AssignCommand:
+        title: AssignCommand
+        description: Assign a contract
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/AssignCommand1'
+      AssignCommand1:
+        title: AssignCommand
+        description: Assign a contract
+        type: object
+        required:
+        - reassignmentId
+        - source
+        - target
+        properties:
+          reassignmentId:
+            description: |-
+              The ID from the unassigned event to be completed by this assignment.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
             type: string
-        workflowId:
-          description: |-
-            Identifier of the on-ledger workflow that this command is a part of.
-            Must be a valid LedgerString (as described in ``value.proto``).
+          source:
+            description: |-
+              The ID of the source synchronizer
+              Must be a valid synchronizer id
 
-            Optional
-          type: string
-        deduplicationPeriod:
-          $ref: '#/components/schemas/DeduplicationPeriod'
-        minLedgerTimeAbs:
-          description: |-
-            Lower bound for the ledger time assigned to the resulting transaction.
-            Note: The ledger time of a transaction is assigned as part of command interpretation.
-            Use this property if you expect that command interpretation will take a considerate amount of time, such that by
-            the time the resulting transaction is sequenced, its assigned ledger time is not valid anymore.
-            Must not be set at the same time as min_ledger_time_rel.
-
-            Optional
-          type: string
-        minLedgerTimeRel:
-          $ref: '#/components/schemas/Duration'
-          description: |-
-            Same as min_ledger_time_abs, but specified as a duration, starting from the time the command is received by the server.
-            Must not be set at the same time as min_ledger_time_abs.
-
-            Optional
-        submissionId:
-          description: |-
-            A unique identifier to distinguish completions for different submissions with the same change ID.
-            Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
-            with the same change ID.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            If omitted, the participant or the committer may set a value of their choice.
-
-            Optional
-          type: string
-        disclosedContracts:
-          description: |-
-            Additional contracts used to resolve contract & contract key lookups.
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/DisclosedContract'
-        synchronizerId:
-          description: |-
-            Must be a valid synchronizer id
-
-            Optional
-          type: string
-        packageIdSelectionPreference:
-          description: |-
-            The package-id selection preference of the client for resolving
-            package names and interface instances in command submission and interpretation
-
-            Optional: can be empty
-          type: array
-          items:
+              Required
             type: string
-        prefetchContractKeys:
-          description: |-
-            Fetches the contract keys into the caches to speed up the command processing.
-            Should only contain contract keys that are expected to be resolved during interpretation of the commands.
-            Keys of disclosed contracts do not need prefetching.
+          target:
+            description: |-
+              The ID of the target synchronizer
+              Must be a valid synchronizer id
 
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/PrefetchContractKey'
-        tapsMaxPasses:
-          description: |-
-            The maximum number of passes for the Topology-Aware Package Selection (TAPS).
-            Higher values can increase the chance of successful package selection for routing of interpreted transactions.
-            If unset, this defaults to the value defined in the participant configuration.
-            The provided value must not exceed the limit specified in the participant configuration.
-
-            Optional
-          type: integer
-          format: int32
-    JsContractEntry:
-      title: JsContractEntry
-      description: |-
-        For a contract there could be multiple contract_entry-s in the entire snapshot. These together define
-        the state of one contract in the snapshot.
-        A contract_entry is included in the result, if and only if there is at least one stakeholder party of the contract
-        that is hosted on the synchronizer at the time of the event and the party satisfies the
-        ``TransactionFilter`` in the query.
-
-        Required
-      oneOf:
-      - type: object
-        required:
-        - JsActiveContract
-        properties:
-          JsActiveContract:
-            $ref: '#/components/schemas/JsActiveContract'
-      - type: object
-        required:
-        - JsEmpty
-        properties:
-          JsEmpty:
-            $ref: '#/components/schemas/JsEmpty'
-      - type: object
-        required:
-        - JsIncompleteAssigned
-        properties:
-          JsIncompleteAssigned:
-            $ref: '#/components/schemas/JsIncompleteAssigned'
-      - type: object
-        required:
-        - JsIncompleteUnassigned
-        properties:
-          JsIncompleteUnassigned:
-            $ref: '#/components/schemas/JsIncompleteUnassigned'
-    JsCreated:
-      title: JsCreated
-      type: object
-      required:
-      - createdEvent
-      - synchronizerId
-      properties:
-        createdEvent:
-          $ref: '#/components/schemas/CreatedEvent'
-          description: |-
-            The event as it appeared in the context of its original update (i.e. daml transaction or
-            reassignment) on this participant node. You can use its offset and node_id to find the
-            corresponding update and the node within it.
-
-            Required
-        synchronizerId:
-          description: |-
-            The synchronizer which sequenced the creation of the contract
-
-            Required
-          type: string
-    JsEmpty:
-      title: JsEmpty
-      type: object
-    JsExecuteSubmissionAndWaitForTransactionRequest:
-      title: JsExecuteSubmissionAndWaitForTransactionRequest
-      type: object
-      required:
-      - preparedTransaction
-      - partySignatures
-      - submissionId
-      - hashingSchemeVersion
-      properties:
-        preparedTransaction:
-          description: |-
-            the prepared transaction
-            Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
-            obtained from calling `prepareSubmission`.
-
-            Required
-          type: string
-        partySignatures:
-          $ref: '#/components/schemas/PartySignatures'
-          description: |-
-            The party(ies) signatures that authorize the prepared submission to be executed by this node.
-            Each party can provide one or more signatures..
-            and one or more parties can sign.
-            Note that currently, only single party submissions are supported.
-
-            Required
-        deduplicationPeriod:
-          $ref: '#/components/schemas/DeduplicationPeriod2'
-        submissionId:
-          description: |-
-            A unique identifier to distinguish completions for different submissions with the same change ID.
-            Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
-            with the same change ID.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        userId:
-          description: |-
-            See [PrepareSubmissionRequest.user_id]
-
-            Optional
-          type: string
-        hashingSchemeVersion:
-          description: |-
-            The hashing scheme version used when building the hash
-
-            Required
-          type: string
-          enum:
-          - HASHING_SCHEME_VERSION_UNSPECIFIED
-          - HASHING_SCHEME_VERSION_V2
-          - HASHING_SCHEME_VERSION_V3
-        minLedgerTime:
-          $ref: '#/components/schemas/MinLedgerTime'
-          description: |-
-            If set will influence the chosen ledger effective time but will not result in a submission delay so any override
-            should be scheduled to executed within the window allowed by synchronizer.
-
-            Optional
-        transactionFormat:
-          $ref: '#/components/schemas/TransactionFormat'
-          description: |-
-            If no ``transaction_format`` is provided, a default will be used where ``transaction_shape`` is set to
-            TRANSACTION_SHAPE_ACS_DELTA, ``event_format`` is defined with ``filters_by_party`` containing wildcard-template
-            filter for all original ``act_as`` and ``read_as`` parties and the ``verbose`` flag is set.
-            When the ``transaction_shape`` TRANSACTION_SHAPE_ACS_DELTA shape is used (explicitly or is defaulted to as explained above),
-            events will only be returned if the submitting party is hosted on this node.
-
-            Optional
-    JsExecuteSubmissionAndWaitForTransactionResponse:
-      title: JsExecuteSubmissionAndWaitForTransactionResponse
-      type: object
-      required:
-      - transaction
-      properties:
-        transaction:
-          $ref: '#/components/schemas/JsTransaction'
-          description: |-
-            The transaction that resulted from the submitted command.
-            The transaction might contain no events (request conditions result in filtering out all of them).
-
-            Required
-    JsExecuteSubmissionAndWaitRequest:
-      title: JsExecuteSubmissionAndWaitRequest
-      type: object
-      required:
-      - preparedTransaction
-      - partySignatures
-      - submissionId
-      - hashingSchemeVersion
-      properties:
-        preparedTransaction:
-          description: |-
-            the prepared transaction
-            Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
-            obtained from calling `prepareSubmission`.
-
-            Required
-          type: string
-        partySignatures:
-          $ref: '#/components/schemas/PartySignatures'
-          description: |-
-            The party(ies) signatures that authorize the prepared submission to be executed by this node.
-            Each party can provide one or more signatures..
-            and one or more parties can sign.
-            Note that currently, only single party submissions are supported.
-
-            Required
-        deduplicationPeriod:
-          $ref: '#/components/schemas/DeduplicationPeriod2'
-        submissionId:
-          description: |-
-            A unique identifier to distinguish completions for different submissions with the same change ID.
-            Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
-            with the same change ID.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        userId:
-          description: |-
-            See [PrepareSubmissionRequest.user_id]
-
-            Optional
-          type: string
-        hashingSchemeVersion:
-          description: |-
-            The hashing scheme version used when building the hash
-
-            Required
-          type: string
-          enum:
-          - HASHING_SCHEME_VERSION_UNSPECIFIED
-          - HASHING_SCHEME_VERSION_V2
-          - HASHING_SCHEME_VERSION_V3
-        minLedgerTime:
-          $ref: '#/components/schemas/MinLedgerTime'
-          description: |-
-            If set will influence the chosen ledger effective time but will not result in a submission delay so any override
-            should be scheduled to executed within the window allowed by synchronizer.
-
-            Optional
-    JsExecuteSubmissionRequest:
-      title: JsExecuteSubmissionRequest
-      type: object
-      required:
-      - preparedTransaction
-      - partySignatures
-      - submissionId
-      - hashingSchemeVersion
-      properties:
-        preparedTransaction:
-          description: |-
-            the prepared transaction
-            Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
-            obtained from calling `prepareSubmission`.
-
-            Required
-          type: string
-        partySignatures:
-          $ref: '#/components/schemas/PartySignatures'
-          description: |-
-            The party(ies) signatures that authorize the prepared submission to be executed by this node.
-            Each party can provide one or more signatures..
-            and one or more parties can sign.
-            Note that currently, only single party submissions are supported.
-
-            Required
-        deduplicationPeriod:
-          $ref: '#/components/schemas/DeduplicationPeriod2'
-        submissionId:
-          description: |-
-            A unique identifier to distinguish completions for different submissions with the same change ID.
-            Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
-            with the same change ID.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        userId:
-          description: |-
-            See [PrepareSubmissionRequest.user_id]
-
-            Optional
-          type: string
-        hashingSchemeVersion:
-          description: |-
-            The hashing scheme version used when building the hash
-
-            Required
-          type: string
-          enum:
-          - HASHING_SCHEME_VERSION_UNSPECIFIED
-          - HASHING_SCHEME_VERSION_V2
-          - HASHING_SCHEME_VERSION_V3
-        minLedgerTime:
-          $ref: '#/components/schemas/MinLedgerTime'
-          description: |-
-            If set will influence the chosen ledger effective time but will not result in a submission delay so any override
-            should be scheduled to executed within the window allowed by synchronizer.
-
-            Optional
-    JsGetActiveContractsResponse:
-      title: JsGetActiveContractsResponse
-      type: object
-      properties:
-        workflowId:
-          description: |-
-            The workflow ID used in command submission which corresponds to the contract_entry. Only set if
-            the ``workflow_id`` for the command was set.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Optional
-          type: string
-        contractEntry:
-          $ref: '#/components/schemas/JsContractEntry'
-        streamContinuationToken:
-          description: |-
-            Opaque representation of a continuation token which can be used in the request to bypass the already processed part
-            of the active contracts snapshot.
-            Only populated for the streaming ``GetActiveContracts`` rpc call.
-
-            Optional: can be empty
-          type: string
-    JsGetEventsByContractIdResponse:
-      title: JsGetEventsByContractIdResponse
-      type: object
-      properties:
-        created:
-          $ref: '#/components/schemas/JsCreated'
-          description: |-
-            The create event for the contract with the ``contract_id`` given in the request
-            provided it exists and has not yet been pruned.
-
-            Optional
-        archived:
-          $ref: '#/components/schemas/JsArchived'
-          description: |-
-            The archive event for the contract with the ``contract_id`` given in the request
-            provided such an archive event exists and it has not yet been pruned.
-
-            Optional
-    JsGetTransactionResponse:
-      title: JsGetTransactionResponse
-      description: Provided for backwards compatibility, it will be removed in the
-        Canton version 3.5.0.
-      type: object
-      required:
-      - transaction
-      properties:
-        transaction:
-          $ref: '#/components/schemas/JsTransaction'
-          description: Required
-    JsGetTransactionTreeResponse:
-      title: JsGetTransactionTreeResponse
-      description: Provided for backwards compatibility, it will be removed in the
-        Canton version 3.5.0.
-      type: object
-      required:
-      - transaction
-      properties:
-        transaction:
-          $ref: '#/components/schemas/JsTransactionTree'
-          description: Required
-    JsGetUpdateResponse:
-      title: JsGetUpdateResponse
-      type: object
-      properties:
-        update:
-          $ref: '#/components/schemas/Update'
-    JsGetUpdateTreesResponse:
-      title: JsGetUpdateTreesResponse
-      description: Provided for backwards compatibility, it will be removed in the
-        Canton version 3.5.0.
-      type: object
-      properties:
-        update:
-          $ref: '#/components/schemas/Update1'
-    JsGetUpdatesResponse:
-      title: JsGetUpdatesResponse
-      type: object
-      properties:
-        update:
-          $ref: '#/components/schemas/Update'
-    JsIncompleteAssigned:
-      title: JsIncompleteAssigned
-      type: object
-      required:
-      - assignedEvent
-      properties:
-        assignedEvent:
-          $ref: '#/components/schemas/JsAssignedEvent'
-          description: Required
-    JsIncompleteUnassigned:
-      title: JsIncompleteUnassigned
-      type: object
-      required:
-      - createdEvent
-      - unassignedEvent
-      properties:
-        createdEvent:
-          $ref: '#/components/schemas/CreatedEvent'
-          description: |-
-            The event as it appeared in the context of its last activation update (i.e. daml transaction or
-            reassignment). In particular, the last activation offset, node_id pair is preserved.
-            The last activation update is the most recent update created or assigned this contract on synchronizer_id synchronizer before
-            the unassigned_event.
-            The offset of the CreatedEvent might point to an already pruned update, therefore it cannot necessarily be used
-            for lookups.
-
-            Required
-        unassignedEvent:
-          $ref: '#/components/schemas/UnassignedEvent'
-          description: Required
-    JsInterfaceView:
-      title: JsInterfaceView
-      description: View of a create event matched by an interface filter.
-      type: object
-      required:
-      - interfaceId
-      - viewStatus
-      properties:
-        interfaceId:
-          description: |-
-            The interface implemented by the matched event.
-            The identifier uses the package-id reference format.
-
-            Required
-          type: string
-        viewStatus:
-          $ref: '#/components/schemas/JsStatus'
-          description: |-
-            Whether the view was successfully computed, and if not,
-            the reason for the error. The error is reported using the same rules
-            for error codes and messages as the errors returned for API requests.
-
-            Required
-        viewValue:
-          description: |-
-            The value of the interface's view method on this event.
-            Set if it was requested in the ``InterfaceFilter`` and it could be
-            successfully computed.
-
-            Optional
-        implementationPackageId:
-          description: |-
-            The package defining the interface implementation used to compute the view.
-            Can be different from the package that was used to create the contract itself,
-            as the contract arguments can be upgraded or downgraded using smart-contract upgrading
-            as part of computing the interface view.
-            Populated if the view computation is successful, otherwise empty.
-
-            Optional
-          type: string
-    JsPrepareSubmissionRequest:
-      title: JsPrepareSubmissionRequest
-      type: object
-      required:
-      - commandId
-      - commands
-      - actAs
-      properties:
-        userId:
-          description: |-
-            Uniquely identifies the participant user that prepares the transaction.
-            Must be a valid UserIdString (as described in ``value.proto``).
-            Required unless authentication is used with a user token.
-            In that case, the token's user-id will be used for the request's user_id.
-
-            Optional
-          type: string
-        commandId:
-          description: |-
-            Uniquely identifies the command.
-            The triple (user_id, act_as, command_id) constitutes the change ID for the intended ledger change,
-            where act_as is interpreted as a set of party names.
-            The change ID can be used for matching the intended ledger changes with all their completions.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        commands:
-          description: |-
-            Individual elements of this atomic command. Must be non-empty.
-            Limitation: Only single command transaction are currently supported by the API.
-            The field is marked as repeated in preparation for future support of multiple commands.
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Command'
-        minLedgerTime:
-          $ref: '#/components/schemas/MinLedgerTime'
-          description: Optional
-        actAs:
-          description: |-
-            Set of parties on whose behalf the command should be executed, if submitted.
-            If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
-            to **read** (not act) on behalf of each of the given parties. This is because this RPC merely prepares a transaction
-            and does not execute it. Therefore read authorization is sufficient even for actAs parties.
-            Note: This may change, and more specific authorization scope may be introduced in the future.
-            Each element must be a valid PartyIdString (as described in ``value.proto``).
-
-            Required: must be non-empty
-          type: array
-          items:
+              Required
             type: string
-        readAs:
-          description: |-
-            Set of parties on whose behalf (in addition to all parties listed in ``act_as``) contracts can be retrieved.
-            This affects Daml operations such as ``fetch``, ``fetchByKey``, ``lookupByKey``, ``exercise``, and ``exerciseByKey``.
-            Note: A command can only use contracts that are visible to at least
-            one of the parties in ``act_as`` or ``read_as``. This visibility check is independent from the Daml authorization
-            rules for fetch operations.
-            If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
-            to read contract data on behalf of each of the given parties.
+      CanActAs:
+        title: CanActAs
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanActAs1'
+      CanActAs1:
+        title: CanActAs
+        type: object
+        required:
+        - party
+        properties:
+          party:
+            description: |-
+              The right to authorize commands for this party.
 
-            Optional: can be empty
-          type: array
-          items:
+              Required
             type: string
-        disclosedContracts:
-          description: |-
-            Additional contracts used to resolve contract & contract key lookups.
+      CanExecuteAs:
+        title: CanExecuteAs
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanExecuteAs1'
+      CanExecuteAs1:
+        title: CanExecuteAs
+        type: object
+        required:
+        - party
+        properties:
+          party:
+            description: |-
+              The right to prepare and execute submissions as this party.
+              This right does not entitle the user to perform any reads.
+              If reading is required, a separate ReadAs right must be added.
+              Right to execute as a party is also implicitly contained in the CanActAs right.
 
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/DisclosedContract'
-        synchronizerId:
-          description: |-
-            Must be a valid synchronizer id
-            If not set, a suitable synchronizer that this node is connected to will be chosen
-
-            Optional
-          type: string
-        packageIdSelectionPreference:
-          description: |-
-            The package-id selection preference of the client for resolving
-            package names and interface instances in command submission and interpretation
-
-            Optional: can be empty
-          type: array
-          items:
+              Required
             type: string
-        verboseHashing:
-          description: |-
-            When true, the response will contain additional details on how the transaction was encoded and hashed
-            This can be useful for troubleshooting of hash mismatches. Should only be used for debugging.
-            Defaults to false
-
-            Optional
-          type: boolean
-        prefetchContractKeys:
-          description: |-
-            Fetches the contract keys into the caches to speed up the command processing.
-            Should only contain contract keys that are expected to be resolved during interpretation of the commands.
-            Keys of disclosed contracts do not need prefetching.
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/PrefetchContractKey'
-        maxRecordTime:
-          description: |-
-            Maximum timestamp at which the transaction can be recorded onto the ledger via the synchronizer specified in the `PrepareSubmissionResponse`.
-            If submitted after it will be rejected even if otherwise valid, in which case it needs to be prepared and signed again
-            with a new valid max_record_time.
-            Use this to limit the time-to-life of a prepared transaction,
-            which is useful to know when it can definitely not be accepted
-            anymore and resorting to preparing another transaction for the same
-            intent is safe again.
-
-            Optional
-          type: string
-        estimateTrafficCost:
-          $ref: '#/components/schemas/CostEstimationHints'
-          description: |-
-            Hints to improve the accuracy of traffic cost estimation.
-            The estimation logic assumes that this node will be used for the execution of the transaction
-            If another node is used instead, the estimation may be less precise.
-            Request amplification is not accounted for in the estimation: each amplified request will
-            result in the cost of the confirmation request to be charged additionally.
-
-            Traffic cost estimation is enabled by default if this field is not set
-            To turn off cost estimation, set the CostEstimationHints#disabled field to true
-
-            Optional
-        tapsMaxPasses:
-          description: |-
-            The maximum number of passes for the Topology-Aware Package Selection (TAPS).
-            Higher values can increase the chance of successful package selection for routing of interpreted transactions.
-            If unset, this defaults to the value defined in the participant configuration.
-            The provided value must not exceed the limit specified in the participant configuration.
-
-            Optional
-          type: integer
-          format: int32
-        hashingSchemeVersion:
-          description: |-
-            The hashing scheme version to be used when building the hash.
-            Defaults to HASHING_SCHEME_VERSION_V2.
-
-            Optional
-          type: string
-          enum:
-          - HASHING_SCHEME_VERSION_UNSPECIFIED
-          - HASHING_SCHEME_VERSION_V2
-          - HASHING_SCHEME_VERSION_V3
-    JsPrepareSubmissionResponse:
-      title: JsPrepareSubmissionResponse
-      description: '[docs-entry-end: HashingSchemeVersion]'
-      type: object
-      required:
-      - preparedTransaction
-      - preparedTransactionHash
-      - hashingSchemeVersion
-      properties:
-        preparedTransaction:
-          description: |-
-            The interpreted transaction, it represents the ledger changes necessary to execute the commands specified in the request.
-            Clients MUST display the content of the transaction to the user for them to validate before signing the hash if the preparing participant is not trusted.
-
-            Required
-          type: string
-        preparedTransactionHash:
-          description: |-
-            Hash of the transaction, this is what needs to be signed by the party to authorize the transaction.
-            Only provided for convenience, clients MUST recompute the hash from the raw transaction if the preparing participant is not trusted.
-            May be removed in future versions
-
-            Required: must be non-empty
-          type: string
-        hashingSchemeVersion:
-          description: |-
-            The hashing scheme version used when building the hash
-
-            Required
-          type: string
-          enum:
-          - HASHING_SCHEME_VERSION_UNSPECIFIED
-          - HASHING_SCHEME_VERSION_V2
-          - HASHING_SCHEME_VERSION_V3
-        hashingDetails:
-          description: |-
-            Optional additional details on how the transaction was encoded and hashed. Only set if verbose_hashing = true in the request
-            Note that there are no guarantees on the stability of the format or content of this field.
-            Its content should NOT be parsed and should only be used for troubleshooting purposes.
-
-            Optional
-          type: string
-        costEstimation:
-          $ref: '#/components/schemas/CostEstimation'
-          description: |-
-            Traffic cost estimation of the prepared transaction
-
-            Optional
-    JsReassignment:
-      title: JsReassignment
-      description: Complete view of an on-ledger reassignment.
-      type: object
-      required:
-      - updateId
-      - offset
-      - recordTime
-      - synchronizerId
-      - events
-      properties:
-        updateId:
-          description: |-
-            Assigned by the server. Useful for correlating logs.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        commandId:
-          description: |-
-            The ID of the command which resulted in this reassignment. Missing for everyone except the submitting party on the submitting participant.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Optional
-          type: string
-        workflowId:
-          description: |-
-            The workflow ID used in reassignment command submission. Only set if the ``workflow_id`` for the command was set.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Optional
-          type: string
-        offset:
-          description: |-
-            The participant's offset. The details of this field are described in ``community/ledger-api/README.md``.
-            Must be a valid absolute offset (positive integer).
-
-            Required
-          type: integer
-          format: int64
-        events:
-          description: |-
-            The collection of reassignment events.
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/JsReassignmentEvent'
-        traceContext:
-          $ref: '#/components/schemas/TraceContext'
-          description: |-
-            Ledger API trace context
-
-            The trace context transported in this message corresponds to the trace context supplied
-            by the client application in a HTTP2 header of the original command submission.
-            We typically use a header to transfer this type of information. Here we use message
-            body, because it is used in gRPC streams which do not support per message headers.
-            This field will be populated with the trace context contained in the original submission.
-            If that was not provided, a unique ledger-api-server generated trace context will be used
-            instead.
-
-            Optional
-        recordTime:
-          description: |-
-            The time at which the reassignment was recorded. The record time refers to the source/target
-            synchronizer for an unassign/assign event respectively.
-
-            Required
-          type: string
-        synchronizerId:
-          description: |-
-            A valid synchronizer id.
-            Identifies the synchronizer that synchronized this Reassignment.
-
-            Required
-          type: string
-        paidTrafficCost:
-          description: |-
-            The traffic cost that this participant node paid for the corresponding (un)assignment request.
-
-            Not set for transactions that were
-            - initiated by another participant
-            - initiated offline via the repair service
-            - processed before the participant started serving traffic cost on the Ledger API
-            - returned as part of a query filtering for a non submitting party
-
-            Optional
-          type: integer
-          format: int64
-    JsReassignmentEvent:
-      title: JsReassignmentEvent
-      oneOf:
-      - type: object
+      CanExecuteAsAnyParty:
+        title: CanExecuteAsAnyParty
+        description: |-
+          The rights of a user to prepare and execute transactions as any party.
+          Its utility is predominantly for users that perform interactive submissions
+          on behalf of many parties.
+        type: object
         required:
-        - JsAssignmentEvent
+        - value
         properties:
-          JsAssignmentEvent:
-            $ref: '#/components/schemas/JsAssignmentEvent'
-      - type: object
+          value:
+            $ref: '#/components/schemas/CanExecuteAsAnyParty1'
+      CanExecuteAsAnyParty1:
+        title: CanExecuteAsAnyParty
+        description: |-
+          The rights of a user to prepare and execute transactions as any party.
+          Its utility is predominantly for users that perform interactive submissions
+          on behalf of many parties.
+        type: object
+      CanReadAs:
+        title: CanReadAs
+        type: object
         required:
-        - JsUnassignedEvent
+        - value
         properties:
-          JsUnassignedEvent:
-            $ref: '#/components/schemas/JsUnassignedEvent'
-    JsStatus:
-      title: JsStatus
-      type: object
-      required:
-      - code
-      - message
-      properties:
-        code:
-          type: integer
-          format: int32
-        message:
-          type: string
-        details:
-          type: array
-          items:
-            $ref: '#/components/schemas/ProtoAny'
-    JsSubmitAndWaitForReassignmentResponse:
-      title: JsSubmitAndWaitForReassignmentResponse
-      type: object
-      required:
-      - reassignment
-      properties:
-        reassignment:
-          $ref: '#/components/schemas/JsReassignment'
-          description: |-
-            The reassignment that resulted from the submitted reassignment command.
-            The reassignment might contain no events (request conditions result in filtering out all of them).
-
-            Required
-    JsSubmitAndWaitForTransactionRequest:
-      title: JsSubmitAndWaitForTransactionRequest
-      description: These commands are executed as a single atomic transaction.
-      type: object
-      required:
-      - commands
-      properties:
-        commands:
-          $ref: '#/components/schemas/JsCommands'
-          description: |-
-            The commands to be submitted.
-
-            Required
-        transactionFormat:
-          $ref: '#/components/schemas/TransactionFormat'
-          description: |-
-            If no ``transaction_format`` is provided, a default will be used where ``transaction_shape`` is set to
-            TRANSACTION_SHAPE_ACS_DELTA, ``event_format`` is defined with ``filters_by_party`` containing wildcard-template
-            filter for all original ``act_as`` and ``read_as`` parties and the ``verbose`` flag is set.
-
-            Optional
-    JsSubmitAndWaitForTransactionResponse:
-      title: JsSubmitAndWaitForTransactionResponse
-      type: object
-      required:
-      - transaction
-      properties:
-        transaction:
-          $ref: '#/components/schemas/JsTransaction'
-          description: |-
-            The transaction that resulted from the submitted command.
-            The transaction might contain no events (request conditions result in filtering out all of them).
-
-            Required
-    JsSubmitAndWaitForTransactionTreeResponse:
-      title: JsSubmitAndWaitForTransactionTreeResponse
-      description: Provided for backwards compatibility, it will be removed in the
-        Canton version 3.5.0.
-      type: object
-      properties:
-        transactionTree:
-          $ref: '#/components/schemas/JsTransactionTree'
-    JsTopologyTransaction:
-      title: JsTopologyTransaction
-      type: object
-      required:
-      - updateId
-      - offset
-      - synchronizerId
-      - recordTime
-      - events
-      properties:
-        updateId:
-          description: |-
-            Assigned by the server. Useful for correlating logs.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        offset:
-          description: |-
-            The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
-            It is a valid absolute offset (positive integer).
-
-            Required
-          type: integer
-          format: int64
-        synchronizerId:
-          description: |-
-            A valid synchronizer id.
-            Identifies the synchronizer that synchronized the topology transaction.
-
-            Required
-          type: string
-        recordTime:
-          description: |-
-            The time at which the changes in the topology transaction become effective. There is a small delay between a
-            topology transaction being sequenced and the changes it contains becoming effective. Topology transactions appear
-            in order relative to a synchronizer based on their effective time rather than their sequencing time.
-
-            Required
-          type: string
-        events:
-          description: |-
-            A non-empty list of topology events.
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/TopologyEvent'
-        traceContext:
-          $ref: '#/components/schemas/TraceContext'
-          description: |-
-            Ledger API trace context
-
-            The trace context transported in this message corresponds to the trace context supplied
-            by the client application in a HTTP2 header of the original command submission.
-            We typically use a header to transfer this type of information. Here we use message
-            body, because it is used in gRPC streams which do not support per message headers.
-            This field will be populated with the trace context contained in the original submission.
-            If that was not provided, a unique ledger-api-server generated trace context will be used
-            instead.
-
-            Optional
-    JsTransaction:
-      title: JsTransaction
-      description: Filtered view of an on-ledger transaction's create and archive
-        events.
-      type: object
-      required:
-      - updateId
-      - effectiveAt
-      - offset
-      - synchronizerId
-      - recordTime
-      - events
-      properties:
-        updateId:
-          description: |-
-            Assigned by the server. Useful for correlating logs.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        commandId:
-          description: |-
-            The ID of the command which resulted in this transaction. Missing for everyone except the submitting party.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Optional
-          type: string
-        workflowId:
-          description: |-
-            The workflow ID used in command submission.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Optional
-          type: string
-        effectiveAt:
-          description: |-
-            Ledger effective time.
-
-            Required
-          type: string
-        events:
-          description: |-
-            The collection of events.
-            Contains:
-
-            - ``CreatedEvent`` or ``ArchivedEvent`` in case of ACS_DELTA transaction shape
-            - ``CreatedEvent`` or ``ExercisedEvent`` in case of LEDGER_EFFECTS transaction shape
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Event'
-        offset:
-          description: |-
-            The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
-            It is a valid absolute offset (positive integer).
-
-            Required
-          type: integer
-          format: int64
-        synchronizerId:
-          description: |-
-            A valid synchronizer id.
-            Identifies the synchronizer that synchronized the transaction.
-
-            Required
-          type: string
-        traceContext:
-          $ref: '#/components/schemas/TraceContext'
-          description: |-
-            Ledger API trace context
-
-            The trace context transported in this message corresponds to the trace context supplied
-            by the client application in a HTTP2 header of the original command submission.
-            We typically use a header to transfer this type of information. Here we use message
-            body, because it is used in gRPC streams which do not support per message headers.
-            This field will be populated with the trace context contained in the original submission.
-            If that was not provided, a unique ledger-api-server generated trace context will be used
-            instead.
-
-            Optional
-        recordTime:
-          description: |-
-            The time at which the transaction was recorded. The record time refers to the synchronizer
-            which synchronized the transaction.
-
-            Required
-          type: string
-        externalTransactionHash:
-          description: |-
-            For transaction externally signed, contains the external transaction hash
-            signed by the external party. Can be used to correlate an external submission with a committed transaction.
-
-            Optional: can be empty
-          type: string
-        paidTrafficCost:
-          description: |-
-            The traffic cost that this participant node paid for the confirmation
-            request for this transaction.
-
-            Not set for transactions that were
-            - initiated by another participant
-            - initiated offline via the repair service
-            - processed before the participant started serving traffic cost on the Ledger API
-            - returned as part of a query filtering for a non submitting party
-
-            Optional
-          type: integer
-          format: int64
-    JsTransactionTree:
-      title: JsTransactionTree
-      description: |-
-        Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
-        Complete view of an on-ledger transaction.
-      type: object
-      required:
-      - updateId
-      - effectiveAt
-      - offset
-      - eventsById
-      - synchronizerId
-      - recordTime
-      properties:
-        updateId:
-          description: |-
-            Assigned by the server. Useful for correlating logs.
-            Must be a valid LedgerString (as described in ``value.proto``).
-            Required
-          type: string
-        commandId:
-          description: |-
-            The ID of the command which resulted in this transaction. Missing for everyone except the submitting party.
-            Must be a valid LedgerString (as described in ``value.proto``).
-            Optional
-          type: string
-        workflowId:
-          description: |-
-            The workflow ID used in command submission. Only set if the ``workflow_id`` for the command was set.
-            Must be a valid LedgerString (as described in ``value.proto``).
-            Optional
-          type: string
-        effectiveAt:
-          description: |-
-            Ledger effective time.
-            Required
-          type: string
-        offset:
-          description: |-
-            The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
-            Required, it is a valid absolute offset (positive integer).
-          type: integer
-          format: int64
-        eventsById:
-          $ref: '#/components/schemas/Map_Int_TreeEvent'
-          description: |-
-            Changes to the ledger that were caused by this transaction. Nodes of the transaction tree.
-            Each key must be a valid node ID (non-negative integer).
-            Required
-        synchronizerId:
-          description: |-
-            A valid synchronizer id.
-            Identifies the synchronizer that synchronized the transaction.
-            Required
-          type: string
-        traceContext:
-          $ref: '#/components/schemas/TraceContext'
-          description: |-
-            Optional; ledger API trace context
-
-            The trace context transported in this message corresponds to the trace context supplied
-            by the client application in a HTTP2 header of the original command submission.
-            We typically use a header to transfer this type of information. Here we use message
-            body, because it is used in gRPC streams which do not support per message headers.
-            This field will be populated with the trace context contained in the original submission.
-            If that was not provided, a unique ledger-api-server generated trace context will be used
-            instead.
-        recordTime:
-          description: |-
-            The time at which the transaction was recorded. The record time refers to the synchronizer
-            which synchronized the transaction.
-            Required
-          type: string
-    JsUnassignedEvent:
-      title: JsUnassignedEvent
-      description: Records that a contract has been unassigned, and it becomes unusable
-        on the source synchronizer
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/UnassignedEvent'
-    Kind:
-      title: Kind
-      description: Required
-      oneOf:
-      - type: object
+          value:
+            $ref: '#/components/schemas/CanReadAs1'
+      CanReadAs1:
+        title: CanReadAs
+        type: object
         required:
-        - CanActAs
+        - party
         properties:
-          CanActAs:
-            $ref: '#/components/schemas/CanActAs'
-      - type: object
-        required:
-        - CanExecuteAs
-        properties:
-          CanExecuteAs:
-            $ref: '#/components/schemas/CanExecuteAs'
-      - type: object
-        required:
-        - CanExecuteAsAnyParty
-        properties:
-          CanExecuteAsAnyParty:
-            $ref: '#/components/schemas/CanExecuteAsAnyParty'
-      - type: object
-        required:
-        - CanReadAs
-        properties:
-          CanReadAs:
-            $ref: '#/components/schemas/CanReadAs'
-      - type: object
-        required:
-        - CanReadAsAnyParty
-        properties:
-          CanReadAsAnyParty:
-            $ref: '#/components/schemas/CanReadAsAnyParty'
-      - type: object
-        required:
-        - Empty
-        properties:
-          Empty:
-            $ref: '#/components/schemas/Empty8'
-      - type: object
-        required:
-        - IdentityProviderAdmin
-        properties:
-          IdentityProviderAdmin:
-            $ref: '#/components/schemas/IdentityProviderAdmin'
-      - type: object
-        required:
-        - ParticipantAdmin
-        properties:
-          ParticipantAdmin:
-            $ref: '#/components/schemas/ParticipantAdmin'
-    ListIdentityProviderConfigsResponse:
-      title: ListIdentityProviderConfigsResponse
-      type: object
-      required:
-      - identityProviderConfigs
-      properties:
-        identityProviderConfigs:
-          description: |-
-            The list of identity provider configs
+          party:
+            description: |-
+              The right to read ledger data visible to this party.
 
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/IdentityProviderConfig'
-    ListKnownPartiesResponse:
-      title: ListKnownPartiesResponse
-      type: object
-      required:
-      - partyDetails
-      properties:
-        partyDetails:
-          description: |-
-            The details of all Daml parties known by the participant.
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/PartyDetails'
-        nextPageToken:
-          description: |-
-            Pagination token to retrieve the next page.
-            Empty, if there are no further results.
-
-            Optional
-          type: string
-    ListPackagesResponse:
-      title: ListPackagesResponse
-      type: object
-      required:
-      - packageIds
-      properties:
-        packageIds:
-          description: |-
-            The IDs of all Daml-LF packages supported by the server.
-            Each element must be a valid PackageIdString (as described in ``value.proto``).
-
-            Required: must be non-empty
-          type: array
-          items:
+              Required
             type: string
-    ListUserRightsResponse:
-      title: ListUserRightsResponse
-      type: object
-      properties:
-        rights:
-          description: |-
-            All rights of the user.
+      CanReadAsAnyParty:
+        title: CanReadAsAnyParty
+        description: |-
+          The rights of a participant's super reader. Its utility is predominantly for
+          feeding external tools, such as PQS, continually without the need to change subscriptions
+          as new parties pop in and out of existence.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CanReadAsAnyParty1'
+      CanReadAsAnyParty1:
+        title: CanReadAsAnyParty
+        description: |-
+          The rights of a participant's super reader. Its utility is predominantly for
+          feeding external tools, such as PQS, continually without the need to change subscriptions
+          as new parties pop in and out of existence.
+        type: object
+      Command:
+        title: Command
+        description: A command can either create a new contract or exercise a choice
+          on an existing contract.
+        oneOf:
+        - type: object
+          required:
+          - CreateAndExerciseCommand
+          properties:
+            CreateAndExerciseCommand:
+              $ref: '#/components/schemas/CreateAndExerciseCommand'
+        - type: object
+          required:
+          - CreateCommand
+          properties:
+            CreateCommand:
+              $ref: '#/components/schemas/CreateCommand'
+        - type: object
+          required:
+          - ExerciseByKeyCommand
+          properties:
+            ExerciseByKeyCommand:
+              $ref: '#/components/schemas/ExerciseByKeyCommand'
+        - type: object
+          required:
+          - ExerciseCommand
+          properties:
+            ExerciseCommand:
+              $ref: '#/components/schemas/ExerciseCommand'
+      Command1:
+        title: Command
+        description: A command can either create a new contract or exercise a choice
+          on an existing contract.
+        oneOf:
+        - type: object
+          required:
+          - AssignCommand
+          properties:
+            AssignCommand:
+              $ref: '#/components/schemas/AssignCommand'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty2'
+        - type: object
+          required:
+          - UnassignCommand
+          properties:
+            UnassignCommand:
+              $ref: '#/components/schemas/UnassignCommand'
+      Completion:
+        title: Completion
+        description: 'A completion represents the status of a submitted command on the
+          ledger: it can be successful or failed.'
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Completion1'
+      Completion1:
+        title: Completion
+        description: 'A completion represents the status of a submitted command on the
+          ledger: it can be successful or failed.'
+        type: object
+        required:
+        - commandId
+        - userId
+        - offset
+        - actAs
+        - synchronizerTime
+        properties:
+          commandId:
+            description: |-
+              The ID of the succeeded or failed command.
+              Must be a valid LedgerString (as described in ``value.proto``).
 
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Right'
-    ListUsersResponse:
-      title: ListUsersResponse
-      type: object
-      properties:
-        users:
-          description: |-
-            A subset of users of the participant node that fit into this page.
-            Can be empty if no more users
+              Required
+            type: string
+          status:
+            $ref: '#/components/schemas/JsStatus'
+            description: |-
+              Identifies the exact type of the error.
+              It uses the same format of conveying error details as it is used for the RPC responses of the APIs.
 
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/User'
-        nextPageToken:
-          description: |-
-            Pagination token to retrieve the next page.
-            Empty, if there are no further results.
+              Optional
+          updateId:
+            description: |-
+              The update_id of the transaction or reassignment that resulted from the command with command_id.
 
-            Optional
-          type: string
-    ListVettedPackagesRequest:
-      title: ListVettedPackagesRequest
-      type: object
-      properties:
-        packageMetadataFilter:
-          $ref: '#/components/schemas/PackageMetadataFilter'
-          description: |-
-            The package metadata filter the returned vetted packages set must satisfy.
+              Only set for successfully executed commands.
+              Must be a valid LedgerString (as described in ``value.proto``).
 
-            Optional
-        topologyStateFilter:
-          $ref: '#/components/schemas/TopologyStateFilter'
-          description: |-
-            The topology filter the returned vetted packages set must satisfy.
+              Optional
+            type: string
+          userId:
+            description: |-
+              The user-id that was used for the submission, as described in ``commands.proto``.
+              Must be a valid UserIdString (as described in ``value.proto``).
 
-            Optional
-        pageToken:
-          description: |-
-            Pagination token to determine the specific page to fetch. Using the token
-            guarantees that ``VettedPackages`` on a subsequent page are all greater
-            (``VettedPackages`` are sorted by synchronizer ID then participant ID) than
-            the last ``VettedPackages`` on a previous page.
+              Required
+            type: string
+          actAs:
+            description: |-
+              The set of parties on whose behalf the commands were executed.
+              Contains the ``act_as`` parties from ``commands.proto``
+              filtered to the requesting parties in CompletionStreamRequest.
+              The order of the parties need not be the same as in the submission.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
 
-            The server does not store intermediate results between calls chained by a
-            series of page tokens. As a consequence, if new vetted packages are being
-            added and a page is requested twice using the same token, more packages can
-            be returned on the second call.
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          submissionId:
+            description: |-
+              The submission ID this completion refers to, as described in ``commands.proto``.
+              Must be a valid LedgerString (as described in ``value.proto``).
 
-            Leave unspecified (i.e. as empty string) to fetch the first page.
+              Optional
+            type: string
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod1'
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              The Ledger API trace context
 
-            Optional
-          type: string
-        pageSize:
-          description: |-
-            Maximum number of ``VettedPackages`` results to return in a single page.
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
 
-            If the page_size is unspecified (i.e. left as 0), the server will decide
-            the number of results to be returned.
+              Optional
+          offset:
+            description: |-
+              May be used in a subsequent CompletionStreamRequest to resume the consumption of this stream at a later time.
+              Must be a valid absolute offset (positive integer).
 
-            If the page_size exceeds the maximum supported by the server, an
-            error will be returned.
-
-            To obtain the server's maximum consult the PackageService descriptor
-            available in the VersionService.
-
-            Optional
-          type: integer
-          format: int32
-    ListVettedPackagesResponse:
-      title: ListVettedPackagesResponse
-      type: object
-      properties:
-        vettedPackages:
-          description: |-
-            All ``VettedPackages`` that contain at least one ``VettedPackage`` matching
-            both a ``PackageMetadataFilter`` and a ``TopologyStateFilter``.
-            Sorted by synchronizer_id then participant_id.
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/VettedPackages'
-        nextPageToken:
-          description: |-
-            Pagination token to retrieve the next page.
-            Empty string if there are no further results.
-
-            Optional
-          type: string
-    Map_Filters:
-      title: Map_Filters
-      type: object
-      additionalProperties:
-        $ref: '#/components/schemas/Filters'
-    Map_Int_Field:
-      title: Map_Int_Field
-      type: object
-      additionalProperties:
-        $ref: '#/components/schemas/Field'
-    Map_Int_TreeEvent:
-      title: Map_Int_TreeEvent
-      type: object
-      additionalProperties:
-        $ref: '#/components/schemas/TreeEvent'
-    Map_String:
-      title: Map_String
-      type: object
-      additionalProperties:
-        type: string
-    MinLedgerTime:
-      title: MinLedgerTime
-      type: object
-      properties:
-        time:
-          $ref: '#/components/schemas/Time'
-    MinLedgerTimeAbs:
-      title: MinLedgerTimeAbs
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          type: string
-    MinLedgerTimeRel:
-      title: MinLedgerTimeRel
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/Duration'
-    NoPrior:
-      title: NoPrior
-      type: object
-    ObjectMeta:
-      title: ObjectMeta
-      description: |-
-        Represents metadata corresponding to a participant resource (e.g. a participant user or participant local information about a party).
-
-        Based on ``ObjectMeta`` meta used in Kubernetes API.
-        See https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/generated.proto#L640
-      type: object
-      properties:
-        resourceVersion:
-          description: |-
-            An opaque, non-empty value, populated by a participant server which represents the internal version of the resource
-            this ``ObjectMeta`` message is attached to. The participant server will change it to a unique value each time the corresponding resource is updated.
-            You must not rely on the format of resource version. The participant server might change it without notice.
-            You can obtain the newest resource version value by issuing a read request.
-            You may use it for concurrent change detection by passing it back unmodified in an update request.
-            The participant server will then compare the passed value with the value maintained by the system to determine
-            if any other updates took place since you had read the resource version.
-            Upon a successful update you are guaranteed that no other update took place during your read-modify-write sequence.
-            However, if another update took place during your read-modify-write sequence then your update will fail with an appropriate error.
-            Concurrent change control is optional. It will be applied only if you include a resource version in an update request.
-            When creating a new instance of a resource you must leave the resource version empty.
-            Its value will be populated by the participant server upon successful resource creation.
-
-            Optional
-          type: string
-        annotations:
-          $ref: '#/components/schemas/Map_String'
-          description: |-
-            A set of modifiable key-value pairs that can be used to represent arbitrary, client-specific metadata.
-            Constraints:
-
-            1. The total size over all keys and values cannot exceed 256kb in UTF-8 encoding.
-            2. Keys are composed of an optional prefix segment and a required name segment such that:
-
-               - key prefix, when present, must be a valid DNS subdomain with at most 253 characters, followed by a '/' (forward slash) character,
-               - name segment must have at most 63 characters that are either alphanumeric ([a-z0-9A-Z]), or a '.' (dot), '-' (dash) or '_' (underscore);
-                 and it must start and end with an alphanumeric character.
-
-            3. Values can be any non-empty strings.
-
-            Keys with empty prefix are reserved for end-users.
-            Properties set by external tools or internally by the participant server must use non-empty key prefixes.
-            Duplicate keys are disallowed by the semantics of the protobuf3 maps.
-            See: https://developers.google.com/protocol-buffers/docs/proto3#maps
-            Annotations may be a part of a modifiable resource.
-            Use the resource's update RPC to update its annotations.
-            In order to add a new annotation or update an existing one using an update RPC, provide the desired annotation in the update request.
-            In order to remove an annotation using an update RPC, provide the target annotation's key but set its value to the empty string in the update request.
-            Modifiable
-
-            Optional: can be empty
-    OffsetCheckpoint:
-      title: OffsetCheckpoint
-      description: |-
-        OffsetCheckpoints may be used to:
-
-        - detect time out of commands.
-        - provide an offset which can be used to restart consumption.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/OffsetCheckpoint1'
-    OffsetCheckpoint1:
-      title: OffsetCheckpoint
-      description: |-
-        OffsetCheckpoints may be used to:
-
-        - detect time out of commands.
-        - provide an offset which can be used to restart consumption.
-      type: object
-      required:
-      - offset
-      properties:
-        offset:
-          description: |-
-            The participant's offset, the details of the offset field are described in ``community/ledger-api/README.md``.
-            Must be a valid absolute offset (positive integer).
-
-            Required
-          type: integer
-          format: int64
-        synchronizerTimes:
-          description: |-
-            The times associated with each synchronizer at this offset.
-
-            Optional: can be empty
-          type: array
-          items:
+              Required
+            type: integer
+            format: int64
+          synchronizerTime:
             $ref: '#/components/schemas/SynchronizerTime'
-    OffsetCheckpoint2:
-      title: OffsetCheckpoint
-      description: |-
-        OffsetCheckpoints may be used to:
+            description: |-
+              The synchronizer along with its record time.
+              The synchronizer id provided, in case of
 
-        - detect time out of commands.
-        - provide an offset which can be used to restart consumption.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/OffsetCheckpoint1'
-    OffsetCheckpoint3:
-      title: OffsetCheckpoint
-      description: |-
-        OffsetCheckpoints may be used to:
+              - successful/failed transactions: identifies the synchronizer of the transaction
+              - for successful/failed unassign commands: identifies the source synchronizer
+              - for successful/failed assign commands: identifies the target synchronizer
 
-        - detect time out of commands.
-        - provide an offset which can be used to restart consumption.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/OffsetCheckpoint1'
-    OffsetCheckpointFeature:
-      title: OffsetCheckpointFeature
-      type: object
-      required:
-      - maxOffsetCheckpointEmissionDelay
-      properties:
-        maxOffsetCheckpointEmissionDelay:
-          $ref: '#/components/schemas/Duration'
-          description: |-
-            The maximum delay to emmit a new OffsetCheckpoint if it exists
+              Required
+          paidTrafficCost:
+            description: |-
+              The traffic cost paid by this participant node for the confirmation request
+              for the submitted command.
 
-            Required
-    Operation:
-      title: Operation
-      description: Required
-      oneOf:
-      - type: object
+              Commands whose execution is rejected before their corresponding
+              confirmation request is ordered by the synchronizer will report a paid
+              traffic cost of zero.
+              If a confirmation request is ordered for a command, but the request fails
+              (e.g., due to contention with a concurrent contract archival), the traffic
+              cost is paid and reported on the failed completion for the request.
+
+              If you want to correlate the traffic cost of a successful completion
+              with the transaction that resulted from the command, you can use the
+              ``offset`` field to retrieve the transaction using
+              ``UpdateService.GetUpdateByOffset`` on the same participant node; or alternatively use the ``update_id``
+              field to retrieve the transaction using ``UpdateService.GetUpdateById`` on any participant node
+              that sees the transaction.
+
+              Note: for completions processed before the participant started serving
+              traffic cost on the Ledger API, this field will be set to zero.
+              Additionally, the total cost incurred by the submitting node for the submission of the transaction may be greater
+              than the reported cost, for example if retries were issued due to failed submissions to the synchronizer.
+              The cost reported here is the one paid for ordering the confirmation request.
+
+              Optional
+            type: integer
+            format: int64
+      CompletionResponse:
+        title: CompletionResponse
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - Completion
+          properties:
+            Completion:
+              $ref: '#/components/schemas/Completion'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty4'
+        - type: object
+          required:
+          - OffsetCheckpoint
+          properties:
+            OffsetCheckpoint:
+              $ref: '#/components/schemas/OffsetCheckpoint'
+      CompletionStreamRequest:
+        title: CompletionStreamRequest
+        type: object
         required:
-        - Empty
+        - parties
         properties:
-          Empty:
-            $ref: '#/components/schemas/Empty5'
-      - type: object
-        required:
-        - Unvet
-        properties:
-          Unvet:
-            $ref: '#/components/schemas/Unvet'
-      - type: object
-        required:
-        - Vet
-        properties:
-          Vet:
-            $ref: '#/components/schemas/Vet'
-    PackageFeature:
-      title: PackageFeature
-      type: object
-      required:
-      - maxVettedPackagesPageSize
-      properties:
-        maxVettedPackagesPageSize:
-          description: |-
-            The maximum number of vetted packages the server can return in a single
-            response (page) when listing them.
+          userId:
+            description: |-
+              Only completions of commands submitted with the same user_id will be visible in the stream.
+              Must be a valid UserIdString (as described in ``value.proto``).
 
-            Required
-          type: integer
-          format: int32
-    PackageMetadataFilter:
-      title: PackageMetadataFilter
-      description: |-
-        Filter the VettedPackages by package metadata.
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
 
-        A PackageMetadataFilter without package_ids and without package_name_prefixes
-        matches any vetted package.
-
-        Non-empty fields specify candidate values of which at least one must match.
-        If both fields are set, then a candidate is returned if it matches one of the fields.
-      type: object
-      properties:
-        packageIds:
-          description: |-
-            If this list is non-empty, any vetted package with a package ID in this
-            list will match the filter.
-
-            Optional: can be empty
-          type: array
-          items:
+              Optional
             type: string
-        packageNamePrefixes:
-          description: |-
-            If this list is non-empty, any vetted package with a name matching at least
-            one prefix in this list will match the filter.
+          parties:
+            description: |-
+              Non-empty list of parties whose data should be included.
+              The stream shows only completions of commands for which at least one of the ``act_as`` parties is in the given set of parties.
+              Must be a valid PartyIdString (as described in ``value.proto``).
 
-            Optional: can be empty
-          type: array
-          items:
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          beginExclusive:
+            description: |-
+              This optional field indicates the minimum offset for completions. This can be used to resume an earlier completion stream.
+              If not set the ledger uses the ledger begin offset instead.
+              If specified, it must be a valid absolute offset (positive integer) or zero (ledger begin offset).
+              If the ledger has been pruned, this parameter must be specified and greater than the pruning offset.
+
+              Optional
+            type: integer
+            format: int64
+      CompletionStreamResponse:
+        title: CompletionStreamResponse
+        type: object
+        properties:
+          completionResponse:
+            $ref: '#/components/schemas/CompletionResponse'
+      ConnectedSynchronizer:
+        title: ConnectedSynchronizer
+        type: object
+        required:
+        - synchronizerAlias
+        - synchronizerId
+        properties:
+          synchronizerAlias:
+            description: |-
+              The alias of the synchronizer
+
+              Required
             type: string
-    PackagePreference:
-      title: PackagePreference
-      type: object
-      required:
-      - synchronizerId
-      - packageReference
-      properties:
-        packageReference:
-          $ref: '#/components/schemas/PackageReference'
-          description: |-
-            The package reference of the preferred package.
+          synchronizerId:
+            description: |-
+              The ID of the synchronizer
 
-            Required
-        synchronizerId:
-          description: |-
-            The synchronizer for which the preferred package was computed.
-            If the synchronizer_id was specified in the request, then it matches the request synchronizer_id.
-
-            Required
-          type: string
-    PackageReference:
-      title: PackageReference
-      type: object
-      required:
-      - packageId
-      - packageName
-      - packageVersion
-      properties:
-        packageId:
-          description: Required
-          type: string
-        packageName:
-          description: Required
-          type: string
-        packageVersion:
-          description: Required
-          type: string
-    PackageVettingRequirement:
-      title: PackageVettingRequirement
-      description: Defines a package-name for which the commonly vetted package with
-        the highest version must be found.
-      type: object
-      required:
-      - packageName
-      - parties
-      properties:
-        parties:
-          description: |-
-            The parties whose participants' vetting state should be considered when resolving the preferred package.
-
-            Required: must be non-empty
-          type: array
-          items:
+              Required
             type: string
-        packageName:
-          description: |-
-            The package-name for which the preferred package should be resolved.
-
-            Required
-          type: string
-    ParticipantAdmin:
-      title: ParticipantAdmin
-      description: The right to administer the participant node.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/ParticipantAdmin1'
-    ParticipantAdmin1:
-      title: ParticipantAdmin
-      description: The right to administer the participant node.
-      type: object
-    ParticipantAuthorizationAdded:
-      title: ParticipantAuthorizationAdded
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/ParticipantAuthorizationAdded1'
-    ParticipantAuthorizationAdded1:
-      title: ParticipantAuthorizationAdded
-      type: object
-      required:
-      - partyId
-      - participantId
-      - participantPermission
-      properties:
-        partyId:
-          description: Required
-          type: string
-        participantId:
-          description: Required
-          type: string
-        participantPermission:
-          description: Required
-          type: string
-          enum:
-          - PARTICIPANT_PERMISSION_UNSPECIFIED
-          - PARTICIPANT_PERMISSION_SUBMISSION
-          - PARTICIPANT_PERMISSION_CONFIRMATION
-          - PARTICIPANT_PERMISSION_OBSERVATION
-    ParticipantAuthorizationChanged:
-      title: ParticipantAuthorizationChanged
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/ParticipantAuthorizationChanged1'
-    ParticipantAuthorizationChanged1:
-      title: ParticipantAuthorizationChanged
-      type: object
-      required:
-      - partyId
-      - participantId
-      - participantPermission
-      properties:
-        partyId:
-          description: Required
-          type: string
-        participantId:
-          description: Required
-          type: string
-        participantPermission:
-          description: Required
-          type: string
-          enum:
-          - PARTICIPANT_PERMISSION_UNSPECIFIED
-          - PARTICIPANT_PERMISSION_SUBMISSION
-          - PARTICIPANT_PERMISSION_CONFIRMATION
-          - PARTICIPANT_PERMISSION_OBSERVATION
-    ParticipantAuthorizationOnboarding:
-      title: ParticipantAuthorizationOnboarding
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/ParticipantAuthorizationOnboarding1'
-    ParticipantAuthorizationOnboarding1:
-      title: ParticipantAuthorizationOnboarding
-      type: object
-      required:
-      - partyId
-      - participantId
-      - participantPermission
-      properties:
-        partyId:
-          description: Required
-          type: string
-        participantId:
-          description: Required
-          type: string
-        participantPermission:
-          description: Required
-          type: string
-          enum:
-          - PARTICIPANT_PERMISSION_UNSPECIFIED
-          - PARTICIPANT_PERMISSION_SUBMISSION
-          - PARTICIPANT_PERMISSION_CONFIRMATION
-          - PARTICIPANT_PERMISSION_OBSERVATION
-    ParticipantAuthorizationRevoked:
-      title: ParticipantAuthorizationRevoked
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/ParticipantAuthorizationRevoked1'
-    ParticipantAuthorizationRevoked1:
-      title: ParticipantAuthorizationRevoked
-      type: object
-      required:
-      - partyId
-      - participantId
-      properties:
-        partyId:
-          description: Required
-          type: string
-        participantId:
-          description: Required
-          type: string
-    ParticipantAuthorizationTopologyFormat:
-      title: ParticipantAuthorizationTopologyFormat
-      description: A format specifying which participant authorization topology transactions
-        to include and how to render them.
-      type: object
-      properties:
-        parties:
-          description: |-
-            List of parties for which the topology transactions should be sent.
-            Empty means: for all parties.
-
-            Optional: can be empty
-          type: array
-          items:
-            type: string
-    PartyDetails:
-      title: PartyDetails
-      type: object
-      required:
-      - party
-      properties:
-        party:
-          description: |-
-            The stable unique identifier of a Daml party.
-            Must be a valid PartyIdString (as described in ``value.proto``).
-
-            Required
-          type: string
-        isLocal:
-          description: |-
-            true if party is hosted by the participant and the party shares the same identity provider as the user issuing the request.
-
-            Optional
-          type: boolean
-        localMetadata:
-          $ref: '#/components/schemas/ObjectMeta'
-          description: |-
-            Participant-local metadata of this party.
-            Modifiable
-
-            Optional
-        identityProviderId:
-          description: |-
-            The id of the ``Identity Provider``
-            Optional, if not set, there could be 3 options:
-
-            1. the party is managed by the default identity provider.
-            2. party is not hosted by the participant.
-            3. party is hosted by the participant, but is outside of the user's identity provider.
-
-            Optional
-          type: string
-    PartyManagementFeature:
-      title: PartyManagementFeature
-      type: object
-      required:
-      - maxPartiesPageSize
-      properties:
-        maxPartiesPageSize:
-          description: |-
-            The maximum number of parties the server can return in a single response (page).
-
-            Required
-          type: integer
-          format: int32
-    PartySignatures:
-      title: PartySignatures
-      description: Additional signatures provided by the submitting parties
-      type: object
-      required:
-      - signatures
-      properties:
-        signatures:
-          description: |-
-            Additional signatures provided by all individual parties
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/SinglePartySignatures'
-    PrefetchContractKey:
-      title: PrefetchContractKey
-      description: Preload contracts
-      type: object
-      required:
-      - templateId
-      - contractKey
-      properties:
-        templateId:
-          description: |-
-            The template of contract the client wants to prefetch.
-            Both package-name and package-id reference identifier formats for the template-id are supported.
-            Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
-
-            Required
-          type: string
-        contractKey:
-          description: |-
-            The key of the contract the client wants to prefetch.
-
-            Required
-    Prior:
-      title: Prior
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          type: integer
-          format: int32
-    PriorTopologySerial:
-      title: PriorTopologySerial
-      description: |-
-        The serial of last ``VettedPackages`` topology transaction on a given
-        participant and synchronizer.
-      type: object
-      properties:
-        serial:
-          $ref: '#/components/schemas/Serial'
-    ProtoAny:
-      title: ProtoAny
-      type: object
-      required:
-      - typeUrl
-      - value
-      - unknownFields
-      properties:
-        typeUrl:
-          type: string
-        value:
-          type: string
-        unknownFields:
-          $ref: '#/components/schemas/UnknownFieldSet'
-        valueDecoded:
-          type: string
-    Reassignment:
-      title: Reassignment
-      description: Complete view of an on-ledger reassignment.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/JsReassignment'
-    Reassignment1:
-      title: Reassignment
-      description: Complete view of an on-ledger reassignment.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/JsReassignment'
-    ReassignmentCommand:
-      title: ReassignmentCommand
-      type: object
-      properties:
-        command:
-          $ref: '#/components/schemas/Command1'
-    ReassignmentCommands:
-      title: ReassignmentCommands
-      type: object
-      required:
-      - commandId
-      - submitter
-      - commands
-      properties:
-        workflowId:
-          description: |-
-            Identifier of the on-ledger workflow that this command is a part of.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Optional
-          type: string
-        userId:
-          description: |-
-            Uniquely identifies the participant user that issued the command.
-            Must be a valid UserIdString (as described in ``value.proto``).
-            Required unless authentication is used with a user token.
-            In that case, the token's user-id will be used for the request's user_id.
-
-            Optional
-          type: string
-        commandId:
-          description: |-
-            Uniquely identifies the command.
-            The triple (user_id, submitter, command_id) constitutes the change ID for the intended ledger change.
-            The change ID can be used for matching the intended ledger changes with all their completions.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        submitter:
-          description: |-
-            Party on whose behalf the command should be executed.
-            If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
-            to act on behalf of the given party.
-            Must be a valid PartyIdString (as described in ``value.proto``).
-
-            Required
-          type: string
-        submissionId:
-          description: |-
-            A unique identifier to distinguish completions for different submissions with the same change ID.
-            Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
-            with the same change ID.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            If omitted, the participant or the committer may set a value of their choice.
-
-            Optional
-          type: string
-        commands:
-          description: |-
-            Individual elements of this reassignment. Must be non-empty.
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/ReassignmentCommand'
-    RevokeUserRightsRequest:
-      title: RevokeUserRightsRequest
-      description: |-
-        Remove the rights from the set of rights granted to the user.
-
-        Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id)``
-      type: object
-      required:
-      - userId
-      properties:
-        userId:
-          description: |-
-            The user from whom to revoke rights.
-
-            Required
-          type: string
-        rights:
-          description: |-
-            The rights to revoke.
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Right'
-        identityProviderId:
-          description: |-
-            The id of the ``Identity Provider``
-            If not set, assume the user is managed by the default identity provider.
-
-            Optional
-          type: string
-    RevokeUserRightsResponse:
-      title: RevokeUserRightsResponse
-      type: object
-      properties:
-        newlyRevokedRights:
-          description: |-
-            The rights that were actually revoked by the request.
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Right'
-    Right:
-      title: Right
-      description: A right granted to a user.
-      type: object
-      properties:
-        kind:
-          $ref: '#/components/schemas/Kind'
-    Serial:
-      title: Serial
-      description: Optional
-      oneOf:
-      - type: object
-        required:
-        - Empty
-        properties:
-          Empty:
-            $ref: '#/components/schemas/Empty6'
-      - type: object
-        required:
-        - NoPrior
-        properties:
-          NoPrior:
-            $ref: '#/components/schemas/NoPrior'
-      - type: object
-        required:
-        - Prior
-        properties:
-          Prior:
-            $ref: '#/components/schemas/Prior'
-    Signature:
-      title: Signature
-      type: object
-      required:
-      - format
-      - signature
-      - signedBy
-      - signingAlgorithmSpec
-      properties:
-        format:
-          description: Required
-          type: string
-        signature:
-          description: 'Required: must be non-empty'
-          type: string
-        signedBy:
-          description: |-
-            The fingerprint/id of the keypair used to create this signature and needed to verify.
-
-            Required
-          type: string
-        signingAlgorithmSpec:
-          description: |-
-            The signing algorithm specification used to produce this signature
-
-            Required
-          type: string
-    SignedTransaction:
-      title: SignedTransaction
-      type: object
-      required:
-      - transaction
-      properties:
-        transaction:
-          description: |-
-            The serialized TopologyTransaction
-
-            Required: must be non-empty
-          type: string
-        signatures:
-          description: |-
-            Additional signatures for this transaction specifically
-            Use for transactions that require additional signatures beyond the namespace key signatures
-            e.g: PartyToParticipant must be signed by all registered keys
-
-            Optional: can be empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Signature'
-    SigningPublicKey:
-      title: SigningPublicKey
-      type: object
-      required:
-      - format
-      - keyData
-      - keySpec
-      properties:
-        format:
-          description: |-
-            The serialization format of the public key
-
-            Required
-          example: CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO
-          type: string
-        keyData:
-          description: |-
-            Serialized public key in the format specified above
-
-            Required: must be non-empty
-          type: string
-        keySpec:
-          description: |-
-            The key specification
-
-            Required
-          example: SIGNING_KEY_SPEC_EC_CURVE25519
-          type: string
-    SinglePartySignatures:
-      title: SinglePartySignatures
-      description: Signatures provided by a single party
-      type: object
-      required:
-      - party
-      - signatures
-      properties:
-        party:
-          description: |-
-            Submitting party
-
-            Required
-          type: string
-        signatures:
-          description: |-
-            Signatures
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/Signature'
-    SubmitAndWaitForReassignmentRequest:
-      title: SubmitAndWaitForReassignmentRequest
-      description: This reassignment is executed as a single atomic update.
-      type: object
-      required:
-      - reassignmentCommands
-      properties:
-        reassignmentCommands:
-          $ref: '#/components/schemas/ReassignmentCommands'
-          description: |-
-            The reassignment commands to be submitted.
-
-            Required
-        eventFormat:
-          $ref: '#/components/schemas/EventFormat'
-          description: |-
-            If no event_format provided, the result will contain no events.
-            The events in the result, will take shape TRANSACTION_SHAPE_ACS_DELTA.
-
-            Optional
-    SubmitAndWaitResponse:
-      title: SubmitAndWaitResponse
-      type: object
-      required:
-      - updateId
-      - completionOffset
-      properties:
-        updateId:
-          description: |-
-            The id of the transaction that resulted from the submitted command.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        completionOffset:
-          description: |-
-            The details of the offset field are described in ``community/ledger-api/README.md``.
-
-            Required
-          type: integer
-          format: int64
-    SubmitReassignmentRequest:
-      title: SubmitReassignmentRequest
-      type: object
-      required:
-      - reassignmentCommands
-      properties:
-        reassignmentCommands:
-          $ref: '#/components/schemas/ReassignmentCommands'
-          description: |-
-            The reassignment command to be submitted.
-
-            Required
-    SubmitReassignmentResponse:
-      title: SubmitReassignmentResponse
-      type: object
-    SubmitResponse:
-      title: SubmitResponse
-      type: object
-    SynchronizerTime:
-      title: SynchronizerTime
-      type: object
-      required:
-      - synchronizerId
-      - recordTime
-      properties:
-        synchronizerId:
-          description: |-
-            The id of the synchronizer.
-
-            Required
-          type: string
-        recordTime:
-          description: |-
-            All commands with a maximum record time below this value MUST be considered lost if their completion has not arrived before this checkpoint.
-
-            Required
-          type: string
-    TemplateFilter:
-      title: TemplateFilter
-      description: This filter matches contracts of a specific template.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/TemplateFilter1'
-    TemplateFilter1:
-      title: TemplateFilter
-      description: This filter matches contracts of a specific template.
-      type: object
-      required:
-      - templateId
-      properties:
-        templateId:
-          description: |-
-            A template for which the payload should be included in the response.
-            The ``template_id`` needs to be valid: corresponding template should be defined in
-            one of the available packages at the time of the query.
-            Both package-name and package-id reference formats for the identifier are supported.
-            Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
-
-            Required
-          type: string
-        includeCreatedEventBlob:
-          description: |-
-            Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
-            Use this to access the contract event payload in your API client
-            for submitting it as a disclosed contract with future commands.
-
-            Optional
-          type: boolean
-    Time:
-      title: Time
-      description: Required
-      oneOf:
-      - type: object
-        required:
-        - Empty
-        properties:
-          Empty:
-            $ref: '#/components/schemas/Empty9'
-      - type: object
-        required:
-        - MinLedgerTimeAbs
-        properties:
-          MinLedgerTimeAbs:
-            $ref: '#/components/schemas/MinLedgerTimeAbs'
-      - type: object
-        required:
-        - MinLedgerTimeRel
-        properties:
-          MinLedgerTimeRel:
-            $ref: '#/components/schemas/MinLedgerTimeRel'
-    TopologyEvent:
-      title: TopologyEvent
-      type: object
-      properties:
-        event:
-          $ref: '#/components/schemas/TopologyEventEvent'
-    TopologyEventEvent:
-      title: TopologyEventEvent
-      oneOf:
-      - type: object
-        required:
-        - Empty
-        properties:
-          Empty:
-            $ref: '#/components/schemas/Empty7'
-      - type: object
-        required:
-        - ParticipantAuthorizationAdded
-        properties:
-          ParticipantAuthorizationAdded:
-            $ref: '#/components/schemas/ParticipantAuthorizationAdded'
-      - type: object
-        required:
-        - ParticipantAuthorizationChanged
-        properties:
-          ParticipantAuthorizationChanged:
-            $ref: '#/components/schemas/ParticipantAuthorizationChanged'
-      - type: object
-        required:
-        - ParticipantAuthorizationOnboarding
-        properties:
-          ParticipantAuthorizationOnboarding:
-            $ref: '#/components/schemas/ParticipantAuthorizationOnboarding'
-      - type: object
-        required:
-        - ParticipantAuthorizationRevoked
-        properties:
-          ParticipantAuthorizationRevoked:
-            $ref: '#/components/schemas/ParticipantAuthorizationRevoked'
-    TopologyFormat:
-      title: TopologyFormat
-      description: A format specifying which topology transactions to include and
-        how to render them.
-      type: object
-      properties:
-        includeParticipantAuthorizationEvents:
-          $ref: '#/components/schemas/ParticipantAuthorizationTopologyFormat'
-          description: |-
-            Include participant authorization topology events in streams.
-            If unset, no participant authorization topology events are emitted in the stream.
-
-            Optional
-    TopologyStateFilter:
-      title: TopologyStateFilter
-      description: |-
-        Filter the vetted packages by the participant and synchronizer that they are
-        hosted on.
-
-        Empty fields are ignored, such that a ``TopologyStateFilter`` without
-        participant_ids and without synchronizer_ids matches a vetted package hosted
-        on any participant and synchronizer.
-
-        Non-empty fields specify candidate values of which at least one must match.
-        If both fields are set then at least one candidate value must match from each
-        field.
-      type: object
-      properties:
-        participantIds:
-          description: |-
-            If this list is non-empty, only vetted packages hosted on participants
-            listed in this field match the filter.
-            Query the current Ledger API's participant's ID via the public
-            ``GetParticipantId`` command in ``PartyManagementService``.
-
-            Optional: can be empty
-          type: array
-          items:
-            type: string
-        synchronizerIds:
-          description: |-
-            If this list is non-empty, only vetted packages from the topology state of
-            the synchronizers in this list match the filter.
-
-            Optional: can be empty
-          type: array
-          items:
-            type: string
-    TopologyTransaction:
-      title: TopologyTransaction
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/JsTopologyTransaction'
-    TraceContext:
-      title: TraceContext
-      type: object
-      properties:
-        traceparent:
-          description: |-
-            https://www.w3.org/TR/trace-context/
-
-            Optional
-          type: string
-        tracestate:
-          description: Optional
-          type: string
-    Transaction:
-      title: Transaction
-      description: Filtered view of an on-ledger transaction's create and archive
-        events.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/JsTransaction'
-    TransactionFilter:
-      title: TransactionFilter
-      description: |-
-        Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
-        Used both for filtering create and archive events as well as for filtering transaction trees.
-      type: object
-      properties:
-        filtersByParty:
-          $ref: '#/components/schemas/Map_Filters'
-          description: |-
-            Each key must be a valid PartyIdString (as described in ``value.proto``).
-            The interpretation of the filter depends on the transaction-shape being filtered:
-
-            1. For **transaction trees** (used in GetUpdateTreesResponse for backwards compatibility) all party keys used as
-               wildcard filters, and all subtrees whose root has one of the listed parties as an informee are returned.
-               If there are ``CumulativeFilter``s, those will control returned ``CreatedEvent`` fields where applicable, but will
-               not be used for template/interface filtering.
-            2. For **ledger-effects** create and exercise events are returned, for which the witnesses include at least one of
-               the listed parties and match the per-party filter.
-            3. For **transaction and active-contract-set streams** create and archive events are returned for all contracts whose
-               stakeholders include at least one of the listed parties and match the per-party filter.
-        filtersForAnyParty:
-          $ref: '#/components/schemas/Filters'
-          description: |-
-            Wildcard filters that apply to all the parties existing on the participant. The interpretation of the filters is the same
-            with the per-party filter as described above.
-    TransactionFormat:
-      title: TransactionFormat
-      description: |-
-        A format that specifies what events to include in Daml transactions
-        and what data to compute and include for them.
-      type: object
-      required:
-      - transactionShape
-      - eventFormat
-      properties:
-        eventFormat:
-          $ref: '#/components/schemas/EventFormat'
-          description: Required
-        transactionShape:
-          description: |-
-            What transaction shape to use for interpreting the filters of the event format.
-
-            Required
-          type: string
-          enum:
-          - TRANSACTION_SHAPE_UNSPECIFIED
-          - TRANSACTION_SHAPE_ACS_DELTA
-          - TRANSACTION_SHAPE_LEDGER_EFFECTS
-    TransactionTree:
-      title: TransactionTree
-      description: |-
-        Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
-        Complete view of an on-ledger transaction.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/JsTransactionTree'
-    TreeEvent:
-      title: TreeEvent
-      description: |-
-        Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
-        Each tree event message type below contains a ``witness_parties`` field which
-        indicates the subset of the requested parties that can see the event
-        in question.
-
-        Note that transaction trees might contain events with
-        _no_ witness parties, which were included simply because they were
-        children of events which have witnesses.
-      oneOf:
-      - type: object
-        required:
-        - CreatedTreeEvent
-        properties:
-          CreatedTreeEvent:
-            $ref: '#/components/schemas/CreatedTreeEvent'
-      - type: object
-        required:
-        - ExercisedTreeEvent
-        properties:
-          ExercisedTreeEvent:
-            $ref: '#/components/schemas/ExercisedTreeEvent'
-    Tuple2_String_String:
-      title: Tuple2_String_String
-      type: array
-      maxItems: 2
-      minItems: 2
-      items:
-        type: string
-    UnassignCommand:
-      title: UnassignCommand
-      description: Unassign a contract
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/UnassignCommand1'
-    UnassignCommand1:
-      title: UnassignCommand
-      description: Unassign a contract
-      type: object
-      required:
-      - contractId
-      - source
-      - target
-      properties:
-        contractId:
-          description: |-
-            The ID of the contract the client wants to unassign.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        source:
-          description: |-
-            The ID of the source synchronizer
-            Must be a valid synchronizer id
-
-            Required
-          type: string
-        target:
-          description: |-
-            The ID of the target synchronizer
-            Must be a valid synchronizer id
-
-            Required
-          type: string
-    UnassignedEvent:
-      title: UnassignedEvent
-      description: Records that a contract has been unassigned, and it becomes unusable
-        on the source synchronizer
-      type: object
-      required:
-      - reassignmentId
-      - contractId
-      - source
-      - target
-      - reassignmentCounter
-      - packageName
-      - offset
-      - nodeId
-      - templateId
-      - witnessParties
-      properties:
-        reassignmentId:
-          description: |-
-            The ID of the unassignment. This needs to be used as an input for a assign ReassignmentCommand.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        contractId:
-          description: |-
-            The ID of the reassigned contract.
-            Must be a valid LedgerString (as described in ``value.proto``).
-
-            Required
-          type: string
-        templateId:
-          description: |-
-            The template of the reassigned contract.
-            The identifier uses the package-id reference format.
-
-            Required
-          type: string
-        source:
-          description: |-
-            The ID of the source synchronizer
-            Must be a valid synchronizer id
-
-            Required
-          type: string
-        target:
-          description: |-
-            The ID of the target synchronizer
-            Must be a valid synchronizer id
-
-            Required
-          type: string
-        submitter:
-          description: |-
-            Party on whose behalf the unassign command was executed.
-            Empty if the unassignment happened offline via the repair service.
-            Must be a valid PartyIdString (as described in ``value.proto``).
-
-            Optional
-          type: string
-        reassignmentCounter:
-          description: |-
-            Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
-            with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
-            equals zero.
-
-            Required
-          type: integer
-          format: int64
-        assignmentExclusivity:
-          description: |-
-            Assignment exclusivity
-            Before this time (measured on the target synchronizer), only the submitter of the unassignment can initiate the assignment
-            Defined for reassigning participants.
-
-            Optional
-          type: string
-        witnessParties:
-          description: |-
-            The parties that are notified of this event.
-
-            Required: must be non-empty
-          type: array
-          items:
-            type: string
-        packageName:
-          description: |-
-            The package name of the contract.
-
-            Required
-          type: string
-        offset:
-          description: |-
-            The offset of origin.
-            Offsets are managed by the participant nodes.
-            Reassignments can thus NOT be assumed to have the same offsets on different participant nodes.
-            Must be a valid absolute offset (positive integer)
-
-            Required
-          type: integer
-          format: int64
-        nodeId:
-          description: |-
-            The position of this event in the originating reassignment.
-            Node IDs are not necessarily equal across participants,
-            as these may see different projections/parts of reassignments.
-            Must be valid node ID (non-negative integer)
-
-            Required
-          type: integer
-          format: int32
-    UnknownFieldSet:
-      title: UnknownFieldSet
-      type: object
-      required:
-      - fields
-      properties:
-        fields:
-          $ref: '#/components/schemas/Map_Int_Field'
-    Unvet:
-      title: Unvet
-      description: Remove packages from the set of vetted packages
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/Unvet1'
-    Unvet1:
-      title: Unvet
-      description: Remove packages from the set of vetted packages
-      type: object
-      required:
-      - packages
-      properties:
-        packages:
-          description: |-
-            Packages to be unvetted.
-
-            If a reference in this list matches multiple packages, they are all
-            unvetted.
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/VettedPackagesRef'
-    Update:
-      title: Update
-      oneOf:
-      - type: object
-        required:
-        - OffsetCheckpoint
-        properties:
-          OffsetCheckpoint:
-            $ref: '#/components/schemas/OffsetCheckpoint2'
-      - type: object
-        required:
-        - Reassignment
-        properties:
-          Reassignment:
-            $ref: '#/components/schemas/Reassignment'
-      - type: object
-        required:
-        - TopologyTransaction
-        properties:
-          TopologyTransaction:
-            $ref: '#/components/schemas/TopologyTransaction'
-      - type: object
-        required:
-        - Transaction
-        properties:
-          Transaction:
-            $ref: '#/components/schemas/Transaction'
-    Update1:
-      title: Update
-      oneOf:
-      - type: object
-        required:
-        - OffsetCheckpoint
-        properties:
-          OffsetCheckpoint:
-            $ref: '#/components/schemas/OffsetCheckpoint3'
-      - type: object
-        required:
-        - Reassignment
-        properties:
-          Reassignment:
-            $ref: '#/components/schemas/Reassignment1'
-      - type: object
-        required:
-        - TransactionTree
-        properties:
-          TransactionTree:
-            $ref: '#/components/schemas/TransactionTree'
-    UpdateFormat:
-      title: UpdateFormat
-      description: A format specifying what updates to include and how to render them.
-      type: object
-      properties:
-        includeTransactions:
-          $ref: '#/components/schemas/TransactionFormat'
-          description: |-
-            Include Daml transactions in streams.
-            If unset, no transactions are emitted in the stream.
-
-            Optional
-        includeReassignments:
-          $ref: '#/components/schemas/EventFormat'
-          description: |-
-            Include (un)assignments in the stream.
-            The events in the result take the shape TRANSACTION_SHAPE_ACS_DELTA.
-            If unset, no (un)assignments are emitted in the stream.
-
-            Optional
-        includeTopologyEvents:
-          $ref: '#/components/schemas/TopologyFormat'
-          description: |-
-            Include topology events in streams.
-            If unset no topology events are emitted in the stream.
-
-            Optional
-    UpdateIdentityProviderConfigRequest:
-      title: UpdateIdentityProviderConfigRequest
-      type: object
-      required:
-      - identityProviderConfig
-      - updateMask
-      properties:
-        identityProviderConfig:
-          $ref: '#/components/schemas/IdentityProviderConfig'
-          description: |-
-            The identity provider config to update.
-            Modifiable
-
-            Required
-        updateMask:
-          $ref: '#/components/schemas/FieldMask'
-          description: |-
-            An update mask specifies how and which properties of the ``IdentityProviderConfig`` message are to be updated.
-            An update mask consists of a set of update paths.
-            A valid update path points to a field or a subfield relative to the ``IdentityProviderConfig`` message.
-            A valid update mask must:
-
-            1. contain at least one update path,
-            2. contain only valid update paths.
-
-            Fields that can be updated are marked as ``Modifiable``.
-            For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
-
-            Required
-    UpdateIdentityProviderConfigResponse:
-      title: UpdateIdentityProviderConfigResponse
-      type: object
-      required:
-      - identityProviderConfig
-      properties:
-        identityProviderConfig:
-          $ref: '#/components/schemas/IdentityProviderConfig'
-          description: |-
-            Updated identity provider config
-
-            Required
-    UpdatePartyDetailsRequest:
-      title: UpdatePartyDetailsRequest
-      description: 'Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(party_details.identity_provider_id)``'
-      type: object
-      required:
-      - partyDetails
-      - updateMask
-      properties:
-        partyDetails:
-          $ref: '#/components/schemas/PartyDetails'
-          description: |-
-            Party to be updated
-            Modifiable
-
-            Required
-        updateMask:
-          $ref: '#/components/schemas/FieldMask'
-          description: |-
-            An update mask specifies how and which properties of the ``PartyDetails`` message are to be updated.
-            An update mask consists of a set of update paths.
-            A valid update path points to a field or a subfield relative to the ``PartyDetails`` message.
-            A valid update mask must:
-
-            1. contain at least one update path,
-            2. contain only valid update paths.
-
-            Fields that can be updated are marked as ``Modifiable``.
-            An update path can also point to non-``Modifiable`` fields such as 'party' and 'local_metadata.resource_version'
-            because they are used:
-
-            1. to identify the party details resource subject to the update,
-            2. for concurrent change control.
-
-            An update path can also point to non-``Modifiable`` fields such as 'is_local'
-            as long as the values provided in the update request match the server values.
-            Examples of update paths: 'local_metadata.annotations', 'local_metadata'.
-            For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
-            For similar Ledger API see ``com.daml.ledger.api.v2.admin.UpdateUserRequest``.
-
-            Required
-    UpdatePartyDetailsResponse:
-      title: UpdatePartyDetailsResponse
-      type: object
-      required:
-      - partyDetails
-      properties:
-        partyDetails:
-          $ref: '#/components/schemas/PartyDetails'
-          description: |-
-            Updated party details
-
-            Required
-    UpdateUserIdentityProviderIdRequest:
-      title: UpdateUserIdentityProviderIdRequest
-      description: 'Required authorization: ``HasRight(ParticipantAdmin)``'
-      type: object
-      required:
-      - userId
-      properties:
-        userId:
-          description: |-
-            User to update
-
-            Required
-          type: string
-        sourceIdentityProviderId:
-          description: |-
-            Current identity provider ID of the user
-            If omitted, the default IDP is assumed
-
-            Optional
-          type: string
-        targetIdentityProviderId:
-          description: |-
-            Target identity provider ID of the user
-            If omitted, the default IDP is assumed
-
-            Optional
-          type: string
-    UpdateUserIdentityProviderIdResponse:
-      title: UpdateUserIdentityProviderIdResponse
-      type: object
-    UpdateUserRequest:
-      title: UpdateUserRequest
-      description: 'Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(user.identity_provider_id)``'
-      type: object
-      required:
-      - user
-      - updateMask
-      properties:
-        user:
-          $ref: '#/components/schemas/User'
-          description: |-
-            The user to update.
-            Modifiable
-
-            Required
-        updateMask:
-          $ref: '#/components/schemas/FieldMask'
-          description: |-
-            An update mask specifies how and which properties of the ``User`` message are to be updated.
-            An update mask consists of a set of update paths.
-            A valid update path points to a field or a subfield relative to the ``User`` message.
-            A valid update mask must:
-
-            1. contain at least one update path,
-            2. contain only valid update paths.
-
-            Fields that can be updated are marked as ``Modifiable``.
-            An update path can also point to a non-``Modifiable`` fields such as 'id' and 'metadata.resource_version'
-            because they are used:
-
-            1. to identify the user resource subject to the update,
-            2. for concurrent change control.
-
-            Examples of valid update paths: 'primary_party', 'metadata', 'metadata.annotations'.
-            For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
-            For similar Ledger API see ``com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest``.
-
-            Required
-    UpdateUserResponse:
-      title: UpdateUserResponse
-      type: object
-      required:
-      - user
-      properties:
-        user:
-          $ref: '#/components/schemas/User'
-          description: |-
-            Updated user
-
-            Required
-    UpdateVettedPackagesRequest:
-      title: UpdateVettedPackagesRequest
-      type: object
-      required:
-      - changes
-      properties:
-        changes:
-          description: |-
-            Changes to apply to the current vetting state of the participant on the
-            specified synchronizer. The changes are applied in order.
-            Any package not changed will keep their previous vetting state.
-
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/VettedPackagesChange'
-        dryRun:
-          description: |-
-            If dry_run is true, then the changes are only prepared, but not applied. If
-            a request would trigger an error when run (e.g. TOPOLOGY_DEPENDENCIES_NOT_VETTED),
-            it will also trigger an error when dry_run.
-
-            Use this flag to preview a change before applying it.
-            Defaults to false.
-
-            Optional
-          type: boolean
-        synchronizerId:
-          description: |-
-            If set, the requested changes will take place on the specified
-            synchronizer. If synchronizer_id is unset and the participant is only
-            connected to a single synchronizer, that synchronizer will be used by
-            default. If synchronizer_id is unset and the participant is connected to
-            multiple synchronizers, the request will error out with
-            PACKAGE_SERVICE_CANNOT_AUTODETECT_SYNCHRONIZER.
-
-            Optional
-          type: string
-        expectedTopologySerial:
-          $ref: '#/components/schemas/PriorTopologySerial'
-          description: |-
-            The serial of the last ``VettedPackages`` topology transaction of this
-            participant and on this synchronizer.
-
-            Execution of the request fails if this is not correct. Use this to guard
-            against concurrent changes.
-
-            If left unspecified, no validation is done against the last transaction's
-            serial.
-
-            Optional
-        updateVettedPackagesForceFlags:
-          description: |-
-            Controls whether potentially unsafe vetting updates are allowed.
-
-            Optional: can be empty
-          type: array
-          items:
+          permission:
+            description: |-
+              The permission on the synchronizer
+              Set if a party was used in the request, otherwise unspecified.
+
+              Optional
             type: string
             enum:
-            - UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED
-            - UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES
-            - UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES
-    UpdateVettedPackagesResponse:
-      title: UpdateVettedPackagesResponse
-      type: object
-      required:
-      - newVettedPackages
-      properties:
-        pastVettedPackages:
-          $ref: '#/components/schemas/VettedPackages'
-          description: |-
-            All vetted packages on this participant and synchronizer, before the
-            specified changes. Empty if no vetting state existed beforehand.
+            - PARTICIPANT_PERMISSION_UNSPECIFIED
+            - PARTICIPANT_PERMISSION_SUBMISSION
+            - PARTICIPANT_PERMISSION_CONFIRMATION
+            - PARTICIPANT_PERMISSION_OBSERVATION
+      CostEstimation:
+        title: CostEstimation
+        description: |-
+          Estimation of the cost of submitting the prepared transaction
+          The estimation is done against the synchronizer chosen during preparation of the transaction
+          (or the one explicitly requested).
+          The cost of re-assigning contracts to another synchronizer when necessary is not included in the estimation.
+        type: object
+        required:
+        - confirmationRequestTrafficCostEstimation
+        - confirmationResponseTrafficCostEstimation
+        - totalTrafficCostEstimation
+        - estimationTimestamp
+        properties:
+          estimationTimestamp:
+            description: |-
+              Timestamp at which the estimation was made
 
-            Not populated if no vetted topology state exists prior to the update.
+              Required
+            type: string
+          confirmationRequestTrafficCostEstimation:
+            description: |-
+              Estimated traffic cost of the confirmation request associated with the transaction
 
-            Optional
-        newVettedPackages:
-          $ref: '#/components/schemas/VettedPackages'
-          description: |-
-            All vetted packages on this participant and synchronizer, after the specified changes.
+              Required
+            type: integer
+            format: int64
+          confirmationResponseTrafficCostEstimation:
+            description: |-
+              Estimated traffic cost of the confirmation response associated with the transaction
+              This field can also be used as an indication of the cost that other potential confirming nodes
+              of the party will incur to approve or reject the transaction
 
-            Required
-    UploadDarFileResponse:
-      title: UploadDarFileResponse
-      description: A message that is received when the upload operation succeeded.
-      type: object
-    User:
-      title: User
-      description: |2-
-         Users and rights
-        /////////////////
-         Users are used to dynamically manage the rights given to Daml applications.
-         They are stored and managed per participant node.
-      type: object
-      required:
-      - id
-      properties:
-        id:
-          description: |-
-            The user identifier, which must be a non-empty string of at most 128
-            characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:()".
+              Required
+            type: integer
+            format: int64
+          totalTrafficCostEstimation:
+            description: |-
+              Sum of the fields above
 
-            Required
+              Required
+            type: integer
+            format: int64
+      CostEstimationHints:
+        title: CostEstimationHints
+        description: Hints to improve cost estimation precision of a prepared transaction
+        type: object
+        properties:
+          disabled:
+            description: |-
+              Disable cost estimation
+              Default (not set) is false
+
+              Optional
+            type: boolean
+          expectedSignatures:
+            description: |-
+              Details on the keys that will be used to sign the transaction (how many and of which type).
+              Signature size impacts the cost of the transaction.
+              If empty, the signature sizes will be approximated with threshold-many signatures (where threshold is defined
+              in the PartyToParticipant of the external party), using keys in the order they are registered.
+              Empty list is equivalent to not providing this field
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+              enum:
+              - SIGNING_ALGORITHM_SPEC_UNSPECIFIED
+              - SIGNING_ALGORITHM_SPEC_ED25519
+              - SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256
+              - SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384
+      CreateAndExerciseCommand:
+        title: CreateAndExerciseCommand
+        description: Create a contract and exercise a choice on it in the same transaction.
+        type: object
+        required:
+        - templateId
+        - createArguments
+        - choice
+        - choiceArgument
+        properties:
+          templateId:
+            description: |-
+              The template of the contract the client wants to create.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          createArguments:
+            description: |-
+              The arguments required for creating a contract from this template.
+
+              Required
+          choice:
+            description: |-
+              The name of the choice the client wants to exercise.
+              Must be a valid NameString (as described in ``value.proto``).
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument for this choice.
+
+              Required
+      CreateCommand:
+        title: CreateCommand
+        description: Create a new contract instance based on a template.
+        type: object
+        required:
+        - templateId
+        - createArguments
+        properties:
+          templateId:
+            description: |-
+              The template of contract the client wants to create.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          createArguments:
+            description: |-
+              The arguments required for creating a contract from this template.
+
+              Required
+      CreateIdentityProviderConfigRequest:
+        title: CreateIdentityProviderConfigRequest
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: Required
+      CreateIdentityProviderConfigResponse:
+        title: CreateIdentityProviderConfigResponse
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: Required
+      CreateUserRequest:
+        title: CreateUserRequest
+        description: |2-
+           RPC requests and responses
+          ///////////////////////////
+           Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(user.identity_provider_id)``
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              The user to create.
+
+              Required
+          rights:
+            description: |-
+              The rights to be assigned to the user upon creation,
+              which SHOULD include appropriate rights for the ``user.primary_party``.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      CreateUserResponse:
+        title: CreateUserResponse
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              Created user.
+
+              Required
+      CreatedEvent:
+        title: CreatedEvent
+        description: Records that a contract has been created, and choices may now be
+          exercised on it.
+        type: object
+        required:
+        - offset
+        - nodeId
+        - contractId
+        - templateId
+        - createdAt
+        - packageName
+        - representativePackageId
+        - acsDelta
+        - createArgument
+        - witnessParties
+        - signatories
+        properties:
+          offset:
+            description: |-
+              The offset of origin, which has contextual meaning, please see description at messages that include a CreatedEvent.
+              Offsets are managed by the participant nodes.
+              Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
+              It is a valid absolute offset (positive integer)
+
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating transaction or reassignment.
+              The origin has contextual meaning, please see description at messages that include a CreatedEvent.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of transactions.
+              Must be valid node ID (non-negative integer)
+
+              Required
+            type: integer
+            format: int32
+          contractId:
+            description: |-
+              The ID of the created contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          templateId:
+            description: |-
+              The template of the created contract.
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          contractKey:
+            description: |-
+              The key of the created contract.
+              This will be set if and only if ``template_id`` defines a contract key.
+
+              Optional
+          contractKeyHash:
+            description: |-
+              The hash of contract_key.
+              This will be set if and only if ``template_id`` defines a contract key.
+
+              Optional: can be empty
+            type: string
+          createArgument:
+            description: |-
+              The arguments that have been used to create the contract.
+
+              Required
+          createdEventBlob:
+            description: |-
+              Opaque representation of contract create event payload intended for forwarding
+              to an API server as a contract disclosed as part of a command
+              submission.
+
+              Optional: can be empty
+            type: string
+          interfaceViews:
+            description: |-
+              Interface views specified in the transaction filter.
+              Includes an ``InterfaceView`` for each interface for which there is a ``InterfaceFilter`` with
+
+              - its party in the ``witness_parties`` of this event,
+              - and which is implemented by the template of this event,
+              - and which has ``include_interface_view`` set.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/JsInterfaceView'
+          witnessParties:
+            description: |-
+              The parties that are notified of this event. When a ``CreatedEvent``
+              is returned as part of a transaction tree or ledger-effects transaction, this will include all
+              the parties specified in the ``TransactionFilter`` that are witnesses  of the event
+              (the stakeholders of the contract and all informees of all the ancestors
+              of this create action that this participant knows about).
+              If served as part of a ACS delta transaction those will
+              be limited to all parties specified in the ``TransactionFilter`` that
+              are stakeholders of the contract (i.e. either signatories or observers).
+              If the ``CreatedEvent`` is returned as part of an AssignedEvent,
+              ActiveContract or IncompleteUnassigned (so the event is related to
+              an assignment or unassignment): this will include all parties of the
+              ``TransactionFilter`` that are stakeholders of the contract.
+
+              The behavior of reading create events visible to parties not hosted
+              on the participant node serving the Ledger API is undefined. Concretely,
+              there is neither a guarantee that the participant node will serve all their
+              create events on the ACS stream, nor is there a guarantee that matching archive
+              events are delivered for such create events.
+
+              For most clients this is not a problem, as they only read events for parties
+              that are hosted on the participant node. If you need to read events
+              for parties that may not be hosted at all times on the participant node,
+              subscribe to the ``TopologyEvent``s for that party by setting a corresponding
+              ``UpdateFormat``.  Using these events, query the ACS as-of an offset where the
+              party is hosted on the participant node, and ignore create events at offsets
+              where the party is not hosted on the participant node.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          signatories:
+            description: |-
+              The signatories for this contract as specified by the template.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          observers:
+            description: |-
+              The observers for this contract as specified explicitly by the template or implicitly as choice controllers.
+              This field never contains parties that are signatories.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          createdAt:
+            description: |-
+              Ledger effective time of the transaction that created the contract.
+
+              Required
+            type: string
+          packageName:
+            description: |-
+              The package name of the created contract.
+
+              Required
+            type: string
+          representativePackageId:
+            description: |-
+              A package-id present in the participant package store that typechecks the contract's argument.
+              This may differ from the package-id of the template used to create the contract.
+              For contracts created before Canton 3.4, this field matches the contract's creation package-id.
+
+              NOTE: Experimental, server internal concept, not for client consumption. Subject to change without notice.
+
+              Required
+            type: string
+          acsDelta:
+            description: |-
+              Whether this event would be part of respective ACS_DELTA shaped stream,
+              and should therefore considered when tracking contract activeness on the client-side.
+
+              Required
+            type: boolean
+      CreatedTreeEvent:
+        title: CreatedTreeEvent
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/CreatedEvent'
+      CumulativeFilter:
+        title: CumulativeFilter
+        description: |-
+          A filter that matches all contracts that are either an instance of one of
+          the ``template_filters`` or that match one of the ``interface_filters``.
+        type: object
+        properties:
+          identifierFilter:
+            $ref: '#/components/schemas/IdentifierFilter'
+      DeduplicationDuration:
+        title: DeduplicationDuration
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      DeduplicationDuration1:
+        title: DeduplicationDuration
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      DeduplicationDuration2:
+        title: DeduplicationDuration
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      DeduplicationOffset:
+        title: DeduplicationOffset
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int64
+      DeduplicationOffset1:
+        title: DeduplicationOffset
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int64
+      DeduplicationOffset2:
+        title: DeduplicationOffset
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int64
+      DeduplicationPeriod:
+        title: DeduplicationPeriod
+        description: |-
+          Specifies the deduplication period for the change ID.
+          If omitted, the participant will assume the configured maximum deduplication time.
+
+          Optional
+        oneOf:
+        - type: object
+          required:
+          - DeduplicationDuration
+          properties:
+            DeduplicationDuration:
+              $ref: '#/components/schemas/DeduplicationDuration'
+        - type: object
+          required:
+          - DeduplicationOffset
+          properties:
+            DeduplicationOffset:
+              $ref: '#/components/schemas/DeduplicationOffset'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty'
+      DeduplicationPeriod1:
+        title: DeduplicationPeriod
+        description: |-
+          The actual deduplication window used for the submission, which is derived from
+          ``Commands.deduplication_period``. The ledger may convert the deduplication period into other
+          descriptions and extend the period in implementation-specified ways.
+
+          Used to audit the deduplication guarantee described in ``commands.proto``.
+
+          The deduplication guarantee applies even if the completion omits this field.
+
+          Optional
+        oneOf:
+        - type: object
+          required:
+          - DeduplicationDuration
+          properties:
+            DeduplicationDuration:
+              $ref: '#/components/schemas/DeduplicationDuration1'
+        - type: object
+          required:
+          - DeduplicationOffset
+          properties:
+            DeduplicationOffset:
+              $ref: '#/components/schemas/DeduplicationOffset1'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty3'
+      DeduplicationPeriod2:
+        title: DeduplicationPeriod
+        oneOf:
+        - type: object
+          required:
+          - DeduplicationDuration
+          properties:
+            DeduplicationDuration:
+              $ref: '#/components/schemas/DeduplicationDuration2'
+        - type: object
+          required:
+          - DeduplicationOffset
+          properties:
+            DeduplicationOffset:
+              $ref: '#/components/schemas/DeduplicationOffset2'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty10'
+      DeleteIdentityProviderConfigResponse:
+        title: DeleteIdentityProviderConfigResponse
+        description: Does not (yet) contain any data.
+        type: object
+      DisclosedContract:
+        title: DisclosedContract
+        description: |-
+          An additional contract that is used to resolve
+          contract & contract key lookups.
+        type: object
+        required:
+        - createdEventBlob
+        properties:
+          templateId:
+            description: |-
+              The template id of the contract.
+              The identifier uses the package-id reference format.
+
+              If provided, used to validate the template id of the contract serialized in the created_event_blob.
+
+              Optional
+            type: string
+          contractId:
+            description: |-
+              The contract id
+
+              If provided, used to validate the contract id of the contract serialized in the created_event_blob.
+
+              Optional
+            type: string
+          createdEventBlob:
+            description: |-
+              Opaque byte string containing the complete payload required by the Daml engine
+              to reconstruct a contract not known to the receiving participant.
+
+              Required: must be non-empty
+            type: string
+          synchronizerId:
+            description: |-
+              The ID of the synchronizer where the contract is currently assigned
+
+              Optional
+            type: string
+      Duration:
+        title: Duration
+        type: object
+        required:
+        - seconds
+        - nanos
+        properties:
+          seconds:
+            type: integer
+            format: int64
+          nanos:
+            type: integer
+            format: int32
+          unknownFields:
+            $ref: '#/components/schemas/UnknownFieldSet'
+            description: This field is automatically added as part of protobuf to json
+              mapping
+      Empty:
+        title: Empty
+        type: object
+      Empty1:
+        title: Empty
+        type: object
+      Empty10:
+        title: Empty
+        type: object
+      Empty2:
+        title: Empty
+        type: object
+      Empty3:
+        title: Empty
+        type: object
+      Empty4:
+        title: Empty
+        type: object
+      Empty5:
+        title: Empty
+        type: object
+      Empty6:
+        title: Empty
+        type: object
+      Empty7:
+        title: Empty
+        type: object
+      Empty8:
+        title: Empty
+        type: object
+      Empty9:
+        title: Empty
+        type: object
+      Event:
+        title: Event
+        description: |-
+          Events in transactions can have two primary shapes:
+
+          - ACS delta: events can be CreatedEvent or ArchivedEvent
+          - ledger effects: events can be CreatedEvent or ExercisedEvent
+
+          In the update service the events are restricted to the events
+          visible for the parties specified in the transaction filter. Each
+          event message type below contains a ``witness_parties`` field which
+          indicates the subset of the requested parties that can see the event
+          in question.
+        oneOf:
+        - type: object
+          required:
+          - ArchivedEvent
+          properties:
+            ArchivedEvent:
+              $ref: '#/components/schemas/ArchivedEvent'
+        - type: object
+          required:
+          - CreatedEvent
+          properties:
+            CreatedEvent:
+              $ref: '#/components/schemas/CreatedEvent'
+        - type: object
+          required:
+          - ExercisedEvent
+          properties:
+            ExercisedEvent:
+              $ref: '#/components/schemas/ExercisedEvent'
+      EventFormat:
+        title: EventFormat
+        description: |-
+          A format for events which defines both which events should be included
+          and what data should be computed and included for them.
+
+          Note that some of the filtering behavior depends on the `TransactionShape`,
+          which is expected to be specified alongside usages of `EventFormat`.
+        type: object
+        properties:
+          filtersByParty:
+            $ref: '#/components/schemas/Map_Filters'
+            description: |-
+              Each key must be a valid PartyIdString (as described in ``value.proto``).
+              The interpretation of the filter depends on the transaction-shape being filtered:
+
+              1. For **ledger-effects** create and exercise events are returned, for which the witnesses include at least one of
+                 the listed parties and match the per-party filter.
+              2. For **transaction and active-contract-set streams** create and archive events are returned for all contracts whose
+                 stakeholders include at least one of the listed parties and match the per-party filter.
+
+              Optional: can be empty
+          filtersForAnyParty:
+            $ref: '#/components/schemas/Filters'
+            description: |-
+              Wildcard filters that apply to all the parties existing on the participant. The interpretation of the filters is the same
+              with the per-party filter as described above.
+
+              Optional
+          verbose:
+            description: |-
+              If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
+              In particular, setting the verbose flag to true triggers the ledger to include labels for record fields.
+
+              Optional
+            type: boolean
+      ExecuteSubmissionAndWaitResponse:
+        title: ExecuteSubmissionAndWaitResponse
+        type: object
+        required:
+        - updateId
+        - completionOffset
+        properties:
+          updateId:
+            description: |-
+              The id of the transaction that resulted from the submitted command.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          completionOffset:
+            description: |-
+              The details of the offset field are described in ``community/ledger-api/README.md``.
+
+              Required
+            type: integer
+            format: int64
+      ExecuteSubmissionResponse:
+        title: ExecuteSubmissionResponse
+        type: object
+      ExerciseByKeyCommand:
+        title: ExerciseByKeyCommand
+        description: Exercise a choice on an existing contract specified by its key.
+        type: object
+        required:
+        - templateId
+        - contractKey
+        - choice
+        - choiceArgument
+        properties:
+          templateId:
+            description: |-
+              The template of contract the client wants to exercise.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          contractKey:
+            description: |-
+              The key of the contract the client wants to exercise upon.
+
+              Required
+          choice:
+            description: |-
+              The name of the choice the client wants to exercise.
+              Must be a valid NameString (as described in ``value.proto``)
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument for this choice.
+
+              Required
+      ExerciseCommand:
+        title: ExerciseCommand
+        description: Exercise a choice on an existing contract.
+        type: object
+        required:
+        - templateId
+        - contractId
+        - choice
+        - choiceArgument
+        properties:
+          templateId:
+            description: |-
+              The template or interface of the contract the client wants to exercise.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+              To exercise a choice on an interface, specify the interface identifier in the template_id field.
+
+              Required
+            type: string
+          contractId:
+            description: |-
+              The ID of the contract the client wants to exercise upon.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          choice:
+            description: |-
+              The name of the choice the client wants to exercise.
+              Must be a valid NameString (as described in ``value.proto``)
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument for this choice.
+
+              Required
+      ExercisedEvent:
+        title: ExercisedEvent
+        description: Records that a choice has been exercised on a target contract.
+        type: object
+        required:
+        - offset
+        - nodeId
+        - contractId
+        - templateId
+        - choice
+        - choiceArgument
+        - consuming
+        - lastDescendantNodeId
+        - packageName
+        - acsDelta
+        - actingParties
+        - witnessParties
+        properties:
+          offset:
+            description: |-
+              The offset of origin.
+              Offsets are managed by the participant nodes.
+              Transactions can thus NOT be assumed to have the same offsets on different participant nodes.
+              It is a valid absolute offset (positive integer)
+
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating transaction or reassignment.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of transactions.
+              Must be valid node ID (non-negative integer)
+
+              Required
+            type: integer
+            format: int32
+          contractId:
+            description: |-
+              The ID of the target contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          templateId:
+            description: |-
+              Identifies the template that defines the executed choice.
+              This template's package-id may differ from the target contract's package-id
+              if the target contract has been upgraded or downgraded.
+
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          interfaceId:
+            description: |-
+              The interface where the choice is defined, if inherited.
+              If defined, the identifier uses the package-id reference format.
+
+              Optional
+            type: string
+          choice:
+            description: |-
+              The choice that was exercised on the target contract.
+              Must be a valid NameString (as described in ``value.proto``).
+
+              Required
+            type: string
+          choiceArgument:
+            description: |-
+              The argument of the exercised choice.
+
+              Required
+          actingParties:
+            description: |-
+              The parties that exercised the choice.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          consuming:
+            description: |-
+              If true, the target contract may no longer be exercised.
+
+              Required
+            type: boolean
+          witnessParties:
+            description: |-
+              The parties that are notified of this event. The witnesses of an exercise
+              node will depend on whether the exercise was consuming or not.
+              If consuming, the witnesses are the union of the stakeholders,
+              the actors and all informees of all the ancestors of this event this
+              participant knows about.
+              If not consuming, the witnesses are the union of the signatories,
+              the actors and all informees of all the ancestors of this event this
+              participant knows about.
+              In both cases the witnesses are limited to the querying parties, or not
+              limited in case anyParty filters are used.
+              Note that the actors might not necessarily be observers
+              and thus stakeholders. This is the case when the controllers of a
+              choice are specified using "flexible controllers", using the
+              ``choice ... controller`` syntax, and said controllers are not
+              explicitly marked as observers.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          lastDescendantNodeId:
+            description: |-
+              Specifies the upper boundary of the node ids of the events in the same transaction that appeared as a result of
+              this ``ExercisedEvent``. This allows unambiguous identification of all the members of the subtree rooted at this
+              node. A full subtree can be constructed when all descendant nodes are present in the stream. If nodes are heavily
+              filtered, it is only possible to determine if a node is in a consequent subtree or not.
+
+              Required
+            type: integer
+            format: int32
+          exerciseResult:
+            description: |-
+              The result of exercising the choice.
+
+              Optional
+          packageName:
+            description: |-
+              The package name of the contract.
+
+              Required
+            type: string
+          implementedInterfaces:
+            description: |-
+              If the event is consuming, the interfaces implemented by the target template that have been
+              matched from the interface filter query.
+              Populated only in case interface filters with include_interface_view set.
+
+              The identifier uses the package-id reference format.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          acsDelta:
+            description: |-
+              Whether this event would be part of respective ACS_DELTA shaped stream,
+              and should therefore considered when tracking contract activeness on the client-side.
+
+              Required
+            type: boolean
+      ExercisedTreeEvent:
+        title: ExercisedTreeEvent
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ExercisedEvent'
+      ExperimentalCommandInspectionService:
+        title: ExperimentalCommandInspectionService
+        description: Whether the Ledger API supports command inspection service
+        type: object
+        required:
+        - supported
+        properties:
+          supported:
+            description: Required
+            type: boolean
+      ExperimentalFeatures:
+        title: ExperimentalFeatures
+        description: See the feature message definitions for descriptions.
+        type: object
+        properties:
+          staticTime:
+            $ref: '#/components/schemas/ExperimentalStaticTime'
+            description: Optional
+          commandInspectionService:
+            $ref: '#/components/schemas/ExperimentalCommandInspectionService'
+            description: Optional
+      ExperimentalStaticTime:
+        title: ExperimentalStaticTime
+        description: Ledger is in the static time mode and exposes a time service.
+        type: object
+        required:
+        - supported
+        properties:
+          supported:
+            description: Required
+            type: boolean
+      FeaturesDescriptor:
+        title: FeaturesDescriptor
+        type: object
+        required:
+        - experimental
+        - userManagement
+        - partyManagement
+        - offsetCheckpoint
+        - packageFeature
+        properties:
+          experimental:
+            $ref: '#/components/schemas/ExperimentalFeatures'
+            description: |-
+              Features under development or features that are used
+              for ledger implementation testing purposes only.
+
+              Daml applications SHOULD not depend on these in production.
+
+              Required
+          userManagement:
+            $ref: '#/components/schemas/UserManagementFeature'
+            description: |-
+              If set, then the Ledger API server supports user management.
+              It is recommended that clients query this field to gracefully adjust their behavior for
+              ledgers that do not support user management.
+
+              Required
+          partyManagement:
+            $ref: '#/components/schemas/PartyManagementFeature'
+            description: |-
+              If set, then the Ledger API server supports party management configurability.
+              It is recommended that clients query this field to gracefully adjust their behavior to
+              maximum party page size.
+
+              Required
+          offsetCheckpoint:
+            $ref: '#/components/schemas/OffsetCheckpointFeature'
+            description: |-
+              It contains the timeouts related to the periodic offset checkpoint emission
+
+              Required
+          packageFeature:
+            $ref: '#/components/schemas/PackageFeature'
+            description: |-
+              If set, then the Ledger API server supports package listing
+              configurability. It is recommended that clients query this field to
+              gracefully adjust their behavior to maximum package listing page size.
+
+              Required
+      Field:
+        title: Field
+        type: object
+        properties:
+          varint:
+            type: array
+            items:
+              type: integer
+              format: int64
+          fixed64:
+            type: array
+            items:
+              type: integer
+              format: int64
+          fixed32:
+            type: array
+            items:
+              type: integer
+              format: int32
+          lengthDelimited:
+            type: array
+            items:
+              type: string
+      FieldMask:
+        title: FieldMask
+        type: object
+        required:
+        - unknownFields
+        properties:
+          paths:
+            type: array
+            items:
+              type: string
+          unknownFields:
+            $ref: '#/components/schemas/UnknownFieldSet'
+      Filters:
+        title: Filters
+        description: The union of a set of template filters, interface filters, or a
+          wildcard.
+        type: object
+        properties:
+          cumulative:
+            description: |-
+              Every filter in the cumulative list expands the scope of the resulting stream. Each interface,
+              template or wildcard filter means additional events that will match the query.
+              The impact of include_interface_view and include_created_event_blob fields in the filters will
+              also be accumulated.
+              A template or an interface SHOULD NOT appear twice in the accumulative field.
+              A wildcard filter SHOULD NOT be defined more than once in the accumulative field.
+              If no ``CumulativeFilter`` defined, the default of a single ``WildcardFilter`` with
+              include_created_event_blob unset is used.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/CumulativeFilter'
+      GenerateExternalPartyTopologyRequest:
+        title: GenerateExternalPartyTopologyRequest
+        type: object
+        required:
+        - synchronizer
+        - partyHint
+        - publicKey
+        properties:
+          synchronizer:
+            description: |-
+              Synchronizer-id for which we are building this request.
+              TODO(#27670) support synchronizer aliases
+
+              Required
+            type: string
+          partyHint:
+            description: |-
+              The actual party id will be constructed from this hint and a fingerprint of the public key
+
+              Required
+            type: string
+          publicKey:
+            $ref: '#/components/schemas/SigningPublicKey'
+            description: |-
+              Public key
+
+              Required
+          localParticipantObservationOnly:
+            description: |-
+              If true, then the local participant will only be observing, not confirming. Default false.
+
+              Optional
+            type: boolean
+          otherConfirmingParticipantUids:
+            description: |-
+              Other participant ids which should be confirming for this party
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          confirmationThreshold:
+            description: |-
+              Confirmation threshold >= 1 for the party. Defaults to all available confirmers (or if set to 0).
+
+              Optional
+            type: integer
+            format: int32
+          observingParticipantUids:
+            description: |-
+              Other observing participant ids for this party
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      GenerateExternalPartyTopologyResponse:
+        title: GenerateExternalPartyTopologyResponse
+        description: Response message with topology transactions and the multi-hash
+          to be signed.
+        type: object
+        required:
+        - partyId
+        - publicKeyFingerprint
+        - multiHash
+        - topologyTransactions
+        properties:
+          partyId:
+            description: |-
+              The generated party id
+
+              Required
+            type: string
+          publicKeyFingerprint:
+            description: |-
+              The fingerprint of the supplied public key
+
+              Required
+            type: string
+          topologyTransactions:
+            description: |-
+              The serialized topology transactions which need to be signed and submitted as part of the allocate party process
+              Note that the serialization includes the versioning information. Therefore, the transaction here is serialized
+              as an `UntypedVersionedMessage` which in turn contains the serialized `TopologyTransaction` in the version
+              supported by the synchronizer.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          multiHash:
+            description: |-
+              the multi-hash which may be signed instead of each individual transaction
+
+              Required: must be non-empty
+            type: string
+      GetActiveContractsRequest:
+        title: GetActiveContractsRequest
+        description: |-
+          If the given offset is different than the ledger end, and there are (un)assignments in-flight at the given offset,
+          the snapshot may fail with "FAILED_PRECONDITION/PARTICIPANT_PRUNED_DATA_ACCESSED".
+          Note that it is ok to request acs snapshots for party migration with offsets other than ledger end, because party
+          migration is not concerned with incomplete (un)assignments.
+        type: object
+        required:
+        - activeAtOffset
+        properties:
+          filter:
+            $ref: '#/components/schemas/TransactionFilter'
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              Templates to include in the served snapshot, per party.
+              Optional, if specified event_format must be unset, if not specified event_format must be set.
+          verbose:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
+              In particular, setting the verbose flag to true triggers the ledger to include labels for record fields.
+              Optional, if specified event_format must be unset.
+            type: boolean
+          activeAtOffset:
+            description: |-
+              The offset at which the snapshot of the active contracts will be computed.
+              Must be no greater than the current ledger end offset.
+              Must be greater than or equal to the last pruning offset.
+              Must be a valid absolute offset (positive integer) or ledger begin offset (zero).
+              If zero, the empty set will be returned.
+
+              Required
+            type: integer
+            format: int64
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              Format of the contract_entries in the result. In case of CreatedEvent the presentation will be of
+              TRANSACTION_SHAPE_ACS_DELTA.
+              Optional for backwards compatibility, defaults to an EventFormat where:
+
+              - filters_by_party is the filter.filters_by_party from this request
+              - filters_for_any_party is the filter.filters_for_any_party from this request
+              - verbose is the verbose field from this request
+          streamContinuationToken:
+            description: |-
+              Opaque representation of a continuation token defining a position in the active contracts snapshot.
+              The prefix of the active contracts snapshot will be omitted up to and including the element from which
+              the continuation token was read.
+              To reuse the continuation token from a `GetActiveContractsPageResponse`:
+
+              - subsequent request must be executed on the same participant with the same version of canton,
+              - subsequent request must have the same active_at_offset,
+              - subsequent request must have the same event_format
+              - and the participant must not have been pruned after the active_at_offset.
+
+              If not specified, the whole active contracts snapshot will be returned.
+
+              Optional: can be empty
+            type: string
+      GetConnectedSynchronizersResponse:
+        title: GetConnectedSynchronizersResponse
+        type: object
+        properties:
+          connectedSynchronizers:
+            description: 'Optional: can be empty'
+            type: array
+            items:
+              $ref: '#/components/schemas/ConnectedSynchronizer'
+      GetContractRequest:
+        title: GetContractRequest
+        type: object
+        required:
+        - contractId
+        properties:
+          contractId:
+            description: |-
+              The ID of the contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          queryingParties:
+            description: |-
+              The list of querying parties
+              The stakeholders of the referenced contract must have an intersection with any of these parties
+              to return the result.
+              If no querying_parties specified, all possible contracts could be returned.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      GetContractResponse:
+        title: GetContractResponse
+        type: object
+        required:
+        - createdEvent
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The representative_package_id will be always set to the contract package ID, therefore this endpoint should
+              not be used to lookup contract which entered the participant via party replication or repair service.
+              The witnesses field will contain only the querying_parties which are also stakeholders of the contract as well.
+              The following fields of the created event cannot be populated, so those should not be used / parsed:
+
+              - offset
+              - node_id
+              - created_event_blob
+              - interface_views
+              - acs_delta
+
+              Required
+      GetEventsByContractIdRequest:
+        title: GetEventsByContractIdRequest
+        type: object
+        required:
+        - contractId
+        - eventFormat
+        properties:
+          contractId:
+            description: |-
+              The contract id being queried.
+
+              Required
+            type: string
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              Format of the events in the result, the presentation will be of TRANSACTION_SHAPE_ACS_DELTA.
+
+              Required
+      GetIdentityProviderConfigResponse:
+        title: GetIdentityProviderConfigResponse
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: Required
+      GetLatestPrunedOffsetsResponse:
+        title: GetLatestPrunedOffsetsResponse
+        type: object
+        properties:
+          participantPrunedUpToInclusive:
+            description: |-
+              It will always be a non-negative integer.
+              If positive, the absolute offset up to which the ledger has been pruned,
+              disregarding the state of all divulged contracts pruning.
+              If zero, the ledger has not been pruned yet.
+
+              Optional
+            type: integer
+            format: int64
+          allDivulgedContractsPrunedUpToInclusive:
+            description: |-
+              It will always be a non-negative integer.
+              If positive, the absolute offset up to which all divulged events have been pruned on the ledger.
+              It can be at or before the ``participant_pruned_up_to_inclusive`` offset.
+              For more details about all divulged events pruning,
+              see ``PruneRequest.prune_all_divulged_contracts`` in ``participant_pruning_service.proto``.
+              If zero, the divulged events have not been pruned yet.
+
+              Optional
+            type: integer
+            format: int64
+      GetLedgerApiVersionResponse:
+        title: GetLedgerApiVersionResponse
+        type: object
+        required:
+        - version
+        - features
+        properties:
+          version:
+            description: |-
+              The version of the ledger API.
+
+              Required
+            type: string
+          features:
+            $ref: '#/components/schemas/FeaturesDescriptor'
+            description: |-
+              The features supported by this Ledger API endpoint.
+
+              Daml applications CAN use the feature descriptor on top of
+              version constraints on the Ledger API version to determine
+              whether a given Ledger API endpoint supports the features
+              required to run the application.
+
+              See the feature descriptions themselves for the relation between
+              Ledger API versions and feature presence.
+
+              Required
+      GetLedgerEndResponse:
+        title: GetLedgerEndResponse
+        type: object
+        properties:
+          offset:
+            description: |-
+              It will always be a non-negative integer.
+              If zero, the participant view of the ledger is empty.
+              If positive, the absolute offset of the ledger as viewed by the participant.
+
+              Optional
+            type: integer
+            format: int64
+      GetPackageStatusResponse:
+        title: GetPackageStatusResponse
+        type: object
+        required:
+        - packageStatus
+        properties:
+          packageStatus:
+            description: |-
+              The status of the package.
+
+              Required
+            type: string
+            enum:
+            - PACKAGE_STATUS_UNSPECIFIED
+            - PACKAGE_STATUS_REGISTERED
+      GetParticipantIdResponse:
+        title: GetParticipantIdResponse
+        type: object
+        required:
+        - participantId
+        properties:
+          participantId:
+            description: |-
+              Identifier of the participant, which SHOULD be globally unique.
+              Must be a valid LedgerString (as describe in ``value.proto``).
+
+              Required
+            type: string
+      GetPartiesResponse:
+        title: GetPartiesResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
+            description: |-
+              The details of the requested Daml parties by the participant, if known.
+              The party details may not be in the same order as requested.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PartyDetails'
+      GetPreferredPackageVersionResponse:
+        title: GetPreferredPackageVersionResponse
+        type: object
+        properties:
+          packagePreference:
+            $ref: '#/components/schemas/PackagePreference'
+            description: |-
+              Not populated when no preferred package is found
+
+              Optional
+      GetPreferredPackagesRequest:
+        title: GetPreferredPackagesRequest
+        type: object
+        required:
+        - packageVettingRequirements
+        properties:
+          packageVettingRequirements:
+            description: |-
+              The package-name vetting requirements for which the preferred packages should be resolved.
+
+              Generally it is enough to provide the requirements for the intended command's root package-names.
+              Additional package-name requirements can be provided when additional Daml transaction informees need to use
+              package dependencies of the command's root packages.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PackageVettingRequirement'
+          synchronizerId:
+            description: |-
+              The synchronizer whose vetting state should be used for resolving this query.
+              If not specified, the vetting states of all synchronizers to which the participant is connected are used.
+
+              Optional
+            type: string
+          vettingValidAt:
+            description: |-
+              The timestamp at which the package vetting validity should be computed
+              on the latest topology snapshot as seen by the participant.
+              If not provided, the participant's current clock time is used.
+
+              Optional
+            type: string
+      GetPreferredPackagesResponse:
+        title: GetPreferredPackagesResponse
+        type: object
+        required:
+        - synchronizerId
+        - packageReferences
+        properties:
+          packageReferences:
+            description: |-
+              The package references of the preferred packages.
+              Must contain one package reference for each requested package-name.
+
+              If you build command submissions whose content depends on the returned
+              preferred packages, then we recommend submitting the preferred package-ids
+              in the ``package_id_selection_preference`` of the command submission to
+              avoid race conditions with concurrent changes of the on-ledger package vetting state.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PackageReference'
+          synchronizerId:
+            description: |-
+              The synchronizer for which the package preferences are computed.
+              If the synchronizer_id was specified in the request, then it matches the request synchronizer_id.
+
+              Required
+            type: string
+      GetTransactionByIdRequest:
+        title: GetTransactionByIdRequest
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - updateId
+        properties:
+          updateId:
+            description: |-
+              The ID of a particular transaction.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Required
+            type: string
+          requestingParties:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              The parties whose events the client expects to see.
+              Events that are not visible for the parties in this collection will not be present in the response.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+              Optional for backwards compatibility for GetTransactionById request: if defined transaction_format must be
+              unset (falling back to defaults).
+            type: array
+            items:
+              type: string
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              Optional for GetTransactionById request for backwards compatibility: defaults to a transaction_format, where:
+
+              - event_format.filters_by_party will have template-wildcard filters for all the requesting_parties
+              - event_format.filters_for_any_party is unset
+              - event_format.verbose = true
+              - transaction_shape = TRANSACTION_SHAPE_ACS_DELTA
+      GetTransactionByOffsetRequest:
+        title: GetTransactionByOffsetRequest
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - offset
+        properties:
+          offset:
+            description: |-
+              The offset of the transaction being looked up.
+              Must be a valid absolute offset (positive integer).
+              Required
+            type: integer
+            format: int64
+          requestingParties:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              The parties whose events the client expects to see.
+              Events that are not visible for the parties in this collection will not be present in the response.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+              Optional for backwards compatibility for GetTransactionByOffset request: if defined transaction_format must be
+              unset (falling back to defaults).
+            type: array
+            items:
+              type: string
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              Optional for GetTransactionByOffset request for backwards compatibility: defaults to a TransactionFormat, where:
+
+              - event_format.filters_by_party will have template-wildcard filters for all the requesting_parties
+              - event_format.filters_for_any_party is unset
+              - event_format.verbose = true
+              - transaction_shape = TRANSACTION_SHAPE_ACS_DELTA
+      GetUpdateByIdRequest:
+        title: GetUpdateByIdRequest
+        type: object
+        required:
+        - updateId
+        - updateFormat
+        properties:
+          updateId:
+            description: |-
+              The ID of a particular update.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          updateFormat:
+            $ref: '#/components/schemas/UpdateFormat'
+            description: |-
+              The format for the update.
+
+              Required
+      GetUpdateByOffsetRequest:
+        title: GetUpdateByOffsetRequest
+        type: object
+        required:
+        - offset
+        - updateFormat
+        properties:
+          offset:
+            description: |-
+              The offset of the update being looked up.
+              Must be a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          updateFormat:
+            $ref: '#/components/schemas/UpdateFormat'
+            description: |-
+              The format for the update.
+
+              Required
+      GetUpdatesRequest:
+        title: GetUpdatesRequest
+        type: object
+        required:
+        - beginExclusive
+        properties:
+          beginExclusive:
+            description: |-
+              Exclusive lower bound offset of the requested ledger section (non-negative integer).
+              The response will only contain transactions whose offset is strictly greater than this.
+              If set to zero, the lower bound is set to the beginning of the ledger.
+              If the participant has been pruned, this parameter must be greater or equal than the pruning offset.
+              Required
+            type: integer
+            format: int64
+          endInclusive:
+            description: |-
+              Inclusive higher bound offset of the requested ledger section.
+              If specified the response will only contain transactions whose offset is less than or equal to this.
+              If not specified,
+
+              - the descending_order must not be selected,
+              - the stream will not terminate.
+
+              Optional
+            type: integer
+            format: int64
+          filter:
+            $ref: '#/components/schemas/TransactionFilter'
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              Requesting parties with template filters.
+              Template filters must be empty for GetUpdateTrees requests.
+              Optional for backwards compatibility, if defined update_format must be unset
+          verbose:
+            description: |-
+              Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+              If enabled, values served over the API will contain more information than strictly necessary to interpret the data.
+              In particular, setting the verbose flag to true triggers the ledger to include labels, record and variant type ids
+              for record fields.
+              Optional for backwards compatibility, if defined update_format must be unset
+            type: boolean
+          updateFormat:
+            $ref: '#/components/schemas/UpdateFormat'
+            description: |-
+              Must be unset for GetUpdateTrees request.
+              Optional for backwards compatibility for GetUpdates request: defaults to an UpdateFormat where:
+
+              - include_transactions.event_format.filters_by_party = the filter.filters_by_party on this request
+              - include_transactions.event_format.filters_for_any_party = the filter.filters_for_any_party on this request
+              - include_transactions.event_format.verbose = the same flag specified on this request
+              - include_transactions.transaction_shape = TRANSACTION_SHAPE_ACS_DELTA
+              - include_reassignments.filter = the same filter specified on this request
+              - include_reassignments.verbose = the same flag specified on this request
+              - include_topology_events.include_participant_authorization_events.parties = all the parties specified in filter
+          descendingOrder:
+            description: |-
+              If set, the stream will populate the elements in descending order.
+
+              Optional
+            type: boolean
+      GetUserResponse:
+        title: GetUserResponse
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              Retrieved user.
+
+              Required
+      GrantUserRightsRequest:
+        title: GrantUserRightsRequest
+        description: |-
+          Add the rights to the set of rights granted to the user.
+
+          Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id)``
+        type: object
+        required:
+        - userId
+        properties:
+          userId:
+            description: |-
+              The user to whom to grant rights.
+
+              Required
+            type: string
+          rights:
+            description: |-
+              The rights to grant.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the user is managed by the default identity provider.
+
+              Optional
+            type: string
+      GrantUserRightsResponse:
+        title: GrantUserRightsResponse
+        type: object
+        properties:
+          newlyGrantedRights:
+            description: |-
+              The rights that were newly granted by the request.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      IdentifierFilter:
+        title: IdentifierFilter
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty1'
+        - type: object
+          required:
+          - InterfaceFilter
+          properties:
+            InterfaceFilter:
+              $ref: '#/components/schemas/InterfaceFilter'
+        - type: object
+          required:
+          - TemplateFilter
+          properties:
+            TemplateFilter:
+              $ref: '#/components/schemas/TemplateFilter'
+        - type: object
+          required:
+          - WildcardFilter
+          properties:
+            WildcardFilter:
+              $ref: '#/components/schemas/WildcardFilter'
+      IdentityProviderAdmin:
+        title: IdentityProviderAdmin
+        description: |-
+          The right to administer the identity provider that the user is assigned to.
+          It means, being able to manage users and parties that are also assigned
+          to the same identity provider.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/IdentityProviderAdmin1'
+      IdentityProviderAdmin1:
+        title: IdentityProviderAdmin
+        description: |-
+          The right to administer the identity provider that the user is assigned to.
+          It means, being able to manage users and parties that are also assigned
+          to the same identity provider.
+        type: object
+      IdentityProviderConfig:
+        title: IdentityProviderConfig
+        type: object
+        required:
+        - identityProviderId
+        - issuer
+        - jwksUrl
+        properties:
+          identityProviderId:
+            description: |-
+              The identity provider identifier
+              Must be a valid LedgerString (as describe in ``value.proto``).
+
+              Required
+            type: string
+          isDeactivated:
+            description: |-
+              When set, the callers using JWT tokens issued by this identity provider are denied all access
+              to the Ledger API.
+              Modifiable
+
+              Optional
+            type: boolean
+          issuer:
+            description: |-
+              Specifies the issuer of the JWT token.
+              The issuer value is a case sensitive URL using the https scheme that contains scheme, host,
+              and optionally, port number and path components and no query or fragment components.
+              Modifiable
+
+              Can be left empty when used in `UpdateIdentityProviderConfigRequest` if the issuer is not being updated.
+
+              Required
+            type: string
+          jwksUrl:
+            description: |-
+              The JWKS (JSON Web Key Set) URL.
+              The Ledger API uses JWKs (JSON Web Keys) from the provided URL to verify that the JWT has been
+              signed with the loaded JWK. Only RS256 (RSA Signature with SHA-256) signing algorithm is supported.
+              Modifiable
+
+              Required
+            type: string
+          audience:
+            description: |-
+              Specifies the audience of the JWT token.
+              When set, the callers using JWT tokens issued by this identity provider are allowed to get an access
+              only if the "aud" claim includes the string specified here
+              Modifiable
+
+              Optional
+            type: string
+      InterfaceFilter:
+        title: InterfaceFilter
+        description: This filter matches contracts that implement a specific interface.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/InterfaceFilter1'
+      InterfaceFilter1:
+        title: InterfaceFilter
+        description: This filter matches contracts that implement a specific interface.
+        type: object
+        required:
+        - interfaceId
+        properties:
+          interfaceId:
+            description: |-
+              The interface that a matching contract must implement.
+              The ``interface_id`` needs to be valid: corresponding interface should be defined in
+              one of the available packages at the time of the query.
+              Both package-name and package-id reference formats for the identifier are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          includeInterfaceView:
+            description: |-
+              Whether to include the interface view on the contract in the returned ``CreatedEvent``.
+              Use this to access contract data in a uniform manner in your API client.
+
+              Optional
+            type: boolean
+          includeCreatedEventBlob:
+            description: |-
+              Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
+              Use this to access the contract create event payload in your API client
+              for submitting it as a disclosed contract with future commands.
+
+              Optional
+            type: boolean
+      JsActiveContract:
+        title: JsActiveContract
+        type: object
+        required:
+        - createdEvent
+        - synchronizerId
+        - reassignmentCounter
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The event as it appeared in the context of its last update (i.e. daml transaction or
+              reassignment). In particular, the last offset, node_id pair is preserved.
+              The last update is the most recent update created or assigned this contract on synchronizer_id synchronizer.
+              The offset of the CreatedEvent might point to an already pruned update, therefore it cannot necessarily be used
+              for lookups.
+
+              Required
+          synchronizerId:
+            description: |-
+              A valid synchronizer id
+
+              Required
+            type: string
+          reassignmentCounter:
+            description: |-
+              Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
+              with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
+              equals zero.
+              This field will be the reassignment_counter of the latest observable activation event on this synchronizer, which is
+              before the active_at_offset.
+
+              Required
+            type: integer
+            format: int64
+      JsArchived:
+        title: JsArchived
+        type: object
+        required:
+        - archivedEvent
+        - synchronizerId
+        properties:
+          archivedEvent:
+            $ref: '#/components/schemas/ArchivedEvent'
+            description: Required
+          synchronizerId:
+            description: |-
+              The synchronizer which sequenced the archival of the contract
+
+              Required
+            type: string
+      JsAssignedEvent:
+        title: JsAssignedEvent
+        description: Records that a contract has been assigned, and it can be used on
+          the target synchronizer.
+        type: object
+        required:
+        - source
+        - target
+        - reassignmentId
+        - reassignmentCounter
+        - createdEvent
+        properties:
+          source:
+            description: |-
+              The ID of the source synchronizer.
+              Must be a valid synchronizer id.
+
+              Required
+            type: string
+          target:
+            description: |-
+              The ID of the target synchronizer.
+              Must be a valid synchronizer id.
+
+              Required
+            type: string
+          reassignmentId:
+            description: |-
+              The ID from the unassigned event.
+              For correlation capabilities.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          submitter:
+            description: |-
+              Party on whose behalf the assign command was executed.
+              Empty if the assignment happened offline via the repair service.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          reassignmentCounter:
+            description: |-
+              Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
+              with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
+              equals zero.
+
+              Required
+            type: integer
+            format: int64
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The offset of this event refers to the offset of the assignment,
+              while the node_id is the index of within the batch.
+
+              Required
+      JsAssignmentEvent:
+        title: JsAssignmentEvent
+        type: object
+        required:
+        - source
+        - target
+        - reassignmentId
+        - submitter
+        - reassignmentCounter
+        - createdEvent
+        properties:
+          source:
+            type: string
+          target:
+            type: string
+          reassignmentId:
+            type: string
+          submitter:
+            type: string
+          reassignmentCounter:
+            type: integer
+            format: int64
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+      JsCantonError:
+        title: JsCantonError
+        type: object
+        required:
+        - code
+        - cause
+        - context
+        - errorCategory
+        properties:
+          code:
+            type: string
+          cause:
+            type: string
+          correlationId:
+            type: string
+          traceId:
+            type: string
+          context:
+            $ref: '#/components/schemas/Map_String'
+          resources:
+            type: array
+            items:
+              $ref: '#/components/schemas/Tuple2_String_String'
+          errorCategory:
+            type: integer
+            format: int32
+          grpcCodeValue:
+            type: integer
+            format: int32
+          retryInfo:
+            type: string
+          definiteAnswer:
+            type: boolean
+      JsCommands:
+        title: JsCommands
+        description: A composite command that groups multiple commands together.
+        type: object
+        required:
+        - commandId
+        - commands
+        - actAs
+        properties:
+          commands:
+            description: |-
+              Individual elements of this atomic command. Must be non-empty.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Command'
+          commandId:
+            description: |-
+              Uniquely identifies the command.
+              The triple (user_id, act_as, command_id) constitutes the change ID for the intended ledger change,
+              where act_as is interpreted as a set of party names.
+              The change ID can be used for matching the intended ledger changes with all their completions.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          actAs:
+            description: |-
+              Set of parties on whose behalf the command should be executed.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to act on behalf of each of the given parties.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          userId:
+            description: |-
+              Uniquely identifies the participant user that issued the command.
+              Must be a valid UserIdString (as described in ``value.proto``).
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
+
+              Optional
+            type: string
+          readAs:
+            description: |-
+              Set of parties on whose behalf (in addition to all parties listed in ``act_as``) contracts can be retrieved.
+              This affects Daml operations such as ``fetch``, ``fetchByKey``, ``lookupByKey``, ``exercise``, and ``exerciseByKey``.
+              Note: A participant node of a Daml network can host multiple parties. Each contract present on the participant
+              node is only visible to a subset of these parties. A command can only use contracts that are visible to at least
+              one of the parties in ``act_as`` or ``read_as``. This visibility check is independent from the Daml authorization
+              rules for fetch operations.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to read contract data on behalf of each of the given parties.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          workflowId:
+            description: |-
+              Identifier of the on-ledger workflow that this command is a part of.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod'
+          minLedgerTimeAbs:
+            description: |-
+              Lower bound for the ledger time assigned to the resulting transaction.
+              Note: The ledger time of a transaction is assigned as part of command interpretation.
+              Use this property if you expect that command interpretation will take a considerate amount of time, such that by
+              the time the resulting transaction is sequenced, its assigned ledger time is not valid anymore.
+              Must not be set at the same time as min_ledger_time_rel.
+
+              Optional
+            type: string
+          minLedgerTimeRel:
+            $ref: '#/components/schemas/Duration'
+            description: |-
+              Same as min_ledger_time_abs, but specified as a duration, starting from the time the command is received by the server.
+              Must not be set at the same time as min_ledger_time_abs.
+
+              Optional
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              If omitted, the participant or the committer may set a value of their choice.
+
+              Optional
+            type: string
+          disclosedContracts:
+            description: |-
+              Additional contracts used to resolve contract & contract key lookups.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/DisclosedContract'
+          synchronizerId:
+            description: |-
+              Must be a valid synchronizer id
+
+              Optional
+            type: string
+          packageIdSelectionPreference:
+            description: |-
+              The package-id selection preference of the client for resolving
+              package names and interface instances in command submission and interpretation
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          prefetchContractKeys:
+            description: |-
+              Fetches the contract keys into the caches to speed up the command processing.
+              Should only contain contract keys that are expected to be resolved during interpretation of the commands.
+              Keys of disclosed contracts do not need prefetching.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PrefetchContractKey'
+          tapsMaxPasses:
+            description: |-
+              The maximum number of passes for the Topology-Aware Package Selection (TAPS).
+              Higher values can increase the chance of successful package selection for routing of interpreted transactions.
+              If unset, this defaults to the value defined in the participant configuration.
+              The provided value must not exceed the limit specified in the participant configuration.
+
+              Optional
+            type: integer
+            format: int32
+      JsContractEntry:
+        title: JsContractEntry
+        description: |-
+          For a contract there could be multiple contract_entry-s in the entire snapshot. These together define
+          the state of one contract in the snapshot.
+          A contract_entry is included in the result, if and only if there is at least one stakeholder party of the contract
+          that is hosted on the synchronizer at the time of the event and the party satisfies the
+          ``TransactionFilter`` in the query.
+
+          Required
+        oneOf:
+        - type: object
+          required:
+          - JsActiveContract
+          properties:
+            JsActiveContract:
+              $ref: '#/components/schemas/JsActiveContract'
+        - type: object
+          required:
+          - JsEmpty
+          properties:
+            JsEmpty:
+              $ref: '#/components/schemas/JsEmpty'
+        - type: object
+          required:
+          - JsIncompleteAssigned
+          properties:
+            JsIncompleteAssigned:
+              $ref: '#/components/schemas/JsIncompleteAssigned'
+        - type: object
+          required:
+          - JsIncompleteUnassigned
+          properties:
+            JsIncompleteUnassigned:
+              $ref: '#/components/schemas/JsIncompleteUnassigned'
+      JsCreated:
+        title: JsCreated
+        type: object
+        required:
+        - createdEvent
+        - synchronizerId
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The event as it appeared in the context of its original update (i.e. daml transaction or
+              reassignment) on this participant node. You can use its offset and node_id to find the
+              corresponding update and the node within it.
+
+              Required
+          synchronizerId:
+            description: |-
+              The synchronizer which sequenced the creation of the contract
+
+              Required
+            type: string
+      JsEmpty:
+        title: JsEmpty
+        type: object
+      JsExecuteSubmissionAndWaitForTransactionRequest:
+        title: JsExecuteSubmissionAndWaitForTransactionRequest
+        type: object
+        required:
+        - preparedTransaction
+        - partySignatures
+        - submissionId
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              the prepared transaction
+              Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
+              obtained from calling `prepareSubmission`.
+
+              Required
+            type: string
+          partySignatures:
+            $ref: '#/components/schemas/PartySignatures'
+            description: |-
+              The party(ies) signatures that authorize the prepared submission to be executed by this node.
+              Each party can provide one or more signatures..
+              and one or more parties can sign.
+              Note that currently, only single party submissions are supported.
+
+              Required
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod2'
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          userId:
+            description: |-
+              See [PrepareSubmissionRequest.user_id]
+
+              Optional
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+            - HASHING_SCHEME_VERSION_V3
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: |-
+              If set will influence the chosen ledger effective time but will not result in a submission delay so any override
+              should be scheduled to executed within the window allowed by synchronizer.
+
+              Optional
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              If no ``transaction_format`` is provided, a default will be used where ``transaction_shape`` is set to
+              TRANSACTION_SHAPE_ACS_DELTA, ``event_format`` is defined with ``filters_by_party`` containing wildcard-template
+              filter for all original ``act_as`` and ``read_as`` parties and the ``verbose`` flag is set.
+              When the ``transaction_shape`` TRANSACTION_SHAPE_ACS_DELTA shape is used (explicitly or is defaulted to as explained above),
+              events will only be returned if the submitting party is hosted on this node.
+
+              Optional
+      JsExecuteSubmissionAndWaitForTransactionResponse:
+        title: JsExecuteSubmissionAndWaitForTransactionResponse
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransaction'
+            description: |-
+              The transaction that resulted from the submitted command.
+              The transaction might contain no events (request conditions result in filtering out all of them).
+
+              Required
+      JsExecuteSubmissionAndWaitRequest:
+        title: JsExecuteSubmissionAndWaitRequest
+        type: object
+        required:
+        - preparedTransaction
+        - partySignatures
+        - submissionId
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              the prepared transaction
+              Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
+              obtained from calling `prepareSubmission`.
+
+              Required
+            type: string
+          partySignatures:
+            $ref: '#/components/schemas/PartySignatures'
+            description: |-
+              The party(ies) signatures that authorize the prepared submission to be executed by this node.
+              Each party can provide one or more signatures..
+              and one or more parties can sign.
+              Note that currently, only single party submissions are supported.
+
+              Required
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod2'
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          userId:
+            description: |-
+              See [PrepareSubmissionRequest.user_id]
+
+              Optional
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+            - HASHING_SCHEME_VERSION_V3
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: |-
+              If set will influence the chosen ledger effective time but will not result in a submission delay so any override
+              should be scheduled to executed within the window allowed by synchronizer.
+
+              Optional
+      JsExecuteSubmissionRequest:
+        title: JsExecuteSubmissionRequest
+        type: object
+        required:
+        - preparedTransaction
+        - partySignatures
+        - submissionId
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              the prepared transaction
+              Typically this is the value of the `prepared_transaction` field in `PrepareSubmissionResponse`
+              obtained from calling `prepareSubmission`.
+
+              Required
+            type: string
+          partySignatures:
+            $ref: '#/components/schemas/PartySignatures'
+            description: |-
+              The party(ies) signatures that authorize the prepared submission to be executed by this node.
+              Each party can provide one or more signatures..
+              and one or more parties can sign.
+              Note that currently, only single party submissions are supported.
+
+              Required
+          deduplicationPeriod:
+            $ref: '#/components/schemas/DeduplicationPeriod2'
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          userId:
+            description: |-
+              See [PrepareSubmissionRequest.user_id]
+
+              Optional
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+            - HASHING_SCHEME_VERSION_V3
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: |-
+              If set will influence the chosen ledger effective time but will not result in a submission delay so any override
+              should be scheduled to executed within the window allowed by synchronizer.
+
+              Optional
+      JsGetActiveContractsResponse:
+        title: JsGetActiveContractsResponse
+        type: object
+        properties:
+          workflowId:
+            description: |-
+              The workflow ID used in command submission which corresponds to the contract_entry. Only set if
+              the ``workflow_id`` for the command was set.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          contractEntry:
+            $ref: '#/components/schemas/JsContractEntry'
+          streamContinuationToken:
+            description: |-
+              Opaque representation of a continuation token which can be used in the request to bypass the already processed part
+              of the active contracts snapshot.
+              Only populated for the streaming ``GetActiveContracts`` rpc call.
+
+              Optional: can be empty
+            type: string
+      JsGetEventsByContractIdResponse:
+        title: JsGetEventsByContractIdResponse
+        type: object
+        properties:
+          created:
+            $ref: '#/components/schemas/JsCreated'
+            description: |-
+              The create event for the contract with the ``contract_id`` given in the request
+              provided it exists and has not yet been pruned.
+
+              Optional
+          archived:
+            $ref: '#/components/schemas/JsArchived'
+            description: |-
+              The archive event for the contract with the ``contract_id`` given in the request
+              provided such an archive event exists and it has not yet been pruned.
+
+              Optional
+      JsGetTransactionResponse:
+        title: JsGetTransactionResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransaction'
+            description: Required
+      JsGetTransactionTreeResponse:
+        title: JsGetTransactionTreeResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransactionTree'
+            description: Required
+      JsGetUpdateResponse:
+        title: JsGetUpdateResponse
+        type: object
+        properties:
+          update:
+            $ref: '#/components/schemas/Update'
+      JsGetUpdateTreesResponse:
+        title: JsGetUpdateTreesResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        properties:
+          update:
+            $ref: '#/components/schemas/Update1'
+      JsGetUpdatesResponse:
+        title: JsGetUpdatesResponse
+        type: object
+        properties:
+          update:
+            $ref: '#/components/schemas/Update'
+      JsIncompleteAssigned:
+        title: JsIncompleteAssigned
+        type: object
+        required:
+        - assignedEvent
+        properties:
+          assignedEvent:
+            $ref: '#/components/schemas/JsAssignedEvent'
+            description: Required
+      JsIncompleteUnassigned:
+        title: JsIncompleteUnassigned
+        type: object
+        required:
+        - createdEvent
+        - unassignedEvent
+        properties:
+          createdEvent:
+            $ref: '#/components/schemas/CreatedEvent'
+            description: |-
+              The event as it appeared in the context of its last activation update (i.e. daml transaction or
+              reassignment). In particular, the last activation offset, node_id pair is preserved.
+              The last activation update is the most recent update created or assigned this contract on synchronizer_id synchronizer before
+              the unassigned_event.
+              The offset of the CreatedEvent might point to an already pruned update, therefore it cannot necessarily be used
+              for lookups.
+
+              Required
+          unassignedEvent:
+            $ref: '#/components/schemas/UnassignedEvent'
+            description: Required
+      JsInterfaceView:
+        title: JsInterfaceView
+        description: View of a create event matched by an interface filter.
+        type: object
+        required:
+        - interfaceId
+        - viewStatus
+        properties:
+          interfaceId:
+            description: |-
+              The interface implemented by the matched event.
+              The identifier uses the package-id reference format.
+
+              Required
+            type: string
+          viewStatus:
+            $ref: '#/components/schemas/JsStatus'
+            description: |-
+              Whether the view was successfully computed, and if not,
+              the reason for the error. The error is reported using the same rules
+              for error codes and messages as the errors returned for API requests.
+
+              Required
+          viewValue:
+            description: |-
+              The value of the interface's view method on this event.
+              Set if it was requested in the ``InterfaceFilter`` and it could be
+              successfully computed.
+
+              Optional
+          implementationPackageId:
+            description: |-
+              The package defining the interface implementation used to compute the view.
+              Can be different from the package that was used to create the contract itself,
+              as the contract arguments can be upgraded or downgraded using smart-contract upgrading
+              as part of computing the interface view.
+              Populated if the view computation is successful, otherwise empty.
+
+              Optional
+            type: string
+      JsPrepareSubmissionRequest:
+        title: JsPrepareSubmissionRequest
+        type: object
+        required:
+        - commandId
+        - commands
+        - actAs
+        properties:
+          userId:
+            description: |-
+              Uniquely identifies the participant user that prepares the transaction.
+              Must be a valid UserIdString (as described in ``value.proto``).
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
+
+              Optional
+            type: string
+          commandId:
+            description: |-
+              Uniquely identifies the command.
+              The triple (user_id, act_as, command_id) constitutes the change ID for the intended ledger change,
+              where act_as is interpreted as a set of party names.
+              The change ID can be used for matching the intended ledger changes with all their completions.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          commands:
+            description: |-
+              Individual elements of this atomic command. Must be non-empty.
+              Limitation: Only single command transaction are currently supported by the API.
+              The field is marked as repeated in preparation for future support of multiple commands.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Command'
+          minLedgerTime:
+            $ref: '#/components/schemas/MinLedgerTime'
+            description: Optional
+          actAs:
+            description: |-
+              Set of parties on whose behalf the command should be executed, if submitted.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to **read** (not act) on behalf of each of the given parties. This is because this RPC merely prepares a transaction
+              and does not execute it. Therefore read authorization is sufficient even for actAs parties.
+              Note: This may change, and more specific authorization scope may be introduced in the future.
+              Each element must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          readAs:
+            description: |-
+              Set of parties on whose behalf (in addition to all parties listed in ``act_as``) contracts can be retrieved.
+              This affects Daml operations such as ``fetch``, ``fetchByKey``, ``lookupByKey``, ``exercise``, and ``exerciseByKey``.
+              Note: A command can only use contracts that are visible to at least
+              one of the parties in ``act_as`` or ``read_as``. This visibility check is independent from the Daml authorization
+              rules for fetch operations.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to read contract data on behalf of each of the given parties.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          disclosedContracts:
+            description: |-
+              Additional contracts used to resolve contract & contract key lookups.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/DisclosedContract'
+          synchronizerId:
+            description: |-
+              Must be a valid synchronizer id
+              If not set, a suitable synchronizer that this node is connected to will be chosen
+
+              Optional
+            type: string
+          packageIdSelectionPreference:
+            description: |-
+              The package-id selection preference of the client for resolving
+              package names and interface instances in command submission and interpretation
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          verboseHashing:
+            description: |-
+              When true, the response will contain additional details on how the transaction was encoded and hashed
+              This can be useful for troubleshooting of hash mismatches. Should only be used for debugging.
+              Defaults to false
+
+              Optional
+            type: boolean
+          prefetchContractKeys:
+            description: |-
+              Fetches the contract keys into the caches to speed up the command processing.
+              Should only contain contract keys that are expected to be resolved during interpretation of the commands.
+              Keys of disclosed contracts do not need prefetching.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PrefetchContractKey'
+          maxRecordTime:
+            description: |-
+              Maximum timestamp at which the transaction can be recorded onto the ledger via the synchronizer specified in the `PrepareSubmissionResponse`.
+              If submitted after it will be rejected even if otherwise valid, in which case it needs to be prepared and signed again
+              with a new valid max_record_time.
+              Use this to limit the time-to-life of a prepared transaction,
+              which is useful to know when it can definitely not be accepted
+              anymore and resorting to preparing another transaction for the same
+              intent is safe again.
+
+              Optional
+            type: string
+          estimateTrafficCost:
+            $ref: '#/components/schemas/CostEstimationHints'
+            description: |-
+              Hints to improve the accuracy of traffic cost estimation.
+              The estimation logic assumes that this node will be used for the execution of the transaction
+              If another node is used instead, the estimation may be less precise.
+              Request amplification is not accounted for in the estimation: each amplified request will
+              result in the cost of the confirmation request to be charged additionally.
+
+              Traffic cost estimation is enabled by default if this field is not set
+              To turn off cost estimation, set the CostEstimationHints#disabled field to true
+
+              Optional
+          tapsMaxPasses:
+            description: |-
+              The maximum number of passes for the Topology-Aware Package Selection (TAPS).
+              Higher values can increase the chance of successful package selection for routing of interpreted transactions.
+              If unset, this defaults to the value defined in the participant configuration.
+              The provided value must not exceed the limit specified in the participant configuration.
+
+              Optional
+            type: integer
+            format: int32
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version to be used when building the hash.
+              Defaults to HASHING_SCHEME_VERSION_V2.
+
+              Optional
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+            - HASHING_SCHEME_VERSION_V3
+      JsPrepareSubmissionResponse:
+        title: JsPrepareSubmissionResponse
+        description: '[docs-entry-end: HashingSchemeVersion]'
+        type: object
+        required:
+        - preparedTransaction
+        - preparedTransactionHash
+        - hashingSchemeVersion
+        properties:
+          preparedTransaction:
+            description: |-
+              The interpreted transaction, it represents the ledger changes necessary to execute the commands specified in the request.
+              Clients MUST display the content of the transaction to the user for them to validate before signing the hash if the preparing participant is not trusted.
+
+              Required
+            type: string
+          preparedTransactionHash:
+            description: |-
+              Hash of the transaction, this is what needs to be signed by the party to authorize the transaction.
+              Only provided for convenience, clients MUST recompute the hash from the raw transaction if the preparing participant is not trusted.
+              May be removed in future versions
+
+              Required: must be non-empty
+            type: string
+          hashingSchemeVersion:
+            description: |-
+              The hashing scheme version used when building the hash
+
+              Required
+            type: string
+            enum:
+            - HASHING_SCHEME_VERSION_UNSPECIFIED
+            - HASHING_SCHEME_VERSION_V2
+            - HASHING_SCHEME_VERSION_V3
+          hashingDetails:
+            description: |-
+              Optional additional details on how the transaction was encoded and hashed. Only set if verbose_hashing = true in the request
+              Note that there are no guarantees on the stability of the format or content of this field.
+              Its content should NOT be parsed and should only be used for troubleshooting purposes.
+
+              Optional
+            type: string
+          costEstimation:
+            $ref: '#/components/schemas/CostEstimation'
+            description: |-
+              Traffic cost estimation of the prepared transaction
+
+              Optional
+      JsReassignment:
+        title: JsReassignment
+        description: Complete view of an on-ledger reassignment.
+        type: object
+        required:
+        - updateId
+        - offset
+        - recordTime
+        - synchronizerId
+        - events
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          commandId:
+            description: |-
+              The ID of the command which resulted in this reassignment. Missing for everyone except the submitting party on the submitting participant.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          workflowId:
+            description: |-
+              The workflow ID used in reassignment command submission. Only set if the ``workflow_id`` for the command was set.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          offset:
+            description: |-
+              The participant's offset. The details of this field are described in ``community/ledger-api/README.md``.
+              Must be a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          events:
+            description: |-
+              The collection of reassignment events.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/JsReassignmentEvent'
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+
+              Optional
+          recordTime:
+            description: |-
+              The time at which the reassignment was recorded. The record time refers to the source/target
+              synchronizer for an unassign/assign event respectively.
+
+              Required
+            type: string
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized this Reassignment.
+
+              Required
+            type: string
+          paidTrafficCost:
+            description: |-
+              The traffic cost that this participant node paid for the corresponding (un)assignment request.
+
+              Not set for transactions that were
+              - initiated by another participant
+              - initiated offline via the repair service
+              - processed before the participant started serving traffic cost on the Ledger API
+              - returned as part of a query filtering for a non submitting party
+
+              Optional
+            type: integer
+            format: int64
+      JsReassignmentEvent:
+        title: JsReassignmentEvent
+        oneOf:
+        - type: object
+          required:
+          - JsAssignmentEvent
+          properties:
+            JsAssignmentEvent:
+              $ref: '#/components/schemas/JsAssignmentEvent'
+        - type: object
+          required:
+          - JsUnassignedEvent
+          properties:
+            JsUnassignedEvent:
+              $ref: '#/components/schemas/JsUnassignedEvent'
+      JsStatus:
+        title: JsStatus
+        type: object
+        required:
+        - code
+        - message
+        properties:
+          code:
+            type: integer
+            format: int32
+          message:
+            type: string
+          details:
+            type: array
+            items:
+              $ref: '#/components/schemas/ProtoAny'
+      JsSubmitAndWaitForReassignmentResponse:
+        title: JsSubmitAndWaitForReassignmentResponse
+        type: object
+        required:
+        - reassignment
+        properties:
+          reassignment:
+            $ref: '#/components/schemas/JsReassignment'
+            description: |-
+              The reassignment that resulted from the submitted reassignment command.
+              The reassignment might contain no events (request conditions result in filtering out all of them).
+
+              Required
+      JsSubmitAndWaitForTransactionRequest:
+        title: JsSubmitAndWaitForTransactionRequest
+        description: These commands are executed as a single atomic transaction.
+        type: object
+        required:
+        - commands
+        properties:
+          commands:
+            $ref: '#/components/schemas/JsCommands'
+            description: |-
+              The commands to be submitted.
+
+              Required
+          transactionFormat:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              If no ``transaction_format`` is provided, a default will be used where ``transaction_shape`` is set to
+              TRANSACTION_SHAPE_ACS_DELTA, ``event_format`` is defined with ``filters_by_party`` containing wildcard-template
+              filter for all original ``act_as`` and ``read_as`` parties and the ``verbose`` flag is set.
+
+              Optional
+      JsSubmitAndWaitForTransactionResponse:
+        title: JsSubmitAndWaitForTransactionResponse
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            $ref: '#/components/schemas/JsTransaction'
+            description: |-
+              The transaction that resulted from the submitted command.
+              The transaction might contain no events (request conditions result in filtering out all of them).
+
+              Required
+      JsSubmitAndWaitForTransactionTreeResponse:
+        title: JsSubmitAndWaitForTransactionTreeResponse
+        description: Provided for backwards compatibility, it will be removed in the
+          Canton version 3.5.0.
+        type: object
+        properties:
+          transactionTree:
+            $ref: '#/components/schemas/JsTransactionTree'
+      JsTopologyTransaction:
+        title: JsTopologyTransaction
+        type: object
+        required:
+        - updateId
+        - offset
+        - synchronizerId
+        - recordTime
+        - events
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          offset:
+            description: |-
+              The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
+              It is a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized the topology transaction.
+
+              Required
+            type: string
+          recordTime:
+            description: |-
+              The time at which the changes in the topology transaction become effective. There is a small delay between a
+              topology transaction being sequenced and the changes it contains becoming effective. Topology transactions appear
+              in order relative to a synchronizer based on their effective time rather than their sequencing time.
+
+              Required
+            type: string
+          events:
+            description: |-
+              A non-empty list of topology events.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/TopologyEvent'
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+
+              Optional
+      JsTransaction:
+        title: JsTransaction
+        description: Filtered view of an on-ledger transaction's create and archive
+          events.
+        type: object
+        required:
+        - updateId
+        - effectiveAt
+        - offset
+        - synchronizerId
+        - recordTime
+        - events
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          commandId:
+            description: |-
+              The ID of the command which resulted in this transaction. Missing for everyone except the submitting party.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          workflowId:
+            description: |-
+              The workflow ID used in command submission.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          effectiveAt:
+            description: |-
+              Ledger effective time.
+
+              Required
+            type: string
+          events:
+            description: |-
+              The collection of events.
+              Contains:
+
+              - ``CreatedEvent`` or ``ArchivedEvent`` in case of ACS_DELTA transaction shape
+              - ``CreatedEvent`` or ``ExercisedEvent`` in case of LEDGER_EFFECTS transaction shape
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Event'
+          offset:
+            description: |-
+              The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
+              It is a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized the transaction.
+
+              Required
+            type: string
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+
+              Optional
+          recordTime:
+            description: |-
+              The time at which the transaction was recorded. The record time refers to the synchronizer
+              which synchronized the transaction.
+
+              Required
+            type: string
+          externalTransactionHash:
+            description: |-
+              For transaction externally signed, contains the external transaction hash
+              signed by the external party. Can be used to correlate an external submission with a committed transaction.
+
+              Optional: can be empty
+            type: string
+          paidTrafficCost:
+            description: |-
+              The traffic cost that this participant node paid for the confirmation
+              request for this transaction.
+
+              Not set for transactions that were
+              - initiated by another participant
+              - initiated offline via the repair service
+              - processed before the participant started serving traffic cost on the Ledger API
+              - returned as part of a query filtering for a non submitting party
+
+              Optional
+            type: integer
+            format: int64
+      JsTransactionTree:
+        title: JsTransactionTree
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Complete view of an on-ledger transaction.
+        type: object
+        required:
+        - updateId
+        - effectiveAt
+        - offset
+        - eventsById
+        - synchronizerId
+        - recordTime
+        properties:
+          updateId:
+            description: |-
+              Assigned by the server. Useful for correlating logs.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Required
+            type: string
+          commandId:
+            description: |-
+              The ID of the command which resulted in this transaction. Missing for everyone except the submitting party.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Optional
+            type: string
+          workflowId:
+            description: |-
+              The workflow ID used in command submission. Only set if the ``workflow_id`` for the command was set.
+              Must be a valid LedgerString (as described in ``value.proto``).
+              Optional
+            type: string
+          effectiveAt:
+            description: |-
+              Ledger effective time.
+              Required
+            type: string
+          offset:
+            description: |-
+              The absolute offset. The details of this field are described in ``community/ledger-api/README.md``.
+              Required, it is a valid absolute offset (positive integer).
+            type: integer
+            format: int64
+          eventsById:
+            $ref: '#/components/schemas/Map_Int_TreeEvent'
+            description: |-
+              Changes to the ledger that were caused by this transaction. Nodes of the transaction tree.
+              Each key must be a valid node ID (non-negative integer).
+              Required
+          synchronizerId:
+            description: |-
+              A valid synchronizer id.
+              Identifies the synchronizer that synchronized the transaction.
+              Required
+            type: string
+          traceContext:
+            $ref: '#/components/schemas/TraceContext'
+            description: |-
+              Optional; ledger API trace context
+
+              The trace context transported in this message corresponds to the trace context supplied
+              by the client application in a HTTP2 header of the original command submission.
+              We typically use a header to transfer this type of information. Here we use message
+              body, because it is used in gRPC streams which do not support per message headers.
+              This field will be populated with the trace context contained in the original submission.
+              If that was not provided, a unique ledger-api-server generated trace context will be used
+              instead.
+          recordTime:
+            description: |-
+              The time at which the transaction was recorded. The record time refers to the synchronizer
+              which synchronized the transaction.
+              Required
+            type: string
+      JsUnassignedEvent:
+        title: JsUnassignedEvent
+        description: Records that a contract has been unassigned, and it becomes unusable
+          on the source synchronizer
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/UnassignedEvent'
+      Kind:
+        title: Kind
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - CanActAs
+          properties:
+            CanActAs:
+              $ref: '#/components/schemas/CanActAs'
+        - type: object
+          required:
+          - CanExecuteAs
+          properties:
+            CanExecuteAs:
+              $ref: '#/components/schemas/CanExecuteAs'
+        - type: object
+          required:
+          - CanExecuteAsAnyParty
+          properties:
+            CanExecuteAsAnyParty:
+              $ref: '#/components/schemas/CanExecuteAsAnyParty'
+        - type: object
+          required:
+          - CanReadAs
+          properties:
+            CanReadAs:
+              $ref: '#/components/schemas/CanReadAs'
+        - type: object
+          required:
+          - CanReadAsAnyParty
+          properties:
+            CanReadAsAnyParty:
+              $ref: '#/components/schemas/CanReadAsAnyParty'
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty8'
+        - type: object
+          required:
+          - IdentityProviderAdmin
+          properties:
+            IdentityProviderAdmin:
+              $ref: '#/components/schemas/IdentityProviderAdmin'
+        - type: object
+          required:
+          - ParticipantAdmin
+          properties:
+            ParticipantAdmin:
+              $ref: '#/components/schemas/ParticipantAdmin'
+      ListIdentityProviderConfigsResponse:
+        title: ListIdentityProviderConfigsResponse
+        type: object
+        required:
+        - identityProviderConfigs
+        properties:
+          identityProviderConfigs:
+            description: |-
+              The list of identity provider configs
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/IdentityProviderConfig'
+      ListKnownPartiesResponse:
+        title: ListKnownPartiesResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
+            description: |-
+              The details of all Daml parties known by the participant.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/PartyDetails'
+          nextPageToken:
+            description: |-
+              Pagination token to retrieve the next page.
+              Empty, if there are no further results.
+
+              Optional
+            type: string
+      ListPackagesResponse:
+        title: ListPackagesResponse
+        type: object
+        required:
+        - packageIds
+        properties:
+          packageIds:
+            description: |-
+              The IDs of all Daml-LF packages supported by the server.
+              Each element must be a valid PackageIdString (as described in ``value.proto``).
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+      ListUserRightsResponse:
+        title: ListUserRightsResponse
+        type: object
+        properties:
+          rights:
+            description: |-
+              All rights of the user.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      ListUsersResponse:
+        title: ListUsersResponse
+        type: object
+        properties:
+          users:
+            description: |-
+              A subset of users of the participant node that fit into this page.
+              Can be empty if no more users
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+          nextPageToken:
+            description: |-
+              Pagination token to retrieve the next page.
+              Empty, if there are no further results.
+
+              Optional
+            type: string
+      ListVettedPackagesRequest:
+        title: ListVettedPackagesRequest
+        type: object
+        properties:
+          packageMetadataFilter:
+            $ref: '#/components/schemas/PackageMetadataFilter'
+            description: |-
+              The package metadata filter the returned vetted packages set must satisfy.
+
+              Optional
+          topologyStateFilter:
+            $ref: '#/components/schemas/TopologyStateFilter'
+            description: |-
+              The topology filter the returned vetted packages set must satisfy.
+
+              Optional
+          pageToken:
+            description: |-
+              Pagination token to determine the specific page to fetch. Using the token
+              guarantees that ``VettedPackages`` on a subsequent page are all greater
+              (``VettedPackages`` are sorted by synchronizer ID then participant ID) than
+              the last ``VettedPackages`` on a previous page.
+
+              The server does not store intermediate results between calls chained by a
+              series of page tokens. As a consequence, if new vetted packages are being
+              added and a page is requested twice using the same token, more packages can
+              be returned on the second call.
+
+              Leave unspecified (i.e. as empty string) to fetch the first page.
+
+              Optional
+            type: string
+          pageSize:
+            description: |-
+              Maximum number of ``VettedPackages`` results to return in a single page.
+
+              If the page_size is unspecified (i.e. left as 0), the server will decide
+              the number of results to be returned.
+
+              If the page_size exceeds the maximum supported by the server, an
+              error will be returned.
+
+              To obtain the server's maximum consult the PackageService descriptor
+              available in the VersionService.
+
+              Optional
+            type: integer
+            format: int32
+      ListVettedPackagesResponse:
+        title: ListVettedPackagesResponse
+        type: object
+        properties:
+          vettedPackages:
+            description: |-
+              All ``VettedPackages`` that contain at least one ``VettedPackage`` matching
+              both a ``PackageMetadataFilter`` and a ``TopologyStateFilter``.
+              Sorted by synchronizer_id then participant_id.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackages'
+          nextPageToken:
+            description: |-
+              Pagination token to retrieve the next page.
+              Empty string if there are no further results.
+
+              Optional
+            type: string
+      Map_Filters:
+        title: Map_Filters
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/Filters'
+      Map_Int_Field:
+        title: Map_Int_Field
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/Field'
+      Map_Int_TreeEvent:
+        title: Map_Int_TreeEvent
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/TreeEvent'
+      Map_String:
+        title: Map_String
+        type: object
+        additionalProperties:
           type: string
-        primaryParty:
-          description: |-
-            The primary party as which this user reads and acts by default on the ledger
-            *provided* it has the corresponding ``CanReadAs(primary_party)`` or
-            ``CanActAs(primary_party)`` rights.
-            Ledger API clients SHOULD set this field to a non-empty value for all users to
-            enable the users to act on the ledger using their own Daml party.
-            Users for participant administrators MAY have an associated primary party.
-            Modifiable
+      MinLedgerTime:
+        title: MinLedgerTime
+        type: object
+        properties:
+          time:
+            $ref: '#/components/schemas/Time'
+      MinLedgerTimeAbs:
+        title: MinLedgerTimeAbs
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: string
+      MinLedgerTimeRel:
+        title: MinLedgerTimeRel
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Duration'
+      NoPrior:
+        title: NoPrior
+        type: object
+      ObjectMeta:
+        title: ObjectMeta
+        description: |-
+          Represents metadata corresponding to a participant resource (e.g. a participant user or participant local information about a party).
 
-            Optional
+          Based on ``ObjectMeta`` meta used in Kubernetes API.
+          See https://github.com/kubernetes/apimachinery/blob/master/pkg/apis/meta/v1/generated.proto#L640
+        type: object
+        properties:
+          resourceVersion:
+            description: |-
+              An opaque, non-empty value, populated by a participant server which represents the internal version of the resource
+              this ``ObjectMeta`` message is attached to. The participant server will change it to a unique value each time the corresponding resource is updated.
+              You must not rely on the format of resource version. The participant server might change it without notice.
+              You can obtain the newest resource version value by issuing a read request.
+              You may use it for concurrent change detection by passing it back unmodified in an update request.
+              The participant server will then compare the passed value with the value maintained by the system to determine
+              if any other updates took place since you had read the resource version.
+              Upon a successful update you are guaranteed that no other update took place during your read-modify-write sequence.
+              However, if another update took place during your read-modify-write sequence then your update will fail with an appropriate error.
+              Concurrent change control is optional. It will be applied only if you include a resource version in an update request.
+              When creating a new instance of a resource you must leave the resource version empty.
+              Its value will be populated by the participant server upon successful resource creation.
+
+              Optional
+            type: string
+          annotations:
+            $ref: '#/components/schemas/Map_String'
+            description: |-
+              A set of modifiable key-value pairs that can be used to represent arbitrary, client-specific metadata.
+              Constraints:
+
+              1. The total size over all keys and values cannot exceed 256kb in UTF-8 encoding.
+              2. Keys are composed of an optional prefix segment and a required name segment such that:
+
+                 - key prefix, when present, must be a valid DNS subdomain with at most 253 characters, followed by a '/' (forward slash) character,
+                 - name segment must have at most 63 characters that are either alphanumeric ([a-z0-9A-Z]), or a '.' (dot), '-' (dash) or '_' (underscore);
+                   and it must start and end with an alphanumeric character.
+
+              3. Values can be any non-empty strings.
+
+              Keys with empty prefix are reserved for end-users.
+              Properties set by external tools or internally by the participant server must use non-empty key prefixes.
+              Duplicate keys are disallowed by the semantics of the protobuf3 maps.
+              See: https://developers.google.com/protocol-buffers/docs/proto3#maps
+              Annotations may be a part of a modifiable resource.
+              Use the resource's update RPC to update its annotations.
+              In order to add a new annotation or update an existing one using an update RPC, provide the desired annotation in the update request.
+              In order to remove an annotation using an update RPC, provide the target annotation's key but set its value to the empty string in the update request.
+              Modifiable
+
+              Optional: can be empty
+      OffsetCheckpoint:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/OffsetCheckpoint1'
+      OffsetCheckpoint1:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - offset
+        properties:
+          offset:
+            description: |-
+              The participant's offset, the details of the offset field are described in ``community/ledger-api/README.md``.
+              Must be a valid absolute offset (positive integer).
+
+              Required
+            type: integer
+            format: int64
+          synchronizerTimes:
+            description: |-
+              The times associated with each synchronizer at this offset.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/SynchronizerTime'
+      OffsetCheckpoint2:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/OffsetCheckpoint1'
+      OffsetCheckpoint3:
+        title: OffsetCheckpoint
+        description: |-
+          OffsetCheckpoints may be used to:
+
+          - detect time out of commands.
+          - provide an offset which can be used to restart consumption.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/OffsetCheckpoint1'
+      OffsetCheckpointFeature:
+        title: OffsetCheckpointFeature
+        type: object
+        required:
+        - maxOffsetCheckpointEmissionDelay
+        properties:
+          maxOffsetCheckpointEmissionDelay:
+            $ref: '#/components/schemas/Duration'
+            description: |-
+              The maximum delay to emmit a new OffsetCheckpoint if it exists
+
+              Required
+      Operation:
+        title: Operation
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty5'
+        - type: object
+          required:
+          - Unvet
+          properties:
+            Unvet:
+              $ref: '#/components/schemas/Unvet'
+        - type: object
+          required:
+          - Vet
+          properties:
+            Vet:
+              $ref: '#/components/schemas/Vet'
+      PackageFeature:
+        title: PackageFeature
+        type: object
+        required:
+        - maxVettedPackagesPageSize
+        properties:
+          maxVettedPackagesPageSize:
+            description: |-
+              The maximum number of vetted packages the server can return in a single
+              response (page) when listing them.
+
+              Required
+            type: integer
+            format: int32
+      PackageMetadataFilter:
+        title: PackageMetadataFilter
+        description: |-
+          Filter the VettedPackages by package metadata.
+
+          A PackageMetadataFilter without package_ids and without package_name_prefixes
+          matches any vetted package.
+
+          Non-empty fields specify candidate values of which at least one must match.
+          If both fields are set, then a candidate is returned if it matches one of the fields.
+        type: object
+        properties:
+          packageIds:
+            description: |-
+              If this list is non-empty, any vetted package with a package ID in this
+              list will match the filter.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          packageNamePrefixes:
+            description: |-
+              If this list is non-empty, any vetted package with a name matching at least
+              one prefix in this list will match the filter.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      PackagePreference:
+        title: PackagePreference
+        type: object
+        required:
+        - synchronizerId
+        - packageReference
+        properties:
+          packageReference:
+            $ref: '#/components/schemas/PackageReference'
+            description: |-
+              The package reference of the preferred package.
+
+              Required
+          synchronizerId:
+            description: |-
+              The synchronizer for which the preferred package was computed.
+              If the synchronizer_id was specified in the request, then it matches the request synchronizer_id.
+
+              Required
+            type: string
+      PackageReference:
+        title: PackageReference
+        type: object
+        required:
+        - packageId
+        - packageName
+        - packageVersion
+        properties:
+          packageId:
+            description: Required
+            type: string
+          packageName:
+            description: Required
+            type: string
+          packageVersion:
+            description: Required
+            type: string
+      PackageVettingRequirement:
+        title: PackageVettingRequirement
+        description: Defines a package-name for which the commonly vetted package with
+          the highest version must be found.
+        type: object
+        required:
+        - packageName
+        - parties
+        properties:
+          parties:
+            description: |-
+              The parties whose participants' vetting state should be considered when resolving the preferred package.
+
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          packageName:
+            description: |-
+              The package-name for which the preferred package should be resolved.
+
+              Required
+            type: string
+      ParticipantAdmin:
+        title: ParticipantAdmin
+        description: The right to administer the participant node.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAdmin1'
+      ParticipantAdmin1:
+        title: ParticipantAdmin
+        description: The right to administer the participant node.
+        type: object
+      ParticipantAuthorizationAdded:
+        title: ParticipantAuthorizationAdded
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAuthorizationAdded1'
+      ParticipantAuthorizationAdded1:
+        title: ParticipantAuthorizationAdded
+        type: object
+        required:
+        - partyId
+        - participantId
+        - participantPermission
+        properties:
+          partyId:
+            description: Required
+            type: string
+          participantId:
+            description: Required
+            type: string
+          participantPermission:
+            description: Required
+            type: string
+            enum:
+            - PARTICIPANT_PERMISSION_UNSPECIFIED
+            - PARTICIPANT_PERMISSION_SUBMISSION
+            - PARTICIPANT_PERMISSION_CONFIRMATION
+            - PARTICIPANT_PERMISSION_OBSERVATION
+      ParticipantAuthorizationChanged:
+        title: ParticipantAuthorizationChanged
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAuthorizationChanged1'
+      ParticipantAuthorizationChanged1:
+        title: ParticipantAuthorizationChanged
+        type: object
+        required:
+        - partyId
+        - participantId
+        - participantPermission
+        properties:
+          partyId:
+            description: Required
+            type: string
+          participantId:
+            description: Required
+            type: string
+          participantPermission:
+            description: Required
+            type: string
+            enum:
+            - PARTICIPANT_PERMISSION_UNSPECIFIED
+            - PARTICIPANT_PERMISSION_SUBMISSION
+            - PARTICIPANT_PERMISSION_CONFIRMATION
+            - PARTICIPANT_PERMISSION_OBSERVATION
+      ParticipantAuthorizationOnboarding:
+        title: ParticipantAuthorizationOnboarding
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAuthorizationOnboarding1'
+      ParticipantAuthorizationOnboarding1:
+        title: ParticipantAuthorizationOnboarding
+        type: object
+        required:
+        - partyId
+        - participantId
+        - participantPermission
+        properties:
+          partyId:
+            description: Required
+            type: string
+          participantId:
+            description: Required
+            type: string
+          participantPermission:
+            description: Required
+            type: string
+            enum:
+            - PARTICIPANT_PERMISSION_UNSPECIFIED
+            - PARTICIPANT_PERMISSION_SUBMISSION
+            - PARTICIPANT_PERMISSION_CONFIRMATION
+            - PARTICIPANT_PERMISSION_OBSERVATION
+      ParticipantAuthorizationRevoked:
+        title: ParticipantAuthorizationRevoked
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/ParticipantAuthorizationRevoked1'
+      ParticipantAuthorizationRevoked1:
+        title: ParticipantAuthorizationRevoked
+        type: object
+        required:
+        - partyId
+        - participantId
+        properties:
+          partyId:
+            description: Required
+            type: string
+          participantId:
+            description: Required
+            type: string
+      ParticipantAuthorizationTopologyFormat:
+        title: ParticipantAuthorizationTopologyFormat
+        description: A format specifying which participant authorization topology transactions
+          to include and how to render them.
+        type: object
+        properties:
+          parties:
+            description: |-
+              List of parties for which the topology transactions should be sent.
+              Empty means: for all parties.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      PartyDetails:
+        title: PartyDetails
+        type: object
+        required:
+        - party
+        properties:
+          party:
+            description: |-
+              The stable unique identifier of a Daml party.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required
+            type: string
+          isLocal:
+            description: |-
+              true if party is hosted by the participant and the party shares the same identity provider as the user issuing the request.
+
+              Optional
+            type: boolean
+          localMetadata:
+            $ref: '#/components/schemas/ObjectMeta'
+            description: |-
+              Participant-local metadata of this party.
+              Modifiable
+
+              Optional
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              Optional, if not set, there could be 3 options:
+
+              1. the party is managed by the default identity provider.
+              2. party is not hosted by the participant.
+              3. party is hosted by the participant, but is outside of the user's identity provider.
+
+              Optional
+            type: string
+      PartyManagementFeature:
+        title: PartyManagementFeature
+        type: object
+        required:
+        - maxPartiesPageSize
+        properties:
+          maxPartiesPageSize:
+            description: |-
+              The maximum number of parties the server can return in a single response (page).
+
+              Required
+            type: integer
+            format: int32
+      PartySignatures:
+        title: PartySignatures
+        description: Additional signatures provided by the submitting parties
+        type: object
+        required:
+        - signatures
+        properties:
+          signatures:
+            description: |-
+              Additional signatures provided by all individual parties
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/SinglePartySignatures'
+      PrefetchContractKey:
+        title: PrefetchContractKey
+        description: Preload contracts
+        type: object
+        required:
+        - templateId
+        - contractKey
+        properties:
+          templateId:
+            description: |-
+              The template of contract the client wants to prefetch.
+              Both package-name and package-id reference identifier formats for the template-id are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          contractKey:
+            description: |-
+              The key of the contract the client wants to prefetch.
+
+              Required
+      Prior:
+        title: Prior
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            type: integer
+            format: int32
+      PriorTopologySerial:
+        title: PriorTopologySerial
+        description: |-
+          The serial of last ``VettedPackages`` topology transaction on a given
+          participant and synchronizer.
+        type: object
+        properties:
+          serial:
+            $ref: '#/components/schemas/Serial'
+      ProtoAny:
+        title: ProtoAny
+        type: object
+        required:
+        - typeUrl
+        - value
+        - unknownFields
+        properties:
+          typeUrl:
+            type: string
+          value:
+            type: string
+          unknownFields:
+            $ref: '#/components/schemas/UnknownFieldSet'
+          valueDecoded:
+            type: string
+      Reassignment:
+        title: Reassignment
+        description: Complete view of an on-ledger reassignment.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsReassignment'
+      Reassignment1:
+        title: Reassignment
+        description: Complete view of an on-ledger reassignment.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsReassignment'
+      ReassignmentCommand:
+        title: ReassignmentCommand
+        type: object
+        properties:
+          command:
+            $ref: '#/components/schemas/Command1'
+      ReassignmentCommands:
+        title: ReassignmentCommands
+        type: object
+        required:
+        - commandId
+        - submitter
+        - commands
+        properties:
+          workflowId:
+            description: |-
+              Identifier of the on-ledger workflow that this command is a part of.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Optional
+            type: string
+          userId:
+            description: |-
+              Uniquely identifies the participant user that issued the command.
+              Must be a valid UserIdString (as described in ``value.proto``).
+              Required unless authentication is used with a user token.
+              In that case, the token's user-id will be used for the request's user_id.
+
+              Optional
+            type: string
+          commandId:
+            description: |-
+              Uniquely identifies the command.
+              The triple (user_id, submitter, command_id) constitutes the change ID for the intended ledger change.
+              The change ID can be used for matching the intended ledger changes with all their completions.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          submitter:
+            description: |-
+              Party on whose behalf the command should be executed.
+              If ledger API authorization is enabled, then the authorization metadata must authorize the sender of the request
+              to act on behalf of the given party.
+              Must be a valid PartyIdString (as described in ``value.proto``).
+
+              Required
+            type: string
+          submissionId:
+            description: |-
+              A unique identifier to distinguish completions for different submissions with the same change ID.
+              Typically a random UUID. Applications are expected to use a different UUID for each retry of a submission
+              with the same change ID.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              If omitted, the participant or the committer may set a value of their choice.
+
+              Optional
+            type: string
+          commands:
+            description: |-
+              Individual elements of this reassignment. Must be non-empty.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/ReassignmentCommand'
+      RevokeUserRightsRequest:
+        title: RevokeUserRightsRequest
+        description: |-
+          Remove the rights from the set of rights granted to the user.
+
+          Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(identity_provider_id)``
+        type: object
+        required:
+        - userId
+        properties:
+          userId:
+            description: |-
+              The user from whom to revoke rights.
+
+              Required
+            type: string
+          rights:
+            description: |-
+              The rights to revoke.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+          identityProviderId:
+            description: |-
+              The id of the ``Identity Provider``
+              If not set, assume the user is managed by the default identity provider.
+
+              Optional
+            type: string
+      RevokeUserRightsResponse:
+        title: RevokeUserRightsResponse
+        type: object
+        properties:
+          newlyRevokedRights:
+            description: |-
+              The rights that were actually revoked by the request.
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Right'
+      Right:
+        title: Right
+        description: A right granted to a user.
+        type: object
+        properties:
+          kind:
+            $ref: '#/components/schemas/Kind'
+      Serial:
+        title: Serial
+        description: Optional
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty6'
+        - type: object
+          required:
+          - NoPrior
+          properties:
+            NoPrior:
+              $ref: '#/components/schemas/NoPrior'
+        - type: object
+          required:
+          - Prior
+          properties:
+            Prior:
+              $ref: '#/components/schemas/Prior'
+      Signature:
+        title: Signature
+        type: object
+        required:
+        - format
+        - signature
+        - signedBy
+        - signingAlgorithmSpec
+        properties:
+          format:
+            description: Required
+            type: string
+          signature:
+            description: 'Required: must be non-empty'
+            type: string
+          signedBy:
+            description: |-
+              The fingerprint/id of the keypair used to create this signature and needed to verify.
+
+              Required
+            type: string
+          signingAlgorithmSpec:
+            description: |-
+              The signing algorithm specification used to produce this signature
+
+              Required
+            type: string
+      SignedTransaction:
+        title: SignedTransaction
+        type: object
+        required:
+        - transaction
+        properties:
+          transaction:
+            description: |-
+              The serialized TopologyTransaction
+
+              Required: must be non-empty
+            type: string
+          signatures:
+            description: |-
+              Additional signatures for this transaction specifically
+              Use for transactions that require additional signatures beyond the namespace key signatures
+              e.g: PartyToParticipant must be signed by all registered keys
+
+              Optional: can be empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Signature'
+      SigningPublicKey:
+        title: SigningPublicKey
+        type: object
+        required:
+        - format
+        - keyData
+        - keySpec
+        properties:
+          format:
+            description: |-
+              The serialization format of the public key
+
+              Required
+            example: CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO
+            type: string
+          keyData:
+            description: |-
+              Serialized public key in the format specified above
+
+              Required: must be non-empty
+            type: string
+          keySpec:
+            description: |-
+              The key specification
+
+              Required
+            example: SIGNING_KEY_SPEC_EC_CURVE25519
+            type: string
+      SinglePartySignatures:
+        title: SinglePartySignatures
+        description: Signatures provided by a single party
+        type: object
+        required:
+        - party
+        - signatures
+        properties:
+          party:
+            description: |-
+              Submitting party
+
+              Required
+            type: string
+          signatures:
+            description: |-
+              Signatures
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/Signature'
+      SubmitAndWaitForReassignmentRequest:
+        title: SubmitAndWaitForReassignmentRequest
+        description: This reassignment is executed as a single atomic update.
+        type: object
+        required:
+        - reassignmentCommands
+        properties:
+          reassignmentCommands:
+            $ref: '#/components/schemas/ReassignmentCommands'
+            description: |-
+              The reassignment commands to be submitted.
+
+              Required
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              If no event_format provided, the result will contain no events.
+              The events in the result, will take shape TRANSACTION_SHAPE_ACS_DELTA.
+
+              Optional
+      SubmitAndWaitResponse:
+        title: SubmitAndWaitResponse
+        type: object
+        required:
+        - updateId
+        - completionOffset
+        properties:
+          updateId:
+            description: |-
+              The id of the transaction that resulted from the submitted command.
+              Must be a valid LedgerString (as described in ``value.proto``).
+
+              Required
+            type: string
+          completionOffset:
+            description: |-
+              The details of the offset field are described in ``community/ledger-api/README.md``.
+
+              Required
+            type: integer
+            format: int64
+      SubmitReassignmentRequest:
+        title: SubmitReassignmentRequest
+        type: object
+        required:
+        - reassignmentCommands
+        properties:
+          reassignmentCommands:
+            $ref: '#/components/schemas/ReassignmentCommands'
+            description: |-
+              The reassignment command to be submitted.
+
+              Required
+      SubmitReassignmentResponse:
+        title: SubmitReassignmentResponse
+        type: object
+      SubmitResponse:
+        title: SubmitResponse
+        type: object
+      SynchronizerTime:
+        title: SynchronizerTime
+        type: object
+        required:
+        - synchronizerId
+        - recordTime
+        properties:
+          synchronizerId:
+            description: |-
+              The id of the synchronizer.
+
+              Required
+            type: string
+          recordTime:
+            description: |-
+              All commands with a maximum record time below this value MUST be considered lost if their completion has not arrived before this checkpoint.
+
+              Required
+            type: string
+      TemplateFilter:
+        title: TemplateFilter
+        description: This filter matches contracts of a specific template.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/TemplateFilter1'
+      TemplateFilter1:
+        title: TemplateFilter
+        description: This filter matches contracts of a specific template.
+        type: object
+        required:
+        - templateId
+        properties:
+          templateId:
+            description: |-
+              A template for which the payload should be included in the response.
+              The ``template_id`` needs to be valid: corresponding template should be defined in
+              one of the available packages at the time of the query.
+              Both package-name and package-id reference formats for the identifier are supported.
+              Note: The package-id reference identifier format is deprecated. We plan to end support for this format in version 3.4.
+
+              Required
+            type: string
+          includeCreatedEventBlob:
+            description: |-
+              Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
+              Use this to access the contract event payload in your API client
+              for submitting it as a disclosed contract with future commands.
+
+              Optional
+            type: boolean
+      Time:
+        title: Time
+        description: Required
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty9'
+        - type: object
+          required:
+          - MinLedgerTimeAbs
+          properties:
+            MinLedgerTimeAbs:
+              $ref: '#/components/schemas/MinLedgerTimeAbs'
+        - type: object
+          required:
+          - MinLedgerTimeRel
+          properties:
+            MinLedgerTimeRel:
+              $ref: '#/components/schemas/MinLedgerTimeRel'
+      TopologyEvent:
+        title: TopologyEvent
+        type: object
+        properties:
+          event:
+            $ref: '#/components/schemas/TopologyEventEvent'
+      TopologyEventEvent:
+        title: TopologyEventEvent
+        oneOf:
+        - type: object
+          required:
+          - Empty
+          properties:
+            Empty:
+              $ref: '#/components/schemas/Empty7'
+        - type: object
+          required:
+          - ParticipantAuthorizationAdded
+          properties:
+            ParticipantAuthorizationAdded:
+              $ref: '#/components/schemas/ParticipantAuthorizationAdded'
+        - type: object
+          required:
+          - ParticipantAuthorizationChanged
+          properties:
+            ParticipantAuthorizationChanged:
+              $ref: '#/components/schemas/ParticipantAuthorizationChanged'
+        - type: object
+          required:
+          - ParticipantAuthorizationOnboarding
+          properties:
+            ParticipantAuthorizationOnboarding:
+              $ref: '#/components/schemas/ParticipantAuthorizationOnboarding'
+        - type: object
+          required:
+          - ParticipantAuthorizationRevoked
+          properties:
+            ParticipantAuthorizationRevoked:
+              $ref: '#/components/schemas/ParticipantAuthorizationRevoked'
+      TopologyFormat:
+        title: TopologyFormat
+        description: A format specifying which topology transactions to include and
+          how to render them.
+        type: object
+        properties:
+          includeParticipantAuthorizationEvents:
+            $ref: '#/components/schemas/ParticipantAuthorizationTopologyFormat'
+            description: |-
+              Include participant authorization topology events in streams.
+              If unset, no participant authorization topology events are emitted in the stream.
+
+              Optional
+      TopologyStateFilter:
+        title: TopologyStateFilter
+        description: |-
+          Filter the vetted packages by the participant and synchronizer that they are
+          hosted on.
+
+          Empty fields are ignored, such that a ``TopologyStateFilter`` without
+          participant_ids and without synchronizer_ids matches a vetted package hosted
+          on any participant and synchronizer.
+
+          Non-empty fields specify candidate values of which at least one must match.
+          If both fields are set then at least one candidate value must match from each
+          field.
+        type: object
+        properties:
+          participantIds:
+            description: |-
+              If this list is non-empty, only vetted packages hosted on participants
+              listed in this field match the filter.
+              Query the current Ledger API's participant's ID via the public
+              ``GetParticipantId`` command in ``PartyManagementService``.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+          synchronizerIds:
+            description: |-
+              If this list is non-empty, only vetted packages from the topology state of
+              the synchronizers in this list match the filter.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+      TopologyTransaction:
+        title: TopologyTransaction
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsTopologyTransaction'
+      TraceContext:
+        title: TraceContext
+        type: object
+        properties:
+          traceparent:
+            description: |-
+              https://www.w3.org/TR/trace-context/
+
+              Optional
+            type: string
+          tracestate:
+            description: Optional
+            type: string
+      Transaction:
+        title: Transaction
+        description: Filtered view of an on-ledger transaction's create and archive
+          events.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsTransaction'
+      TransactionFilter:
+        title: TransactionFilter
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Used both for filtering create and archive events as well as for filtering transaction trees.
+        type: object
+        properties:
+          filtersByParty:
+            $ref: '#/components/schemas/Map_Filters'
+            description: |-
+              Each key must be a valid PartyIdString (as described in ``value.proto``).
+              The interpretation of the filter depends on the transaction-shape being filtered:
+
+              1. For **transaction trees** (used in GetUpdateTreesResponse for backwards compatibility) all party keys used as
+                 wildcard filters, and all subtrees whose root has one of the listed parties as an informee are returned.
+                 If there are ``CumulativeFilter``s, those will control returned ``CreatedEvent`` fields where applicable, but will
+                 not be used for template/interface filtering.
+              2. For **ledger-effects** create and exercise events are returned, for which the witnesses include at least one of
+                 the listed parties and match the per-party filter.
+              3. For **transaction and active-contract-set streams** create and archive events are returned for all contracts whose
+                 stakeholders include at least one of the listed parties and match the per-party filter.
+          filtersForAnyParty:
+            $ref: '#/components/schemas/Filters'
+            description: |-
+              Wildcard filters that apply to all the parties existing on the participant. The interpretation of the filters is the same
+              with the per-party filter as described above.
+      TransactionFormat:
+        title: TransactionFormat
+        description: |-
+          A format that specifies what events to include in Daml transactions
+          and what data to compute and include for them.
+        type: object
+        required:
+        - transactionShape
+        - eventFormat
+        properties:
+          eventFormat:
+            $ref: '#/components/schemas/EventFormat'
+            description: Required
+          transactionShape:
+            description: |-
+              What transaction shape to use for interpreting the filters of the event format.
+
+              Required
+            type: string
+            enum:
+            - TRANSACTION_SHAPE_UNSPECIFIED
+            - TRANSACTION_SHAPE_ACS_DELTA
+            - TRANSACTION_SHAPE_LEDGER_EFFECTS
+      TransactionTree:
+        title: TransactionTree
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Complete view of an on-ledger transaction.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/JsTransactionTree'
+      TreeEvent:
+        title: TreeEvent
+        description: |-
+          Provided for backwards compatibility, it will be removed in the Canton version 3.5.0.
+          Each tree event message type below contains a ``witness_parties`` field which
+          indicates the subset of the requested parties that can see the event
+          in question.
+
+          Note that transaction trees might contain events with
+          _no_ witness parties, which were included simply because they were
+          children of events which have witnesses.
+        oneOf:
+        - type: object
+          required:
+          - CreatedTreeEvent
+          properties:
+            CreatedTreeEvent:
+              $ref: '#/components/schemas/CreatedTreeEvent'
+        - type: object
+          required:
+          - ExercisedTreeEvent
+          properties:
+            ExercisedTreeEvent:
+              $ref: '#/components/schemas/ExercisedTreeEvent'
+      Tuple2_String_String:
+        title: Tuple2_String_String
+        type: array
+        maxItems: 2
+        minItems: 2
+        items:
           type: string
-        isDeactivated:
-          description: |-
-            When set, then the user is denied all access to the Ledger API.
-            Otherwise, the user has access to the Ledger API as per the user's rights.
-            Modifiable
+      UnassignCommand:
+        title: UnassignCommand
+        description: Unassign a contract
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/UnassignCommand1'
+      UnassignCommand1:
+        title: UnassignCommand
+        description: Unassign a contract
+        type: object
+        required:
+        - contractId
+        - source
+        - target
+        properties:
+          contractId:
+            description: |-
+              The ID of the contract the client wants to unassign.
+              Must be a valid LedgerString (as described in ``value.proto``).
 
-            Optional
-          type: boolean
-        metadata:
-          $ref: '#/components/schemas/ObjectMeta'
-          description: |-
-            The metadata of this user.
-            Note that the ``metadata.resource_version`` tracks changes to the properties described by the ``User`` message and not the user's rights.
-            Modifiable
+              Required
+            type: string
+          source:
+            description: |-
+              The ID of the source synchronizer
+              Must be a valid synchronizer id
 
-            Optional
-        identityProviderId:
-          description: |-
-            The ID of the identity provider configured by ``Identity Provider Config``
-            If not set, assume the user is managed by the default identity provider.
+              Required
+            type: string
+          target:
+            description: |-
+              The ID of the target synchronizer
+              Must be a valid synchronizer id
 
-            Optional
-          type: string
-    UserManagementFeature:
-      title: UserManagementFeature
-      type: object
-      required:
-      - supported
-      - maxRightsPerUser
-      - maxUsersPageSize
-      properties:
-        supported:
-          description: |-
-            Whether the Ledger API server provides the user management service.
+              Required
+            type: string
+      UnassignedEvent:
+        title: UnassignedEvent
+        description: Records that a contract has been unassigned, and it becomes unusable
+          on the source synchronizer
+        type: object
+        required:
+        - reassignmentId
+        - contractId
+        - source
+        - target
+        - reassignmentCounter
+        - packageName
+        - offset
+        - nodeId
+        - templateId
+        - witnessParties
+        properties:
+          reassignmentId:
+            description: |-
+              The ID of the unassignment. This needs to be used as an input for a assign ReassignmentCommand.
+              Must be a valid LedgerString (as described in ``value.proto``).
 
-            Required
-          type: boolean
-        maxRightsPerUser:
-          description: |-
-            The maximum number of rights that can be assigned to a single user.
-            Servers MUST support at least 100 rights per user.
-            A value of 0 means that the server enforces no rights per user limit.
+              Required
+            type: string
+          contractId:
+            description: |-
+              The ID of the reassigned contract.
+              Must be a valid LedgerString (as described in ``value.proto``).
 
-            Required
-          type: integer
-          format: int32
-        maxUsersPageSize:
-          description: |-
-            The maximum number of users the server can return in a single response (page).
-            Servers MUST support at least a 100 users per page.
-            A value of 0 means that the server enforces no page size limit.
+              Required
+            type: string
+          templateId:
+            description: |-
+              The template of the reassigned contract.
+              The identifier uses the package-id reference format.
 
-            Required
-          type: integer
-          format: int32
-    Vet:
-      title: Vet
-      description: |-
-        Set vetting bounds of a list of packages. Packages that were not previously
-        vetted have their bounds added, previous vetting bounds are overwritten.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/Vet1'
-    Vet1:
-      title: Vet
-      description: |-
-        Set vetting bounds of a list of packages. Packages that were not previously
-        vetted have their bounds added, previous vetting bounds are overwritten.
-      type: object
-      required:
-      - packages
-      properties:
-        packages:
-          description: |-
-            Packages to be vetted.
+              Required
+            type: string
+          source:
+            description: |-
+              The ID of the source synchronizer
+              Must be a valid synchronizer id
 
-            If a reference in this list matches more than one package, the change is
-            considered ambiguous and the entire update request is rejected. In other
-            words, every reference must match exactly one package.
+              Required
+            type: string
+          target:
+            description: |-
+              The ID of the target synchronizer
+              Must be a valid synchronizer id
 
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/VettedPackagesRef'
-        newValidFromInclusive:
-          description: |-
-            The time from which these packages should be vetted, prior lower bounds
-            are overwritten.
-            Optional
-          type: string
-        newValidUntilExclusive:
-          description: |-
-            The time until which these packages should be vetted, prior upper bounds
-            are overwritten.
-            Optional
-          type: string
-    VettedPackage:
-      title: VettedPackage
-      description: |-
-        A package that is vetting on a given participant and synchronizer,
-        modelled after ``VettedPackage`` in `topology.proto <https://github.com/digital-asset/canton/blob/main/community/base/src/main/protobuf/com/digitalasset/canton/protocol/v30/topology.proto#L206>`_,
-        enriched with the package name and version.
-      type: object
-      required:
-      - packageId
-      properties:
-        packageId:
-          description: |-
-            Package ID of this package
+              Required
+            type: string
+          submitter:
+            description: |-
+              Party on whose behalf the unassign command was executed.
+              Empty if the unassignment happened offline via the repair service.
+              Must be a valid PartyIdString (as described in ``value.proto``).
 
-            Required
-          type: string
-        validFromInclusive:
-          description: |-
-            The time from which this package is vetted. Empty if vetting time has no
-            lower bound.
+              Optional
+            type: string
+          reassignmentCounter:
+            description: |-
+              Each corresponding assigned and unassigned event has the same reassignment_counter. This strictly increases
+              with each unassign command for the same contract. Creation of the contract corresponds to reassignment_counter
+              equals zero.
 
-            Optional
-          type: string
-        validUntilExclusive:
-          description: |-
-            The time until which this package is vetted. Empty if vetting time has no
-            upper bound.
+              Required
+            type: integer
+            format: int64
+          assignmentExclusivity:
+            description: |-
+              Assignment exclusivity
+              Before this time (measured on the target synchronizer), only the submitter of the unassignment can initiate the assignment
+              Defined for reassigning participants.
 
-            Optional
-          type: string
-        packageName:
-          description: |-
-            Name of this package.
-            Only available if the package has been uploaded to the current participant.
+              Optional
+            type: string
+          witnessParties:
+            description: |-
+              The parties that are notified of this event.
 
-            Optional
-          type: string
-        packageVersion:
-          description: |-
-            Version of this package.
-            Only available if the package has been uploaded to the current participant.
+              Required: must be non-empty
+            type: array
+            items:
+              type: string
+          packageName:
+            description: |-
+              The package name of the contract.
 
-            Optional
-          type: string
-    VettedPackages:
-      title: VettedPackages
-      description: |-
-        The list of packages vetted on a given participant and synchronizer, modelled
-        after ``VettedPackages`` in `topology.proto <https://github.com/digital-asset/canton/blob/main/community/base/src/main/protobuf/com/digitalasset/canton/protocol/v30/topology.proto#L206>`_.
-        The list only contains packages that matched a filter in the query that
-        originated it.
-      type: object
-      required:
-      - participantId
-      - synchronizerId
-      - topologySerial
-      - packages
-      properties:
-        packages:
-          description: |-
-            Sorted by package_name and package_version where known, and package_id as a
-            last resort.
+              Required
+            type: string
+          offset:
+            description: |-
+              The offset of origin.
+              Offsets are managed by the participant nodes.
+              Reassignments can thus NOT be assumed to have the same offsets on different participant nodes.
+              Must be a valid absolute offset (positive integer)
 
-            Required: must be non-empty
-          type: array
-          items:
-            $ref: '#/components/schemas/VettedPackage'
-        participantId:
-          description: |-
-            Participant on which these packages are vetted.
+              Required
+            type: integer
+            format: int64
+          nodeId:
+            description: |-
+              The position of this event in the originating reassignment.
+              Node IDs are not necessarily equal across participants,
+              as these may see different projections/parts of reassignments.
+              Must be valid node ID (non-negative integer)
 
-            Required
-          type: string
-        synchronizerId:
-          description: |-
-            Synchronizer on which these packages are vetted.
+              Required
+            type: integer
+            format: int32
+      UnknownFieldSet:
+        title: UnknownFieldSet
+        type: object
+        required:
+        - fields
+        properties:
+          fields:
+            $ref: '#/components/schemas/Map_Int_Field'
+      Unvet:
+        title: Unvet
+        description: Remove packages from the set of vetted packages
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Unvet1'
+      Unvet1:
+        title: Unvet
+        description: Remove packages from the set of vetted packages
+        type: object
+        required:
+        - packages
+        properties:
+          packages:
+            description: |-
+              Packages to be unvetted.
 
-            Required
-          type: string
-        topologySerial:
-          description: |-
-            Serial of last ``VettedPackages`` topology transaction of this participant
-            and on this synchronizer.
+              If a reference in this list matches multiple packages, they are all
+              unvetted.
 
-            Required
-          type: integer
-          format: int32
-    VettedPackagesChange:
-      title: VettedPackagesChange
-      description: A change to the set of vetted packages.
-      type: object
-      properties:
-        operation:
-          $ref: '#/components/schemas/Operation'
-    VettedPackagesRef:
-      title: VettedPackagesRef
-      description: |-
-        A reference to identify one or more packages.
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackagesRef'
+      Update:
+        title: Update
+        oneOf:
+        - type: object
+          required:
+          - OffsetCheckpoint
+          properties:
+            OffsetCheckpoint:
+              $ref: '#/components/schemas/OffsetCheckpoint2'
+        - type: object
+          required:
+          - Reassignment
+          properties:
+            Reassignment:
+              $ref: '#/components/schemas/Reassignment'
+        - type: object
+          required:
+          - TopologyTransaction
+          properties:
+            TopologyTransaction:
+              $ref: '#/components/schemas/TopologyTransaction'
+        - type: object
+          required:
+          - Transaction
+          properties:
+            Transaction:
+              $ref: '#/components/schemas/Transaction'
+      Update1:
+        title: Update
+        oneOf:
+        - type: object
+          required:
+          - OffsetCheckpoint
+          properties:
+            OffsetCheckpoint:
+              $ref: '#/components/schemas/OffsetCheckpoint3'
+        - type: object
+          required:
+          - Reassignment
+          properties:
+            Reassignment:
+              $ref: '#/components/schemas/Reassignment1'
+        - type: object
+          required:
+          - TransactionTree
+          properties:
+            TransactionTree:
+              $ref: '#/components/schemas/TransactionTree'
+      UpdateFormat:
+        title: UpdateFormat
+        description: A format specifying what updates to include and how to render them.
+        type: object
+        properties:
+          includeTransactions:
+            $ref: '#/components/schemas/TransactionFormat'
+            description: |-
+              Include Daml transactions in streams.
+              If unset, no transactions are emitted in the stream.
 
-        A reference matches a package if its ``package_id`` matches the package's ID,
-        its ``package_name`` matches the package's name, and its ``package_version``
-        matches the package's version. If an attribute in the reference is left
-        unspecified (i.e. as an empty string), that attribute is treated as a
-        wildcard. At a minimum, ``package_id`` or the ``package_name`` must be
-        specified.
+              Optional
+          includeReassignments:
+            $ref: '#/components/schemas/EventFormat'
+            description: |-
+              Include (un)assignments in the stream.
+              The events in the result take the shape TRANSACTION_SHAPE_ACS_DELTA.
+              If unset, no (un)assignments are emitted in the stream.
 
-        If a reference does not match any package, the reference is considered
-        unresolved and the entire update request is rejected.
-      type: object
-      properties:
-        packageId:
-          description: |-
-            Package's package id must be the same as this field.
+              Optional
+          includeTopologyEvents:
+            $ref: '#/components/schemas/TopologyFormat'
+            description: |-
+              Include topology events in streams.
+              If unset no topology events are emitted in the stream.
 
-            Optional
-          type: string
-        packageName:
-          description: |-
-            Package's name must be the same as this field.
+              Optional
+      UpdateIdentityProviderConfigRequest:
+        title: UpdateIdentityProviderConfigRequest
+        type: object
+        required:
+        - identityProviderConfig
+        - updateMask
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: |-
+              The identity provider config to update.
+              Modifiable
 
-            Optional
-          type: string
-        packageVersion:
-          description: |-
-            Package's version must be the same as this field.
+              Required
+          updateMask:
+            $ref: '#/components/schemas/FieldMask'
+            description: |-
+              An update mask specifies how and which properties of the ``IdentityProviderConfig`` message are to be updated.
+              An update mask consists of a set of update paths.
+              A valid update path points to a field or a subfield relative to the ``IdentityProviderConfig`` message.
+              A valid update mask must:
 
-            Optional
-          type: string
-    WildcardFilter:
-      title: WildcardFilter
-      description: This filter matches all templates.
-      type: object
-      required:
-      - value
-      properties:
-        value:
-          $ref: '#/components/schemas/WildcardFilter1'
-    WildcardFilter1:
-      title: WildcardFilter
-      description: This filter matches all templates.
-      type: object
-      properties:
-        includeCreatedEventBlob:
-          description: |-
-            Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
-            Use this to access the contract create event payload in your API client
-            for submitting it as a disclosed contract with future commands.
+              1. contain at least one update path,
+              2. contain only valid update paths.
 
-            Optional
-          type: boolean
-  securitySchemes:
-    apiKeyAuth:
-      type: apiKey
-      description: Ledger API standard JWT token (websocket)
-      name: Sec-WebSocket-Protocol
-      in: header
-    httpAuth:
-      type: http
-      description: Ledger API standard JWT token
-      scheme: bearer
+              Fields that can be updated are marked as ``Modifiable``.
+              For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
+
+              Required
+      UpdateIdentityProviderConfigResponse:
+        title: UpdateIdentityProviderConfigResponse
+        type: object
+        required:
+        - identityProviderConfig
+        properties:
+          identityProviderConfig:
+            $ref: '#/components/schemas/IdentityProviderConfig'
+            description: |-
+              Updated identity provider config
+
+              Required
+      UpdatePartyDetailsRequest:
+        title: UpdatePartyDetailsRequest
+        description: 'Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(party_details.identity_provider_id)``'
+        type: object
+        required:
+        - partyDetails
+        - updateMask
+        properties:
+          partyDetails:
+            $ref: '#/components/schemas/PartyDetails'
+            description: |-
+              Party to be updated
+              Modifiable
+
+              Required
+          updateMask:
+            $ref: '#/components/schemas/FieldMask'
+            description: |-
+              An update mask specifies how and which properties of the ``PartyDetails`` message are to be updated.
+              An update mask consists of a set of update paths.
+              A valid update path points to a field or a subfield relative to the ``PartyDetails`` message.
+              A valid update mask must:
+
+              1. contain at least one update path,
+              2. contain only valid update paths.
+
+              Fields that can be updated are marked as ``Modifiable``.
+              An update path can also point to non-``Modifiable`` fields such as 'party' and 'local_metadata.resource_version'
+              because they are used:
+
+              1. to identify the party details resource subject to the update,
+              2. for concurrent change control.
+
+              An update path can also point to non-``Modifiable`` fields such as 'is_local'
+              as long as the values provided in the update request match the server values.
+              Examples of update paths: 'local_metadata.annotations', 'local_metadata'.
+              For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
+              For similar Ledger API see ``com.daml.ledger.api.v2.admin.UpdateUserRequest``.
+
+              Required
+      UpdatePartyDetailsResponse:
+        title: UpdatePartyDetailsResponse
+        type: object
+        required:
+        - partyDetails
+        properties:
+          partyDetails:
+            $ref: '#/components/schemas/PartyDetails'
+            description: |-
+              Updated party details
+
+              Required
+      UpdateUserIdentityProviderIdRequest:
+        title: UpdateUserIdentityProviderIdRequest
+        description: 'Required authorization: ``HasRight(ParticipantAdmin)``'
+        type: object
+        required:
+        - userId
+        properties:
+          userId:
+            description: |-
+              User to update
+
+              Required
+            type: string
+          sourceIdentityProviderId:
+            description: |-
+              Current identity provider ID of the user
+              If omitted, the default IDP is assumed
+
+              Optional
+            type: string
+          targetIdentityProviderId:
+            description: |-
+              Target identity provider ID of the user
+              If omitted, the default IDP is assumed
+
+              Optional
+            type: string
+      UpdateUserIdentityProviderIdResponse:
+        title: UpdateUserIdentityProviderIdResponse
+        type: object
+      UpdateUserRequest:
+        title: UpdateUserRequest
+        description: 'Required authorization: ``HasRight(ParticipantAdmin) OR IsAuthenticatedIdentityProviderAdmin(user.identity_provider_id)``'
+        type: object
+        required:
+        - user
+        - updateMask
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              The user to update.
+              Modifiable
+
+              Required
+          updateMask:
+            $ref: '#/components/schemas/FieldMask'
+            description: |-
+              An update mask specifies how and which properties of the ``User`` message are to be updated.
+              An update mask consists of a set of update paths.
+              A valid update path points to a field or a subfield relative to the ``User`` message.
+              A valid update mask must:
+
+              1. contain at least one update path,
+              2. contain only valid update paths.
+
+              Fields that can be updated are marked as ``Modifiable``.
+              An update path can also point to a non-``Modifiable`` fields such as 'id' and 'metadata.resource_version'
+              because they are used:
+
+              1. to identify the user resource subject to the update,
+              2. for concurrent change control.
+
+              Examples of valid update paths: 'primary_party', 'metadata', 'metadata.annotations'.
+              For additional information see the documentation for standard protobuf3's ``google.protobuf.FieldMask``.
+              For similar Ledger API see ``com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest``.
+
+              Required
+      UpdateUserResponse:
+        title: UpdateUserResponse
+        type: object
+        required:
+        - user
+        properties:
+          user:
+            $ref: '#/components/schemas/User'
+            description: |-
+              Updated user
+
+              Required
+      UpdateVettedPackagesRequest:
+        title: UpdateVettedPackagesRequest
+        type: object
+        required:
+        - changes
+        properties:
+          changes:
+            description: |-
+              Changes to apply to the current vetting state of the participant on the
+              specified synchronizer. The changes are applied in order.
+              Any package not changed will keep their previous vetting state.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackagesChange'
+          dryRun:
+            description: |-
+              If dry_run is true, then the changes are only prepared, but not applied. If
+              a request would trigger an error when run (e.g. TOPOLOGY_DEPENDENCIES_NOT_VETTED),
+              it will also trigger an error when dry_run.
+
+              Use this flag to preview a change before applying it.
+              Defaults to false.
+
+              Optional
+            type: boolean
+          synchronizerId:
+            description: |-
+              If set, the requested changes will take place on the specified
+              synchronizer. If synchronizer_id is unset and the participant is only
+              connected to a single synchronizer, that synchronizer will be used by
+              default. If synchronizer_id is unset and the participant is connected to
+              multiple synchronizers, the request will error out with
+              PACKAGE_SERVICE_CANNOT_AUTODETECT_SYNCHRONIZER.
+
+              Optional
+            type: string
+          expectedTopologySerial:
+            $ref: '#/components/schemas/PriorTopologySerial'
+            description: |-
+              The serial of the last ``VettedPackages`` topology transaction of this
+              participant and on this synchronizer.
+
+              Execution of the request fails if this is not correct. Use this to guard
+              against concurrent changes.
+
+              If left unspecified, no validation is done against the last transaction's
+              serial.
+
+              Optional
+          updateVettedPackagesForceFlags:
+            description: |-
+              Controls whether potentially unsafe vetting updates are allowed.
+
+              Optional: can be empty
+            type: array
+            items:
+              type: string
+              enum:
+              - UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED
+              - UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES
+              - UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES
+      UpdateVettedPackagesResponse:
+        title: UpdateVettedPackagesResponse
+        type: object
+        required:
+        - newVettedPackages
+        properties:
+          pastVettedPackages:
+            $ref: '#/components/schemas/VettedPackages'
+            description: |-
+              All vetted packages on this participant and synchronizer, before the
+              specified changes. Empty if no vetting state existed beforehand.
+
+              Not populated if no vetted topology state exists prior to the update.
+
+              Optional
+          newVettedPackages:
+            $ref: '#/components/schemas/VettedPackages'
+            description: |-
+              All vetted packages on this participant and synchronizer, after the specified changes.
+
+              Required
+      UploadDarFileResponse:
+        title: UploadDarFileResponse
+        description: A message that is received when the upload operation succeeded.
+        type: object
+      User:
+        title: User
+        description: |2-
+           Users and rights
+          /////////////////
+           Users are used to dynamically manage the rights given to Daml applications.
+           They are stored and managed per participant node.
+        type: object
+        required:
+        - id
+        properties:
+          id:
+            description: |-
+              The user identifier, which must be a non-empty string of at most 128
+              characters that are either alphanumeric ASCII characters or one of the symbols "@^$.!`-#+'~_|:()".
+
+              Required
+            type: string
+          primaryParty:
+            description: |-
+              The primary party as which this user reads and acts by default on the ledger
+              *provided* it has the corresponding ``CanReadAs(primary_party)`` or
+              ``CanActAs(primary_party)`` rights.
+              Ledger API clients SHOULD set this field to a non-empty value for all users to
+              enable the users to act on the ledger using their own Daml party.
+              Users for participant administrators MAY have an associated primary party.
+              Modifiable
+
+              Optional
+            type: string
+          isDeactivated:
+            description: |-
+              When set, then the user is denied all access to the Ledger API.
+              Otherwise, the user has access to the Ledger API as per the user's rights.
+              Modifiable
+
+              Optional
+            type: boolean
+          metadata:
+            $ref: '#/components/schemas/ObjectMeta'
+            description: |-
+              The metadata of this user.
+              Note that the ``metadata.resource_version`` tracks changes to the properties described by the ``User`` message and not the user's rights.
+              Modifiable
+
+              Optional
+          identityProviderId:
+            description: |-
+              The ID of the identity provider configured by ``Identity Provider Config``
+              If not set, assume the user is managed by the default identity provider.
+
+              Optional
+            type: string
+      UserManagementFeature:
+        title: UserManagementFeature
+        type: object
+        required:
+        - supported
+        - maxRightsPerUser
+        - maxUsersPageSize
+        properties:
+          supported:
+            description: |-
+              Whether the Ledger API server provides the user management service.
+
+              Required
+            type: boolean
+          maxRightsPerUser:
+            description: |-
+              The maximum number of rights that can be assigned to a single user.
+              Servers MUST support at least 100 rights per user.
+              A value of 0 means that the server enforces no rights per user limit.
+
+              Required
+            type: integer
+            format: int32
+          maxUsersPageSize:
+            description: |-
+              The maximum number of users the server can return in a single response (page).
+              Servers MUST support at least a 100 users per page.
+              A value of 0 means that the server enforces no page size limit.
+
+              Required
+            type: integer
+            format: int32
+      Vet:
+        title: Vet
+        description: |-
+          Set vetting bounds of a list of packages. Packages that were not previously
+          vetted have their bounds added, previous vetting bounds are overwritten.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/Vet1'
+      Vet1:
+        title: Vet
+        description: |-
+          Set vetting bounds of a list of packages. Packages that were not previously
+          vetted have their bounds added, previous vetting bounds are overwritten.
+        type: object
+        required:
+        - packages
+        properties:
+          packages:
+            description: |-
+              Packages to be vetted.
+
+              If a reference in this list matches more than one package, the change is
+              considered ambiguous and the entire update request is rejected. In other
+              words, every reference must match exactly one package.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackagesRef'
+          newValidFromInclusive:
+            description: |-
+              The time from which these packages should be vetted, prior lower bounds
+              are overwritten.
+              Optional
+            type: string
+          newValidUntilExclusive:
+            description: |-
+              The time until which these packages should be vetted, prior upper bounds
+              are overwritten.
+              Optional
+            type: string
+      VettedPackage:
+        title: VettedPackage
+        description: |-
+          A package that is vetting on a given participant and synchronizer,
+          modelled after ``VettedPackage`` in `topology.proto <https://github.com/digital-asset/canton/blob/main/community/base/src/main/protobuf/com/digitalasset/canton/protocol/v30/topology.proto#L206>`_,
+          enriched with the package name and version.
+        type: object
+        required:
+        - packageId
+        properties:
+          packageId:
+            description: |-
+              Package ID of this package
+
+              Required
+            type: string
+          validFromInclusive:
+            description: |-
+              The time from which this package is vetted. Empty if vetting time has no
+              lower bound.
+
+              Optional
+            type: string
+          validUntilExclusive:
+            description: |-
+              The time until which this package is vetted. Empty if vetting time has no
+              upper bound.
+
+              Optional
+            type: string
+          packageName:
+            description: |-
+              Name of this package.
+              Only available if the package has been uploaded to the current participant.
+
+              Optional
+            type: string
+          packageVersion:
+            description: |-
+              Version of this package.
+              Only available if the package has been uploaded to the current participant.
+
+              Optional
+            type: string
+      VettedPackages:
+        title: VettedPackages
+        description: |-
+          The list of packages vetted on a given participant and synchronizer, modelled
+          after ``VettedPackages`` in `topology.proto <https://github.com/digital-asset/canton/blob/main/community/base/src/main/protobuf/com/digitalasset/canton/protocol/v30/topology.proto#L206>`_.
+          The list only contains packages that matched a filter in the query that
+          originated it.
+        type: object
+        required:
+        - participantId
+        - synchronizerId
+        - topologySerial
+        - packages
+        properties:
+          packages:
+            description: |-
+              Sorted by package_name and package_version where known, and package_id as a
+              last resort.
+
+              Required: must be non-empty
+            type: array
+            items:
+              $ref: '#/components/schemas/VettedPackage'
+          participantId:
+            description: |-
+              Participant on which these packages are vetted.
+
+              Required
+            type: string
+          synchronizerId:
+            description: |-
+              Synchronizer on which these packages are vetted.
+
+              Required
+            type: string
+          topologySerial:
+            description: |-
+              Serial of last ``VettedPackages`` topology transaction of this participant
+              and on this synchronizer.
+
+              Required
+            type: integer
+            format: int32
+      VettedPackagesChange:
+        title: VettedPackagesChange
+        description: A change to the set of vetted packages.
+        type: object
+        properties:
+          operation:
+            $ref: '#/components/schemas/Operation'
+      VettedPackagesRef:
+        title: VettedPackagesRef
+        description: |-
+          A reference to identify one or more packages.
+
+          A reference matches a package if its ``package_id`` matches the package's ID,
+          its ``package_name`` matches the package's name, and its ``package_version``
+          matches the package's version. If an attribute in the reference is left
+          unspecified (i.e. as an empty string), that attribute is treated as a
+          wildcard. At a minimum, ``package_id`` or the ``package_name`` must be
+          specified.
+
+          If a reference does not match any package, the reference is considered
+          unresolved and the entire update request is rejected.
+        type: object
+        properties:
+          packageId:
+            description: |-
+              Package's package id must be the same as this field.
+
+              Optional
+            type: string
+          packageName:
+            description: |-
+              Package's name must be the same as this field.
+
+              Optional
+            type: string
+          packageVersion:
+            description: |-
+              Package's version must be the same as this field.
+
+              Optional
+            type: string
+      WildcardFilter:
+        title: WildcardFilter
+        description: This filter matches all templates.
+        type: object
+        required:
+        - value
+        properties:
+          value:
+            $ref: '#/components/schemas/WildcardFilter1'
+      WildcardFilter1:
+        title: WildcardFilter
+        description: This filter matches all templates.
+        type: object
+        properties:
+          includeCreatedEventBlob:
+            description: |-
+              Whether to include a ``created_event_blob`` in the returned ``CreatedEvent``.
+              Use this to access the contract create event payload in your API client
+              for submitting it as a disclosed contract with future commands.
+
+              Optional
+            type: boolean
+    securitySchemes:
+      apiKeyAuth:
+        type: apiKey
+        description: Ledger API standard JWT token (websocket)
+        name: Sec-WebSocket-Protocol
+        in: header
+      httpAuth:
+        type: http
+        description: Ledger API standard JWT token
+        scheme: bearer

--- a/docs-main/reference/grpc-ledger-api-reference/index.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/index.mdx
@@ -1,67 +1,643 @@
 ---
-title: "gRPC Ledger API Reference"
+title: "Canton Protobuf Reference"
 description: "Generated Ledger API gRPC reference grouped by package."
 ---
 
-# gRPC Ledger API Reference
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">Protobuf Reference</p>
+  
+  
+  <h1 class="x2mdx-ref-title">Canton Protobuf Reference</h1>
+  
+  
+  <p class="x2mdx-ref-summary">Operation-first gRPC pages with package-level browsing and recursive related schema sections.</p>
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Protobuf</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">v3.4.11</span>
+  
+</div>
 
-This page is generated from published Canton protobuf release bundles and filtered to the Ledger API gRPC packages.
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Canton Ledger API protobuf release bundles</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>stable Canton release bundles &gt;= 3.4.4</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Latest release</dt>
+    <dd>v3.4.11</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Packages</dt>
+    <dd>5</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>56</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>229</dd>
+  </div>
+  
+</dl>
 
-## Source
+</div>
 
-- Source name: `Canton Ledger API protobuf release bundles`
-- Version filter: `stable Canton release bundles >= 3.4.4`
-- Latest release: `v3.4.11`
-- Source repo: `https://github.com/DACH-NY/canton.git`
-
-## Latest Snapshot
-
-- Packages: `5`
-- Services: `17`
-- Endpoints: `56`
-- Messages: `229`
-- Enums: `12`
-
-## Table of Contents
-
-🟢 Active Since  🔵 Changed  🔴 Removed
-
-| NAME | STATUS | SUMMARY |
-| --- | --- | --- |
-| [`com.daml.ledger.api.v2`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2) | 🟢 `v3.4` | 9 services, 20 endpoints, 115 messages, 8 enums |
-| [`com.daml.ledger.api.v2.admin`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-admin) | 🟢 `v3.4` | 6 services, 28 endpoints, 78 messages, 3 enums |
-| [`com.daml.ledger.api.v2.interactive`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive) | 🟢 `v3.4` | 1 services, 6 endpoints, 28 messages, 1 enums |
-| [`com.daml.ledger.api.v2.testing`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-testing) | 🟢 `v3.4` | 1 services, 2 endpoints, 3 messages |
-| [`com.daml.ledger.api.v2.interactive.transaction.v1`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive-transaction-v1) | - | 0 services, 0 endpoints, 5 messages |
 
 ## Release Summary
 
-| Version | Endpoints +/~/- | Messages +/~/- | Enums +/~/- | Files +/~/- |
-| --- | --- | --- | --- | --- |
-| `3.4.4` | `55/0/0` | `227/0/0` | `12/0/0` | `33/0/0` |
-| `3.4.5` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.6` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.7` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.8` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.9` | `0/0/0` | `0/0/0` | `0/0/0` | `0/0/0` |
-| `3.4.10` | `0/0/0` | `0/1/0` | `0/0/0` | `0/1/0` |
-| `3.4.11` | `1/0/0` | `2/0/0` | `0/0/0` | `1/0/0` |
 
-## Reference
+Counts are shown as added / changed / removed within each release slice.
 
-Packages are grouped by API area. Each package page contains its services, endpoint history, and shared type reference.
 
-### Ledger API
 
-| Package | Services | Endpoints | Messages | Enums |
-| --- | --- | --- | --- | --- |
-| [`com.daml.ledger.api.v2`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2) | `9` | `20` | `115` | `8` |
-| [`com.daml.ledger.api.v2.admin`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-admin) | `6` | `28` | `78` | `3` |
-| [`com.daml.ledger.api.v2.interactive`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive) | `1` | `6` | `28` | `1` |
-| [`com.daml.ledger.api.v2.testing`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-testing) | `1` | `2` | `3` | `0` |
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.4</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+  
+</div>
 
-### Schema Packages
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>55 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>227 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>12 / 0 / 0</dd>
+  </div>
+  
+</dl>
 
-| Package | Services | Endpoints | Messages | Enums |
-| --- | --- | --- | --- | --- |
-| [`com.daml.ledger.api.v2.interactive.transaction.v1`](grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive-transaction-v1) | `0` | `0` | `5` | `0` |
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.5</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.6</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.7</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.8</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.9</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.10</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>0 / 1 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.11</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">Release</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Endpoint / message / enum deltas for this release.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>1 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>2 / 0 / 0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0 / 0 / 0</dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+</div>
+
+
+
+
+
+## Ledger API
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="packages/com-daml-ledger-api-v2">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>com.daml.ledger.api.v2</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">9 services, 20 endpoints, 115 messages, 8 enums</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>9</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>20</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>115</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>8</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="packages/com-daml-ledger-api-v2-admin">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>com.daml.ledger.api.v2.admin</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">6 services, 28 endpoints, 78 messages, 3 enums</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>6</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>28</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>78</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>3</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="packages/com-daml-ledger-api-v2-interactive">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>com.daml.ledger.api.v2.interactive</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">1 services, 6 endpoints, 28 messages, 1 enums</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>6</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>28</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>1</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="packages/com-daml-ledger-api-v2-testing">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>com.daml.ledger.api.v2.testing</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">1 services, 2 endpoints, 3 messages</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>2</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>3</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## Schema Packages
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="packages/com-daml-ledger-api-v2-interactive-transaction-v1">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>com.daml.ledger.api.v2.interactive.transaction.v1</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">0 services, 0 endpoints, 5 messages</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>5</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus.mdx
@@ -1,0 +1,1514 @@
+---
+title: "GetCommandStatus"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetCommandStatus</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetCommandStatus</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.CommandInspectionService/GetCommandStatus</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>CommandInspectionService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetCommandStatus</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetCommandStatusRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetCommandStatusRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id_prefix</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">state</code>
+      <span class="x2mdx-ref-type-badge">CommandState</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">limit</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetCommandStatusResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetCommandStatusResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_status</code>
+      <span class="x2mdx-ref-type-badge">repeated CommandStatus</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GetCommandStatusRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id_prefix</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">state</code>
+      <span class="x2mdx-ref-type-badge">CommandState</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">limit</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.CommandState">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstate">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>COMMAND_STATE_UNSPECIFIED</code></li>
+    
+    <li><code>COMMAND_STATE_PENDING</code></li>
+    
+    <li><code>COMMAND_STATE_SUCCEEDED</code></li>
+    
+    <li><code>COMMAND_STATE_FAILED</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GetCommandStatusResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_status</code>
+      <span class="x2mdx-ref-type-badge">repeated CommandStatus</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.CommandStatus">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstatus">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">started</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completed</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completion</code>
+      <span class="x2mdx-ref-type-badge">Completion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">state</code>
+      <span class="x2mdx-ref-type-badge">CommandState</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated Command</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">request_statistics</code>
+      <span class="x2mdx-ref-type-badge">RequestStatistics</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">updates</code>
+      <span class="x2mdx-ref-type-badge">CommandUpdates</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Completion">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_time</code>
+      <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TraceContext">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">traceparent</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">tracestate</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SynchronizerTime">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Command">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">CreateCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_by_key</code>
+      <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_and_exercise</code>
+      <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreateCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.RequestStatistics">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-requeststatistics">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">envelopes</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">request_size</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">recipients</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.CommandUpdates">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandupdates">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">repeated Contract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">repeated Contract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercised</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fetched</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">looked_up_by_key</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Contract">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-contract">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.CommandInspectionService/GetCommandStatus <<'EOF'
+{
+  "commandIdPrefix": "string",
+  "state": "COMMAND_STATE_UNSPECIFIED",
+  "limit": 0
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "commandStatus": [
+    {
+      "started": "string",
+      "completed": "string",
+      "completion": {
+        "commandId": "string",
+        "status": "string",
+        "updateId": "string",
+        "userId": "string",
+        "actAs": [
+          "string"
+        ],
+        "submissionId": "string",
+        "deduplicationOffset": "0"
+      },
+      "state": "COMMAND_STATE_UNSPECIFIED",
+      "commands": [
+        {
+          "create": {
+            "templateId": {},
+            "createArguments": {}
+          }
+        }
+      ],
+      "requestStatistics": {
+        "envelopes": 0,
+        "requestSize": 0,
+        "recipients": 0
+      },
+      "updates": {
+        "created": [
+          {
+            "templateId": {},
+            "contractId": "string",
+            "contractKey": {}
+          }
+        ],
+        "archived": [
+          {
+            "templateId": {},
+            "contractId": "string",
+            "contractKey": {}
+          }
+        ],
+        "exercised": 0,
+        "fetched": 0,
+        "lookedUpByKey": 0
+      }
+    }
+  ]
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig.mdx
@@ -1,0 +1,381 @@
+---
+title: "CreateIdentityProviderConfig"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>CreateIdentityProviderConfig</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">CreateIdentityProviderConfig</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/CreateIdentityProviderConfig</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>IdentityProviderConfigService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>CreateIdentityProviderConfig</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>CreateIdentityProviderConfigRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>CreateIdentityProviderConfigResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_deactivated</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">issuer</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">jwks_url</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">audience</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.IdentityProviderConfigService/CreateIdentityProviderConfig <<'EOF'
+{
+  "identityProviderConfig": {
+    "identityProviderId": "string",
+    "isDeactivated": true,
+    "issuer": "string",
+    "jwksUrl": "string",
+    "audience": "string"
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "identityProviderConfig": {
+    "identityProviderId": "string",
+    "isDeactivated": true,
+    "issuer": "string",
+    "jwksUrl": "string",
+    "audience": "string"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig.mdx
@@ -1,0 +1,283 @@
+---
+title: "DeleteIdentityProviderConfig"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>DeleteIdentityProviderConfig</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">DeleteIdentityProviderConfig</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/DeleteIdentityProviderConfig</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>IdentityProviderConfigService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>DeleteIdentityProviderConfig</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>DeleteIdentityProviderConfigRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>DeleteIdentityProviderConfigResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.IdentityProviderConfigService/DeleteIdentityProviderConfig <<'EOF'
+{
+  "identityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig.mdx
@@ -1,0 +1,375 @@
+---
+title: "GetIdentityProviderConfig"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetIdentityProviderConfig</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetIdentityProviderConfig</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/GetIdentityProviderConfig</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>IdentityProviderConfigService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetIdentityProviderConfig</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetIdentityProviderConfigRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetIdentityProviderConfigResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_deactivated</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">issuer</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">jwks_url</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">audience</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.IdentityProviderConfigService/GetIdentityProviderConfig <<'EOF'
+{
+  "identityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "identityProviderConfig": {
+    "identityProviderId": "string",
+    "isDeactivated": true,
+    "issuer": "string",
+    "jwksUrl": "string",
+    "audience": "string"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs.mdx
@@ -1,0 +1,349 @@
+---
+title: "ListIdentityProviderConfigs"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>ListIdentityProviderConfigs</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">ListIdentityProviderConfigs</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/ListIdentityProviderConfigs</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>IdentityProviderConfigService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>ListIdentityProviderConfigs</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListIdentityProviderConfigsRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListIdentityProviderConfigsResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_configs</code>
+      <span class="x2mdx-ref-type-badge">repeated IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_configs</code>
+      <span class="x2mdx-ref-type-badge">repeated IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_deactivated</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">issuer</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">jwks_url</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">audience</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.IdentityProviderConfigService/ListIdentityProviderConfigs <<'EOF'
+{}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "identityProviderConfigs": [
+    {
+      "identityProviderId": "string",
+      "isDeactivated": true,
+      "issuer": "string",
+      "jwksUrl": "string",
+      "audience": "string"
+    }
+  ]
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig.mdx
@@ -1,0 +1,400 @@
+---
+title: "UpdateIdentityProviderConfig"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>UpdateIdentityProviderConfig</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">UpdateIdentityProviderConfig</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.IdentityProviderConfigService/UpdateIdentityProviderConfig</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>IdentityProviderConfigService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>UpdateIdentityProviderConfig</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdateIdentityProviderConfigRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_mask</code>
+      <span class="x2mdx-ref-type-badge">FieldMask</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdateIdentityProviderConfigResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_mask</code>
+      <span class="x2mdx-ref-type-badge">FieldMask</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.IdentityProviderConfig">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_deactivated</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">issuer</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">jwks_url</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">audience</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.IdentityProviderConfigService/UpdateIdentityProviderConfig <<'EOF'
+{
+  "identityProviderConfig": {
+    "identityProviderId": "string",
+    "isDeactivated": true,
+    "issuer": "string",
+    "jwksUrl": "string",
+    "audience": "string"
+  },
+  "updateMask": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "identityProviderConfig": {
+    "identityProviderId": "string",
+    "isDeactivated": true,
+    "issuer": "string",
+    "jwksUrl": "string",
+    "audience": "string"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages.mdx
@@ -1,0 +1,349 @@
+---
+title: "ListKnownPackages"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>ListKnownPackages</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">ListKnownPackages</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PackageManagementService/ListKnownPackages</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PackageManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>ListKnownPackages</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListKnownPackagesRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListKnownPackagesResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_details</code>
+      <span class="x2mdx-ref-type-badge">repeated PackageDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ListKnownPackagesRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesrequest">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ListKnownPackagesResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_details</code>
+      <span class="x2mdx-ref-type-badge">repeated PackageDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.PackageDetails">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-packagedetails">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_size</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">known_since</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PackageManagementService/ListKnownPackages <<'EOF'
+{}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "packageDetails": [
+    {
+      "packageId": "string",
+      "packageSize": "0",
+      "knownSince": "string",
+      "name": "string",
+      "version": "string"
+    }
+  ]
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages.mdx
@@ -1,0 +1,740 @@
+---
+title: "UpdateVettedPackages"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>UpdateVettedPackages</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">UpdateVettedPackages</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PackageManagementService/UpdateVettedPackages</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PackageManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>UpdateVettedPackages</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdateVettedPackagesRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">changes</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackagesChange</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">dry_run</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">expected_topology_serial</code>
+      <span class="x2mdx-ref-type-badge">PriorTopologySerial</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_vetted_packages_force_flags</code>
+      <span class="x2mdx-ref-type-badge">repeated UpdateVettedPackagesForceFlag</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdateVettedPackagesResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">past_vetted_packages</code>
+      <span class="x2mdx-ref-type-badge">VettedPackages</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">new_vetted_packages</code>
+      <span class="x2mdx-ref-type-badge">VettedPackages</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">changes</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackagesChange</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">dry_run</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">expected_topology_serial</code>
+      <span class="x2mdx-ref-type-badge">PriorTopologySerial</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_vetted_packages_force_flags</code>
+      <span class="x2mdx-ref-type-badge">repeated UpdateVettedPackagesForceFlag</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesChange">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vet</code>
+      <span class="x2mdx-ref-type-badge">Vet</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unvet</code>
+      <span class="x2mdx-ref-type-badge">Unvet</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesChange.Unvet">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-unvet">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">packages</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesRef">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackagesref">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.VettedPackagesChange.Vet">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-vet">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">packages</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">new_valid_from_inclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">new_valid_until_exclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.PriorTopologySerial">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-priortopologyserial">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prior</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">no_prior</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdateVettedPackagesForceFlag">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesforceflag">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED</code></li>
+    
+    <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES</code></li>
+    
+    <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">past_vetted_packages</code>
+      <span class="x2mdx-ref-type-badge">VettedPackages</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">new_vetted_packages</code>
+      <span class="x2mdx-ref-type-badge">VettedPackages</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.VettedPackages">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">packages</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_serial</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.VettedPackage">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PackageManagementService/UpdateVettedPackages <<'EOF'
+{
+  "changes": [
+    {
+      "vet": {
+        "packages": [
+          {
+            "packageId": "string",
+            "packageName": "string",
+            "packageVersion": "string"
+          }
+        ],
+        "newValidFromInclusive": "string",
+        "newValidUntilExclusive": "string"
+      }
+    }
+  ],
+  "dryRun": true,
+  "synchronizerId": "string",
+  "expectedTopologySerial": {
+    "prior": 0
+  },
+  "updateVettedPackagesForceFlags": [
+    "UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED"
+  ]
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "pastVettedPackages": {
+    "packages": [
+      {
+        "packageId": "string",
+        "validFromInclusive": "string",
+        "validUntilExclusive": "string",
+        "packageName": "string",
+        "packageVersion": "string"
+      }
+    ],
+    "participantId": "string",
+    "synchronizerId": "string",
+    "topologySerial": 0
+  },
+  "newVettedPackages": {
+    "packages": [
+      {
+        "packageId": "string",
+        "validFromInclusive": "string",
+        "validUntilExclusive": "string",
+        "packageName": "string",
+        "packageVersion": "string"
+      }
+    ],
+    "participantId": "string",
+    "synchronizerId": "string",
+    "topologySerial": 0
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile.mdx
@@ -1,0 +1,359 @@
+---
+title: "UploadDarFile"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>UploadDarFile</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">UploadDarFile</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PackageManagementService/UploadDarFile</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PackageManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>UploadDarFile</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UploadDarFileRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UploadDarFileRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">dar_file</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetting_change</code>
+      <span class="x2mdx-ref-type-badge">VettingChange</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UploadDarFileResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UploadDarFileResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UploadDarFileRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">dar_file</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetting_change</code>
+      <span class="x2mdx-ref-type-badge">VettingChange</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UploadDarFileRequest.VettingChange">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest-vettingchange">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>VETTING_CHANGE_UNSPECIFIED</code></li>
+    
+    <li><code>VETTING_CHANGE_VET_ALL_PACKAGES</code></li>
+    
+    <li><code>VETTING_CHANGE_DONT_VET_ANY_PACKAGES</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UploadDarFileResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfileresponse">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PackageManagementService/UploadDarFile <<'EOF'
+{
+  "darFile": "BASE64_ENCODED_BYTES",
+  "submissionId": "string",
+  "vettingChange": "VETTING_CHANGE_UNSPECIFIED",
+  "synchronizerId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile.mdx
@@ -1,0 +1,321 @@
+---
+title: "ValidateDarFile"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>ValidateDarFile</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">ValidateDarFile</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PackageManagementService/ValidateDarFile</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PackageManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>ValidateDarFile</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ValidateDarFileRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ValidateDarFileRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">dar_file</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ValidateDarFileResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ValidateDarFileResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ValidateDarFileRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfilerequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">dar_file</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ValidateDarFileResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfileresponse">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PackageManagementService/ValidateDarFile <<'EOF'
+{
+  "darFile": "BASE64_ENCODED_BYTES",
+  "submissionId": "string",
+  "synchronizerId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune.mdx
@@ -1,0 +1,321 @@
+---
+title: "Prune"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>Prune</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">Prune</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.ParticipantPruningService/Prune</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>ParticipantPruningService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>Prune</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>PruneRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.PruneRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prune_up_to</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prune_all_divulged_contracts</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>PruneResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.PruneResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.PruneRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-prunerequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prune_up_to</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prune_all_divulged_contracts</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.PruneResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-pruneresponse">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.ParticipantPruningService/Prune <<'EOF'
+{
+  "pruneUpTo": "0",
+  "submissionId": "string",
+  "pruneAllDivulgedContracts": true
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty.mdx
@@ -1,0 +1,511 @@
+---
+title: "AllocateExternalParty"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>AllocateExternalParty</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">AllocateExternalParty</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PartyManagementService/AllocateExternalParty</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PartyManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>AllocateExternalParty</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>AllocateExternalPartyRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">onboarding_transactions</code>
+      <span class="x2mdx-ref-type-badge">repeated SignedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">multi_hash_signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated Signature</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>AllocateExternalPartyResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">onboarding_transactions</code>
+      <span class="x2mdx-ref-type-badge">repeated SignedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">multi_hash_signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated Signature</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest.SignedTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest-signedtransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated Signature</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Signature">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">format</code>
+      <span class="x2mdx-ref-type-badge">SignatureFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signature</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signed_by</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
+      <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SignatureFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_RAW</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_DER</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PartyManagementService/AllocateExternalParty <<'EOF'
+{
+  "synchronizer": "string",
+  "onboardingTransactions": [
+    {
+      "transaction": "BASE64_ENCODED_BYTES",
+      "signatures": [
+        {
+          "format": "SIGNATURE_FORMAT_UNSPECIFIED",
+          "signature": "BASE64_ENCODED_BYTES",
+          "signedBy": "string",
+          "signingAlgorithmSpec": "SIGNING_ALGORITHM_SPEC_UNSPECIFIED"
+        }
+      ]
+    }
+  ],
+  "multiHashSignatures": [
+    {
+      "format": "SIGNATURE_FORMAT_UNSPECIFIED",
+      "signature": "BASE64_ENCODED_BYTES",
+      "signedBy": "string",
+      "signingAlgorithmSpec": "SIGNING_ALGORITHM_SPEC_UNSPECIFIED"
+    }
+  ],
+  "identityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "partyId": "string"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty.mdx
@@ -1,0 +1,486 @@
+---
+title: "AllocateParty"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>AllocateParty</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">AllocateParty</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PartyManagementService/AllocateParty</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PartyManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>AllocateParty</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>AllocatePartyRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.AllocatePartyRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id_hint</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">local_metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>AllocatePartyResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.AllocatePartyResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.AllocatePartyRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id_hint</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">local_metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">resource_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">annotations</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.AllocatePartyResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_local</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">local_metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PartyManagementService/AllocateParty <<'EOF'
+{
+  "partyIdHint": "string",
+  "localMetadata": {
+    "resourceVersion": "string",
+    "annotations": [
+      {
+        "key": "string"
+      }
+    ]
+  },
+  "identityProviderId": "string",
+  "synchronizerId": "string",
+  "userId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "partyDetails": {
+    "party": "string",
+    "isLocal": true,
+    "localMetadata": {
+      "resourceVersion": "string",
+      "annotations": [
+        {
+          "key": "string"
+        }
+      ]
+    },
+    "identityProviderId": "string"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology.mdx
@@ -1,0 +1,576 @@
+---
+title: "GenerateExternalPartyTopology"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GenerateExternalPartyTopology</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GenerateExternalPartyTopology</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PartyManagementService/GenerateExternalPartyTopology</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PartyManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GenerateExternalPartyTopology</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GenerateExternalPartyTopologyRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_hint</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">public_key</code>
+      <span class="x2mdx-ref-type-badge">SigningPublicKey</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">local_participant_observation_only</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">other_confirming_participant_uids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">confirmation_threshold</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observing_participant_uids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GenerateExternalPartyTopologyResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">public_key_fingerprint</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_transactions</code>
+      <span class="x2mdx-ref-type-badge">repeated bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">multi_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_hint</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">public_key</code>
+      <span class="x2mdx-ref-type-badge">SigningPublicKey</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">local_participant_observation_only</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">other_confirming_participant_uids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">confirmation_threshold</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observing_participant_uids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SigningPublicKey">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingpublickey">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">format</code>
+      <span class="x2mdx-ref-type-badge">CryptoKeyFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key_data</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key_spec</code>
+      <span class="x2mdx-ref-type-badge">SigningKeySpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CryptoKeyFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cryptokeyformat">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>CRYPTO_KEY_FORMAT_UNSPECIFIED</code></li>
+    
+    <li><code>CRYPTO_KEY_FORMAT_DER</code></li>
+    
+    <li><code>CRYPTO_KEY_FORMAT_RAW</code></li>
+    
+    <li><code>CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SigningKeySpec">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingkeyspec">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNING_KEY_SPEC_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_CURVE25519</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_P256</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_P384</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_SECP256K1</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">public_key_fingerprint</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_transactions</code>
+      <span class="x2mdx-ref-type-badge">repeated bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">multi_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PartyManagementService/GenerateExternalPartyTopology <<'EOF'
+{
+  "synchronizer": "string",
+  "partyHint": "string",
+  "publicKey": {
+    "format": "CRYPTO_KEY_FORMAT_UNSPECIFIED",
+    "keyData": "BASE64_ENCODED_BYTES",
+    "keySpec": "SIGNING_KEY_SPEC_UNSPECIFIED"
+  },
+  "localParticipantObservationOnly": true,
+  "otherConfirmingParticipantUids": [
+    "string"
+  ],
+  "confirmationThreshold": 0,
+  "observingParticipantUids": [
+    "string"
+  ]
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "partyId": "string",
+  "publicKeyFingerprint": "string",
+  "topologyTransactions": [
+    "BASE64_ENCODED_BYTES"
+  ],
+  "multiHash": "BASE64_ENCODED_BYTES"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid.mdx
@@ -1,0 +1,283 @@
+---
+title: "GetParticipantId"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetParticipantId</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetParticipantId</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PartyManagementService/GetParticipantId</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PartyManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetParticipantId</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetParticipantIdRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetParticipantIdRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetParticipantIdResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetParticipantIdResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GetParticipantIdRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidrequest">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GetParticipantIdResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PartyManagementService/GetParticipantId <<'EOF'
+{}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "participantId": "string"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties.mdx
@@ -1,0 +1,426 @@
+---
+title: "GetParties"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetParties</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetParties</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PartyManagementService/GetParties</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PartyManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetParties</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetPartiesRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetPartiesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetPartiesResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetPartiesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GetPartiesRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GetPartiesResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_local</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">local_metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">resource_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">annotations</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PartyManagementService/GetParties <<'EOF'
+{
+  "parties": [
+    "string"
+  ],
+  "identityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "partyDetails": [
+    {
+      "party": "string",
+      "isLocal": true,
+      "localMetadata": {
+        "resourceVersion": "string",
+        "annotations": [
+          {
+            "key": "string"
+          }
+        ]
+      },
+      "identityProviderId": "string"
+    }
+  ]
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties.mdx
@@ -1,0 +1,481 @@
+---
+title: "ListKnownParties"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>ListKnownParties</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">ListKnownParties</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PartyManagementService/ListKnownParties</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PartyManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>ListKnownParties</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListKnownPartiesRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filter_party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListKnownPartiesResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">next_page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ListKnownPartiesRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filter_party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ListKnownPartiesResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">next_page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_local</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">local_metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">resource_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">annotations</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PartyManagementService/ListKnownParties <<'EOF'
+{
+  "pageToken": "string",
+  "pageSize": 0,
+  "identityProviderId": "string",
+  "filterParty": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "partyDetails": [
+    {
+      "party": "string",
+      "isLocal": true,
+      "localMetadata": {
+        "resourceVersion": "string",
+        "annotations": [
+          {
+            "key": "string"
+          }
+        ]
+      },
+      "identityProviderId": "string"
+    }
+  ],
+  "nextPageToken": "string"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails.mdx
@@ -1,0 +1,434 @@
+---
+title: "UpdatePartyDetails"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>UpdatePartyDetails</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">UpdatePartyDetails</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PartyManagementService/UpdatePartyDetails</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PartyManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>UpdatePartyDetails</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdatePartyDetailsRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_mask</code>
+      <span class="x2mdx-ref-type-badge">FieldMask</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdatePartyDetailsResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_mask</code>
+      <span class="x2mdx-ref-type-badge">FieldMask</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.PartyDetails">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_local</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">local_metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">resource_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">annotations</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PartyManagementService/UpdatePartyDetails <<'EOF'
+{
+  "partyDetails": {
+    "party": "string",
+    "isLocal": true,
+    "localMetadata": {
+      "resourceVersion": "string",
+      "annotations": [
+        {
+          "key": "string"
+        }
+      ]
+    },
+    "identityProviderId": "string"
+  },
+  "updateMask": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "partyDetails": {
+    "party": "string",
+    "isLocal": true,
+    "localMetadata": {
+      "resourceVersion": "string",
+      "annotations": [
+        {
+          "key": "string"
+        }
+      ]
+    },
+    "identityProviderId": "string"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid.mdx
@@ -1,0 +1,321 @@
+---
+title: "UpdatePartyIdentityProviderId"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>UpdatePartyIdentityProviderId</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">UpdatePartyIdentityProviderId</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.PartyManagementService/UpdatePartyIdentityProviderId</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PartyManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>UpdatePartyIdentityProviderId</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdatePartyIdentityProviderIdRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdatePartyIdentityProviderIdResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.PartyManagementService/UpdatePartyIdentityProviderId <<'EOF'
+{
+  "party": "string",
+  "sourceIdentityProviderId": "string",
+  "targetIdentityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser.mdx
@@ -1,0 +1,627 @@
+---
+title: "CreateUser"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>CreateUser</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">CreateUser</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.UserManagementService/CreateUser</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UserManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>CreateUser</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>CreateUserRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.CreateUserRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>CreateUserResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.CreateUserResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.CreateUserRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.User">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">primary_party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_deactivated</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">resource_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">annotations</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_admin</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_act_as</code>
+      <span class="x2mdx-ref-type-badge">CanActAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_read_as</code>
+      <span class="x2mdx-ref-type-badge">CanReadAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_admin</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
+      <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_execute_as</code>
+      <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
+      <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.CreateUserResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.UserManagementService/CreateUser <<'EOF'
+{
+  "user": {
+    "id": "string",
+    "primaryParty": "string",
+    "isDeactivated": true,
+    "metadata": {
+      "resourceVersion": "string",
+      "annotations": [
+        {
+          "key": "string"
+        }
+      ]
+    },
+    "identityProviderId": "string"
+  },
+  "rights": [
+    {
+      "participantAdmin": {}
+    }
+  ]
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "user": {
+    "id": "string",
+    "primaryParty": "string",
+    "isDeactivated": true,
+    "metadata": {
+      "resourceVersion": "string",
+      "annotations": [
+        {
+          "key": "string"
+        }
+      ]
+    },
+    "identityProviderId": "string"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser.mdx
@@ -1,0 +1,302 @@
+---
+title: "DeleteUser"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>DeleteUser</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">DeleteUser</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.UserManagementService/DeleteUser</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UserManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>DeleteUser</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>DeleteUserRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.DeleteUserRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>DeleteUserResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.DeleteUserResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.DeleteUserRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.DeleteUserResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserresponse">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.UserManagementService/DeleteUser <<'EOF'
+{
+  "userId": "string",
+  "identityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser.mdx
@@ -1,0 +1,432 @@
+---
+title: "GetUser"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetUser</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetUser</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.UserManagementService/GetUser</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UserManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetUser</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetUserRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetUserRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetUserResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetUserResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GetUserRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GetUserResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.User">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">primary_party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_deactivated</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">resource_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">annotations</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.UserManagementService/GetUser <<'EOF'
+{
+  "userId": "string",
+  "identityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "user": {
+    "id": "string",
+    "primaryParty": "string",
+    "isDeactivated": true,
+    "metadata": {
+      "resourceVersion": "string",
+      "annotations": [
+        {
+          "key": "string"
+        }
+      ]
+    },
+    "identityProviderId": "string"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights.mdx
@@ -1,0 +1,535 @@
+---
+title: "GrantUserRights"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GrantUserRights</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GrantUserRights</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.UserManagementService/GrantUserRights</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UserManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GrantUserRights</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GrantUserRightsRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GrantUserRightsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GrantUserRightsResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.GrantUserRightsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">newly_granted_rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GrantUserRightsRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_admin</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_act_as</code>
+      <span class="x2mdx-ref-type-badge">CanActAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_read_as</code>
+      <span class="x2mdx-ref-type-badge">CanReadAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_admin</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
+      <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_execute_as</code>
+      <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
+      <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.GrantUserRightsResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">newly_granted_rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.UserManagementService/GrantUserRights <<'EOF'
+{
+  "userId": "string",
+  "rights": [
+    {
+      "participantAdmin": {}
+    }
+  ],
+  "identityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "newlyGrantedRights": [
+    {
+      "participantAdmin": {}
+    }
+  ]
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights.mdx
@@ -1,0 +1,512 @@
+---
+title: "ListUserRights"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>ListUserRights</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">ListUserRights</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.UserManagementService/ListUserRights</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UserManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>ListUserRights</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListUserRightsRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListUserRightsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListUserRightsResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListUserRightsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ListUserRightsRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ListUserRightsResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_admin</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_act_as</code>
+      <span class="x2mdx-ref-type-badge">CanActAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_read_as</code>
+      <span class="x2mdx-ref-type-badge">CanReadAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_admin</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
+      <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_execute_as</code>
+      <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
+      <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.UserManagementService/ListUserRights <<'EOF'
+{
+  "userId": "string",
+  "identityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "rights": [
+    {
+      "participantAdmin": {}
+    }
+  ]
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers.mdx
@@ -1,0 +1,472 @@
+---
+title: "ListUsers"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>ListUsers</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">ListUsers</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.UserManagementService/ListUsers</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UserManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>ListUsers</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListUsersRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListUsersRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListUsersResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListUsersResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">users</code>
+      <span class="x2mdx-ref-type-badge">repeated User</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">next_page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ListUsersRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ListUsersResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">users</code>
+      <span class="x2mdx-ref-type-badge">repeated User</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">next_page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.User">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">primary_party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_deactivated</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">resource_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">annotations</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.UserManagementService/ListUsers <<'EOF'
+{
+  "pageToken": "string",
+  "pageSize": 0,
+  "identityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "users": [
+    {
+      "id": "string",
+      "primaryParty": "string",
+      "isDeactivated": true,
+      "metadata": {
+        "resourceVersion": "string",
+        "annotations": [
+          {
+            "key": "string"
+          }
+        ]
+      },
+      "identityProviderId": "string"
+    }
+  ],
+  "nextPageToken": "string"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights.mdx
@@ -1,0 +1,535 @@
+---
+title: "RevokeUserRights"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>RevokeUserRights</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">RevokeUserRights</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.UserManagementService/RevokeUserRights</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UserManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>RevokeUserRights</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>RevokeUserRightsRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>RevokeUserRightsResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">newly_revoked_rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.RevokeUserRightsRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_admin</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_act_as</code>
+      <span class="x2mdx-ref-type-badge">CanActAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_read_as</code>
+      <span class="x2mdx-ref-type-badge">CanReadAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_admin</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
+      <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_execute_as</code>
+      <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
+      <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.ParticipantAdmin">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanActAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAs">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.RevokeUserRightsResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">newly_revoked_rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.UserManagementService/RevokeUserRights <<'EOF'
+{
+  "userId": "string",
+  "rights": [
+    {
+      "participantAdmin": {}
+    }
+  ],
+  "identityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "newlyRevokedRights": [
+    {
+      "participantAdmin": {}
+    }
+  ]
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser.mdx
@@ -1,0 +1,445 @@
+---
+title: "UpdateUser"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>UpdateUser</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">UpdateUser</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.UserManagementService/UpdateUser</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UserManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>UpdateUser</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdateUserRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateUserRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_mask</code>
+      <span class="x2mdx-ref-type-badge">FieldMask</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdateUserResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateUserResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdateUserRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_mask</code>
+      <span class="x2mdx-ref-type-badge">FieldMask</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.User">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">primary_party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_deactivated</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.ObjectMeta">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">resource_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">annotations</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdateUserResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.UserManagementService/UpdateUser <<'EOF'
+{
+  "user": {
+    "id": "string",
+    "primaryParty": "string",
+    "isDeactivated": true,
+    "metadata": {
+      "resourceVersion": "string",
+      "annotations": [
+        {
+          "key": "string"
+        }
+      ]
+    },
+    "identityProviderId": "string"
+  },
+  "updateMask": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "user": {
+    "id": "string",
+    "primaryParty": "string",
+    "isDeactivated": true,
+    "metadata": {
+      "resourceVersion": "string",
+      "annotations": [
+        {
+          "key": "string"
+        }
+      ]
+    },
+    "identityProviderId": "string"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid.mdx
@@ -1,0 +1,321 @@
+---
+title: "UpdateUserIdentityProviderId"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-admin">com.daml.ledger.api.v2.admin</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>UpdateUserIdentityProviderId</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.admin</p>
+  
+  
+  <h1 class="x2mdx-ref-title">UpdateUserIdentityProviderId</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.admin.UserManagementService/UpdateUserIdentityProviderId</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UserManagementService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>UpdateUserIdentityProviderId</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdateUserIdentityProviderIdRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>UpdateUserIdentityProviderIdResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.admin.UserManagementService/UpdateUserIdentityProviderId <<'EOF'
+{
+  "userId": "string",
+  "sourceIdentityProviderId": "string",
+  "targetIdentityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission.mdx
@@ -1,0 +1,1912 @@
+---
+title: "ExecuteSubmission"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>ExecuteSubmission</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
+  
+  
+  <h1 class="x2mdx-ref-title">ExecuteSubmission</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmission</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>InteractiveSubmissionService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>ExecuteSubmission</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ExecuteSubmissionRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_signatures</code>
+      <span class="x2mdx-ref-type-badge">PartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ExecuteSubmissionResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_signatures</code>
+      <span class="x2mdx-ref-type-badge">PartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">DamlTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">metadata</code>
+      <span class="x2mdx-ref-type-badge">Metadata</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">roots</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">nodes</code>
+      <span class="x2mdx-ref-type-badge">repeated Node</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_seeds</code>
+      <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">seed</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">v1</code>
+      <span class="x2mdx-ref-type-badge">Node</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">Create</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fetch</code>
+      <span class="x2mdx-ref-type-badge">Fetch</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">Exercise</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rollback</code>
+      <span class="x2mdx-ref-type-badge">Rollback</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">chosen_value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter_info</code>
+      <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">mediator_group</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_uuid</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">preparation_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">input_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated InputContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">global_key_mapping</code>
+      <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_record_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">GlobalKey</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.GlobalKey">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-globalkey">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">v1</code>
+      <span class="x2mdx-ref-type-badge">Create</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.PartySignatures">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.SinglePartySignatures">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated Signature</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Signature">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">format</code>
+      <span class="x2mdx-ref-type-badge">SignatureFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signature</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signed_by</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
+      <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SignatureFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_RAW</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_DER</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.HashingSchemeVersion">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
+    
+    <li><code>HASHING_SCHEME_VERSION_V2</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionresponse">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmission <<'EOF'
+{
+  "preparedTransaction": {
+    "transaction": {
+      "version": "string",
+      "roots": [
+        "string"
+      ],
+      "nodes": [
+        {
+          "nodeId": "string",
+          "v1": {}
+        }
+      ],
+      "nodeSeeds": [
+        {
+          "nodeId": 0,
+          "seed": "BASE64_ENCODED_BYTES"
+        }
+      ]
+    },
+    "metadata": {
+      "submitterInfo": {
+        "actAs": [
+          "string"
+        ],
+        "commandId": "string"
+      },
+      "synchronizerId": "string",
+      "mediatorGroup": 0,
+      "transactionUuid": "string",
+      "preparationTime": "0",
+      "inputContracts": [
+        {
+          "v1": {},
+          "createdAt": "0",
+          "eventBlob": "BASE64_ENCODED_BYTES"
+        }
+      ],
+      "minLedgerEffectiveTime": "0",
+      "maxLedgerEffectiveTime": "0"
+    }
+  },
+  "partySignatures": {
+    "signatures": [
+      {
+        "party": "string",
+        "signatures": [
+          {
+            "format": "SIGNATURE_FORMAT_UNSPECIFIED",
+            "signature": "BASE64_ENCODED_BYTES",
+            "signedBy": "string",
+            "signingAlgorithmSpec": "SIGNING_ALGORITHM_SPEC_UNSPECIFIED"
+          }
+        ]
+      }
+    ]
+  },
+  "deduplicationDuration": "string",
+  "submissionId": "string",
+  "userId": "string",
+  "hashingSchemeVersion": "HASHING_SCHEME_VERSION_UNSPECIFIED",
+  "minLedgerTime": {
+    "minLedgerTimeAbs": "string"
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait.mdx
@@ -1,0 +1,1959 @@
+---
+title: "ExecuteSubmissionAndWait"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>ExecuteSubmissionAndWait</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
+  
+  
+  <h1 class="x2mdx-ref-title">ExecuteSubmissionAndWait</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmissionAndWait</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>InteractiveSubmissionService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>ExecuteSubmissionAndWait</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ExecuteSubmissionAndWaitRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_signatures</code>
+      <span class="x2mdx-ref-type-badge">PartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ExecuteSubmissionAndWaitResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completion_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_signatures</code>
+      <span class="x2mdx-ref-type-badge">PartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">DamlTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">metadata</code>
+      <span class="x2mdx-ref-type-badge">Metadata</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">roots</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">nodes</code>
+      <span class="x2mdx-ref-type-badge">repeated Node</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_seeds</code>
+      <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">seed</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">v1</code>
+      <span class="x2mdx-ref-type-badge">Node</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">Create</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fetch</code>
+      <span class="x2mdx-ref-type-badge">Fetch</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">Exercise</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rollback</code>
+      <span class="x2mdx-ref-type-badge">Rollback</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">chosen_value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter_info</code>
+      <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">mediator_group</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_uuid</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">preparation_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">input_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated InputContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">global_key_mapping</code>
+      <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_record_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">GlobalKey</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.GlobalKey">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-globalkey">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">v1</code>
+      <span class="x2mdx-ref-type-badge">Create</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.PartySignatures">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.SinglePartySignatures">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated Signature</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Signature">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">format</code>
+      <span class="x2mdx-ref-type-badge">SignatureFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signature</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signed_by</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
+      <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SignatureFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_RAW</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_DER</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.HashingSchemeVersion">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
+    
+    <li><code>HASHING_SCHEME_VERSION_V2</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completion_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmissionAndWait <<'EOF'
+{
+  "preparedTransaction": {
+    "transaction": {
+      "version": "string",
+      "roots": [
+        "string"
+      ],
+      "nodes": [
+        {
+          "nodeId": "string",
+          "v1": {}
+        }
+      ],
+      "nodeSeeds": [
+        {
+          "nodeId": 0,
+          "seed": "BASE64_ENCODED_BYTES"
+        }
+      ]
+    },
+    "metadata": {
+      "submitterInfo": {
+        "actAs": [
+          "string"
+        ],
+        "commandId": "string"
+      },
+      "synchronizerId": "string",
+      "mediatorGroup": 0,
+      "transactionUuid": "string",
+      "preparationTime": "0",
+      "inputContracts": [
+        {
+          "v1": {},
+          "createdAt": "0",
+          "eventBlob": "BASE64_ENCODED_BYTES"
+        }
+      ],
+      "minLedgerEffectiveTime": "0",
+      "maxLedgerEffectiveTime": "0"
+    }
+  },
+  "partySignatures": {
+    "signatures": [
+      {
+        "party": "string",
+        "signatures": [
+          {
+            "format": "SIGNATURE_FORMAT_UNSPECIFIED",
+            "signature": "BASE64_ENCODED_BYTES",
+            "signedBy": "string",
+            "signingAlgorithmSpec": "SIGNING_ALGORITHM_SPEC_UNSPECIFIED"
+          }
+        ]
+      }
+    ]
+  },
+  "deduplicationDuration": "string",
+  "submissionId": "string",
+  "userId": "string",
+  "hashingSchemeVersion": "HASHING_SCHEME_VERSION_UNSPECIFIED",
+  "minLedgerTime": {
+    "minLedgerTimeAbs": "string"
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "updateId": "string",
+  "completionOffset": "0"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction.mdx
@@ -1,0 +1,2816 @@
+---
+title: "ExecuteSubmissionAndWaitForTransaction"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>ExecuteSubmissionAndWaitForTransaction</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
+  
+  
+  <h1 class="x2mdx-ref-title">ExecuteSubmissionAndWaitForTransaction</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmissionAndWaitForTransaction</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>InteractiveSubmissionService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>ExecuteSubmissionAndWaitForTransaction</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ExecuteSubmissionAndWaitForTransactionRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_signatures</code>
+      <span class="x2mdx-ref-type-badge">PartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_format</code>
+      <span class="x2mdx-ref-type-badge">TransactionFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ExecuteSubmissionAndWaitForTransactionResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_signatures</code>
+      <span class="x2mdx-ref-type-badge">PartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_format</code>
+      <span class="x2mdx-ref-type-badge">TransactionFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">DamlTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">metadata</code>
+      <span class="x2mdx-ref-type-badge">Metadata</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">roots</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">nodes</code>
+      <span class="x2mdx-ref-type-badge">repeated Node</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_seeds</code>
+      <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">seed</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">v1</code>
+      <span class="x2mdx-ref-type-badge">Node</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">Create</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fetch</code>
+      <span class="x2mdx-ref-type-badge">Fetch</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">Exercise</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rollback</code>
+      <span class="x2mdx-ref-type-badge">Rollback</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">chosen_value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter_info</code>
+      <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">mediator_group</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_uuid</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">preparation_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">input_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated InputContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">global_key_mapping</code>
+      <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_record_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">GlobalKey</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.GlobalKey">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-globalkey">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">v1</code>
+      <span class="x2mdx-ref-type-badge">Create</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.PartySignatures">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.SinglePartySignatures">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated Signature</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Signature">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">format</code>
+      <span class="x2mdx-ref-type-badge">SignatureFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signature</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signed_by</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
+      <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SignatureFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_RAW</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_DER</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.HashingSchemeVersion">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
+    
+    <li><code>HASHING_SCHEME_VERSION_V2</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TransactionFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_shape</code>
+      <span class="x2mdx-ref-type-badge">TransactionShape</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.EventFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_by_party</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_for_any_party</code>
+      <span class="x2mdx-ref-type-badge">Filters</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Filters">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cumulative</code>
+      <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">wildcard_filter</code>
+      <span class="x2mdx-ref-type-badge">WildcardFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_filter</code>
+      <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_filter</code>
+      <span class="x2mdx-ref-type-badge">TemplateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.WildcardFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_interface_view</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TemplateFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TransactionShape">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Transaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">effective_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated Event</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">external_transaction_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Event">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercised</code>
+      <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreatedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_views</code>
+      <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">representative_package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceView">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_value</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TraceContext">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">traceparent</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">tracestate</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/ExecuteSubmissionAndWaitForTransaction <<'EOF'
+{
+  "preparedTransaction": {
+    "transaction": {
+      "version": "string",
+      "roots": [
+        "string"
+      ],
+      "nodes": [
+        {
+          "nodeId": "string",
+          "v1": {}
+        }
+      ],
+      "nodeSeeds": [
+        {
+          "nodeId": 0,
+          "seed": "BASE64_ENCODED_BYTES"
+        }
+      ]
+    },
+    "metadata": {
+      "submitterInfo": {
+        "actAs": [
+          "string"
+        ],
+        "commandId": "string"
+      },
+      "synchronizerId": "string",
+      "mediatorGroup": 0,
+      "transactionUuid": "string",
+      "preparationTime": "0",
+      "inputContracts": [
+        {
+          "v1": {},
+          "createdAt": "0",
+          "eventBlob": "BASE64_ENCODED_BYTES"
+        }
+      ],
+      "minLedgerEffectiveTime": "0",
+      "maxLedgerEffectiveTime": "0"
+    }
+  },
+  "partySignatures": {
+    "signatures": [
+      {
+        "party": "string",
+        "signatures": [
+          {
+            "format": "SIGNATURE_FORMAT_UNSPECIFIED",
+            "signature": "BASE64_ENCODED_BYTES",
+            "signedBy": "string",
+            "signingAlgorithmSpec": "SIGNING_ALGORITHM_SPEC_UNSPECIFIED"
+          }
+        ]
+      }
+    ]
+  },
+  "deduplicationDuration": "string",
+  "submissionId": "string",
+  "userId": "string",
+  "hashingSchemeVersion": "HASHING_SCHEME_VERSION_UNSPECIFIED",
+  "minLedgerTime": {
+    "minLedgerTimeAbs": "string"
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "transaction": {
+    "updateId": "string",
+    "commandId": "string",
+    "workflowId": "string",
+    "effectiveAt": "string",
+    "events": [
+      {
+        "created": {
+          "offset": "0",
+          "nodeId": 0,
+          "contractId": "string",
+          "templateId": {},
+          "contractKey": {},
+          "createArguments": {},
+          "createdEventBlob": "BASE64_ENCODED_BYTES",
+          "interfaceViews": [
+            {}
+          ]
+        }
+      }
+    ],
+    "offset": "0",
+    "synchronizerId": "string",
+    "traceContext": {
+      "traceparent": "string",
+      "tracestate": "string"
+    }
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages.mdx
@@ -1,0 +1,452 @@
+---
+title: "GetPreferredPackages"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetPreferredPackages</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetPreferredPackages</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/GetPreferredPackages</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>InteractiveSubmissionService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetPreferredPackages</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetPreferredPackagesRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_vetting_requirements</code>
+      <span class="x2mdx-ref-type-badge">repeated PackageVettingRequirement</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetting_valid_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetPreferredPackagesResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_references</code>
+      <span class="x2mdx-ref-type-badge">repeated PackageReference</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_vetting_requirements</code>
+      <span class="x2mdx-ref-type-badge">repeated PackageVettingRequirement</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetting_valid_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.PackageVettingRequirement">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagevettingrequirement">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_references</code>
+      <span class="x2mdx-ref-type-badge">repeated PackageReference</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.PackageReference">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/GetPreferredPackages <<'EOF'
+{
+  "packageVettingRequirements": [
+    {
+      "parties": [
+        "string"
+      ],
+      "packageName": "string"
+    }
+  ],
+  "synchronizerId": "string",
+  "vettingValidAt": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "packageReferences": [
+    {
+      "packageId": "string",
+      "packageName": "string",
+      "packageVersion": "string"
+    }
+  ],
+  "synchronizerId": "string"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion.mdx
@@ -1,0 +1,448 @@
+---
+title: "GetPreferredPackageVersion"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetPreferredPackageVersion</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetPreferredPackageVersion</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/GetPreferredPackageVersion</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>InteractiveSubmissionService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetPreferredPackageVersion</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetPreferredPackageVersionRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetting_valid_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetPreferredPackageVersionResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_preference</code>
+      <span class="x2mdx-ref-type-badge">PackagePreference</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetting_valid_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_preference</code>
+      <span class="x2mdx-ref-type-badge">PackagePreference</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.PackagePreference">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagepreference">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_reference</code>
+      <span class="x2mdx-ref-type-badge">PackageReference</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.PackageReference">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/GetPreferredPackageVersion <<'EOF'
+{
+  "parties": [
+    "string"
+  ],
+  "packageName": "string",
+  "synchronizerId": "string",
+  "vettingValidAt": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "packagePreference": {
+    "packageReference": {
+      "packageId": "string",
+      "packageName": "string",
+      "packageVersion": "string"
+    },
+    "synchronizerId": "string"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission.mdx
@@ -1,0 +1,2391 @@
+---
+title: "PrepareSubmission"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-interactive">com.daml.ledger.api.v2.interactive</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>PrepareSubmission</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.interactive</p>
+  
+  
+  <h1 class="x2mdx-ref-title">PrepareSubmission</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/PrepareSubmission</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>InteractiveSubmissionService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>PrepareSubmission</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>PrepareSubmissionRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated Command</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">read_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">disclosed_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose_hashing</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
+      <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">estimate_traffic_cost</code>
+      <span class="x2mdx-ref-type-badge">CostEstimationHints</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>PrepareSubmissionResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_details</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cost_estimation</code>
+      <span class="x2mdx-ref-type-badge">CostEstimation</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated Command</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">read_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">disclosed_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose_hashing</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
+      <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">estimate_traffic_cost</code>
+      <span class="x2mdx-ref-type-badge">CostEstimationHints</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Command">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">CreateCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_by_key</code>
+      <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_and_exercise</code>
+      <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreateCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.MinLedgerTime">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.DisclosedContract">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.CostEstimationHints">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimationhints">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">disabled</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">expected_signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated SigningAlgorithmSpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SigningAlgorithmSpec">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_details</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cost_estimation</code>
+      <span class="x2mdx-ref-type-badge">CostEstimation</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.PreparedTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">DamlTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">metadata</code>
+      <span class="x2mdx-ref-type-badge">Metadata</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">roots</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">nodes</code>
+      <span class="x2mdx-ref-type-badge">repeated Node</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_seeds</code>
+      <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">seed</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.DamlTransaction.Node">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">v1</code>
+      <span class="x2mdx-ref-type-badge">Node</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Node">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">Create</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fetch</code>
+      <span class="x2mdx-ref-type-badge">Fetch</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">Exercise</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rollback</code>
+      <span class="x2mdx-ref-type-badge">Rollback</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Create">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Fetch">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Exercise">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">chosen_value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.transaction.v1.Rollback">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter_info</code>
+      <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">mediator_group</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_uuid</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">preparation_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">input_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated InputContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">global_key_mapping</code>
+      <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_record_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">GlobalKey</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.GlobalKey">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-globalkey">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.Metadata.InputContract">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">v1</code>
+      <span class="x2mdx-ref-type-badge">Create</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.HashingSchemeVersion">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
+    
+    <li><code>HASHING_SCHEME_VERSION_V2</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.interactive.CostEstimation">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimation">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">estimation_timestamp</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">confirmation_request_traffic_cost_estimation</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">confirmation_response_traffic_cost_estimation</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">total_traffic_cost_estimation</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.interactive.InteractiveSubmissionService/PrepareSubmission <<'EOF'
+{
+  "userId": "string",
+  "commandId": "string",
+  "commands": [
+    {
+      "create": {
+        "templateId": {
+          "packageId": "string",
+          "moduleName": "string",
+          "entityName": "string"
+        },
+        "createArguments": {
+          "recordId": {},
+          "fields": [
+            {}
+          ]
+        }
+      }
+    }
+  ],
+  "minLedgerTime": {
+    "minLedgerTimeAbs": "string"
+  },
+  "maxRecordTime": "string",
+  "actAs": [
+    "string"
+  ],
+  "readAs": [
+    "string"
+  ],
+  "disclosedContracts": [
+    {
+      "templateId": {
+        "packageId": "string",
+        "moduleName": "string",
+        "entityName": "string"
+      },
+      "contractId": "string",
+      "createdEventBlob": "BASE64_ENCODED_BYTES",
+      "synchronizerId": "string"
+    }
+  ]
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "preparedTransaction": {
+    "transaction": {
+      "version": "string",
+      "roots": [
+        "string"
+      ],
+      "nodes": [
+        {
+          "nodeId": "string",
+          "v1": {}
+        }
+      ],
+      "nodeSeeds": [
+        {
+          "nodeId": 0,
+          "seed": "BASE64_ENCODED_BYTES"
+        }
+      ]
+    },
+    "metadata": {
+      "submitterInfo": {
+        "actAs": [
+          "string"
+        ],
+        "commandId": "string"
+      },
+      "synchronizerId": "string",
+      "mediatorGroup": 0,
+      "transactionUuid": "string",
+      "preparationTime": "0",
+      "inputContracts": [
+        {
+          "v1": {},
+          "createdAt": "0",
+          "eventBlob": "BASE64_ENCODED_BYTES"
+        }
+      ],
+      "minLedgerEffectiveTime": "0",
+      "maxLedgerEffectiveTime": "0"
+    }
+  },
+  "preparedTransactionHash": "BASE64_ENCODED_BYTES",
+  "hashingSchemeVersion": "HASHING_SCHEME_VERSION_UNSPECIFIED",
+  "hashingDetails": "string",
+  "costEstimation": {
+    "estimationTimestamp": "string",
+    "confirmationRequestTrafficCostEstimation": "0",
+    "confirmationResponseTrafficCostEstimation": "0",
+    "totalTrafficCostEstimation": "0"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-testing/timeservice/gettime.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-testing/timeservice/gettime.mdx
@@ -1,0 +1,283 @@
+---
+title: "GetTime"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-testing">com.daml.ledger.api.v2.testing</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetTime</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.testing</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetTime</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.testing.TimeService/GetTime</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>TimeService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetTime</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetTimeRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.testing.GetTimeRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetTimeResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.testing.GetTimeResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">current_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.testing.GetTimeRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimerequest">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.testing.GetTimeResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimeresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">current_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.testing.TimeService/GetTime <<'EOF'
+{}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "currentTime": "string"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-testing/timeservice/settime.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2-testing/timeservice/settime.mdx
@@ -1,0 +1,288 @@
+---
+title: "SetTime"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2-testing">com.daml.ledger.api.v2.testing</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>SetTime</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2.testing</p>
+  
+  
+  <h1 class="x2mdx-ref-title">SetTime</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.testing.TimeService/SetTime</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>TimeService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>SetTime</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>SetTimeRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.testing.SetTimeRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">current_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">new_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>Empty</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>google.protobuf.Empty</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.testing.SetTimeRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-settimerequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">current_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">new_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.testing.TimeService/SetTime <<'EOF'
+{
+  "currentTime": "string",
+  "newTime": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream.mdx
@@ -1,0 +1,585 @@
+---
+title: "CompletionStream"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>CompletionStream</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">CompletionStream</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.CommandCompletionService/CompletionStream</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>CommandCompletionService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>CompletionStream</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>Yes</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>CompletionStreamRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.CompletionStreamRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">begin_exclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>CompletionStreamResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.CompletionStreamResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>Yes</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completion</code>
+      <span class="x2mdx-ref-type-badge">Completion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset_checkpoint</code>
+      <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.CompletionStreamRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">begin_exclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CompletionStreamResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completion</code>
+      <span class="x2mdx-ref-type-badge">Completion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset_checkpoint</code>
+      <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Completion">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_time</code>
+      <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TraceContext">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">traceparent</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">tracestate</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SynchronizerTime">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.OffsetCheckpoint">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpoint">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_times</code>
+      <span class="x2mdx-ref-type-badge">repeated SynchronizerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+# This RPC uses streaming semantics. Send additional JSON messages on stdin as needed.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.CommandCompletionService/CompletionStream <<'EOF'
+{
+  "userId": "string",
+  "parties": [
+    "string"
+  ],
+  "beginExclusive": "0"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "completion": {
+    "commandId": "string",
+    "status": "string",
+    "updateId": "string",
+    "userId": "string",
+    "actAs": [
+      "string"
+    ],
+    "submissionId": "string",
+    "deduplicationOffset": "0"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandservice/submitandwait.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandservice/submitandwait.mdx
@@ -1,0 +1,1280 @@
+---
+title: "SubmitAndWait"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>SubmitAndWait</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">SubmitAndWait</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.CommandService/SubmitAndWait</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>CommandService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>SubmitAndWait</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>SubmitAndWaitRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">Commands</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>SubmitAndWaitResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completion_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.SubmitAndWaitRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">Commands</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Commands">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated Command</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">read_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">disclosed_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
+      <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Command">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">CreateCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_by_key</code>
+      <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_and_exercise</code>
+      <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreateCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.DisclosedContract">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SubmitAndWaitResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completion_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.CommandService/SubmitAndWait <<'EOF'
+{
+  "commands": {
+    "workflowId": "string",
+    "userId": "string",
+    "commandId": "string",
+    "commands": [
+      {
+        "create": {
+          "templateId": {},
+          "createArguments": {}
+        }
+      }
+    ],
+    "deduplicationDuration": "string",
+    "minLedgerTimeAbs": "string",
+    "minLedgerTimeRel": "string"
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "updateId": "string",
+  "completionOffset": "0"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment.mdx
@@ -1,0 +1,1766 @@
+---
+title: "SubmitAndWaitForReassignment"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>SubmitAndWaitForReassignment</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">SubmitAndWaitForReassignment</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.CommandService/SubmitAndWaitForReassignment</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>CommandService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>SubmitAndWaitForReassignment</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>SubmitAndWaitForReassignmentRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_commands</code>
+      <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>SubmitAndWaitForReassignmentResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment</code>
+      <span class="x2mdx-ref-type-badge">Reassignment</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_commands</code>
+      <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ReassignmentCommands">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommands">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated ReassignmentCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ReassignmentCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unassign_command</code>
+      <span class="x2mdx-ref-type-badge">UnassignCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assign_command</code>
+      <span class="x2mdx-ref-type-badge">AssignCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.UnassignCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassigncommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.AssignCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assigncommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.EventFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_by_party</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_for_any_party</code>
+      <span class="x2mdx-ref-type-badge">Filters</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Filters">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cumulative</code>
+      <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">wildcard_filter</code>
+      <span class="x2mdx-ref-type-badge">WildcardFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_filter</code>
+      <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_filter</code>
+      <span class="x2mdx-ref-type-badge">TemplateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.WildcardFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_interface_view</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TemplateFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment</code>
+      <span class="x2mdx-ref-type-badge">Reassignment</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Reassignment">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unassigned</code>
+      <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assigned</code>
+      <span class="x2mdx-ref-type-badge">AssignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.AssignedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreatedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_views</code>
+      <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">representative_package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceView">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_value</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TraceContext">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">traceparent</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">tracestate</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.CommandService/SubmitAndWaitForReassignment <<'EOF'
+{
+  "reassignmentCommands": {
+    "workflowId": "string",
+    "userId": "string",
+    "commandId": "string",
+    "submitter": "string",
+    "submissionId": "string",
+    "commands": [
+      {
+        "unassignCommand": {
+          "contractId": "string",
+          "source": "string",
+          "target": "string"
+        }
+      }
+    ]
+  },
+  "eventFormat": {
+    "filtersByParty": [
+      {
+        "key": {
+          "cumulative": [
+            {
+              "wildcardFilter": {}
+            }
+          ]
+        }
+      }
+    ],
+    "filtersForAnyParty": {
+      "cumulative": [
+        {
+          "wildcardFilter": {}
+        }
+      ]
+    },
+    "verbose": true
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "reassignment": {
+    "updateId": "string",
+    "commandId": "string",
+    "workflowId": "string",
+    "offset": "0",
+    "events": [
+      {
+        "unassigned": {
+          "reassignmentId": "string",
+          "contractId": "string",
+          "templateId": {},
+          "source": "string",
+          "target": "string",
+          "submitter": "string",
+          "reassignmentCounter": "0",
+          "assignmentExclusivity": "string"
+        }
+      }
+    ],
+    "traceContext": {
+      "traceparent": "string",
+      "tracestate": "string"
+    },
+    "recordTime": "string",
+    "synchronizerId": "string"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction.mdx
@@ -1,0 +1,2157 @@
+---
+title: "SubmitAndWaitForTransaction"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>SubmitAndWaitForTransaction</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">SubmitAndWaitForTransaction</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.CommandService/SubmitAndWaitForTransaction</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>CommandService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>SubmitAndWaitForTransaction</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>SubmitAndWaitForTransactionRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">Commands</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_format</code>
+      <span class="x2mdx-ref-type-badge">TransactionFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>SubmitAndWaitForTransactionResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">Commands</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_format</code>
+      <span class="x2mdx-ref-type-badge">TransactionFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Commands">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated Command</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">read_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">disclosed_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
+      <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Command">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">CreateCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_by_key</code>
+      <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_and_exercise</code>
+      <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreateCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.DisclosedContract">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TransactionFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_shape</code>
+      <span class="x2mdx-ref-type-badge">TransactionShape</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.EventFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_by_party</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_for_any_party</code>
+      <span class="x2mdx-ref-type-badge">Filters</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Filters">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cumulative</code>
+      <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">wildcard_filter</code>
+      <span class="x2mdx-ref-type-badge">WildcardFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_filter</code>
+      <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_filter</code>
+      <span class="x2mdx-ref-type-badge">TemplateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.WildcardFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_interface_view</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TemplateFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TransactionShape">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Transaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">effective_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated Event</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">external_transaction_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Event">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercised</code>
+      <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreatedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_views</code>
+      <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">representative_package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceView">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_value</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TraceContext">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">traceparent</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">tracestate</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.CommandService/SubmitAndWaitForTransaction <<'EOF'
+{
+  "commands": {
+    "workflowId": "string",
+    "userId": "string",
+    "commandId": "string",
+    "commands": [
+      {
+        "create": {
+          "templateId": {},
+          "createArguments": {}
+        }
+      }
+    ],
+    "deduplicationDuration": "string",
+    "minLedgerTimeAbs": "string",
+    "minLedgerTimeRel": "string"
+  },
+  "transactionFormat": {
+    "eventFormat": {
+      "filtersByParty": [
+        {
+          "key": {
+            "cumulative": [
+              {}
+            ]
+          }
+        }
+      ],
+      "filtersForAnyParty": {
+        "cumulative": [
+          {}
+        ]
+      },
+      "verbose": true
+    },
+    "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "transaction": {
+    "updateId": "string",
+    "commandId": "string",
+    "workflowId": "string",
+    "effectiveAt": "string",
+    "events": [
+      {
+        "created": {
+          "offset": "0",
+          "nodeId": 0,
+          "contractId": "string",
+          "templateId": {},
+          "contractKey": {},
+          "createArguments": {},
+          "createdEventBlob": "BASE64_ENCODED_BYTES",
+          "interfaceViews": [
+            {}
+          ]
+        }
+      }
+    ],
+    "offset": "0",
+    "synchronizerId": "string",
+    "traceContext": {
+      "traceparent": "string",
+      "tracestate": "string"
+    }
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandsubmissionservice/submit.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandsubmissionservice/submit.mdx
@@ -1,0 +1,1233 @@
+---
+title: "Submit"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>Submit</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">Submit</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.CommandSubmissionService/Submit</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>CommandSubmissionService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>Submit</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>SubmitRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.SubmitRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">Commands</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>SubmitResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.SubmitResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.SubmitRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">Commands</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Commands">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated Command</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">read_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">disclosed_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
+      <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Command">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">CreateCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_by_key</code>
+      <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_and_exercise</code>
+      <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreateCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExerciseCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExerciseByKeyCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreateAndExerciseCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.DisclosedContract">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.PrefetchContractKey">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SubmitResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitresponse">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.CommandSubmissionService/Submit <<'EOF'
+{
+  "commands": {
+    "workflowId": "string",
+    "userId": "string",
+    "commandId": "string",
+    "commands": [
+      {
+        "create": {
+          "templateId": {},
+          "createArguments": {}
+        }
+      }
+    ],
+    "deduplicationDuration": "string",
+    "minLedgerTimeAbs": "string",
+    "minLedgerTimeRel": "string"
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment.mdx
@@ -1,0 +1,476 @@
+---
+title: "SubmitReassignment"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>SubmitReassignment</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">SubmitReassignment</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.CommandSubmissionService/SubmitReassignment</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>CommandSubmissionService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>SubmitReassignment</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>SubmitReassignmentRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.SubmitReassignmentRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_commands</code>
+      <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>SubmitReassignmentResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.SubmitReassignmentResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.SubmitReassignmentRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_commands</code>
+      <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ReassignmentCommands">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommands">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated ReassignmentCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ReassignmentCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unassign_command</code>
+      <span class="x2mdx-ref-type-badge">UnassignCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assign_command</code>
+      <span class="x2mdx-ref-type-badge">AssignCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.UnassignCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassigncommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.AssignCommand">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assigncommand">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SubmitReassignmentResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentresponse">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.CommandSubmissionService/SubmitReassignment <<'EOF'
+{
+  "reassignmentCommands": {
+    "workflowId": "string",
+    "userId": "string",
+    "commandId": "string",
+    "submitter": "string",
+    "submissionId": "string",
+    "commands": [
+      {
+        "unassignCommand": {
+          "contractId": "string",
+          "source": "string",
+          "target": "string"
+        }
+      }
+    ]
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/contractservice/getcontract.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/contractservice/getcontract.mdx
@@ -1,0 +1,1042 @@
+---
+title: "GetContract"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetContract</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetContract</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.11</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.ContractService/GetContract</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>ContractService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetContract</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetContractRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetContractRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">querying_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetContractResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetContractResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.11</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetContractRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">querying_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetContractResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreatedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_views</code>
+      <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">representative_package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceView">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_value</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.ContractService/GetContract <<'EOF'
+{
+  "contractId": "string",
+  "queryingParties": [
+    "string"
+  ]
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "createdEvent": {
+    "offset": "0",
+    "nodeId": 0,
+    "contractId": "string",
+    "templateId": {
+      "packageId": "string",
+      "moduleName": "string",
+      "entityName": "string"
+    },
+    "contractKey": {
+      "unit": "string"
+    },
+    "createArguments": {
+      "recordId": {
+        "packageId": "string",
+        "moduleName": "string",
+        "entityName": "string"
+      },
+      "fields": [
+        {
+          "label": "string",
+          "value": {}
+        }
+      ]
+    },
+    "createdEventBlob": "BASE64_ENCODED_BYTES",
+    "interfaceViews": [
+      {
+        "interfaceId": {
+          "packageId": "string",
+          "moduleName": "string",
+          "entityName": "string"
+        },
+        "viewStatus": "string",
+        "viewValue": {
+          "recordId": {},
+          "fields": [
+            {}
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid.mdx
@@ -1,0 +1,1422 @@
+---
+title: "GetEventsByContractId"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetEventsByContractId</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetEventsByContractId</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.EventQueryService/GetEventsByContractId</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>EventQueryService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetEventsByContractId</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetEventsByContractIdRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetEventsByContractIdRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetEventsByContractIdResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetEventsByContractIdResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">Created</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">Archived</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetEventsByContractIdRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.EventFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_by_party</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_for_any_party</code>
+      <span class="x2mdx-ref-type-badge">Filters</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Filters">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cumulative</code>
+      <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">wildcard_filter</code>
+      <span class="x2mdx-ref-type-badge">WildcardFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_filter</code>
+      <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_filter</code>
+      <span class="x2mdx-ref-type-badge">TemplateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.WildcardFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_interface_view</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TemplateFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetEventsByContractIdResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">Created</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">Archived</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Created">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-created">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreatedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_views</code>
+      <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">representative_package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceView">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_value</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Archived">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archived">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived_event</code>
+      <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.EventQueryService/GetEventsByContractId <<'EOF'
+{
+  "contractId": "string",
+  "eventFormat": {
+    "filtersByParty": [
+      {
+        "key": {
+          "cumulative": [
+            {
+              "wildcardFilter": {}
+            }
+          ]
+        }
+      }
+    ],
+    "filtersForAnyParty": {
+      "cumulative": [
+        {
+          "wildcardFilter": {}
+        }
+      ]
+    },
+    "verbose": true
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "created": {
+    "createdEvent": {
+      "offset": "0",
+      "nodeId": 0,
+      "contractId": "string",
+      "templateId": {
+        "packageId": "string",
+        "moduleName": "string",
+        "entityName": "string"
+      },
+      "contractKey": {
+        "unit": "string"
+      },
+      "createArguments": {
+        "recordId": {},
+        "fields": [
+          {}
+        ]
+      },
+      "createdEventBlob": "BASE64_ENCODED_BYTES",
+      "interfaceViews": [
+        {
+          "interfaceId": {},
+          "viewStatus": "string",
+          "viewValue": {}
+        }
+      ]
+    },
+    "synchronizerId": "string"
+  },
+  "archived": {
+    "archivedEvent": {
+      "offset": "0",
+      "nodeId": 0,
+      "contractId": "string",
+      "templateId": {
+        "packageId": "string",
+        "moduleName": "string",
+        "entityName": "string"
+      },
+      "witnessParties": [
+        "string"
+      ],
+      "packageName": "string",
+      "implementedInterfaces": [
+        {
+          "packageId": "string",
+          "moduleName": "string",
+          "entityName": "string"
+        }
+      ]
+    },
+    "synchronizerId": "string"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/getpackage.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/getpackage.mdx
@@ -1,0 +1,364 @@
+---
+title: "GetPackage"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetPackage</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetPackage</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.PackageService/GetPackage</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PackageService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetPackage</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetPackageRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetPackageRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetPackageResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetPackageResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hash_function</code>
+      <span class="x2mdx-ref-type-badge">HashFunction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archive_payload</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hash</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetPackageRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagerequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetPackageResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackageresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hash_function</code>
+      <span class="x2mdx-ref-type-badge">HashFunction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archive_payload</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hash</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.HashFunction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-hashfunction">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>HASH_FUNCTION_SHA256</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.PackageService/GetPackage <<'EOF'
+{
+  "packageId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "hashFunction": "HASH_FUNCTION_SHA256",
+  "archivePayload": "BASE64_ENCODED_BYTES",
+  "hash": "string"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/getpackagestatus.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/getpackagestatus.mdx
@@ -1,0 +1,328 @@
+---
+title: "GetPackageStatus"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetPackageStatus</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetPackageStatus</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.PackageService/GetPackageStatus</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PackageService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetPackageStatus</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetPackageStatusRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetPackageStatusRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetPackageStatusResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetPackageStatusResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_status</code>
+      <span class="x2mdx-ref-type-badge">PackageStatus</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetPackageStatusRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetPackageStatusResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_status</code>
+      <span class="x2mdx-ref-type-badge">PackageStatus</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.PackageStatus">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagestatus">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>PACKAGE_STATUS_UNSPECIFIED</code></li>
+    
+    <li><code>PACKAGE_STATUS_REGISTERED</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.PackageService/GetPackageStatus <<'EOF'
+{
+  "packageId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "packageStatus": "PACKAGE_STATUS_UNSPECIFIED"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/listpackages.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/listpackages.mdx
@@ -1,0 +1,285 @@
+---
+title: "ListPackages"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>ListPackages</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">ListPackages</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.PackageService/ListPackages</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PackageService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>ListPackages</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListPackagesRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.ListPackagesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListPackagesResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.ListPackagesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_ids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.ListPackagesRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesrequest">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ListPackagesResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_ids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.PackageService/ListPackages <<'EOF'
+{}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "packageIds": [
+    "string"
+  ]
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/listvettedpackages.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/packageservice/listvettedpackages.mdx
@@ -1,0 +1,585 @@
+---
+title: "ListVettedPackages"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>ListVettedPackages</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">ListVettedPackages</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.PackageService/ListVettedPackages</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>PackageService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>ListVettedPackages</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListVettedPackagesRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.ListVettedPackagesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_metadata_filter</code>
+      <span class="x2mdx-ref-type-badge">PackageMetadataFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_state_filter</code>
+      <span class="x2mdx-ref-type-badge">TopologyStateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_size</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>ListVettedPackagesResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.ListVettedPackagesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetted_packages</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackages</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">next_page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.ListVettedPackagesRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_metadata_filter</code>
+      <span class="x2mdx-ref-type-badge">PackageMetadataFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_state_filter</code>
+      <span class="x2mdx-ref-type-badge">TopologyStateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_size</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.PackageMetadataFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagemetadatafilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_ids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name_prefixes</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TopologyStateFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologystatefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_ids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_ids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ListVettedPackagesResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetted_packages</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackages</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">next_page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.VettedPackages">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">packages</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_serial</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.VettedPackage">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.PackageService/ListVettedPackages <<'EOF'
+{
+  "packageMetadataFilter": {
+    "packageIds": [
+      "string"
+    ],
+    "packageNamePrefixes": [
+      "string"
+    ]
+  },
+  "topologyStateFilter": {
+    "participantIds": [
+      "string"
+    ],
+    "synchronizerIds": [
+      "string"
+    ]
+  },
+  "pageToken": "string",
+  "pageSize": 0
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "vettedPackages": [
+    {
+      "packages": [
+        {
+          "packageId": "string",
+          "validFromInclusive": "string",
+          "validUntilExclusive": "string",
+          "packageName": "string",
+          "packageVersion": "string"
+        }
+      ],
+      "participantId": "string",
+      "synchronizerId": "string",
+      "topologySerial": 0
+    }
+  ],
+  "nextPageToken": "string"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getactivecontracts.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getactivecontracts.mdx
@@ -1,0 +1,1580 @@
+---
+title: "GetActiveContracts"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetActiveContracts</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetActiveContracts</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.StateService/GetActiveContracts</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>StateService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetActiveContracts</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>Yes</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetActiveContractsRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetActiveContractsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">active_at_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetActiveContractsResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetActiveContractsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>Yes</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">active_contract</code>
+      <span class="x2mdx-ref-type-badge">ActiveContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">incomplete_unassigned</code>
+      <span class="x2mdx-ref-type-badge">IncompleteUnassigned</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">incomplete_assigned</code>
+      <span class="x2mdx-ref-type-badge">IncompleteAssigned</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetActiveContractsRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractsrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">active_at_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.EventFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_by_party</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_for_any_party</code>
+      <span class="x2mdx-ref-type-badge">Filters</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Filters">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cumulative</code>
+      <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">wildcard_filter</code>
+      <span class="x2mdx-ref-type-badge">WildcardFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_filter</code>
+      <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_filter</code>
+      <span class="x2mdx-ref-type-badge">TemplateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.WildcardFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_interface_view</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TemplateFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetActiveContractsResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractsresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">active_contract</code>
+      <span class="x2mdx-ref-type-badge">ActiveContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">incomplete_unassigned</code>
+      <span class="x2mdx-ref-type-badge">IncompleteUnassigned</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">incomplete_assigned</code>
+      <span class="x2mdx-ref-type-badge">IncompleteAssigned</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ActiveContract">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-activecontract">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreatedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_views</code>
+      <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">representative_package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceView">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_value</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.IncompleteUnassigned">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteunassigned">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unassigned_event</code>
+      <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.IncompleteAssigned">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteassigned">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assigned_event</code>
+      <span class="x2mdx-ref-type-badge">AssignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.AssignedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+# This RPC uses streaming semantics. Send additional JSON messages on stdin as needed.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.StateService/GetActiveContracts <<'EOF'
+{
+  "activeAtOffset": "0",
+  "eventFormat": {
+    "filtersByParty": [
+      {
+        "key": {
+          "cumulative": [
+            {
+              "wildcardFilter": {}
+            }
+          ]
+        }
+      }
+    ],
+    "filtersForAnyParty": {
+      "cumulative": [
+        {
+          "wildcardFilter": {}
+        }
+      ]
+    },
+    "verbose": true
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "workflowId": "string",
+  "activeContract": {
+    "createdEvent": {
+      "offset": "0",
+      "nodeId": 0,
+      "contractId": "string",
+      "templateId": {
+        "packageId": "string",
+        "moduleName": "string",
+        "entityName": "string"
+      },
+      "contractKey": {
+        "unit": "string"
+      },
+      "createArguments": {
+        "recordId": {},
+        "fields": [
+          {}
+        ]
+      },
+      "createdEventBlob": "BASE64_ENCODED_BYTES",
+      "interfaceViews": [
+        {
+          "interfaceId": {},
+          "viewStatus": "string",
+          "viewValue": {}
+        }
+      ]
+    },
+    "synchronizerId": "string",
+    "reassignmentCounter": "0"
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers.mdx
@@ -1,0 +1,416 @@
+---
+title: "GetConnectedSynchronizers"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetConnectedSynchronizers</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetConnectedSynchronizers</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.StateService/GetConnectedSynchronizers</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>StateService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetConnectedSynchronizers</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetConnectedSynchronizersRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetConnectedSynchronizersResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">connected_synchronizers</code>
+      <span class="x2mdx-ref-type-badge">repeated ConnectedSynchronizer</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetConnectedSynchronizersRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetConnectedSynchronizersResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">connected_synchronizers</code>
+      <span class="x2mdx-ref-type-badge">repeated ConnectedSynchronizer</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetConnectedSynchronizersResponse.ConnectedSynchronizer">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse-connectedsynchronizer">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_alias</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">permission</code>
+      <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.StateService/GetConnectedSynchronizers <<'EOF'
+{
+  "party": "string",
+  "participantId": "string",
+  "identityProviderId": "string"
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "connectedSynchronizers": [
+    {
+      "synchronizerAlias": "string",
+      "synchronizerId": "string",
+      "permission": "PARTICIPANT_PERMISSION_UNSPECIFIED"
+    }
+  ]
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets.mdx
@@ -1,0 +1,302 @@
+---
+title: "GetLatestPrunedOffsets"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetLatestPrunedOffsets</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetLatestPrunedOffsets</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.StateService/GetLatestPrunedOffsets</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>StateService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetLatestPrunedOffsets</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetLatestPrunedOffsetsRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetLatestPrunedOffsetsResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_pruned_up_to_inclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">all_divulged_contracts_pruned_up_to_inclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_pruned_up_to_inclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">all_divulged_contracts_pruned_up_to_inclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.StateService/GetLatestPrunedOffsets <<'EOF'
+{}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "participantPrunedUpToInclusive": "0",
+  "allDivulgedContractsPrunedUpToInclusive": "0"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getledgerend.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/stateservice/getledgerend.mdx
@@ -1,0 +1,283 @@
+---
+title: "GetLedgerEnd"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetLedgerEnd</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetLedgerEnd</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.StateService/GetLedgerEnd</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>StateService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetLedgerEnd</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetLedgerEndRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetLedgerEndRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetLedgerEndResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetLedgerEndResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetLedgerEndRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendrequest">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetLedgerEndResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.StateService/GetLedgerEnd <<'EOF'
+{}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "offset": "0"
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/updateservice/getupdatebyid.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/updateservice/getupdatebyid.mdx
@@ -1,0 +1,2368 @@
+---
+title: "GetUpdateById"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetUpdateById</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetUpdateById</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.UpdateService/GetUpdateById</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UpdateService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetUpdateById</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetUpdateByIdRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdateByIdRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_format</code>
+      <span class="x2mdx-ref-type-badge">UpdateFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetUpdateResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment</code>
+      <span class="x2mdx-ref-type-badge">Reassignment</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_transaction</code>
+      <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetUpdateByIdRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyidrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_format</code>
+      <span class="x2mdx-ref-type-badge">UpdateFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.UpdateFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_transactions</code>
+      <span class="x2mdx-ref-type-badge">TransactionFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_reassignments</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_topology_events</code>
+      <span class="x2mdx-ref-type-badge">TopologyFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TransactionFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_shape</code>
+      <span class="x2mdx-ref-type-badge">TransactionShape</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.EventFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_by_party</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_for_any_party</code>
+      <span class="x2mdx-ref-type-badge">Filters</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Filters">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cumulative</code>
+      <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">wildcard_filter</code>
+      <span class="x2mdx-ref-type-badge">WildcardFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_filter</code>
+      <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_filter</code>
+      <span class="x2mdx-ref-type-badge">TemplateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.WildcardFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_interface_view</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TemplateFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TransactionShape">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TopologyFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetUpdateResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdateresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment</code>
+      <span class="x2mdx-ref-type-badge">Reassignment</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_transaction</code>
+      <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Transaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">effective_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated Event</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">external_transaction_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Event">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercised</code>
+      <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreatedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_views</code>
+      <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">representative_package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceView">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_value</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TraceContext">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">traceparent</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">tracestate</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Reassignment">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unassigned</code>
+      <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assigned</code>
+      <span class="x2mdx-ref-type-badge">AssignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.AssignedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TopologyTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TopologyEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_added</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationChanged">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_permission</code>
+      <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationRevoked">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationAdded">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_permission</code>
+      <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.UpdateService/GetUpdateById <<'EOF'
+{
+  "updateId": "string",
+  "updateFormat": {
+    "includeTransactions": {
+      "eventFormat": {
+        "filtersByParty": [
+          {
+            "key": {}
+          }
+        ],
+        "filtersForAnyParty": {},
+        "verbose": true
+      },
+      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+    },
+    "includeReassignments": {
+      "filtersByParty": [
+        {
+          "key": {
+            "cumulative": [
+              {}
+            ]
+          }
+        }
+      ],
+      "filtersForAnyParty": {
+        "cumulative": [
+          {}
+        ]
+      },
+      "verbose": true
+    },
+    "includeTopologyEvents": {
+      "includeParticipantAuthorizationEvents": {
+        "parties": [
+          "string"
+        ]
+      }
+    }
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "transaction": {
+    "updateId": "string",
+    "commandId": "string",
+    "workflowId": "string",
+    "effectiveAt": "string",
+    "events": [
+      {
+        "created": {
+          "offset": "0",
+          "nodeId": 0,
+          "contractId": "string",
+          "templateId": {},
+          "contractKey": {},
+          "createArguments": {},
+          "createdEventBlob": "BASE64_ENCODED_BYTES",
+          "interfaceViews": [
+            {}
+          ]
+        }
+      }
+    ],
+    "offset": "0",
+    "synchronizerId": "string",
+    "traceContext": {
+      "traceparent": "string",
+      "tracestate": "string"
+    }
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset.mdx
@@ -1,0 +1,2368 @@
+---
+title: "GetUpdateByOffset"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetUpdateByOffset</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetUpdateByOffset</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.UpdateService/GetUpdateByOffset</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UpdateService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetUpdateByOffset</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetUpdateByOffsetRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdateByOffsetRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_format</code>
+      <span class="x2mdx-ref-type-badge">UpdateFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetUpdateResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment</code>
+      <span class="x2mdx-ref-type-badge">Reassignment</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_transaction</code>
+      <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetUpdateByOffsetRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyoffsetrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_format</code>
+      <span class="x2mdx-ref-type-badge">UpdateFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.UpdateFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_transactions</code>
+      <span class="x2mdx-ref-type-badge">TransactionFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_reassignments</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_topology_events</code>
+      <span class="x2mdx-ref-type-badge">TopologyFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TransactionFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_shape</code>
+      <span class="x2mdx-ref-type-badge">TransactionShape</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.EventFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_by_party</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_for_any_party</code>
+      <span class="x2mdx-ref-type-badge">Filters</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Filters">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cumulative</code>
+      <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">wildcard_filter</code>
+      <span class="x2mdx-ref-type-badge">WildcardFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_filter</code>
+      <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_filter</code>
+      <span class="x2mdx-ref-type-badge">TemplateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.WildcardFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_interface_view</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TemplateFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TransactionShape">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TopologyFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetUpdateResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdateresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment</code>
+      <span class="x2mdx-ref-type-badge">Reassignment</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_transaction</code>
+      <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Transaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">effective_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated Event</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">external_transaction_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Event">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercised</code>
+      <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreatedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_views</code>
+      <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">representative_package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceView">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_value</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TraceContext">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">traceparent</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">tracestate</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Reassignment">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unassigned</code>
+      <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assigned</code>
+      <span class="x2mdx-ref-type-badge">AssignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.AssignedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TopologyTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TopologyEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_added</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationChanged">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_permission</code>
+      <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationRevoked">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationAdded">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_permission</code>
+      <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.UpdateService/GetUpdateByOffset <<'EOF'
+{
+  "offset": "0",
+  "updateFormat": {
+    "includeTransactions": {
+      "eventFormat": {
+        "filtersByParty": [
+          {
+            "key": {}
+          }
+        ],
+        "filtersForAnyParty": {},
+        "verbose": true
+      },
+      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+    },
+    "includeReassignments": {
+      "filtersByParty": [
+        {
+          "key": {
+            "cumulative": [
+              {}
+            ]
+          }
+        }
+      ],
+      "filtersForAnyParty": {
+        "cumulative": [
+          {}
+        ]
+      },
+      "verbose": true
+    },
+    "includeTopologyEvents": {
+      "includeParticipantAuthorizationEvents": {
+        "parties": [
+          "string"
+        ]
+      }
+    }
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "transaction": {
+    "updateId": "string",
+    "commandId": "string",
+    "workflowId": "string",
+    "effectiveAt": "string",
+    "events": [
+      {
+        "created": {
+          "offset": "0",
+          "nodeId": 0,
+          "contractId": "string",
+          "templateId": {},
+          "contractKey": {},
+          "createArguments": {},
+          "createdEventBlob": "BASE64_ENCODED_BYTES",
+          "interfaceViews": [
+            {}
+          ]
+        }
+      }
+    ],
+    "offset": "0",
+    "synchronizerId": "string",
+    "traceContext": {
+      "traceparent": "string",
+      "tracestate": "string"
+    }
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/updateservice/getupdates.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/updateservice/getupdates.mdx
@@ -1,0 +1,2468 @@
+---
+title: "GetUpdates"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetUpdates</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetUpdates</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.UpdateService/GetUpdates</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>UpdateService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetUpdates</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>Yes</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetUpdatesRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdatesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">begin_exclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">end_inclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_format</code>
+      <span class="x2mdx-ref-type-badge">UpdateFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetUpdatesResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdatesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>Yes</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment</code>
+      <span class="x2mdx-ref-type-badge">Reassignment</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset_checkpoint</code>
+      <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_transaction</code>
+      <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetUpdatesRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesrequest">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">begin_exclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">end_inclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_format</code>
+      <span class="x2mdx-ref-type-badge">UpdateFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.UpdateFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_transactions</code>
+      <span class="x2mdx-ref-type-badge">TransactionFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_reassignments</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_topology_events</code>
+      <span class="x2mdx-ref-type-badge">TopologyFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TransactionFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_shape</code>
+      <span class="x2mdx-ref-type-badge">TransactionShape</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.EventFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_by_party</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_for_any_party</code>
+      <span class="x2mdx-ref-type-badge">Filters</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Filters">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cumulative</code>
+      <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CumulativeFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">wildcard_filter</code>
+      <span class="x2mdx-ref-type-badge">WildcardFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_filter</code>
+      <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_filter</code>
+      <span class="x2mdx-ref-type-badge">TemplateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.WildcardFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_interface_view</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Identifier">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TemplateFilter">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TransactionShape">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TopologyFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetUpdatesResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment</code>
+      <span class="x2mdx-ref-type-badge">Reassignment</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset_checkpoint</code>
+      <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_transaction</code>
+      <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Transaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">effective_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated Event</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">external_transaction_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Event">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercised</code>
+      <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.CreatedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_views</code>
+      <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">representative_package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Value">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Optional">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.List">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TextMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GenMap.Entry">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Record">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.RecordField">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Variant">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Enum">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.InterfaceView">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_value</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ArchivedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExercisedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TraceContext">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">traceparent</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">tracestate</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.Reassignment">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ReassignmentEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unassigned</code>
+      <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assigned</code>
+      <span class="x2mdx-ref-type-badge">AssignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.UnassignedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.AssignedEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.OffsetCheckpoint">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpoint">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_times</code>
+      <span class="x2mdx-ref-type-badge">repeated SynchronizerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.SynchronizerTime">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TopologyTransaction">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.TopologyEvent">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_added</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationChanged">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_permission</code>
+      <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantPermission">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
+    
+  </ul>
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationRevoked">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ParticipantAuthorizationAdded">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_permission</code>
+      <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+# This RPC uses streaming semantics. Send additional JSON messages on stdin as needed.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.UpdateService/GetUpdates <<'EOF'
+{
+  "beginExclusive": "0",
+  "endInclusive": "0",
+  "updateFormat": {
+    "includeTransactions": {
+      "eventFormat": {
+        "filtersByParty": [
+          {
+            "key": {}
+          }
+        ],
+        "filtersForAnyParty": {},
+        "verbose": true
+      },
+      "transactionShape": "TRANSACTION_SHAPE_UNSPECIFIED"
+    },
+    "includeReassignments": {
+      "filtersByParty": [
+        {
+          "key": {
+            "cumulative": [
+              {}
+            ]
+          }
+        }
+      ],
+      "filtersForAnyParty": {
+        "cumulative": [
+          {}
+        ]
+      },
+      "verbose": true
+    },
+    "includeTopologyEvents": {
+      "includeParticipantAuthorizationEvents": {
+        "parties": [
+          "string"
+        ]
+      }
+    }
+  }
+}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "transaction": {
+    "updateId": "string",
+    "commandId": "string",
+    "workflowId": "string",
+    "effectiveAt": "string",
+    "events": [
+      {
+        "created": {
+          "offset": "0",
+          "nodeId": 0,
+          "contractId": "string",
+          "templateId": {},
+          "contractKey": {},
+          "createArguments": {},
+          "createdEventBlob": "BASE64_ENCODED_BYTES",
+          "interfaceViews": [
+            {}
+          ]
+        }
+      }
+    ],
+    "offset": "0",
+    "synchronizerId": "string",
+    "traceContext": {
+      "traceparent": "string",
+      "tracestate": "string"
+    }
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion.mdx
@@ -1,0 +1,564 @@
+---
+title: "GetLedgerApiVersion"
+---
+
+<div class="x2mdx-ref-page x2mdx-ref-page--operation"></div>
+
+<div className="x2mdx-ref-operation-shell">
+<div className="x2mdx-ref-operation-main">
+
+
+<div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
+  
+  
+  <span>Ledger API</span>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../index">Protobuf</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <a href="../../../packages/com-daml-ledger-api-v2">com.daml.ledger.api.v2</a>
+  
+  
+  <span class="x2mdx-ref-breadcrumb-separator">›</span>
+  
+  
+  
+  <span>GetLedgerApiVersion</span>
+  
+  
+  
+</div>
+
+
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">com.daml.ledger.api.v2</p>
+  
+  
+  <h1 class="x2mdx-ref-title">GetLedgerApiVersion</h1>
+  
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+  
+</div>
+
+<div class="x2mdx-ref-operation-bar">
+  
+  <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--rpc">RPC</span>
+  
+  <code>/com.daml.ledger.api.v2.VersionService/GetLedgerApiVersion</code>
+</div>
+
+## Protocol Details
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Protocol</dt>
+    <dd>gRPC</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Service</dt>
+    <dd>VersionService</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>RPC</dt>
+    <dd>GetLedgerApiVersion</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+
+## Inputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetLedgerApiVersionRequest</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetLedgerApiVersionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+  
+  
+  
+  
+</div>
+
+
+## Outputs
+
+
+<div class="x2mdx-ref-panel">
+  <div class="x2mdx-ref-panel-head">
+    <h3>GetLedgerApiVersionResponse</h3>
+    
+  </div>
+  
+  
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Message</dt>
+    <dd>com.daml.ledger.api.v2.GetLedgerApiVersionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">features</code>
+      <span class="x2mdx-ref-type-badge">FeaturesDescriptor</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+  
+  
+</div>
+
+
+
+
+
+## Lifecycle Changes
+
+<div class="x2mdx-ref-change-list">
+  
+  <div class="x2mdx-ref-change-item">
+    <span class="x2mdx-ref-change-version">3.4.4</span>
+    <span class="x2mdx-ref-change-detail">introduced</span>
+  </div>
+  
+</div>
+
+
+
+## Related Schemas
+
+<AccordionGroup>
+
+<Accordion title="com.daml.ledger.api.v2.GetLedgerApiVersionRequest">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionrequest">
+  
+  
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.GetLedgerApiVersionResponse">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionresponse">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">features</code>
+      <span class="x2mdx-ref-type-badge">FeaturesDescriptor</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.FeaturesDescriptor">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-featuresdescriptor">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">experimental</code>
+      <span class="x2mdx-ref-type-badge">ExperimentalFeatures</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_management</code>
+      <span class="x2mdx-ref-type-badge">UserManagementFeature</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_management</code>
+      <span class="x2mdx-ref-type-badge">PartyManagementFeature</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset_checkpoint</code>
+      <span class="x2mdx-ref-type-badge">OffsetCheckpointFeature</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_feature</code>
+      <span class="x2mdx-ref-type-badge">PackageFeature</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExperimentalFeatures">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalfeatures">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">static_time</code>
+      <span class="x2mdx-ref-type-badge">ExperimentalStaticTime</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_inspection_service</code>
+      <span class="x2mdx-ref-type-badge">ExperimentalCommandInspectionService</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExperimentalStaticTime">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalstatictime">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">supported</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.ExperimentalCommandInspectionService">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalcommandinspectionservice">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">supported</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.UserManagementFeature">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-usermanagementfeature">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">supported</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_rights_per_user</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_users_page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.PartyManagementFeature">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-partymanagementfeature">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_parties_page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.OffsetCheckpointFeature">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpointfeature">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_offset_checkpoint_emission_delay</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+<Accordion title="com.daml.ledger.api.v2.PackageFeature">
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagefeature">
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_vetted_packages_page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+</Accordion>
+
+</AccordionGroup>
+
+
+</div>
+
+<div className="x2mdx-ref-right-rail" role="complementary" aria-label="Examples and responses">
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">grpcurl</span>
+  
+</div>
+
+```bash grpcurl
+# Add -plaintext if the server is not using TLS.
+grpcurl \
+  -d @ \
+  <HOST:PORT> \
+  com.daml.ledger.api.v2.VersionService/GetLedgerApiVersion <<'EOF'
+{}
+EOF
+```
+
+</div>
+  </div>
+  
+  <div className="x2mdx-ref-rail-panel">
+  <div className="x2mdx-ref-rail-code x2mdx-ref-rail-code--response">
+<div className="x2mdx-ref-rail-head">
+  <span className="x2mdx-ref-rail-heading">OK</span>
+  
+  <span className="x2mdx-ref-response-label">application/json</span>
+  
+</div>
+
+```json OK
+{
+  "version": "string",
+  "features": {
+    "experimental": {
+      "staticTime": {
+        "supported": true
+      },
+      "commandInspectionService": {
+        "supported": true
+      }
+    },
+    "userManagement": {
+      "supported": true,
+      "maxRightsPerUser": 0,
+      "maxUsersPageSize": 0
+    },
+    "partyManagement": {
+      "maxPartiesPageSize": 0
+    },
+    "offsetCheckpoint": {
+      "maxOffsetCheckpointEmissionDelay": "string"
+    },
+    "packageFeature": {
+      "maxVettedPackagesPageSize": 0
+    }
+  }
+}
+```
+
+</div>
+  </div>
+  
+</div>
+
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-admin.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-admin.mdx
@@ -1,2019 +1,5912 @@
 ---
 title: "com.daml.ledger.api.v2.admin"
-description: "Descriptor-backed protobuf API history for package com.daml.ledger.api.v2.admin."
+description: "Package-level overview for com.daml.ledger.api.v2.admin."
 ---
 
-# Package `com.daml.ledger.api.v2.admin`
+<p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
-[Back to gRPC Ledger API Reference](../index)
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
+  
+  
+  <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.admin</h1>
+  
+  
+  <p class="x2mdx-ref-summary">6 services, 28 endpoints, 78 messages, 3 enums</p>
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+</div>
 
-## Snapshot
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Files</dt>
+    <dd>7</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>6</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>28</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>78</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>3</dd>
+  </div>
+  
+</dl>
 
-- Current files: `7`
-- Current services: `6`
-- Current endpoints: `28`
-- Current messages: `78`
-- Current enums: `3`
-- Lifecycle endpoints tracked: `28`
+</div>
+
 
 ## Source Files
 
-| File | Services | Messages | Enums | Source |
-| --- | --- | --- | --- | --- |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto | `1` | `6` | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto | `1` | `11` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto | `0` | `1` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto | `1` | `11` | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto | `1` | `2` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto | `1` | `17` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto | `1` | `20` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
 
-## Services
 
-| Service | Endpoints | Source | Description |
-| --- | --- | --- | --- |
-| [`CommandInspectionService`](#service-com-daml-ledger-api-v2-admin-commandinspectionservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto) |  |
-| [`IdentityProviderConfigService`](#service-com-daml-ledger-api-v2-admin-identityproviderconfigservice) | `5` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |  |
-| [`PackageManagementService`](#service-com-daml-ledger-api-v2-admin-packagemanagementservice) | `4` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |  |
-| [`ParticipantPruningService`](#service-com-daml-ledger-api-v2-admin-participantpruningservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto) |  |
-| [`PartyManagementService`](#service-com-daml-ledger-api-v2-admin-partymanagementservice) | `8` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |  |
-| [`UserManagementService`](#service-com-daml-ledger-api-v2-admin-usermanagementservice) | `9` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |  |
 
-<a id="service-com-daml-ledger-api-v2-admin-commandinspectionservice"></a>
-### Service `CommandInspectionService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
-- Endpoints tracked: `1`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`GetCommandStatus`](#endpoint-com-daml-ledger-api-v2-admin-commandinspectionservice-getcommandstatus) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GetCommandStatusRequest`](#type-com-daml-ledger-api-v2-admin-getcommandstatusrequest) | [`com.daml.ledger.api.v2.admin.GetCommandStatusResponse`](#type-com-daml-ledger-api-v2-admin-getcommandstatusresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-commandinspectionservice-getcommandstatus"></a>
-**Endpoint `CommandInspectionService.GetCommandStatus`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
-
-**Signature**
-
-```protobuf
-rpc CommandInspectionService.GetCommandStatus(com.daml.ledger.api.v2.admin.GetCommandStatusRequest) returns (com.daml.ledger.api.v2.admin.GetCommandStatusResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.GetCommandStatusRequest`](#type-com-daml-ledger-api-v2-admin-getcommandstatusrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.GetCommandStatusResponse`](#type-com-daml-ledger-api-v2-admin-getcommandstatusresponse)
-
-<a id="service-com-daml-ledger-api-v2-admin-identityproviderconfigservice"></a>
-### Service `IdentityProviderConfigService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Endpoints tracked: `5`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`CreateIdentityProviderConfig`](#endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-createidentityproviderconfig) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest) | [`com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
-| [`DeleteIdentityProviderConfig`](#endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-deleteidentityproviderconfig) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest) | [`com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
-| [`GetIdentityProviderConfig`](#endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-getidentityproviderconfig) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest) | [`com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
-| [`ListIdentityProviderConfigs`](#endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-listidentityproviderconfigs) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest`](#type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest) | [`com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse`](#type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
-| [`UpdateIdentityProviderConfig`](#endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-updateidentityproviderconfig) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest) | [`com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-createidentityproviderconfig"></a>
-**Endpoint `IdentityProviderConfigService.CreateIdentityProviderConfig`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-
-**Signature**
-
-```protobuf
-rpc IdentityProviderConfigService.CreateIdentityProviderConfig(com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-deleteidentityproviderconfig"></a>
-**Endpoint `IdentityProviderConfigService.DeleteIdentityProviderConfig`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-
-**Signature**
-
-```protobuf
-rpc IdentityProviderConfigService.DeleteIdentityProviderConfig(com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-getidentityproviderconfig"></a>
-**Endpoint `IdentityProviderConfigService.GetIdentityProviderConfig`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-
-**Signature**
-
-```protobuf
-rpc IdentityProviderConfigService.GetIdentityProviderConfig(com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-listidentityproviderconfigs"></a>
-**Endpoint `IdentityProviderConfigService.ListIdentityProviderConfigs`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-
-**Signature**
-
-```protobuf
-rpc IdentityProviderConfigService.ListIdentityProviderConfigs(com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest) returns (com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest`](#type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse`](#type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-identityproviderconfigservice-updateidentityproviderconfig"></a>
-**Endpoint `IdentityProviderConfigService.UpdateIdentityProviderConfig`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-
-**Signature**
-
-```protobuf
-rpc IdentityProviderConfigService.UpdateIdentityProviderConfig(com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest`](#type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse`](#type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse)
-
-<a id="service-com-daml-ledger-api-v2-admin-packagemanagementservice"></a>
-### Service `PackageManagementService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Endpoints tracked: `4`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`ListKnownPackages`](#endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-listknownpackages) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ListKnownPackagesRequest`](#type-com-daml-ledger-api-v2-admin-listknownpackagesrequest) | [`com.daml.ledger.api.v2.admin.ListKnownPackagesResponse`](#type-com-daml-ledger-api-v2-admin-listknownpackagesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |
-| [`UpdateVettedPackages`](#endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-updatevettedpackages) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest`](#type-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest) | [`com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse`](#type-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |
-| [`UploadDarFile`](#endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-uploaddarfile) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UploadDarFileRequest`](#type-com-daml-ledger-api-v2-admin-uploaddarfilerequest) | [`com.daml.ledger.api.v2.admin.UploadDarFileResponse`](#type-com-daml-ledger-api-v2-admin-uploaddarfileresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |
-| [`ValidateDarFile`](#endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-validatedarfile) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ValidateDarFileRequest`](#type-com-daml-ledger-api-v2-admin-validatedarfilerequest) | [`com.daml.ledger.api.v2.admin.ValidateDarFileResponse`](#type-com-daml-ledger-api-v2-admin-validatedarfileresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-listknownpackages"></a>
-**Endpoint `PackageManagementService.ListKnownPackages`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PackageManagementService.ListKnownPackages(com.daml.ledger.api.v2.admin.ListKnownPackagesRequest) returns (com.daml.ledger.api.v2.admin.ListKnownPackagesResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.ListKnownPackagesRequest`](#type-com-daml-ledger-api-v2-admin-listknownpackagesrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.ListKnownPackagesResponse`](#type-com-daml-ledger-api-v2-admin-listknownpackagesresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-updatevettedpackages"></a>
-**Endpoint `PackageManagementService.UpdateVettedPackages`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PackageManagementService.UpdateVettedPackages(com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest) returns (com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest`](#type-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse`](#type-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-uploaddarfile"></a>
-**Endpoint `PackageManagementService.UploadDarFile`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PackageManagementService.UploadDarFile(com.daml.ledger.api.v2.admin.UploadDarFileRequest) returns (com.daml.ledger.api.v2.admin.UploadDarFileResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.UploadDarFileRequest`](#type-com-daml-ledger-api-v2-admin-uploaddarfilerequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.UploadDarFileResponse`](#type-com-daml-ledger-api-v2-admin-uploaddarfileresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-packagemanagementservice-validatedarfile"></a>
-**Endpoint `PackageManagementService.ValidateDarFile`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PackageManagementService.ValidateDarFile(com.daml.ledger.api.v2.admin.ValidateDarFileRequest) returns (com.daml.ledger.api.v2.admin.ValidateDarFileResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.ValidateDarFileRequest`](#type-com-daml-ledger-api-v2-admin-validatedarfilerequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.ValidateDarFileResponse`](#type-com-daml-ledger-api-v2-admin-validatedarfileresponse)
-
-<a id="service-com-daml-ledger-api-v2-admin-participantpruningservice"></a>
-### Service `ParticipantPruningService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto)
-- Endpoints tracked: `1`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`Prune`](#endpoint-com-daml-ledger-api-v2-admin-participantpruningservice-prune) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.PruneRequest`](#type-com-daml-ledger-api-v2-admin-prunerequest) | [`com.daml.ledger.api.v2.admin.PruneResponse`](#type-com-daml-ledger-api-v2-admin-pruneresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-participantpruningservice-prune"></a>
-**Endpoint `ParticipantPruningService.Prune`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto)
-
-**Signature**
-
-```protobuf
-rpc ParticipantPruningService.Prune(com.daml.ledger.api.v2.admin.PruneRequest) returns (com.daml.ledger.api.v2.admin.PruneResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.PruneRequest`](#type-com-daml-ledger-api-v2-admin-prunerequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.PruneResponse`](#type-com-daml-ledger-api-v2-admin-pruneresponse)
-
-<a id="service-com-daml-ledger-api-v2-admin-partymanagementservice"></a>
-### Service `PartyManagementService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Endpoints tracked: `8`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`AllocateExternalParty`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-allocateexternalparty) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest`](#type-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest) | [`com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse`](#type-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
-| [`AllocateParty`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-allocateparty) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.AllocatePartyRequest`](#type-com-daml-ledger-api-v2-admin-allocatepartyrequest) | [`com.daml.ledger.api.v2.admin.AllocatePartyResponse`](#type-com-daml-ledger-api-v2-admin-allocatepartyresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
-| [`GenerateExternalPartyTopology`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-generateexternalpartytopology) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest`](#type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest) | [`com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse`](#type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
-| [`GetParticipantId`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-getparticipantid) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GetParticipantIdRequest`](#type-com-daml-ledger-api-v2-admin-getparticipantidrequest) | [`com.daml.ledger.api.v2.admin.GetParticipantIdResponse`](#type-com-daml-ledger-api-v2-admin-getparticipantidresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
-| [`GetParties`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-getparties) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GetPartiesRequest`](#type-com-daml-ledger-api-v2-admin-getpartiesrequest) | [`com.daml.ledger.api.v2.admin.GetPartiesResponse`](#type-com-daml-ledger-api-v2-admin-getpartiesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
-| [`ListKnownParties`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-listknownparties) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ListKnownPartiesRequest`](#type-com-daml-ledger-api-v2-admin-listknownpartiesrequest) | [`com.daml.ledger.api.v2.admin.ListKnownPartiesResponse`](#type-com-daml-ledger-api-v2-admin-listknownpartiesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
-| [`UpdatePartyDetails`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-updatepartydetails) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest`](#type-com-daml-ledger-api-v2-admin-updatepartydetailsrequest) | [`com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse`](#type-com-daml-ledger-api-v2-admin-updatepartydetailsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
-| [`UpdatePartyIdentityProviderId`](#endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-updatepartyidentityproviderid) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest`](#type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest) | [`com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse`](#type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-allocateexternalparty"></a>
-**Endpoint `PartyManagementService.AllocateExternalParty`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PartyManagementService.AllocateExternalParty(com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest) returns (com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest`](#type-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse`](#type-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-allocateparty"></a>
-**Endpoint `PartyManagementService.AllocateParty`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PartyManagementService.AllocateParty(com.daml.ledger.api.v2.admin.AllocatePartyRequest) returns (com.daml.ledger.api.v2.admin.AllocatePartyResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.AllocatePartyRequest`](#type-com-daml-ledger-api-v2-admin-allocatepartyrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.AllocatePartyResponse`](#type-com-daml-ledger-api-v2-admin-allocatepartyresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-generateexternalpartytopology"></a>
-**Endpoint `PartyManagementService.GenerateExternalPartyTopology`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PartyManagementService.GenerateExternalPartyTopology(com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest) returns (com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest`](#type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse`](#type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-getparticipantid"></a>
-**Endpoint `PartyManagementService.GetParticipantId`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PartyManagementService.GetParticipantId(com.daml.ledger.api.v2.admin.GetParticipantIdRequest) returns (com.daml.ledger.api.v2.admin.GetParticipantIdResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.GetParticipantIdRequest`](#type-com-daml-ledger-api-v2-admin-getparticipantidrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.GetParticipantIdResponse`](#type-com-daml-ledger-api-v2-admin-getparticipantidresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-getparties"></a>
-**Endpoint `PartyManagementService.GetParties`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PartyManagementService.GetParties(com.daml.ledger.api.v2.admin.GetPartiesRequest) returns (com.daml.ledger.api.v2.admin.GetPartiesResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.GetPartiesRequest`](#type-com-daml-ledger-api-v2-admin-getpartiesrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.GetPartiesResponse`](#type-com-daml-ledger-api-v2-admin-getpartiesresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-listknownparties"></a>
-**Endpoint `PartyManagementService.ListKnownParties`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PartyManagementService.ListKnownParties(com.daml.ledger.api.v2.admin.ListKnownPartiesRequest) returns (com.daml.ledger.api.v2.admin.ListKnownPartiesResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.ListKnownPartiesRequest`](#type-com-daml-ledger-api-v2-admin-listknownpartiesrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.ListKnownPartiesResponse`](#type-com-daml-ledger-api-v2-admin-listknownpartiesresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-updatepartydetails"></a>
-**Endpoint `PartyManagementService.UpdatePartyDetails`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PartyManagementService.UpdatePartyDetails(com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest) returns (com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest`](#type-com-daml-ledger-api-v2-admin-updatepartydetailsrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse`](#type-com-daml-ledger-api-v2-admin-updatepartydetailsresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-partymanagementservice-updatepartyidentityproviderid"></a>
-**Endpoint `PartyManagementService.UpdatePartyIdentityProviderId`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PartyManagementService.UpdatePartyIdentityProviderId(com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest) returns (com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest`](#type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse`](#type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse)
-
-<a id="service-com-daml-ledger-api-v2-admin-usermanagementservice"></a>
-### Service `UserManagementService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Endpoints tracked: `9`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`CreateUser`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-createuser) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.CreateUserRequest`](#type-com-daml-ledger-api-v2-admin-createuserrequest) | [`com.daml.ledger.api.v2.admin.CreateUserResponse`](#type-com-daml-ledger-api-v2-admin-createuserresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
-| [`DeleteUser`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-deleteuser) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.DeleteUserRequest`](#type-com-daml-ledger-api-v2-admin-deleteuserrequest) | [`com.daml.ledger.api.v2.admin.DeleteUserResponse`](#type-com-daml-ledger-api-v2-admin-deleteuserresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
-| [`GetUser`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-getuser) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GetUserRequest`](#type-com-daml-ledger-api-v2-admin-getuserrequest) | [`com.daml.ledger.api.v2.admin.GetUserResponse`](#type-com-daml-ledger-api-v2-admin-getuserresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
-| [`GrantUserRights`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-grantuserrights) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.GrantUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-grantuserrightsrequest) | [`com.daml.ledger.api.v2.admin.GrantUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-grantuserrightsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
-| [`ListUserRights`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-listuserrights) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ListUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-listuserrightsrequest) | [`com.daml.ledger.api.v2.admin.ListUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-listuserrightsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
-| [`ListUsers`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-listusers) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.ListUsersRequest`](#type-com-daml-ledger-api-v2-admin-listusersrequest) | [`com.daml.ledger.api.v2.admin.ListUsersResponse`](#type-com-daml-ledger-api-v2-admin-listusersresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
-| [`RevokeUserRights`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-revokeuserrights) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.RevokeUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-revokeuserrightsrequest) | [`com.daml.ledger.api.v2.admin.RevokeUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-revokeuserrightsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
-| [`UpdateUser`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-updateuser) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdateUserRequest`](#type-com-daml-ledger-api-v2-admin-updateuserrequest) | [`com.daml.ledger.api.v2.admin.UpdateUserResponse`](#type-com-daml-ledger-api-v2-admin-updateuserresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
-| [`UpdateUserIdentityProviderId`](#endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-updateuseridentityproviderid) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest`](#type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest) | [`com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse`](#type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-createuser"></a>
-**Endpoint `UserManagementService.CreateUser`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UserManagementService.CreateUser(com.daml.ledger.api.v2.admin.CreateUserRequest) returns (com.daml.ledger.api.v2.admin.CreateUserResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.CreateUserRequest`](#type-com-daml-ledger-api-v2-admin-createuserrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.CreateUserResponse`](#type-com-daml-ledger-api-v2-admin-createuserresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-deleteuser"></a>
-**Endpoint `UserManagementService.DeleteUser`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UserManagementService.DeleteUser(com.daml.ledger.api.v2.admin.DeleteUserRequest) returns (com.daml.ledger.api.v2.admin.DeleteUserResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.DeleteUserRequest`](#type-com-daml-ledger-api-v2-admin-deleteuserrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.DeleteUserResponse`](#type-com-daml-ledger-api-v2-admin-deleteuserresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-getuser"></a>
-**Endpoint `UserManagementService.GetUser`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UserManagementService.GetUser(com.daml.ledger.api.v2.admin.GetUserRequest) returns (com.daml.ledger.api.v2.admin.GetUserResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.GetUserRequest`](#type-com-daml-ledger-api-v2-admin-getuserrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.GetUserResponse`](#type-com-daml-ledger-api-v2-admin-getuserresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-grantuserrights"></a>
-**Endpoint `UserManagementService.GrantUserRights`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UserManagementService.GrantUserRights(com.daml.ledger.api.v2.admin.GrantUserRightsRequest) returns (com.daml.ledger.api.v2.admin.GrantUserRightsResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.GrantUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-grantuserrightsrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.GrantUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-grantuserrightsresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-listuserrights"></a>
-**Endpoint `UserManagementService.ListUserRights`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UserManagementService.ListUserRights(com.daml.ledger.api.v2.admin.ListUserRightsRequest) returns (com.daml.ledger.api.v2.admin.ListUserRightsResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.ListUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-listuserrightsrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.ListUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-listuserrightsresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-listusers"></a>
-**Endpoint `UserManagementService.ListUsers`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UserManagementService.ListUsers(com.daml.ledger.api.v2.admin.ListUsersRequest) returns (com.daml.ledger.api.v2.admin.ListUsersResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.ListUsersRequest`](#type-com-daml-ledger-api-v2-admin-listusersrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.ListUsersResponse`](#type-com-daml-ledger-api-v2-admin-listusersresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-revokeuserrights"></a>
-**Endpoint `UserManagementService.RevokeUserRights`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UserManagementService.RevokeUserRights(com.daml.ledger.api.v2.admin.RevokeUserRightsRequest) returns (com.daml.ledger.api.v2.admin.RevokeUserRightsResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.RevokeUserRightsRequest`](#type-com-daml-ledger-api-v2-admin-revokeuserrightsrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.RevokeUserRightsResponse`](#type-com-daml-ledger-api-v2-admin-revokeuserrightsresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-updateuser"></a>
-**Endpoint `UserManagementService.UpdateUser`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UserManagementService.UpdateUser(com.daml.ledger.api.v2.admin.UpdateUserRequest) returns (com.daml.ledger.api.v2.admin.UpdateUserResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdateUserRequest`](#type-com-daml-ledger-api-v2-admin-updateuserrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdateUserResponse`](#type-com-daml-ledger-api-v2-admin-updateuserresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-admin-usermanagementservice-updateuseridentityproviderid"></a>
-**Endpoint `UserManagementService.UpdateUserIdentityProviderId`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UserManagementService.UpdateUserIdentityProviderId(com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest) returns (com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest`](#type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse`](#type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse)
-
-## Type Reference
-
-<a id="type-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| synchronizer | `string` | optional |  |
-| onboarding_transactions | [`com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest.SignedTransaction`](#type-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest-signedtransaction) | repeated |  |
-| multi_hash_signatures | [`com.daml.ledger.api.v2.Signature`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-signature) | repeated |  |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest-signedtransaction"></a>
-**Message `com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest.SignedTransaction`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| transaction | `bytes` | optional |  |
-| signatures | [`com.daml.ledger.api.v2.Signature`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-signature) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-allocatepartyrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.AllocatePartyRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 5
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party_id_hint | `string` | optional |  |
-| local_metadata | [`com.daml.ledger.api.v2.admin.ObjectMeta`](#type-com-daml-ledger-api-v2-admin-objectmeta) | optional |  |
-| identity_provider_id | `string` | optional |  |
-| synchronizer_id | `string` | optional |  |
-| user_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-allocatepartyresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.AllocatePartyResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party_details | [`com.daml.ledger.api.v2.admin.PartyDetails`](#type-com-daml-ledger-api-v2-admin-partydetails) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-commandstatus"></a>
-**Message `com.daml.ledger.api.v2.admin.CommandStatus`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
-- Fields: 7
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| started | `google.protobuf.Timestamp` | optional |  |
-| completed | `google.protobuf.Timestamp` | optional |  |
-| completion | [`com.daml.ledger.api.v2.Completion`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-completion) | optional |  |
-| state | [`com.daml.ledger.api.v2.admin.CommandState`](#type-com-daml-ledger-api-v2-admin-commandstate) | optional |  |
-| commands | [`com.daml.ledger.api.v2.Command`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-command) | repeated |  |
-| request_statistics | [`com.daml.ledger.api.v2.admin.RequestStatistics`](#type-com-daml-ledger-api-v2-admin-requeststatistics) | optional |  |
-| updates | [`com.daml.ledger.api.v2.admin.CommandUpdates`](#type-com-daml-ledger-api-v2-admin-commandupdates) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-commandupdates"></a>
-**Message `com.daml.ledger.api.v2.admin.CommandUpdates`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
-- Fields: 5
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| created | [`com.daml.ledger.api.v2.admin.Contract`](#type-com-daml-ledger-api-v2-admin-contract) | repeated |  |
-| archived | [`com.daml.ledger.api.v2.admin.Contract`](#type-com-daml-ledger-api-v2-admin-contract) | repeated |  |
-| exercised | `uint32` | optional |  |
-| fetched | `uint32` | optional |  |
-| looked_up_by_key | `uint32` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-contract"></a>
-**Message `com.daml.ledger.api.v2.admin.Contract`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| contract_id | `string` | optional |  |
-| contract_key | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| identity_provider_config | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| identity_provider_config | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-createuserrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.CreateUserRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | optional |  |
-| rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-createuserresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.CreateUserResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-deleteuserrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.DeleteUserRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user_id | `string` | optional |  |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-deleteuserresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.DeleteUserResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 7
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| synchronizer | `string` | optional |  |
-| party_hint | `string` | optional |  |
-| public_key | [`com.daml.ledger.api.v2.SigningPublicKey`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-signingpublickey) | optional |  |
-| local_participant_observation_only | `bool` | optional |  |
-| other_confirming_participant_uids | `string` | repeated |  |
-| confirmation_threshold | `uint32` | optional |  |
-| observing_participant_uids | `string` | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party_id | `string` | optional |  |
-| public_key_fingerprint | `string` | optional |  |
-| topology_transactions | `bytes` | repeated |  |
-| multi_hash | `bytes` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-getcommandstatusrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.GetCommandStatusRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| command_id_prefix | `string` | optional |  |
-| state | [`com.daml.ledger.api.v2.admin.CommandState`](#type-com-daml-ledger-api-v2-admin-commandstate) | optional |  |
-| limit | `uint32` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-getcommandstatusresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.GetCommandStatusResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| command_status | [`com.daml.ledger.api.v2.admin.CommandStatus`](#type-com-daml-ledger-api-v2-admin-commandstatus) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| identity_provider_config | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-getparticipantidrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.GetParticipantIdRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-getparticipantidresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.GetParticipantIdResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| participant_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-getpartiesrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.GetPartiesRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| parties | `string` | repeated |  |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-getpartiesresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.GetPartiesResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party_details | [`com.daml.ledger.api.v2.admin.PartyDetails`](#type-com-daml-ledger-api-v2-admin-partydetails) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-getuserrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.GetUserRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user_id | `string` | optional |  |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-getuserresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.GetUserResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-grantuserrightsrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.GrantUserRightsRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user_id | `string` | optional |  |
-| rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-grantuserrightsresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.GrantUserRightsResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| newly_granted_rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-identityproviderconfig"></a>
-**Message `com.daml.ledger.api.v2.admin.IdentityProviderConfig`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Fields: 5
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| identity_provider_id | `string` | optional |  |
-| is_deactivated | `bool` | optional |  |
-| issuer | `string` | optional |  |
-| jwks_url | `string` | optional |  |
-| audience | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| identity_provider_configs | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-listknownpackagesrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.ListKnownPackagesRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-listknownpackagesresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.ListKnownPackagesResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_details | [`com.daml.ledger.api.v2.admin.PackageDetails`](#type-com-daml-ledger-api-v2-admin-packagedetails) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-listknownpartiesrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.ListKnownPartiesRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| page_token | `string` | optional |  |
-| page_size | `int32` | optional |  |
-| identity_provider_id | `string` | optional |  |
-| filter_party | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-listknownpartiesresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.ListKnownPartiesResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party_details | [`com.daml.ledger.api.v2.admin.PartyDetails`](#type-com-daml-ledger-api-v2-admin-partydetails) | repeated |  |
-| next_page_token | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-listuserrightsrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.ListUserRightsRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user_id | `string` | optional |  |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-listuserrightsresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.ListUserRightsResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-listusersrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.ListUsersRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| page_token | `string` | optional |  |
-| page_size | `int32` | optional |  |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-listusersresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.ListUsersResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| users | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | repeated |  |
-| next_page_token | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-objectmeta"></a>
-**Message `com.daml.ledger.api.v2.admin.ObjectMeta`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| resource_version | `string` | optional |  |
-| annotations | `map<string, string>` | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-packagedetails"></a>
-**Message `com.daml.ledger.api.v2.admin.PackageDetails`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 5
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_id | `string` | optional |  |
-| package_size | `uint64` | optional |  |
-| known_since | `google.protobuf.Timestamp` | optional |  |
-| name | `string` | optional |  |
-| version | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-partydetails"></a>
-**Message `com.daml.ledger.api.v2.admin.PartyDetails`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party | `string` | optional |  |
-| is_local | `bool` | optional |  |
-| local_metadata | [`com.daml.ledger.api.v2.admin.ObjectMeta`](#type-com-daml-ledger-api-v2-admin-objectmeta) | optional |  |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-prunerequest"></a>
-**Message `com.daml.ledger.api.v2.admin.PruneRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| prune_up_to | `int64` | optional |  |
-| submission_id | `string` | optional |  |
-| prune_all_divulged_contracts | `bool` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-pruneresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.PruneResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-requeststatistics"></a>
-**Message `com.daml.ledger.api.v2.admin.RequestStatistics`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| envelopes | `uint32` | optional |  |
-| request_size | `uint32` | optional |  |
-| recipients | `uint32` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-revokeuserrightsrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.RevokeUserRightsRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user_id | `string` | optional |  |
-| rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-revokeuserrightsresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.RevokeUserRightsResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| newly_revoked_rights | [`com.daml.ledger.api.v2.admin.Right`](#type-com-daml-ledger-api-v2-admin-right) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-right"></a>
-**Message `com.daml.ledger.api.v2.admin.Right`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 7
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| participant_admin | [`com.daml.ledger.api.v2.admin.Right.ParticipantAdmin`](#type-com-daml-ledger-api-v2-admin-right-participantadmin) | optional |  |
-| can_act_as | [`com.daml.ledger.api.v2.admin.Right.CanActAs`](#type-com-daml-ledger-api-v2-admin-right-canactas) | optional |  |
-| can_read_as | [`com.daml.ledger.api.v2.admin.Right.CanReadAs`](#type-com-daml-ledger-api-v2-admin-right-canreadas) | optional |  |
-| identity_provider_admin | [`com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin`](#type-com-daml-ledger-api-v2-admin-right-identityprovideradmin) | optional |  |
-| can_read_as_any_party | [`com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty`](#type-com-daml-ledger-api-v2-admin-right-canreadasanyparty) | optional |  |
-| can_execute_as | [`com.daml.ledger.api.v2.admin.Right.CanExecuteAs`](#type-com-daml-ledger-api-v2-admin-right-canexecuteas) | optional |  |
-| can_execute_as_any_party | [`com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty`](#type-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-right-participantadmin"></a>
-**Message `com.daml.ledger.api.v2.admin.Right.ParticipantAdmin`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-right-canactas"></a>
-**Message `com.daml.ledger.api.v2.admin.Right.CanActAs`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-right-canreadas"></a>
-**Message `com.daml.ledger.api.v2.admin.Right.CanReadAs`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-right-canexecuteas"></a>
-**Message `com.daml.ledger.api.v2.admin.Right.CanExecuteAs`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-right-identityprovideradmin"></a>
-**Message `com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-right-canreadasanyparty"></a>
-**Message `com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty"></a>
-**Message `com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| identity_provider_config | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | optional |  |
-| update_mask | `google.protobuf.FieldMask` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| identity_provider_config | [`com.daml.ledger.api.v2.admin.IdentityProviderConfig`](#type-com-daml-ledger-api-v2-admin-identityproviderconfig) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-updatepartydetailsrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party_details | [`com.daml.ledger.api.v2.admin.PartyDetails`](#type-com-daml-ledger-api-v2-admin-partydetails) | optional |  |
-| update_mask | `google.protobuf.FieldMask` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-updatepartydetailsresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party_details | [`com.daml.ledger.api.v2.admin.PartyDetails`](#type-com-daml-ledger-api-v2-admin-partydetails) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party | `string` | optional |  |
-| source_identity_provider_id | `string` | optional |  |
-| target_identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user_id | `string` | optional |  |
-| source_identity_provider_id | `string` | optional |  |
-| target_identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-updateuserrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdateUserRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | optional |  |
-| update_mask | `google.protobuf.FieldMask` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-updateuserresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdateUserResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user | [`com.daml.ledger.api.v2.admin.User`](#type-com-daml-ledger-api-v2-admin-user) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 5
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| changes | [`com.daml.ledger.api.v2.admin.VettedPackagesChange`](#type-com-daml-ledger-api-v2-admin-vettedpackageschange) | repeated |  |
-| dry_run | `bool` | optional |  |
-| synchronizer_id | `string` | optional |  |
-| expected_topology_serial | [`com.daml.ledger.api.v2.PriorTopologySerial`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-priortopologyserial) | optional |  |
-| update_vetted_packages_force_flags | [`com.daml.ledger.api.v2.admin.UpdateVettedPackagesForceFlag`](#type-com-daml-ledger-api-v2-admin-updatevettedpackagesforceflag) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| past_vetted_packages | [`com.daml.ledger.api.v2.VettedPackages`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-vettedpackages) | optional |  |
-| new_vetted_packages | [`com.daml.ledger.api.v2.VettedPackages`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-vettedpackages) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-uploaddarfilerequest"></a>
-**Message `com.daml.ledger.api.v2.admin.UploadDarFileRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| dar_file | `bytes` | optional |  |
-| submission_id | `string` | optional |  |
-| vetting_change | [`com.daml.ledger.api.v2.admin.UploadDarFileRequest.VettingChange`](#type-com-daml-ledger-api-v2-admin-uploaddarfilerequest-vettingchange) | optional |  |
-| synchronizer_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-uploaddarfilerequest-vettingchange"></a>
-**Enum `com.daml.ledger.api.v2.admin.UploadDarFileRequest.VettingChange`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| VETTING_CHANGE_UNSPECIFIED | `0` |
-| VETTING_CHANGE_VET_ALL_PACKAGES | `1` |
-| VETTING_CHANGE_DONT_VET_ANY_PACKAGES | `2` |
-
-<a id="type-com-daml-ledger-api-v2-admin-uploaddarfileresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.UploadDarFileResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-user"></a>
-**Message `com.daml.ledger.api.v2.admin.User`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto)
-- Fields: 5
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| id | `string` | optional |  |
-| primary_party | `string` | optional |  |
-| is_deactivated | `bool` | optional |  |
-| metadata | [`com.daml.ledger.api.v2.admin.ObjectMeta`](#type-com-daml-ledger-api-v2-admin-objectmeta) | optional |  |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-validatedarfilerequest"></a>
-**Message `com.daml.ledger.api.v2.admin.ValidateDarFileRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| dar_file | `bytes` | optional |  |
-| submission_id | `string` | optional |  |
-| synchronizer_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-validatedarfileresponse"></a>
-**Message `com.daml.ledger.api.v2.admin.ValidateDarFileResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-admin-vettedpackageschange"></a>
-**Message `com.daml.ledger.api.v2.admin.VettedPackagesChange`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| vet | [`com.daml.ledger.api.v2.admin.VettedPackagesChange.Vet`](#type-com-daml-ledger-api-v2-admin-vettedpackageschange-vet) | optional |  |
-| unvet | [`com.daml.ledger.api.v2.admin.VettedPackagesChange.Unvet`](#type-com-daml-ledger-api-v2-admin-vettedpackageschange-unvet) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-vettedpackageschange-unvet"></a>
-**Message `com.daml.ledger.api.v2.admin.VettedPackagesChange.Unvet`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| packages | [`com.daml.ledger.api.v2.admin.VettedPackagesRef`](#type-com-daml-ledger-api-v2-admin-vettedpackagesref) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-vettedpackageschange-vet"></a>
-**Message `com.daml.ledger.api.v2.admin.VettedPackagesChange.Vet`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| packages | [`com.daml.ledger.api.v2.admin.VettedPackagesRef`](#type-com-daml-ledger-api-v2-admin-vettedpackagesref) | repeated |  |
-| new_valid_from_inclusive | `google.protobuf.Timestamp` | optional |  |
-| new_valid_until_exclusive | `google.protobuf.Timestamp` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-vettedpackagesref"></a>
-**Message `com.daml.ledger.api.v2.admin.VettedPackagesRef`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_id | `string` | optional |  |
-| package_name | `string` | optional |  |
-| package_version | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-admin-commandstate"></a>
-**Enum `com.daml.ledger.api.v2.admin.CommandState`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| COMMAND_STATE_UNSPECIFIED | `0` |
-| COMMAND_STATE_PENDING | `1` |
-| COMMAND_STATE_SUCCEEDED | `2` |
-| COMMAND_STATE_FAILED | `3` |
-
-<a id="type-com-daml-ledger-api-v2-admin-updatevettedpackagesforceflag"></a>
-**Enum `com.daml.ledger.api.v2.admin.UpdateVettedPackagesForceFlag`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED | `0` |
-| UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES | `2` |
-| UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES | `3` |
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>6</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>11</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/object_meta.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>11</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>2</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>17</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>20</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+</div>
+
+
+
+
+
+## CommandInspectionService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/command_inspection_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>1</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>CommandInspectionService.GetCommandStatus</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc CommandInspectionService.GetCommandStatus(com.daml.ledger.api.v2.admin.GetCommandStatusRequest) returns (com.daml.ledger.api.v2.admin.GetCommandStatusResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetCommandStatusRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetCommandStatusResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## IdentityProviderConfigService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/identity_provider_config_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>5</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>IdentityProviderConfigService.CreateIdentityProviderConfig</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.CreateIdentityProviderConfig(com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.CreateIden...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>IdentityProviderConfigService.DeleteIdentityProviderConfig</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.DeleteIdentityProviderConfig(com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.DeleteIden...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>IdentityProviderConfigService.GetIdentityProviderConfig</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.GetIdentityProviderConfig(com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.GetIdentityProvi...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>IdentityProviderConfigService.ListIdentityProviderConfigs</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.ListIdentityProviderConfigs(com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest) returns (com.daml.ledger.api.v2.admin.ListIdentity...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>IdentityProviderConfigService.UpdateIdentityProviderConfig</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc IdentityProviderConfigService.UpdateIdentityProviderConfig(com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest) returns (com.daml.ledger.api.v2.admin.UpdateIden...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## PackageManagementService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/package_management_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>4</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PackageManagementService.ListKnownPackages</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PackageManagementService.ListKnownPackages(com.daml.ledger.api.v2.admin.ListKnownPackagesRequest) returns (com.daml.ledger.api.v2.admin.ListKnownPackagesResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListKnownPackagesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PackageManagementService.UpdateVettedPackages</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PackageManagementService.UpdateVettedPackages(com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest) returns (com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PackageManagementService.UploadDarFile</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PackageManagementService.UploadDarFile(com.daml.ledger.api.v2.admin.UploadDarFileRequest) returns (com.daml.ledger.api.v2.admin.UploadDarFileResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.UploadDarFileRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.UploadDarFileResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PackageManagementService.ValidateDarFile</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PackageManagementService.ValidateDarFile(com.daml.ledger.api.v2.admin.ValidateDarFileRequest) returns (com.daml.ledger.api.v2.admin.ValidateDarFileResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.ValidateDarFileRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.ValidateDarFileResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## ParticipantPruningService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/participant_pruning_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>1</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>ParticipantPruningService.Prune</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc ParticipantPruningService.Prune(com.daml.ledger.api.v2.admin.PruneRequest) returns (com.daml.ledger.api.v2.admin.PruneResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.PruneRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.PruneResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## PartyManagementService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/party_management_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>8</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PartyManagementService.AllocateExternalParty</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PartyManagementService.AllocateExternalParty(com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest) returns (com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PartyManagementService.AllocateParty</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PartyManagementService.AllocateParty(com.daml.ledger.api.v2.admin.AllocatePartyRequest) returns (com.daml.ledger.api.v2.admin.AllocatePartyResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.AllocatePartyRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.AllocatePartyResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PartyManagementService.GenerateExternalPartyTopology</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PartyManagementService.GenerateExternalPartyTopology(com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest) returns (com.daml.ledger.api.v2.admin.GenerateExterna...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PartyManagementService.GetParticipantId</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PartyManagementService.GetParticipantId(com.daml.ledger.api.v2.admin.GetParticipantIdRequest) returns (com.daml.ledger.api.v2.admin.GetParticipantIdResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetParticipantIdRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetParticipantIdResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PartyManagementService.GetParties</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PartyManagementService.GetParties(com.daml.ledger.api.v2.admin.GetPartiesRequest) returns (com.daml.ledger.api.v2.admin.GetPartiesResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetPartiesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetPartiesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PartyManagementService.ListKnownParties</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PartyManagementService.ListKnownParties(com.daml.ledger.api.v2.admin.ListKnownPartiesRequest) returns (com.daml.ledger.api.v2.admin.ListKnownPartiesResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListKnownPartiesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PartyManagementService.UpdatePartyDetails</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PartyManagementService.UpdatePartyDetails(com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest) returns (com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PartyManagementService.UpdatePartyIdentityProviderId</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PartyManagementService.UpdatePartyIdentityProviderId(com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest) returns (com.daml.ledger.api.v2.admin.UpdatePartyIden...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## UserManagementService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/admin/user_management_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>9</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UserManagementService.CreateUser</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UserManagementService.CreateUser(com.daml.ledger.api.v2.admin.CreateUserRequest) returns (com.daml.ledger.api.v2.admin.CreateUserResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.CreateUserRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.CreateUserResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UserManagementService.DeleteUser</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UserManagementService.DeleteUser(com.daml.ledger.api.v2.admin.DeleteUserRequest) returns (com.daml.ledger.api.v2.admin.DeleteUserResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.DeleteUserRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.DeleteUserResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UserManagementService.GetUser</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UserManagementService.GetUser(com.daml.ledger.api.v2.admin.GetUserRequest) returns (com.daml.ledger.api.v2.admin.GetUserResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetUserRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.GetUserResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UserManagementService.GrantUserRights</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UserManagementService.GrantUserRights(com.daml.ledger.api.v2.admin.GrantUserRightsRequest) returns (com.daml.ledger.api.v2.admin.GrantUserRightsResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.GrantUserRightsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.GrantUserRightsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UserManagementService.ListUserRights</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UserManagementService.ListUserRights(com.daml.ledger.api.v2.admin.ListUserRightsRequest) returns (com.daml.ledger.api.v2.admin.ListUserRightsResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListUserRightsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListUserRightsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UserManagementService.ListUsers</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UserManagementService.ListUsers(com.daml.ledger.api.v2.admin.ListUsersRequest) returns (com.daml.ledger.api.v2.admin.ListUsersResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListUsersRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.ListUsersResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UserManagementService.RevokeUserRights</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UserManagementService.RevokeUserRights(com.daml.ledger.api.v2.admin.RevokeUserRightsRequest) returns (com.daml.ledger.api.v2.admin.RevokeUserRightsResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.RevokeUserRightsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UserManagementService.UpdateUser</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UserManagementService.UpdateUser(com.daml.ledger.api.v2.admin.UpdateUserRequest) returns (com.daml.ledger.api.v2.admin.UpdateUserResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateUserRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateUserResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UserManagementService.UpdateUserIdentityProviderId</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UserManagementService.UpdateUserIdentityProviderId(com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest) returns (com.daml.ledger.api.v2.admin.UpdateUserIdentity...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## Type Inventory
+
+
+These are the package-level message and enum shapes in the publish-version snapshot.
+
+
+
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">onboarding_transactions</code>
+      <span class="x2mdx-ref-type-badge">repeated SignedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">multi_hash_signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated Signature</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyrequest-signedtransaction">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.AllocateExternalPartyRequest.SignedTransaction</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated Signature</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Signature</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">format</code>
+      <span class="x2mdx-ref-type-badge">SignatureFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signature</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signed_by</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
+      <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SignatureFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_RAW</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_DER</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SigningAlgorithmSpec</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocateexternalpartyresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.AllocateExternalPartyResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.AllocatePartyRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id_hint</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">local_metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-objectmeta">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ObjectMeta</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">resource_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">annotations</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-allocatepartyresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.AllocatePartyResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-partydetails">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.PartyDetails</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_local</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">local_metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstatus">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.CommandStatus</h3>
+    
+    <p class="x2mdx-ref-schema-summary">7 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">started</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completed</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completion</code>
+      <span class="x2mdx-ref-type-badge">Completion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">state</code>
+      <span class="x2mdx-ref-type-badge">CommandState</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated Command</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">request_statistics</code>
+      <span class="x2mdx-ref-type-badge">RequestStatistics</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">updates</code>
+      <span class="x2mdx-ref-type-badge">CommandUpdates</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Completion</h3>
+    
+    <p class="x2mdx-ref-schema-summary">11 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_time</code>
+      <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TraceContext</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">traceparent</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">tracestate</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SynchronizerTime</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandstate">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.CommandState</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>COMMAND_STATE_UNSPECIFIED</code></li>
+    
+    <li><code>COMMAND_STATE_PENDING</code></li>
+    
+    <li><code>COMMAND_STATE_SUCCEEDED</code></li>
+    
+    <li><code>COMMAND_STATE_FAILED</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Command</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">CreateCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_by_key</code>
+      <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_and_exercise</code>
+      <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CreateCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Identifier</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Record</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.RecordField</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Value</h3>
+    
+    <p class="x2mdx-ref-schema-summary">16 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Optional</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.List</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TextMap</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GenMap</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Variant</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Enum</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExerciseCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExerciseByKeyCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CreateAndExerciseCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-requeststatistics">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.RequestStatistics</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">envelopes</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">request_size</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">recipients</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-commandupdates">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.CommandUpdates</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">repeated Contract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">repeated Contract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercised</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fetched</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">looked_up_by_key</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-contract">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.Contract</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-identityproviderconfig">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.IdentityProviderConfig</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_deactivated</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">issuer</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">jwks_url</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">audience</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createidentityproviderconfigresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.CreateIdentityProviderConfigResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.CreateUserRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-user">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.User</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">primary_party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">is_deactivated</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">metadata</code>
+      <span class="x2mdx-ref-type-badge">ObjectMeta</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.Right</h3>
+    
+    <p class="x2mdx-ref-schema-summary">7 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_admin</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAdmin</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_act_as</code>
+      <span class="x2mdx-ref-type-badge">CanActAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_read_as</code>
+      <span class="x2mdx-ref-type-badge">CanReadAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_admin</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderAdmin</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_read_as_any_party</code>
+      <span class="x2mdx-ref-type-badge">CanReadAsAnyParty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_execute_as</code>
+      <span class="x2mdx-ref-type-badge">CanExecuteAs</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">can_execute_as_any_party</code>
+      <span class="x2mdx-ref-type-badge">CanExecuteAsAnyParty</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-participantadmin">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.Right.ParticipantAdmin</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canactas">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.Right.CanActAs</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadas">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.Right.CanReadAs</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteas">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.Right.CanExecuteAs</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-identityprovideradmin">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.Right.IdentityProviderAdmin</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canreadasanyparty">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.Right.CanReadAsAnyParty</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-right-canexecuteasanyparty">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.Right.CanExecuteAsAnyParty</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-createuserresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.CreateUserResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteidentityproviderconfigresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.DeleteIdentityProviderConfigResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.DeleteUserRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-deleteuserresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.DeleteUserResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">7 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_hint</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">public_key</code>
+      <span class="x2mdx-ref-type-badge">SigningPublicKey</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">local_participant_observation_only</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">other_confirming_participant_uids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">confirmation_threshold</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observing_participant_uids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingpublickey">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SigningPublicKey</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">format</code>
+      <span class="x2mdx-ref-type-badge">CryptoKeyFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key_data</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key_spec</code>
+      <span class="x2mdx-ref-type-badge">SigningKeySpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cryptokeyformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CryptoKeyFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>CRYPTO_KEY_FORMAT_UNSPECIFIED</code></li>
+    
+    <li><code>CRYPTO_KEY_FORMAT_DER</code></li>
+    
+    <li><code>CRYPTO_KEY_FORMAT_RAW</code></li>
+    
+    <li><code>CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingkeyspec">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SigningKeySpec</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNING_KEY_SPEC_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_CURVE25519</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_P256</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_P384</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_SECP256K1</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-generateexternalpartytopologyresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GenerateExternalPartyTopologyResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">public_key_fingerprint</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_transactions</code>
+      <span class="x2mdx-ref-type-badge">repeated bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">multi_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GetCommandStatusRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id_prefix</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">state</code>
+      <span class="x2mdx-ref-type-badge">CommandState</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">limit</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getcommandstatusresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GetCommandStatusResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_status</code>
+      <span class="x2mdx-ref-type-badge">repeated CommandStatus</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getidentityproviderconfigresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GetIdentityProviderConfigResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GetParticipantIdRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getparticipantidresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GetParticipantIdResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GetPartiesRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getpartiesresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GetPartiesResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GetUserRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-getuserresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GetUserResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GrantUserRightsRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-grantuserrightsresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.GrantUserRightsResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">newly_granted_rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listidentityproviderconfigsresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ListIdentityProviderConfigsResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_configs</code>
+      <span class="x2mdx-ref-type-badge">repeated IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ListKnownPackagesRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpackagesresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ListKnownPackagesResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_details</code>
+      <span class="x2mdx-ref-type-badge">repeated PackageDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-packagedetails">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.PackageDetails</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_size</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">known_since</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ListKnownPartiesRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filter_party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listknownpartiesresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ListKnownPartiesResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">repeated PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">next_page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ListUserRightsRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listuserrightsresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ListUserRightsResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ListUsersRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-listusersresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ListUsersResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">users</code>
+      <span class="x2mdx-ref-type-badge">repeated User</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">next_page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-prunerequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.PruneRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prune_up_to</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prune_all_divulged_contracts</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-pruneresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.PruneResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.RevokeUserRightsRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-revokeuserrightsresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.RevokeUserRightsResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">newly_revoked_rights</code>
+      <span class="x2mdx-ref-type-badge">repeated Right</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_mask</code>
+      <span class="x2mdx-ref-type-badge">FieldMask</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateidentityproviderconfigresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdateIdentityProviderConfigResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_config</code>
+      <span class="x2mdx-ref-type-badge">IdentityProviderConfig</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdatePartyDetailsRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_mask</code>
+      <span class="x2mdx-ref-type-badge">FieldMask</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartydetailsresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdatePartyDetailsResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_details</code>
+      <span class="x2mdx-ref-type-badge">PartyDetails</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatepartyidentityprovideridresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdatePartyIdentityProviderIdResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target_identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuseridentityprovideridresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdateUserIdentityProviderIdResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdateUserRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_mask</code>
+      <span class="x2mdx-ref-type-badge">FieldMask</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updateuserresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdateUserResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user</code>
+      <span class="x2mdx-ref-type-badge">User</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdateVettedPackagesRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">changes</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackagesChange</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">dry_run</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">expected_topology_serial</code>
+      <span class="x2mdx-ref-type-badge">PriorTopologySerial</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_vetted_packages_force_flags</code>
+      <span class="x2mdx-ref-type-badge">repeated UpdateVettedPackagesForceFlag</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.VettedPackagesChange</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vet</code>
+      <span class="x2mdx-ref-type-badge">Vet</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unvet</code>
+      <span class="x2mdx-ref-type-badge">Unvet</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-unvet">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.VettedPackagesChange.Unvet</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">packages</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackagesref">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.VettedPackagesRef</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-vettedpackageschange-vet">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.VettedPackagesChange.Vet</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">packages</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackagesRef</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">new_valid_from_inclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">new_valid_until_exclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-priortopologyserial">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.PriorTopologySerial</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prior</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">no_prior</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesforceflag">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdateVettedPackagesForceFlag</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_UNSPECIFIED</code></li>
+    
+    <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_VET_INCOMPATIBLE_UPGRADES</code></li>
+    
+    <li><code>UPDATE_VETTED_PACKAGES_FORCE_FLAG_ALLOW_UNVETTED_DEPENDENCIES</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-updatevettedpackagesresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UpdateVettedPackagesResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">past_vetted_packages</code>
+      <span class="x2mdx-ref-type-badge">VettedPackages</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">new_vetted_packages</code>
+      <span class="x2mdx-ref-type-badge">VettedPackages</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.VettedPackages</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">packages</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_serial</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.VettedPackage</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UploadDarFileRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">dar_file</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetting_change</code>
+      <span class="x2mdx-ref-type-badge">VettingChange</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfilerequest-vettingchange">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UploadDarFileRequest.VettingChange</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>VETTING_CHANGE_UNSPECIFIED</code></li>
+    
+    <li><code>VETTING_CHANGE_VET_ALL_PACKAGES</code></li>
+    
+    <li><code>VETTING_CHANGE_DONT_VET_ANY_PACKAGES</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-uploaddarfileresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.UploadDarFileResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfilerequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ValidateDarFileRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">dar_file</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-admin-validatedarfileresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.admin.ValidateDarFileResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive-transaction-v1.mdx
@@ -1,114 +1,1035 @@
 ---
 title: "com.daml.ledger.api.v2.interactive.transaction.v1"
-description: "Descriptor-backed protobuf API history for package com.daml.ledger.api.v2.interactive.transaction.v1."
+description: "Package-level overview for com.daml.ledger.api.v2.interactive.transaction.v1."
 ---
 
-# Package `com.daml.ledger.api.v2.interactive.transaction.v1`
+<p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
-[Back to gRPC Ledger API Reference](../index)
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
+  
+  
+  <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.interactive.transaction.v1</h1>
+  
+  
+  <p class="x2mdx-ref-summary">0 services, 0 endpoints, 5 messages</p>
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+</div>
 
-## Snapshot
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Files</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>5</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+</dl>
 
-- Current files: `1`
-- Current services: `0`
-- Current endpoints: `0`
-- Current messages: `5`
-- Current enums: `0`
-- Lifecycle endpoints tracked: `0`
+</div>
+
 
 ## Source Files
 
-| File | Services | Messages | Enums | Source |
-| --- | --- | --- | --- | --- |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto | `0` | `5` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto) |
 
-## Type Reference
 
-<a id="type-com-daml-ledger-api-v2-interactive-transaction-v1-create"></a>
-**Message `com.daml.ledger.api.v2.interactive.transaction.v1.Create`**
 
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto)
-- Fields: 7
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>5</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto</a></dd>
+  </div>
+  
+</dl>
 
-_No description._
+  
+  </div>
+  
+  
+</div>
 
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| lf_version | `string` | optional |  |
-| contract_id | `string` | optional |  |
-| package_name | `string` | optional |  |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| argument | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
-| signatories | `string` | repeated |  |
-| stakeholders | `string` | repeated |  |
 
-<a id="type-com-daml-ledger-api-v2-interactive-transaction-v1-exercise"></a>
-**Message `com.daml.ledger.api.v2.interactive.transaction.v1.Exercise`**
 
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto)
-- Fields: 14
 
-_No description._
 
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| lf_version | `string` | optional |  |
-| contract_id | `string` | optional |  |
-| package_name | `string` | optional |  |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| signatories | `string` | repeated |  |
-| stakeholders | `string` | repeated |  |
-| acting_parties | `string` | repeated |  |
-| interface_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| choice_id | `string` | optional |  |
-| chosen_value | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
-| consuming | `bool` | optional |  |
-| children | `string` | repeated |  |
-| exercise_result | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
-| choice_observers | `string` | repeated |  |
+## Type Inventory
 
-<a id="type-com-daml-ledger-api-v2-interactive-transaction-v1-fetch"></a>
-**Message `com.daml.ledger.api.v2.interactive.transaction.v1.Fetch`**
 
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto)
-- Fields: 8
+These are the package-level message and enum shapes in the publish-version snapshot.
 
-_No description._
 
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| lf_version | `string` | optional |  |
-| contract_id | `string` | optional |  |
-| package_name | `string` | optional |  |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| signatories | `string` | repeated |  |
-| stakeholders | `string` | repeated |  |
-| acting_parties | `string` | repeated |  |
-| interface_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
 
-<a id="type-com-daml-ledger-api-v2-interactive-transaction-v1-node"></a>
-**Message `com.daml.ledger.api.v2.interactive.transaction.v1.Node`**
 
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto)
-- Fields: 4
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Create</h3>
+    
+    <p class="x2mdx-ref-schema-summary">7 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
 
-_No description._
+  
+  
+</div>
 
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| create | [`com.daml.ledger.api.v2.interactive.transaction.v1.Create`](#type-com-daml-ledger-api-v2-interactive-transaction-v1-create) | optional |  |
-| fetch | [`com.daml.ledger.api.v2.interactive.transaction.v1.Fetch`](#type-com-daml-ledger-api-v2-interactive-transaction-v1-fetch) | optional |  |
-| exercise | [`com.daml.ledger.api.v2.interactive.transaction.v1.Exercise`](#type-com-daml-ledger-api-v2-interactive-transaction-v1-exercise) | optional |  |
-| rollback | [`com.daml.ledger.api.v2.interactive.transaction.v1.Rollback`](#type-com-daml-ledger-api-v2-interactive-transaction-v1-rollback) | optional |  |
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Identifier</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
 
-<a id="type-com-daml-ledger-api-v2-interactive-transaction-v1-rollback"></a>
-**Message `com.daml.ledger.api.v2.interactive.transaction.v1.Rollback`**
+  
+  
+</div>
 
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/transaction/v1/interactive_submission_data.proto)
-- Fields: 1
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Value</h3>
+    
+    <p class="x2mdx-ref-schema-summary">16 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
 
-_No description._
+  
+  
+</div>
 
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| children | `string` | repeated |  |
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Optional</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.List</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TextMap</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GenMap</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Record</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.RecordField</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Variant</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Enum</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Exercise</h3>
+    
+    <p class="x2mdx-ref-schema-summary">14 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">chosen_value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Fetch</h3>
+    
+    <p class="x2mdx-ref-schema-summary">8 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Node</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">Create</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fetch</code>
+      <span class="x2mdx-ref-type-badge">Fetch</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">Exercise</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rollback</code>
+      <span class="x2mdx-ref-type-badge">Rollback</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Rollback</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-interactive.mdx
@@ -1,654 +1,4169 @@
 ---
 title: "com.daml.ledger.api.v2.interactive"
-description: "Descriptor-backed protobuf API history for package com.daml.ledger.api.v2.interactive."
+description: "Package-level overview for com.daml.ledger.api.v2.interactive."
 ---
 
-# Package `com.daml.ledger.api.v2.interactive`
+<p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
-[Back to gRPC Ledger API Reference](../index)
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
+  
+  
+  <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.interactive</h1>
+  
+  
+  <p class="x2mdx-ref-summary">1 services, 6 endpoints, 28 messages, 1 enums</p>
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+</div>
 
-## Snapshot
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Files</dt>
+    <dd>2</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>6</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>28</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>1</dd>
+  </div>
+  
+</dl>
 
-- Current files: `2`
-- Current services: `1`
-- Current endpoints: `6`
-- Current messages: `28`
-- Current enums: `1`
-- Lifecycle endpoints tracked: `6`
+</div>
+
 
 ## Source Files
 
-| File | Services | Messages | Enums | Source |
-| --- | --- | --- | --- | --- |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto | `0` | `1` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto | `1` | `22` | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
 
-## Services
 
-| Service | Endpoints | Source | Description |
-| --- | --- | --- | --- |
-| [`InteractiveSubmissionService`](#service-com-daml-ledger-api-v2-interactive-interactivesubmissionservice) | `6` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |  |
 
-<a id="service-com-daml-ledger-api-v2-interactive-interactivesubmissionservice"></a>
-### Service `InteractiveSubmissionService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Endpoints tracked: `6`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`ExecuteSubmission`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmission) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionrequest) | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
-| [`ExecuteSubmissionAndWait`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmissionandwait) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest) | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
-| [`ExecuteSubmissionAndWaitForTransaction`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmissionandwaitfortransaction) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest) | [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
-| [`GetPreferredPackageVersion`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-getpreferredpackageversion) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest) | [`com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
-| [`GetPreferredPackages`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-getpreferredpackages) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest) | [`com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
-| [`PrepareSubmission`](#endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-preparesubmission) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest`](#type-com-daml-ledger-api-v2-interactive-preparesubmissionrequest) | [`com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse`](#type-com-daml-ledger-api-v2-interactive-preparesubmissionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmission"></a>
-**Endpoint `InteractiveSubmissionService.ExecuteSubmission`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-
-**Signature**
-
-```protobuf
-rpc InteractiveSubmissionService.ExecuteSubmission(com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest) returns (com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmissionandwait"></a>
-**Endpoint `InteractiveSubmissionService.ExecuteSubmissionAndWait`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-
-**Signature**
-
-```protobuf
-rpc InteractiveSubmissionService.ExecuteSubmissionAndWait(com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest) returns (com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-executesubmissionandwaitfortransaction"></a>
-**Endpoint `InteractiveSubmissionService.ExecuteSubmissionAndWaitForTransaction`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-
-**Signature**
-
-```protobuf
-rpc InteractiveSubmissionService.ExecuteSubmissionAndWaitForTransaction(com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest) returns (com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse`](#type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-getpreferredpackageversion"></a>
-**Endpoint `InteractiveSubmissionService.GetPreferredPackageVersion`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-
-**Signature**
-
-```protobuf
-rpc InteractiveSubmissionService.GetPreferredPackageVersion(com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest) returns (com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-getpreferredpackages"></a>
-**Endpoint `InteractiveSubmissionService.GetPreferredPackages`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-
-**Signature**
-
-```protobuf
-rpc InteractiveSubmissionService.GetPreferredPackages(com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest) returns (com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse`](#type-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-interactive-interactivesubmissionservice-preparesubmission"></a>
-**Endpoint `InteractiveSubmissionService.PrepareSubmission`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-
-**Signature**
-
-```protobuf
-rpc InteractiveSubmissionService.PrepareSubmission(com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest) returns (com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest`](#type-com-daml-ledger-api-v2-interactive-preparesubmissionrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse`](#type-com-daml-ledger-api-v2-interactive-preparesubmissionresponse)
-
-## Type Reference
-
-<a id="type-com-daml-ledger-api-v2-interactive-costestimation"></a>
-**Message `com.daml.ledger.api.v2.interactive.CostEstimation`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| estimation_timestamp | `google.protobuf.Timestamp` | optional |  |
-| confirmation_request_traffic_cost_estimation | `uint64` | optional |  |
-| confirmation_response_traffic_cost_estimation | `uint64` | optional |  |
-| total_traffic_cost_estimation | `uint64` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-costestimationhints"></a>
-**Message `com.daml.ledger.api.v2.interactive.CostEstimationHints`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| disabled | `bool` | optional |  |
-| expected_signatures | [`com.daml.ledger.api.v2.SigningAlgorithmSpec`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-signingalgorithmspec) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-damltransaction"></a>
-**Message `com.daml.ledger.api.v2.interactive.DamlTransaction`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| version | `string` | optional |  |
-| roots | `string` | repeated |  |
-| nodes | [`com.daml.ledger.api.v2.interactive.DamlTransaction.Node`](#type-com-daml-ledger-api-v2-interactive-damltransaction-node) | repeated |  |
-| node_seeds | [`com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed`](#type-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed"></a>
-**Message `com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| node_id | `int32` | optional |  |
-| seed | `bytes` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-damltransaction-node"></a>
-**Message `com.daml.ledger.api.v2.interactive.DamlTransaction.Node`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| node_id | `string` | optional |  |
-| v1 | [`com.daml.ledger.api.v2.interactive.transaction.v1.Node`](com-daml-ledger-api-v2-interactive-transaction-v1#type-com-daml-ledger-api-v2-interactive-transaction-v1-node) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest"></a>
-**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 9
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| prepared_transaction | [`com.daml.ledger.api.v2.interactive.PreparedTransaction`](#type-com-daml-ledger-api-v2-interactive-preparedtransaction) | optional |  |
-| party_signatures | [`com.daml.ledger.api.v2.interactive.PartySignatures`](#type-com-daml-ledger-api-v2-interactive-partysignatures) | optional |  |
-| deduplication_duration | `google.protobuf.Duration` | optional |  |
-| deduplication_offset | `int64` | optional |  |
-| submission_id | `string` | optional |  |
-| user_id | `string` | optional |  |
-| hashing_scheme_version | [`com.daml.ledger.api.v2.interactive.HashingSchemeVersion`](#type-com-daml-ledger-api-v2-interactive-hashingschemeversion) | optional |  |
-| min_ledger_time | [`com.daml.ledger.api.v2.interactive.MinLedgerTime`](#type-com-daml-ledger-api-v2-interactive-minledgertime) | optional |  |
-| transaction_format | [`com.daml.ledger.api.v2.TransactionFormat`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-transactionformat) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse"></a>
-**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| transaction | [`com.daml.ledger.api.v2.Transaction`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-transaction) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest"></a>
-**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 8
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| prepared_transaction | [`com.daml.ledger.api.v2.interactive.PreparedTransaction`](#type-com-daml-ledger-api-v2-interactive-preparedtransaction) | optional |  |
-| party_signatures | [`com.daml.ledger.api.v2.interactive.PartySignatures`](#type-com-daml-ledger-api-v2-interactive-partysignatures) | optional |  |
-| deduplication_duration | `google.protobuf.Duration` | optional |  |
-| deduplication_offset | `int64` | optional |  |
-| submission_id | `string` | optional |  |
-| user_id | `string` | optional |  |
-| hashing_scheme_version | [`com.daml.ledger.api.v2.interactive.HashingSchemeVersion`](#type-com-daml-ledger-api-v2-interactive-hashingschemeversion) | optional |  |
-| min_ledger_time | [`com.daml.ledger.api.v2.interactive.MinLedgerTime`](#type-com-daml-ledger-api-v2-interactive-minledgertime) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse"></a>
-**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| update_id | `string` | optional |  |
-| completion_offset | `int64` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionrequest"></a>
-**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 8
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| prepared_transaction | [`com.daml.ledger.api.v2.interactive.PreparedTransaction`](#type-com-daml-ledger-api-v2-interactive-preparedtransaction) | optional |  |
-| party_signatures | [`com.daml.ledger.api.v2.interactive.PartySignatures`](#type-com-daml-ledger-api-v2-interactive-partysignatures) | optional |  |
-| deduplication_duration | `google.protobuf.Duration` | optional |  |
-| deduplication_offset | `int64` | optional |  |
-| submission_id | `string` | optional |  |
-| user_id | `string` | optional |  |
-| hashing_scheme_version | [`com.daml.ledger.api.v2.interactive.HashingSchemeVersion`](#type-com-daml-ledger-api-v2-interactive-hashingschemeversion) | optional |  |
-| min_ledger_time | [`com.daml.ledger.api.v2.interactive.MinLedgerTime`](#type-com-daml-ledger-api-v2-interactive-minledgertime) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-executesubmissionresponse"></a>
-**Message `com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest"></a>
-**Message `com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| parties | `string` | repeated |  |
-| package_name | `string` | optional |  |
-| synchronizer_id | `string` | optional |  |
-| vetting_valid_at | `google.protobuf.Timestamp` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse"></a>
-**Message `com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_preference | [`com.daml.ledger.api.v2.interactive.PackagePreference`](#type-com-daml-ledger-api-v2-interactive-packagepreference) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest"></a>
-**Message `com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_vetting_requirements | [`com.daml.ledger.api.v2.interactive.PackageVettingRequirement`](#type-com-daml-ledger-api-v2-interactive-packagevettingrequirement) | repeated |  |
-| synchronizer_id | `string` | optional |  |
-| vetting_valid_at | `google.protobuf.Timestamp` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse"></a>
-**Message `com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_references | [`com.daml.ledger.api.v2.PackageReference`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-packagereference) | repeated |  |
-| synchronizer_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-globalkey"></a>
-**Message `com.daml.ledger.api.v2.interactive.GlobalKey`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| package_name | `string` | optional |  |
-| key | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
-| hash | `bytes` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-metadata"></a>
-**Message `com.daml.ledger.api.v2.interactive.Metadata`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 10
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| submitter_info | [`com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo`](#type-com-daml-ledger-api-v2-interactive-metadata-submitterinfo) | optional |  |
-| synchronizer_id | `string` | optional |  |
-| mediator_group | `uint32` | optional |  |
-| transaction_uuid | `string` | optional |  |
-| preparation_time | `uint64` | optional |  |
-| input_contracts | [`com.daml.ledger.api.v2.interactive.Metadata.InputContract`](#type-com-daml-ledger-api-v2-interactive-metadata-inputcontract) | repeated |  |
-| min_ledger_effective_time | `uint64` | optional |  |
-| max_ledger_effective_time | `uint64` | optional |  |
-| global_key_mapping | [`com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry`](#type-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry) | repeated |  |
-| max_record_time | `uint64` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-metadata-submitterinfo"></a>
-**Message `com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| act_as | `string` | repeated |  |
-| command_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry"></a>
-**Message `com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| key | [`com.daml.ledger.api.v2.interactive.GlobalKey`](#type-com-daml-ledger-api-v2-interactive-globalkey) | optional |  |
-| value | [`com.daml.ledger.api.v2.Value`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-value) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-metadata-inputcontract"></a>
-**Message `com.daml.ledger.api.v2.interactive.Metadata.InputContract`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| v1 | [`com.daml.ledger.api.v2.interactive.transaction.v1.Create`](com-daml-ledger-api-v2-interactive-transaction-v1#type-com-daml-ledger-api-v2-interactive-transaction-v1-create) | optional |  |
-| created_at | `uint64` | optional |  |
-| event_blob | `bytes` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-minledgertime"></a>
-**Message `com.daml.ledger.api.v2.interactive.MinLedgerTime`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| min_ledger_time_abs | `google.protobuf.Timestamp` | optional |  |
-| min_ledger_time_rel | `google.protobuf.Duration` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-packagepreference"></a>
-**Message `com.daml.ledger.api.v2.interactive.PackagePreference`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_reference | [`com.daml.ledger.api.v2.PackageReference`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-packagereference) | optional |  |
-| synchronizer_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-packagevettingrequirement"></a>
-**Message `com.daml.ledger.api.v2.interactive.PackageVettingRequirement`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| parties | `string` | repeated |  |
-| package_name | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-partysignatures"></a>
-**Message `com.daml.ledger.api.v2.interactive.PartySignatures`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| signatures | [`com.daml.ledger.api.v2.interactive.SinglePartySignatures`](#type-com-daml-ledger-api-v2-interactive-singlepartysignatures) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-preparesubmissionrequest"></a>
-**Message `com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 13
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user_id | `string` | optional |  |
-| command_id | `string` | optional |  |
-| commands | [`com.daml.ledger.api.v2.Command`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-command) | repeated |  |
-| min_ledger_time | [`com.daml.ledger.api.v2.interactive.MinLedgerTime`](#type-com-daml-ledger-api-v2-interactive-minledgertime) | optional |  |
-| max_record_time | `google.protobuf.Timestamp` | optional |  |
-| act_as | `string` | repeated |  |
-| read_as | `string` | repeated |  |
-| disclosed_contracts | [`com.daml.ledger.api.v2.DisclosedContract`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-disclosedcontract) | repeated |  |
-| synchronizer_id | `string` | optional |  |
-| package_id_selection_preference | `string` | repeated |  |
-| verbose_hashing | `bool` | optional |  |
-| prefetch_contract_keys | [`com.daml.ledger.api.v2.PrefetchContractKey`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-prefetchcontractkey) | repeated |  |
-| estimate_traffic_cost | [`com.daml.ledger.api.v2.interactive.CostEstimationHints`](#type-com-daml-ledger-api-v2-interactive-costestimationhints) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-preparesubmissionresponse"></a>
-**Message `com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 5
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| prepared_transaction | [`com.daml.ledger.api.v2.interactive.PreparedTransaction`](#type-com-daml-ledger-api-v2-interactive-preparedtransaction) | optional |  |
-| prepared_transaction_hash | `bytes` | optional |  |
-| hashing_scheme_version | [`com.daml.ledger.api.v2.interactive.HashingSchemeVersion`](#type-com-daml-ledger-api-v2-interactive-hashingschemeversion) | optional |  |
-| hashing_details | `string` | optional |  |
-| cost_estimation | [`com.daml.ledger.api.v2.interactive.CostEstimation`](#type-com-daml-ledger-api-v2-interactive-costestimation) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-preparedtransaction"></a>
-**Message `com.daml.ledger.api.v2.interactive.PreparedTransaction`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| transaction | [`com.daml.ledger.api.v2.interactive.DamlTransaction`](#type-com-daml-ledger-api-v2-interactive-damltransaction) | optional |  |
-| metadata | [`com.daml.ledger.api.v2.interactive.Metadata`](#type-com-daml-ledger-api-v2-interactive-metadata) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-singlepartysignatures"></a>
-**Message `com.daml.ledger.api.v2.interactive.SinglePartySignatures`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party | `string` | optional |  |
-| signatures | [`com.daml.ledger.api.v2.Signature`](com-daml-ledger-api-v2#type-com-daml-ledger-api-v2-signature) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-interactive-hashingschemeversion"></a>
-**Enum `com.daml.ledger.api.v2.interactive.HashingSchemeVersion`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| HASHING_SCHEME_VERSION_UNSPECIFIED | `0` |
-| HASHING_SCHEME_VERSION_V2 | `2` |
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_common_data.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>22</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+</div>
+
+
+
+
+
+## InteractiveSubmissionService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/interactive/interactive_submission_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>6</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>InteractiveSubmissionService.ExecuteSubmission</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.ExecuteSubmission(com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest) returns (com.daml.ledger.api.v2.interactive.ExecuteSubmissionResp...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>InteractiveSubmissionService.ExecuteSubmissionAndWait</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.ExecuteSubmissionAndWait(com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest) returns (com.daml.ledger.api.v2.interactive.Execute...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>InteractiveSubmissionService.ExecuteSubmissionAndWaitForTransaction</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.ExecuteSubmissionAndWaitForTransaction(com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest) returns (com.daml.ledge...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>InteractiveSubmissionService.GetPreferredPackageVersion</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.GetPreferredPackageVersion(com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest) returns (com.daml.ledger.api.v2.interactive.Get...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>InteractiveSubmissionService.GetPreferredPackages</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.GetPreferredPackages(com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest) returns (com.daml.ledger.api.v2.interactive.GetPreferredPac...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>InteractiveSubmissionService.PrepareSubmission</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc InteractiveSubmissionService.PrepareSubmission(com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest) returns (com.daml.ledger.api.v2.interactive.PrepareSubmissionResp...</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## Type Inventory
+
+
+These are the package-level message and enum shapes in the publish-version snapshot.
+
+
+
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimation">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.CostEstimation</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">estimation_timestamp</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">confirmation_request_traffic_cost_estimation</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">confirmation_response_traffic_cost_estimation</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">total_traffic_cost_estimation</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-costestimationhints">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.CostEstimationHints</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">disabled</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">expected_signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated SigningAlgorithmSpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SigningAlgorithmSpec</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.DamlTransaction</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">roots</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">nodes</code>
+      <span class="x2mdx-ref-type-badge">repeated Node</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_seeds</code>
+      <span class="x2mdx-ref-type-badge">repeated NodeSeed</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-nodeseed">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.DamlTransaction.NodeSeed</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">seed</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-damltransaction-node">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.DamlTransaction.Node</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">v1</code>
+      <span class="x2mdx-ref-type-badge">Node</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-node">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Node</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">Create</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fetch</code>
+      <span class="x2mdx-ref-type-badge">Fetch</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">Exercise</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">rollback</code>
+      <span class="x2mdx-ref-type-badge">Rollback</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-create">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Create</h3>
+    
+    <p class="x2mdx-ref-schema-summary">7 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Identifier</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Value</h3>
+    
+    <p class="x2mdx-ref-schema-summary">16 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Optional</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.List</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TextMap</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GenMap</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Record</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.RecordField</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Variant</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Enum</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-fetch">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Fetch</h3>
+    
+    <p class="x2mdx-ref-schema-summary">8 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-exercise">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Exercise</h3>
+    
+    <p class="x2mdx-ref-schema-summary">14 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">lf_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">stakeholders</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">chosen_value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-transaction-v1-rollback">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.transaction.v1.Rollback</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">children</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">9 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_signatures</code>
+      <span class="x2mdx-ref-type-badge">PartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_format</code>
+      <span class="x2mdx-ref-type-badge">TransactionFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparedtransaction">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.PreparedTransaction</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">DamlTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">metadata</code>
+      <span class="x2mdx-ref-type-badge">Metadata</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.Metadata</h3>
+    
+    <p class="x2mdx-ref-schema-summary">10 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter_info</code>
+      <span class="x2mdx-ref-type-badge">SubmitterInfo</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">mediator_group</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_uuid</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">preparation_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">input_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated InputContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_effective_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_ledger_effective_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">global_key_mapping</code>
+      <span class="x2mdx-ref-type-badge">repeated GlobalKeyMappingEntry</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_record_time</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-submitterinfo">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.Metadata.SubmitterInfo</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-globalkeymappingentry">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.Metadata.GlobalKeyMappingEntry</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">GlobalKey</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-globalkey">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.GlobalKey</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-metadata-inputcontract">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.Metadata.InputContract</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">v1</code>
+      <span class="x2mdx-ref-type-badge">Create</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-partysignatures">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.PartySignatures</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated SinglePartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-singlepartysignatures">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.SinglePartySignatures</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatures</code>
+      <span class="x2mdx-ref-type-badge">repeated Signature</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Signature</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">format</code>
+      <span class="x2mdx-ref-type-badge">SignatureFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signature</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signed_by</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
+      <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SignatureFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_RAW</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_DER</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-hashingschemeversion">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.HashingSchemeVersion</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>HASHING_SCHEME_VERSION_UNSPECIFIED</code></li>
+    
+    <li><code>HASHING_SCHEME_VERSION_V2</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-minledgertime">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.MinLedgerTime</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TransactionFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_shape</code>
+      <span class="x2mdx-ref-type-badge">TransactionShape</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.EventFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_by_party</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_for_any_party</code>
+      <span class="x2mdx-ref-type-badge">Filters</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Filters</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cumulative</code>
+      <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CumulativeFilter</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">wildcard_filter</code>
+      <span class="x2mdx-ref-type-badge">WildcardFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_filter</code>
+      <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_filter</code>
+      <span class="x2mdx-ref-type-badge">TemplateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.WildcardFilter</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.InterfaceFilter</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_interface_view</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TemplateFilter</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TransactionShape</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitfortransactionresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitForTransactionResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Transaction</h3>
+    
+    <p class="x2mdx-ref-schema-summary">10 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">effective_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated Event</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">external_transaction_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Event</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercised</code>
+      <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CreatedEvent</h3>
+    
+    <p class="x2mdx-ref-schema-summary">15 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_views</code>
+      <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">representative_package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.InterfaceView</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_value</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ArchivedEvent</h3>
+    
+    <p class="x2mdx-ref-schema-summary">7 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExercisedEvent</h3>
+    
+    <p class="x2mdx-ref-schema-summary">15 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TraceContext</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">traceparent</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">tracestate</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">8 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_signatures</code>
+      <span class="x2mdx-ref-type-badge">PartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionandwaitresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionAndWaitResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completion_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">8 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_signatures</code>
+      <span class="x2mdx-ref-type-badge">PartySignatures</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-executesubmissionresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.ExecuteSubmissionResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetting_valid_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackageversionresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackageVersionResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_preference</code>
+      <span class="x2mdx-ref-type-badge">PackagePreference</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagepreference">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.PackagePreference</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_reference</code>
+      <span class="x2mdx-ref-type-badge">PackageReference</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.PackageReference</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackagesRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_vetting_requirements</code>
+      <span class="x2mdx-ref-type-badge">repeated PackageVettingRequirement</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetting_valid_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-packagevettingrequirement">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.PackageVettingRequirement</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-getpreferredpackagesresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.GetPreferredPackagesResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_references</code>
+      <span class="x2mdx-ref-type-badge">repeated PackageReference</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.PrepareSubmissionRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">13 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated Command</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time</code>
+      <span class="x2mdx-ref-type-badge">MinLedgerTime</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">read_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">disclosed_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose_hashing</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
+      <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">estimate_traffic_cost</code>
+      <span class="x2mdx-ref-type-badge">CostEstimationHints</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Command</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">CreateCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_by_key</code>
+      <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_and_exercise</code>
+      <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CreateCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExerciseCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExerciseByKeyCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CreateAndExerciseCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.DisclosedContract</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.PrefetchContractKey</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interactive-preparesubmissionresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.interactive.PrepareSubmissionResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction</code>
+      <span class="x2mdx-ref-type-badge">PreparedTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prepared_transaction_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_scheme_version</code>
+      <span class="x2mdx-ref-type-badge">HashingSchemeVersion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hashing_details</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cost_estimation</code>
+      <span class="x2mdx-ref-type-badge">CostEstimation</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-testing.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2-testing.mdx
@@ -1,139 +1,311 @@
 ---
 title: "com.daml.ledger.api.v2.testing"
-description: "Descriptor-backed protobuf API history for package com.daml.ledger.api.v2.testing."
+description: "Package-level overview for com.daml.ledger.api.v2.testing."
 ---
 
-# Package `com.daml.ledger.api.v2.testing`
+<p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
-[Back to gRPC Ledger API Reference](../index)
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
+  
+  
+  <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2.testing</h1>
+  
+  
+  <p class="x2mdx-ref-summary">1 services, 2 endpoints, 3 messages</p>
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+</div>
 
-## Snapshot
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Files</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>2</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>3</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+</dl>
 
-- Current files: `1`
-- Current services: `1`
-- Current endpoints: `2`
-- Current messages: `3`
-- Current enums: `0`
-- Lifecycle endpoints tracked: `2`
+</div>
+
 
 ## Source Files
 
-| File | Services | Messages | Enums | Source |
-| --- | --- | --- | --- | --- |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto | `1` | `3` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto) |
 
-## Services
 
-| Service | Endpoints | Source | Description |
-| --- | --- | --- | --- |
-| [`TimeService`](#service-com-daml-ledger-api-v2-testing-timeservice) | `2` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto) |  |
 
-<a id="service-com-daml-ledger-api-v2-testing-timeservice"></a>
-### Service `TimeService`
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>3</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</a></dd>
+  </div>
+  
+</dl>
 
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
-- Endpoints tracked: `2`
+  
+  </div>
+  
+  
+</div>
 
-_No description._
 
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`GetTime`](#endpoint-com-daml-ledger-api-v2-testing-timeservice-gettime) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.testing.GetTimeRequest`](#type-com-daml-ledger-api-v2-testing-gettimerequest) | [`com.daml.ledger.api.v2.testing.GetTimeResponse`](#type-com-daml-ledger-api-v2-testing-gettimeresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto) |
-| [`SetTime`](#endpoint-com-daml-ledger-api-v2-testing-timeservice-settime) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.testing.SetTimeRequest`](#type-com-daml-ledger-api-v2-testing-settimerequest) | `google.protobuf.Empty` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto) |
 
-<a id="endpoint-com-daml-ledger-api-v2-testing-timeservice-gettime"></a>
-**Endpoint `TimeService.GetTime`**
 
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
 
-**Signature**
+## TimeService
 
-```protobuf
-rpc TimeService.GetTime(com.daml.ledger.api.v2.testing.GetTimeRequest) returns (com.daml.ledger.api.v2.testing.GetTimeResponse);
-```
 
-_No description._
 
-**History**
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>2</dd>
+  </div>
+  
+</dl>
 
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
 
-**Request Type**
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-testing/timeservice/gettime">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>TimeService.GetTime</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
 
-- [`com.daml.ledger.api.v2.testing.GetTimeRequest`](#type-com-daml-ledger-api-v2-testing-gettimerequest)
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc TimeService.GetTime(com.daml.ledger.api.v2.testing.GetTimeRequest) returns (com.daml.ledger.api.v2.testing.GetTimeResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.testing.GetTimeRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.testing.GetTimeResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
 
-**Response Type**
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2-testing/timeservice/settime">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>TimeService.SetTime</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
 
-- [`com.daml.ledger.api.v2.testing.GetTimeResponse`](#type-com-daml-ledger-api-v2-testing-gettimeresponse)
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc TimeService.SetTime(com.daml.ledger.api.v2.testing.SetTimeRequest) returns (google.protobuf.Empty);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.testing.SetTimeRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>google.protobuf.Empty</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
 
-<a id="endpoint-com-daml-ledger-api-v2-testing-timeservice-settime"></a>
-**Endpoint `TimeService.SetTime`**
+  
+  </a>
+  
+  
+</div>
 
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
 
-**Signature**
 
-```protobuf
-rpc TimeService.SetTime(com.daml.ledger.api.v2.testing.SetTimeRequest) returns (google.protobuf.Empty);
-```
 
-_No description._
 
-**History**
+## Type Inventory
 
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
 
-**Request Type**
+These are the package-level message and enum shapes in the publish-version snapshot.
 
-- [`com.daml.ledger.api.v2.testing.SetTimeRequest`](#type-com-daml-ledger-api-v2-testing-settimerequest)
 
-**Response Type**
 
-- `google.protobuf.Empty`
 
-## Type Reference
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimerequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.testing.GetTimeRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
 
-<a id="type-com-daml-ledger-api-v2-testing-gettimerequest"></a>
-**Message `com.daml.ledger.api.v2.testing.GetTimeRequest`**
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-gettimeresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.testing.GetTimeResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">current_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
 
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
-- Fields: 0
+  
+  
+</div>
 
-_No description._
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-testing-settimerequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.testing.SetTimeRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">current_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">new_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
 
-<a id="type-com-daml-ledger-api-v2-testing-gettimeresponse"></a>
-**Message `com.daml.ledger.api.v2.testing.GetTimeResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| current_time | `google.protobuf.Timestamp` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-testing-settimerequest"></a>
-**Message `com.daml.ledger.api.v2.testing.SetTimeRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/testing/time_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| current_time | `google.protobuf.Timestamp` | optional |  |
-| new_time | `google.protobuf.Timestamp` | optional |  |
+  
+  
+</div>

--- a/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2.mdx
+++ b/docs-main/reference/grpc-ledger-api-reference/packages/com-daml-ledger-api-v2.mdx
@@ -1,2498 +1,7367 @@
 ---
 title: "com.daml.ledger.api.v2"
-description: "Descriptor-backed protobuf API history for package com.daml.ledger.api.v2."
+description: "Package-level overview for com.daml.ledger.api.v2."
 ---
 
-# Package `com.daml.ledger.api.v2`
+<p class="x2mdx-ref-back"><a href="../index">Back to overview</a></p>
 
-[Back to gRPC Ledger API Reference](../index)
+<div class="x2mdx-ref-hero">
+  
+  <p class="x2mdx-ref-eyebrow">Protobuf Package</p>
+  
+  
+  <h1 class="x2mdx-ref-title">com.daml.ledger.api.v2</h1>
+  
+  
+  <p class="x2mdx-ref-summary">9 services, 20 endpoints, 115 messages, 8 enums</p>
+  
+  
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+</div>
 
-## Snapshot
+  
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Files</dt>
+    <dd>23</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>9</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Endpoints</dt>
+    <dd>20</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>115</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>8</dd>
+  </div>
+  
+</dl>
 
-- Current files: `23`
-- Current services: `9`
-- Current endpoints: `20`
-- Current messages: `115`
-- Current enums: `8`
-- Lifecycle endpoints tracked: `20`
+</div>
+
 
 ## Source Files
 
-| File | Services | Messages | Enums | Source |
-| --- | --- | --- | --- | --- |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto | `1` | `2` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto | `1` | `6` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto | `1` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto | `0` | `8` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto | `0` | `1` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto | `1` | `2` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto | `0` | `2` | `4` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto | `0` | `5` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto | `1` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto | `0` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto | `0` | `2` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto | `0` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto | `1` | `10` | `2` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto | `0` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto | `0` | `4` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto | `1` | `11` | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto | `0` | `5` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto | `0` | `1` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto | `0` | `1` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto | `0` | `10` | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto | `1` | `5` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto | `0` | `10` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto) |
-| community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto | `1` | `7` | `0` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto) |
-
-## Services
 
-| Service | Endpoints | Source | Description |
-| --- | --- | --- | --- |
-| [`CommandCompletionService`](#service-com-daml-ledger-api-v2-commandcompletionservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto) |  |
-| [`CommandService`](#service-com-daml-ledger-api-v2-commandservice) | `3` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto) |  |
-| [`CommandSubmissionService`](#service-com-daml-ledger-api-v2-commandsubmissionservice) | `2` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto) |  |
-| [`ContractService`](#service-com-daml-ledger-api-v2-contractservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto) |  |
-| [`EventQueryService`](#service-com-daml-ledger-api-v2-eventqueryservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto) |  |
-| [`PackageService`](#service-com-daml-ledger-api-v2-packageservice) | `4` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |  |
-| [`StateService`](#service-com-daml-ledger-api-v2-stateservice) | `4` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |  |
-| [`UpdateService`](#service-com-daml-ledger-api-v2-updateservice) | `3` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto) |  |
-| [`VersionService`](#service-com-daml-ledger-api-v2-versionservice) | `1` | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto) |  |
 
-<a id="service-com-daml-ledger-api-v2-commandcompletionservice"></a>
-### Service `CommandCompletionService`
 
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto)
-- Endpoints tracked: `1`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`CompletionStream`](#endpoint-com-daml-ledger-api-v2-commandcompletionservice-completionstream) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.CompletionStreamRequest`](#type-com-daml-ledger-api-v2-completionstreamrequest) | [`com.daml.ledger.api.v2.CompletionStreamResponse`](#type-com-daml-ledger-api-v2-completionstreamresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-commandcompletionservice-completionstream"></a>
-**Endpoint `CommandCompletionService.CompletionStream`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto)
-
-**Signature**
-
-```protobuf
-rpc CommandCompletionService.CompletionStream(com.daml.ledger.api.v2.CompletionStreamRequest) returns (stream com.daml.ledger.api.v2.CompletionStreamResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.CompletionStreamRequest`](#type-com-daml-ledger-api-v2-completionstreamrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.CompletionStreamResponse`](#type-com-daml-ledger-api-v2-completionstreamresponse)
-
-<a id="service-com-daml-ledger-api-v2-commandservice"></a>
-### Service `CommandService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
-- Endpoints tracked: `3`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`SubmitAndWait`](#endpoint-com-daml-ledger-api-v2-commandservice-submitandwait) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.SubmitAndWaitRequest`](#type-com-daml-ledger-api-v2-submitandwaitrequest) | [`com.daml.ledger.api.v2.SubmitAndWaitResponse`](#type-com-daml-ledger-api-v2-submitandwaitresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto) |
-| [`SubmitAndWaitForReassignment`](#endpoint-com-daml-ledger-api-v2-commandservice-submitandwaitforreassignment) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest`](#type-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest) | [`com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse`](#type-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto) |
-| [`SubmitAndWaitForTransaction`](#endpoint-com-daml-ledger-api-v2-commandservice-submitandwaitfortransaction) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest`](#type-com-daml-ledger-api-v2-submitandwaitfortransactionrequest) | [`com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse`](#type-com-daml-ledger-api-v2-submitandwaitfortransactionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-commandservice-submitandwait"></a>
-**Endpoint `CommandService.SubmitAndWait`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
-
-**Signature**
-
-```protobuf
-rpc CommandService.SubmitAndWait(com.daml.ledger.api.v2.SubmitAndWaitRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.SubmitAndWaitRequest`](#type-com-daml-ledger-api-v2-submitandwaitrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.SubmitAndWaitResponse`](#type-com-daml-ledger-api-v2-submitandwaitresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-commandservice-submitandwaitforreassignment"></a>
-**Endpoint `CommandService.SubmitAndWaitForReassignment`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
-
-**Signature**
-
-```protobuf
-rpc CommandService.SubmitAndWaitForReassignment(com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest`](#type-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse`](#type-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-commandservice-submitandwaitfortransaction"></a>
-**Endpoint `CommandService.SubmitAndWaitForTransaction`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
-
-**Signature**
-
-```protobuf
-rpc CommandService.SubmitAndWaitForTransaction(com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest`](#type-com-daml-ledger-api-v2-submitandwaitfortransactionrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse`](#type-com-daml-ledger-api-v2-submitandwaitfortransactionresponse)
-
-<a id="service-com-daml-ledger-api-v2-commandsubmissionservice"></a>
-### Service `CommandSubmissionService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
-- Endpoints tracked: `2`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`Submit`](#endpoint-com-daml-ledger-api-v2-commandsubmissionservice-submit) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.SubmitRequest`](#type-com-daml-ledger-api-v2-submitrequest) | [`com.daml.ledger.api.v2.SubmitResponse`](#type-com-daml-ledger-api-v2-submitresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto) |
-| [`SubmitReassignment`](#endpoint-com-daml-ledger-api-v2-commandsubmissionservice-submitreassignment) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.SubmitReassignmentRequest`](#type-com-daml-ledger-api-v2-submitreassignmentrequest) | [`com.daml.ledger.api.v2.SubmitReassignmentResponse`](#type-com-daml-ledger-api-v2-submitreassignmentresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-commandsubmissionservice-submit"></a>
-**Endpoint `CommandSubmissionService.Submit`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
-
-**Signature**
-
-```protobuf
-rpc CommandSubmissionService.Submit(com.daml.ledger.api.v2.SubmitRequest) returns (com.daml.ledger.api.v2.SubmitResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.SubmitRequest`](#type-com-daml-ledger-api-v2-submitrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.SubmitResponse`](#type-com-daml-ledger-api-v2-submitresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-commandsubmissionservice-submitreassignment"></a>
-**Endpoint `CommandSubmissionService.SubmitReassignment`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
-
-**Signature**
-
-```protobuf
-rpc CommandSubmissionService.SubmitReassignment(com.daml.ledger.api.v2.SubmitReassignmentRequest) returns (com.daml.ledger.api.v2.SubmitReassignmentResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.SubmitReassignmentRequest`](#type-com-daml-ledger-api-v2-submitreassignmentrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.SubmitReassignmentResponse`](#type-com-daml-ledger-api-v2-submitreassignmentresponse)
-
-<a id="service-com-daml-ledger-api-v2-contractservice"></a>
-### Service `ContractService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto)
-- Endpoints tracked: `1`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`GetContract`](#endpoint-com-daml-ledger-api-v2-contractservice-getcontract) | `3.4.11` | `3.4.11` | `` | [`com.daml.ledger.api.v2.GetContractRequest`](#type-com-daml-ledger-api-v2-getcontractrequest) | [`com.daml.ledger.api.v2.GetContractResponse`](#type-com-daml-ledger-api-v2-getcontractresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-contractservice-getcontract"></a>
-**Endpoint `ContractService.GetContract`**
-
-- Introduced in: `3.4.11`
-- Last changed in: `3.4.11`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto)
-
-**Signature**
-
-```protobuf
-rpc ContractService.GetContract(com.daml.ledger.api.v2.GetContractRequest) returns (com.daml.ledger.api.v2.GetContractResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.11` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetContractRequest`](#type-com-daml-ledger-api-v2-getcontractrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetContractResponse`](#type-com-daml-ledger-api-v2-getcontractresponse)
-
-<a id="service-com-daml-ledger-api-v2-eventqueryservice"></a>
-### Service `EventQueryService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
-- Endpoints tracked: `1`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`GetEventsByContractId`](#endpoint-com-daml-ledger-api-v2-eventqueryservice-geteventsbycontractid) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetEventsByContractIdRequest`](#type-com-daml-ledger-api-v2-geteventsbycontractidrequest) | [`com.daml.ledger.api.v2.GetEventsByContractIdResponse`](#type-com-daml-ledger-api-v2-geteventsbycontractidresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-eventqueryservice-geteventsbycontractid"></a>
-**Endpoint `EventQueryService.GetEventsByContractId`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
-
-**Signature**
-
-```protobuf
-rpc EventQueryService.GetEventsByContractId(com.daml.ledger.api.v2.GetEventsByContractIdRequest) returns (com.daml.ledger.api.v2.GetEventsByContractIdResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetEventsByContractIdRequest`](#type-com-daml-ledger-api-v2-geteventsbycontractidrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetEventsByContractIdResponse`](#type-com-daml-ledger-api-v2-geteventsbycontractidresponse)
-
-<a id="service-com-daml-ledger-api-v2-packageservice"></a>
-### Service `PackageService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-- Endpoints tracked: `4`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`GetPackage`](#endpoint-com-daml-ledger-api-v2-packageservice-getpackage) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetPackageRequest`](#type-com-daml-ledger-api-v2-getpackagerequest) | [`com.daml.ledger.api.v2.GetPackageResponse`](#type-com-daml-ledger-api-v2-getpackageresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |
-| [`GetPackageStatus`](#endpoint-com-daml-ledger-api-v2-packageservice-getpackagestatus) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetPackageStatusRequest`](#type-com-daml-ledger-api-v2-getpackagestatusrequest) | [`com.daml.ledger.api.v2.GetPackageStatusResponse`](#type-com-daml-ledger-api-v2-getpackagestatusresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |
-| [`ListPackages`](#endpoint-com-daml-ledger-api-v2-packageservice-listpackages) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.ListPackagesRequest`](#type-com-daml-ledger-api-v2-listpackagesrequest) | [`com.daml.ledger.api.v2.ListPackagesResponse`](#type-com-daml-ledger-api-v2-listpackagesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |
-| [`ListVettedPackages`](#endpoint-com-daml-ledger-api-v2-packageservice-listvettedpackages) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.ListVettedPackagesRequest`](#type-com-daml-ledger-api-v2-listvettedpackagesrequest) | [`com.daml.ledger.api.v2.ListVettedPackagesResponse`](#type-com-daml-ledger-api-v2-listvettedpackagesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-packageservice-getpackage"></a>
-**Endpoint `PackageService.GetPackage`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PackageService.GetPackage(com.daml.ledger.api.v2.GetPackageRequest) returns (com.daml.ledger.api.v2.GetPackageResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetPackageRequest`](#type-com-daml-ledger-api-v2-getpackagerequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetPackageResponse`](#type-com-daml-ledger-api-v2-getpackageresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-packageservice-getpackagestatus"></a>
-**Endpoint `PackageService.GetPackageStatus`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PackageService.GetPackageStatus(com.daml.ledger.api.v2.GetPackageStatusRequest) returns (com.daml.ledger.api.v2.GetPackageStatusResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetPackageStatusRequest`](#type-com-daml-ledger-api-v2-getpackagestatusrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetPackageStatusResponse`](#type-com-daml-ledger-api-v2-getpackagestatusresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-packageservice-listpackages"></a>
-**Endpoint `PackageService.ListPackages`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PackageService.ListPackages(com.daml.ledger.api.v2.ListPackagesRequest) returns (com.daml.ledger.api.v2.ListPackagesResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.ListPackagesRequest`](#type-com-daml-ledger-api-v2-listpackagesrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.ListPackagesResponse`](#type-com-daml-ledger-api-v2-listpackagesresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-packageservice-listvettedpackages"></a>
-**Endpoint `PackageService.ListVettedPackages`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-
-**Signature**
-
-```protobuf
-rpc PackageService.ListVettedPackages(com.daml.ledger.api.v2.ListVettedPackagesRequest) returns (com.daml.ledger.api.v2.ListVettedPackagesResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.ListVettedPackagesRequest`](#type-com-daml-ledger-api-v2-listvettedpackagesrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.ListVettedPackagesResponse`](#type-com-daml-ledger-api-v2-listvettedpackagesresponse)
-
-<a id="service-com-daml-ledger-api-v2-stateservice"></a>
-### Service `StateService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Endpoints tracked: `4`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`GetActiveContracts`](#endpoint-com-daml-ledger-api-v2-stateservice-getactivecontracts) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetActiveContractsRequest`](#type-com-daml-ledger-api-v2-getactivecontractsrequest) | [`com.daml.ledger.api.v2.GetActiveContractsResponse`](#type-com-daml-ledger-api-v2-getactivecontractsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |
-| [`GetConnectedSynchronizers`](#endpoint-com-daml-ledger-api-v2-stateservice-getconnectedsynchronizers) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetConnectedSynchronizersRequest`](#type-com-daml-ledger-api-v2-getconnectedsynchronizersrequest) | [`com.daml.ledger.api.v2.GetConnectedSynchronizersResponse`](#type-com-daml-ledger-api-v2-getconnectedsynchronizersresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |
-| [`GetLatestPrunedOffsets`](#endpoint-com-daml-ledger-api-v2-stateservice-getlatestprunedoffsets) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest`](#type-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest) | [`com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse`](#type-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |
-| [`GetLedgerEnd`](#endpoint-com-daml-ledger-api-v2-stateservice-getledgerend) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetLedgerEndRequest`](#type-com-daml-ledger-api-v2-getledgerendrequest) | [`com.daml.ledger.api.v2.GetLedgerEndResponse`](#type-com-daml-ledger-api-v2-getledgerendresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-stateservice-getactivecontracts"></a>
-**Endpoint `StateService.GetActiveContracts`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-
-**Signature**
-
-```protobuf
-rpc StateService.GetActiveContracts(com.daml.ledger.api.v2.GetActiveContractsRequest) returns (stream com.daml.ledger.api.v2.GetActiveContractsResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetActiveContractsRequest`](#type-com-daml-ledger-api-v2-getactivecontractsrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetActiveContractsResponse`](#type-com-daml-ledger-api-v2-getactivecontractsresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-stateservice-getconnectedsynchronizers"></a>
-**Endpoint `StateService.GetConnectedSynchronizers`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-
-**Signature**
-
-```protobuf
-rpc StateService.GetConnectedSynchronizers(com.daml.ledger.api.v2.GetConnectedSynchronizersRequest) returns (com.daml.ledger.api.v2.GetConnectedSynchronizersResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetConnectedSynchronizersRequest`](#type-com-daml-ledger-api-v2-getconnectedsynchronizersrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetConnectedSynchronizersResponse`](#type-com-daml-ledger-api-v2-getconnectedsynchronizersresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-stateservice-getlatestprunedoffsets"></a>
-**Endpoint `StateService.GetLatestPrunedOffsets`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-
-**Signature**
-
-```protobuf
-rpc StateService.GetLatestPrunedOffsets(com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest) returns (com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest`](#type-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse`](#type-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-stateservice-getledgerend"></a>
-**Endpoint `StateService.GetLedgerEnd`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-
-**Signature**
-
-```protobuf
-rpc StateService.GetLedgerEnd(com.daml.ledger.api.v2.GetLedgerEndRequest) returns (com.daml.ledger.api.v2.GetLedgerEndResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetLedgerEndRequest`](#type-com-daml-ledger-api-v2-getledgerendrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetLedgerEndResponse`](#type-com-daml-ledger-api-v2-getledgerendresponse)
-
-<a id="service-com-daml-ledger-api-v2-updateservice"></a>
-### Service `UpdateService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
-- Endpoints tracked: `3`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`GetUpdateById`](#endpoint-com-daml-ledger-api-v2-updateservice-getupdatebyid) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetUpdateByIdRequest`](#type-com-daml-ledger-api-v2-getupdatebyidrequest) | [`com.daml.ledger.api.v2.GetUpdateResponse`](#type-com-daml-ledger-api-v2-getupdateresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto) |
-| [`GetUpdateByOffset`](#endpoint-com-daml-ledger-api-v2-updateservice-getupdatebyoffset) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetUpdateByOffsetRequest`](#type-com-daml-ledger-api-v2-getupdatebyoffsetrequest) | [`com.daml.ledger.api.v2.GetUpdateResponse`](#type-com-daml-ledger-api-v2-getupdateresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto) |
-| [`GetUpdates`](#endpoint-com-daml-ledger-api-v2-updateservice-getupdates) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetUpdatesRequest`](#type-com-daml-ledger-api-v2-getupdatesrequest) | [`com.daml.ledger.api.v2.GetUpdatesResponse`](#type-com-daml-ledger-api-v2-getupdatesresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-updateservice-getupdatebyid"></a>
-**Endpoint `UpdateService.GetUpdateById`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UpdateService.GetUpdateById(com.daml.ledger.api.v2.GetUpdateByIdRequest) returns (com.daml.ledger.api.v2.GetUpdateResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetUpdateByIdRequest`](#type-com-daml-ledger-api-v2-getupdatebyidrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetUpdateResponse`](#type-com-daml-ledger-api-v2-getupdateresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-updateservice-getupdatebyoffset"></a>
-**Endpoint `UpdateService.GetUpdateByOffset`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UpdateService.GetUpdateByOffset(com.daml.ledger.api.v2.GetUpdateByOffsetRequest) returns (com.daml.ledger.api.v2.GetUpdateResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetUpdateByOffsetRequest`](#type-com-daml-ledger-api-v2-getupdatebyoffsetrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetUpdateResponse`](#type-com-daml-ledger-api-v2-getupdateresponse)
-
-<a id="endpoint-com-daml-ledger-api-v2-updateservice-getupdates"></a>
-**Endpoint `UpdateService.GetUpdates`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
-
-**Signature**
-
-```protobuf
-rpc UpdateService.GetUpdates(com.daml.ledger.api.v2.GetUpdatesRequest) returns (stream com.daml.ledger.api.v2.GetUpdatesResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetUpdatesRequest`](#type-com-daml-ledger-api-v2-getupdatesrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetUpdatesResponse`](#type-com-daml-ledger-api-v2-getupdatesresponse)
-
-<a id="service-com-daml-ledger-api-v2-versionservice"></a>
-### Service `VersionService`
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
-- Endpoints tracked: `1`
-
-_No description._
-
-| Endpoint | Introduced | Last Changed | Removed | Request | Response | Source |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`GetLedgerApiVersion`](#endpoint-com-daml-ledger-api-v2-versionservice-getledgerapiversion) | `3.4.4` | `3.4.4` | `` | [`com.daml.ledger.api.v2.GetLedgerApiVersionRequest`](#type-com-daml-ledger-api-v2-getledgerapiversionrequest) | [`com.daml.ledger.api.v2.GetLedgerApiVersionResponse`](#type-com-daml-ledger-api-v2-getledgerapiversionresponse) | [file](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto) |
-
-<a id="endpoint-com-daml-ledger-api-v2-versionservice-getledgerapiversion"></a>
-**Endpoint `VersionService.GetLedgerApiVersion`**
-
-- Introduced in: `3.4.4`
-- Last changed in: `3.4.4`
-- Removed in: `-`
-- Status: `current`
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
-
-**Signature**
-
-```protobuf
-rpc VersionService.GetLedgerApiVersion(com.daml.ledger.api.v2.GetLedgerApiVersionRequest) returns (com.daml.ledger.api.v2.GetLedgerApiVersionResponse);
-```
-
-_No description._
-
-**History**
-
-| Version | Kind | Details |
-| --- | --- | --- |
-| `3.4.4` | `introduced` |  |
-
-**Request Type**
-
-- [`com.daml.ledger.api.v2.GetLedgerApiVersionRequest`](#type-com-daml-ledger-api-v2-getledgerapiversionrequest)
-
-**Response Type**
-
-- [`com.daml.ledger.api.v2.GetLedgerApiVersionResponse`](#type-com-daml-ledger-api-v2-getledgerapiversionresponse)
-
-## Type Reference
-
-<a id="type-com-daml-ledger-api-v2-activecontract"></a>
-**Message `com.daml.ledger.api.v2.ActiveContract`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| created_event | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
-| synchronizer_id | `string` | optional |  |
-| reassignment_counter | `uint64` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-archived"></a>
-**Message `com.daml.ledger.api.v2.Archived`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| archived_event | [`com.daml.ledger.api.v2.ArchivedEvent`](#type-com-daml-ledger-api-v2-archivedevent) | optional |  |
-| synchronizer_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-archivedevent"></a>
-**Message `com.daml.ledger.api.v2.ArchivedEvent`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto)
-- Fields: 7
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| offset | `int64` | optional |  |
-| node_id | `int32` | optional |  |
-| contract_id | `string` | optional |  |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| witness_parties | `string` | repeated |  |
-| package_name | `string` | optional |  |
-| implemented_interfaces | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-assigncommand"></a>
-**Message `com.daml.ledger.api.v2.AssignCommand`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| reassignment_id | `string` | optional |  |
-| source | `string` | optional |  |
-| target | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-assignedevent"></a>
-**Message `com.daml.ledger.api.v2.AssignedEvent`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto)
-- Fields: 6
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| source | `string` | optional |  |
-| target | `string` | optional |  |
-| reassignment_id | `string` | optional |  |
-| submitter | `string` | optional |  |
-| reassignment_counter | `uint64` | optional |  |
-| created_event | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-command"></a>
-**Message `com.daml.ledger.api.v2.Command`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| create | [`com.daml.ledger.api.v2.CreateCommand`](#type-com-daml-ledger-api-v2-createcommand) | optional |  |
-| exercise | [`com.daml.ledger.api.v2.ExerciseCommand`](#type-com-daml-ledger-api-v2-exercisecommand) | optional |  |
-| exercise_by_key | [`com.daml.ledger.api.v2.ExerciseByKeyCommand`](#type-com-daml-ledger-api-v2-exercisebykeycommand) | optional |  |
-| create_and_exercise | [`com.daml.ledger.api.v2.CreateAndExerciseCommand`](#type-com-daml-ledger-api-v2-createandexercisecommand) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-commands"></a>
-**Message `com.daml.ledger.api.v2.Commands`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
-- Fields: 15
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| workflow_id | `string` | optional |  |
-| user_id | `string` | optional |  |
-| command_id | `string` | optional |  |
-| commands | [`com.daml.ledger.api.v2.Command`](#type-com-daml-ledger-api-v2-command) | repeated |  |
-| deduplication_duration | `google.protobuf.Duration` | optional |  |
-| deduplication_offset | `int64` | optional |  |
-| min_ledger_time_abs | `google.protobuf.Timestamp` | optional |  |
-| min_ledger_time_rel | `google.protobuf.Duration` | optional |  |
-| act_as | `string` | repeated |  |
-| read_as | `string` | repeated |  |
-| submission_id | `string` | optional |  |
-| disclosed_contracts | [`com.daml.ledger.api.v2.DisclosedContract`](#type-com-daml-ledger-api-v2-disclosedcontract) | repeated |  |
-| synchronizer_id | `string` | optional |  |
-| package_id_selection_preference | `string` | repeated |  |
-| prefetch_contract_keys | [`com.daml.ledger.api.v2.PrefetchContractKey`](#type-com-daml-ledger-api-v2-prefetchcontractkey) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-completion"></a>
-**Message `com.daml.ledger.api.v2.Completion`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto)
-- Fields: 11
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| command_id | `string` | optional |  |
-| status | `google.rpc.Status` | optional |  |
-| update_id | `string` | optional |  |
-| user_id | `string` | optional |  |
-| act_as | `string` | repeated |  |
-| submission_id | `string` | optional |  |
-| deduplication_offset | `int64` | optional |  |
-| deduplication_duration | `google.protobuf.Duration` | optional |  |
-| trace_context | [`com.daml.ledger.api.v2.TraceContext`](#type-com-daml-ledger-api-v2-tracecontext) | optional |  |
-| offset | `int64` | optional |  |
-| synchronizer_time | [`com.daml.ledger.api.v2.SynchronizerTime`](#type-com-daml-ledger-api-v2-synchronizertime) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-completionstreamrequest"></a>
-**Message `com.daml.ledger.api.v2.CompletionStreamRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| user_id | `string` | optional |  |
-| parties | `string` | repeated |  |
-| begin_exclusive | `int64` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-completionstreamresponse"></a>
-**Message `com.daml.ledger.api.v2.CompletionStreamResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| completion | [`com.daml.ledger.api.v2.Completion`](#type-com-daml-ledger-api-v2-completion) | optional |  |
-| offset_checkpoint | [`com.daml.ledger.api.v2.OffsetCheckpoint`](#type-com-daml-ledger-api-v2-offsetcheckpoint) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-createandexercisecommand"></a>
-**Message `com.daml.ledger.api.v2.CreateAndExerciseCommand`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| create_arguments | [`com.daml.ledger.api.v2.Record`](#type-com-daml-ledger-api-v2-record) | optional |  |
-| choice | `string` | optional |  |
-| choice_argument | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-createcommand"></a>
-**Message `com.daml.ledger.api.v2.CreateCommand`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| create_arguments | [`com.daml.ledger.api.v2.Record`](#type-com-daml-ledger-api-v2-record) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-created"></a>
-**Message `com.daml.ledger.api.v2.Created`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| created_event | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
-| synchronizer_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-createdevent"></a>
-**Message `com.daml.ledger.api.v2.CreatedEvent`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto)
-- Fields: 15
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| offset | `int64` | optional |  |
-| node_id | `int32` | optional |  |
-| contract_id | `string` | optional |  |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| contract_key | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-| create_arguments | [`com.daml.ledger.api.v2.Record`](#type-com-daml-ledger-api-v2-record) | optional |  |
-| created_event_blob | `bytes` | optional |  |
-| interface_views | [`com.daml.ledger.api.v2.InterfaceView`](#type-com-daml-ledger-api-v2-interfaceview) | repeated |  |
-| witness_parties | `string` | repeated |  |
-| signatories | `string` | repeated |  |
-| observers | `string` | repeated |  |
-| created_at | `google.protobuf.Timestamp` | optional |  |
-| package_name | `string` | optional |  |
-| acs_delta | `bool` | optional |  |
-| representative_package_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-cumulativefilter"></a>
-**Message `com.daml.ledger.api.v2.CumulativeFilter`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| wildcard_filter | [`com.daml.ledger.api.v2.WildcardFilter`](#type-com-daml-ledger-api-v2-wildcardfilter) | optional |  |
-| interface_filter | [`com.daml.ledger.api.v2.InterfaceFilter`](#type-com-daml-ledger-api-v2-interfacefilter) | optional |  |
-| template_filter | [`com.daml.ledger.api.v2.TemplateFilter`](#type-com-daml-ledger-api-v2-templatefilter) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-disclosedcontract"></a>
-**Message `com.daml.ledger.api.v2.DisclosedContract`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| contract_id | `string` | optional |  |
-| created_event_blob | `bytes` | optional |  |
-| synchronizer_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-enum"></a>
-**Message `com.daml.ledger.api.v2.Enum`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| enum_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| constructor | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-event"></a>
-**Message `com.daml.ledger.api.v2.Event`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| created | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
-| archived | [`com.daml.ledger.api.v2.ArchivedEvent`](#type-com-daml-ledger-api-v2-archivedevent) | optional |  |
-| exercised | [`com.daml.ledger.api.v2.ExercisedEvent`](#type-com-daml-ledger-api-v2-exercisedevent) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-eventformat"></a>
-**Message `com.daml.ledger.api.v2.EventFormat`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| filters_by_party | `map<string, com.daml.ledger.api.v2.Filters>` | repeated |  |
-| filters_for_any_party | [`com.daml.ledger.api.v2.Filters`](#type-com-daml-ledger-api-v2-filters) | optional |  |
-| verbose | `bool` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-exercisebykeycommand"></a>
-**Message `com.daml.ledger.api.v2.ExerciseByKeyCommand`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| contract_key | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-| choice | `string` | optional |  |
-| choice_argument | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-exercisecommand"></a>
-**Message `com.daml.ledger.api.v2.ExerciseCommand`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| contract_id | `string` | optional |  |
-| choice | `string` | optional |  |
-| choice_argument | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-exercisedevent"></a>
-**Message `com.daml.ledger.api.v2.ExercisedEvent`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto)
-- Fields: 15
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| offset | `int64` | optional |  |
-| node_id | `int32` | optional |  |
-| contract_id | `string` | optional |  |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| interface_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| choice | `string` | optional |  |
-| choice_argument | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-| acting_parties | `string` | repeated |  |
-| consuming | `bool` | optional |  |
-| witness_parties | `string` | repeated |  |
-| last_descendant_node_id | `int32` | optional |  |
-| exercise_result | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-| package_name | `string` | optional |  |
-| implemented_interfaces | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | repeated |  |
-| acs_delta | `bool` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-experimentalcommandinspectionservice"></a>
-**Message `com.daml.ledger.api.v2.ExperimentalCommandInspectionService`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| supported | `bool` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-experimentalfeatures"></a>
-**Message `com.daml.ledger.api.v2.ExperimentalFeatures`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| static_time | [`com.daml.ledger.api.v2.ExperimentalStaticTime`](#type-com-daml-ledger-api-v2-experimentalstatictime) | optional |  |
-| command_inspection_service | [`com.daml.ledger.api.v2.ExperimentalCommandInspectionService`](#type-com-daml-ledger-api-v2-experimentalcommandinspectionservice) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-experimentalpartytopologyevents"></a>
-**Message `com.daml.ledger.api.v2.ExperimentalPartyTopologyEvents`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| supported | `bool` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-experimentalstatictime"></a>
-**Message `com.daml.ledger.api.v2.ExperimentalStaticTime`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| supported | `bool` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-featuresdescriptor"></a>
-**Message `com.daml.ledger.api.v2.FeaturesDescriptor`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
-- Fields: 5
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| experimental | [`com.daml.ledger.api.v2.ExperimentalFeatures`](#type-com-daml-ledger-api-v2-experimentalfeatures) | optional |  |
-| user_management | [`com.daml.ledger.api.v2.UserManagementFeature`](#type-com-daml-ledger-api-v2-usermanagementfeature) | optional |  |
-| party_management | [`com.daml.ledger.api.v2.PartyManagementFeature`](#type-com-daml-ledger-api-v2-partymanagementfeature) | optional |  |
-| offset_checkpoint | [`com.daml.ledger.api.v2.OffsetCheckpointFeature`](#type-com-daml-ledger-api-v2-offsetcheckpointfeature) | optional |  |
-| package_feature | [`com.daml.ledger.api.v2.PackageFeature`](#type-com-daml-ledger-api-v2-packagefeature) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-filters"></a>
-**Message `com.daml.ledger.api.v2.Filters`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| cumulative | [`com.daml.ledger.api.v2.CumulativeFilter`](#type-com-daml-ledger-api-v2-cumulativefilter) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-genmap"></a>
-**Message `com.daml.ledger.api.v2.GenMap`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| entries | [`com.daml.ledger.api.v2.GenMap.Entry`](#type-com-daml-ledger-api-v2-genmap-entry) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-genmap-entry"></a>
-**Message `com.daml.ledger.api.v2.GenMap.Entry`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| key | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-| value | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getactivecontractsrequest"></a>
-**Message `com.daml.ledger.api.v2.GetActiveContractsRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| active_at_offset | `int64` | optional |  |
-| event_format | [`com.daml.ledger.api.v2.EventFormat`](#type-com-daml-ledger-api-v2-eventformat) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getactivecontractsresponse"></a>
-**Message `com.daml.ledger.api.v2.GetActiveContractsResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| workflow_id | `string` | optional |  |
-| active_contract | [`com.daml.ledger.api.v2.ActiveContract`](#type-com-daml-ledger-api-v2-activecontract) | optional |  |
-| incomplete_unassigned | [`com.daml.ledger.api.v2.IncompleteUnassigned`](#type-com-daml-ledger-api-v2-incompleteunassigned) | optional |  |
-| incomplete_assigned | [`com.daml.ledger.api.v2.IncompleteAssigned`](#type-com-daml-ledger-api-v2-incompleteassigned) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getconnectedsynchronizersrequest"></a>
-**Message `com.daml.ledger.api.v2.GetConnectedSynchronizersRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party | `string` | optional |  |
-| participant_id | `string` | optional |  |
-| identity_provider_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getconnectedsynchronizersresponse"></a>
-**Message `com.daml.ledger.api.v2.GetConnectedSynchronizersResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| connected_synchronizers | [`com.daml.ledger.api.v2.GetConnectedSynchronizersResponse.ConnectedSynchronizer`](#type-com-daml-ledger-api-v2-getconnectedsynchronizersresponse-connectedsynchronizer) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-getconnectedsynchronizersresponse-connectedsynchronizer"></a>
-**Message `com.daml.ledger.api.v2.GetConnectedSynchronizersResponse.ConnectedSynchronizer`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| synchronizer_alias | `string` | optional |  |
-| synchronizer_id | `string` | optional |  |
-| permission | [`com.daml.ledger.api.v2.ParticipantPermission`](#type-com-daml-ledger-api-v2-participantpermission) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getcontractrequest"></a>
-**Message `com.daml.ledger.api.v2.GetContractRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| contract_id | `string` | optional |  |
-| querying_parties | `string` | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-getcontractresponse"></a>
-**Message `com.daml.ledger.api.v2.GetContractResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| created_event | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-geteventsbycontractidrequest"></a>
-**Message `com.daml.ledger.api.v2.GetEventsByContractIdRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| contract_id | `string` | optional |  |
-| event_format | [`com.daml.ledger.api.v2.EventFormat`](#type-com-daml-ledger-api-v2-eventformat) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-geteventsbycontractidresponse"></a>
-**Message `com.daml.ledger.api.v2.GetEventsByContractIdResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| created | [`com.daml.ledger.api.v2.Created`](#type-com-daml-ledger-api-v2-created) | optional |  |
-| archived | [`com.daml.ledger.api.v2.Archived`](#type-com-daml-ledger-api-v2-archived) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest"></a>
-**Message `com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse"></a>
-**Message `com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| participant_pruned_up_to_inclusive | `int64` | optional |  |
-| all_divulged_contracts_pruned_up_to_inclusive | `int64` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getledgerapiversionrequest"></a>
-**Message `com.daml.ledger.api.v2.GetLedgerApiVersionRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-getledgerapiversionresponse"></a>
-**Message `com.daml.ledger.api.v2.GetLedgerApiVersionResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| version | `string` | optional |  |
-| features | [`com.daml.ledger.api.v2.FeaturesDescriptor`](#type-com-daml-ledger-api-v2-featuresdescriptor) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getledgerendrequest"></a>
-**Message `com.daml.ledger.api.v2.GetLedgerEndRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-getledgerendresponse"></a>
-**Message `com.daml.ledger.api.v2.GetLedgerEndResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| offset | `int64` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getpackagerequest"></a>
-**Message `com.daml.ledger.api.v2.GetPackageRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getpackageresponse"></a>
-**Message `com.daml.ledger.api.v2.GetPackageResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| hash_function | [`com.daml.ledger.api.v2.HashFunction`](#type-com-daml-ledger-api-v2-hashfunction) | optional |  |
-| archive_payload | `bytes` | optional |  |
-| hash | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getpackagestatusrequest"></a>
-**Message `com.daml.ledger.api.v2.GetPackageStatusRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getpackagestatusresponse"></a>
-**Message `com.daml.ledger.api.v2.GetPackageStatusResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_status | [`com.daml.ledger.api.v2.PackageStatus`](#type-com-daml-ledger-api-v2-packagestatus) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getupdatebyidrequest"></a>
-**Message `com.daml.ledger.api.v2.GetUpdateByIdRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| update_id | `string` | optional |  |
-| update_format | [`com.daml.ledger.api.v2.UpdateFormat`](#type-com-daml-ledger-api-v2-updateformat) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getupdatebyoffsetrequest"></a>
-**Message `com.daml.ledger.api.v2.GetUpdateByOffsetRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| offset | `int64` | optional |  |
-| update_format | [`com.daml.ledger.api.v2.UpdateFormat`](#type-com-daml-ledger-api-v2-updateformat) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getupdateresponse"></a>
-**Message `com.daml.ledger.api.v2.GetUpdateResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| transaction | [`com.daml.ledger.api.v2.Transaction`](#type-com-daml-ledger-api-v2-transaction) | optional |  |
-| reassignment | [`com.daml.ledger.api.v2.Reassignment`](#type-com-daml-ledger-api-v2-reassignment) | optional |  |
-| topology_transaction | [`com.daml.ledger.api.v2.TopologyTransaction`](#type-com-daml-ledger-api-v2-topologytransaction) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getupdatesrequest"></a>
-**Message `com.daml.ledger.api.v2.GetUpdatesRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| begin_exclusive | `int64` | optional |  |
-| end_inclusive | `int64` | optional |  |
-| update_format | [`com.daml.ledger.api.v2.UpdateFormat`](#type-com-daml-ledger-api-v2-updateformat) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-getupdatesresponse"></a>
-**Message `com.daml.ledger.api.v2.GetUpdatesResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| transaction | [`com.daml.ledger.api.v2.Transaction`](#type-com-daml-ledger-api-v2-transaction) | optional |  |
-| reassignment | [`com.daml.ledger.api.v2.Reassignment`](#type-com-daml-ledger-api-v2-reassignment) | optional |  |
-| offset_checkpoint | [`com.daml.ledger.api.v2.OffsetCheckpoint`](#type-com-daml-ledger-api-v2-offsetcheckpoint) | optional |  |
-| topology_transaction | [`com.daml.ledger.api.v2.TopologyTransaction`](#type-com-daml-ledger-api-v2-topologytransaction) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-identifier"></a>
-**Message `com.daml.ledger.api.v2.Identifier`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_id | `string` | optional |  |
-| module_name | `string` | optional |  |
-| entity_name | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-incompleteassigned"></a>
-**Message `com.daml.ledger.api.v2.IncompleteAssigned`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| assigned_event | [`com.daml.ledger.api.v2.AssignedEvent`](#type-com-daml-ledger-api-v2-assignedevent) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-incompleteunassigned"></a>
-**Message `com.daml.ledger.api.v2.IncompleteUnassigned`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| created_event | [`com.daml.ledger.api.v2.CreatedEvent`](#type-com-daml-ledger-api-v2-createdevent) | optional |  |
-| unassigned_event | [`com.daml.ledger.api.v2.UnassignedEvent`](#type-com-daml-ledger-api-v2-unassignedevent) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interfacefilter"></a>
-**Message `com.daml.ledger.api.v2.InterfaceFilter`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| interface_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| include_interface_view | `bool` | optional |  |
-| include_created_event_blob | `bool` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-interfaceview"></a>
-**Message `com.daml.ledger.api.v2.InterfaceView`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| interface_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| view_status | `google.rpc.Status` | optional |  |
-| view_value | [`com.daml.ledger.api.v2.Record`](#type-com-daml-ledger-api-v2-record) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-list"></a>
-**Message `com.daml.ledger.api.v2.List`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| elements | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-listpackagesrequest"></a>
-**Message `com.daml.ledger.api.v2.ListPackagesRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-listpackagesresponse"></a>
-**Message `com.daml.ledger.api.v2.ListPackagesResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_ids | `string` | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-listvettedpackagesrequest"></a>
-**Message `com.daml.ledger.api.v2.ListVettedPackagesRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_metadata_filter | [`com.daml.ledger.api.v2.PackageMetadataFilter`](#type-com-daml-ledger-api-v2-packagemetadatafilter) | optional |  |
-| topology_state_filter | [`com.daml.ledger.api.v2.TopologyStateFilter`](#type-com-daml-ledger-api-v2-topologystatefilter) | optional |  |
-| page_token | `string` | optional |  |
-| page_size | `uint32` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-listvettedpackagesresponse"></a>
-**Message `com.daml.ledger.api.v2.ListVettedPackagesResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| vetted_packages | [`com.daml.ledger.api.v2.VettedPackages`](#type-com-daml-ledger-api-v2-vettedpackages) | repeated |  |
-| next_page_token | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-offsetcheckpoint"></a>
-**Message `com.daml.ledger.api.v2.OffsetCheckpoint`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| offset | `int64` | optional |  |
-| synchronizer_times | [`com.daml.ledger.api.v2.SynchronizerTime`](#type-com-daml-ledger-api-v2-synchronizertime) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-offsetcheckpointfeature"></a>
-**Message `com.daml.ledger.api.v2.OffsetCheckpointFeature`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| max_offset_checkpoint_emission_delay | `google.protobuf.Duration` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-optional"></a>
-**Message `com.daml.ledger.api.v2.Optional`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| value | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-packagefeature"></a>
-**Message `com.daml.ledger.api.v2.PackageFeature`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| max_vetted_packages_page_size | `int32` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-packagemetadatafilter"></a>
-**Message `com.daml.ledger.api.v2.PackageMetadataFilter`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_ids | `string` | repeated |  |
-| package_name_prefixes | `string` | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-packagereference"></a>
-**Message `com.daml.ledger.api.v2.PackageReference`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_id | `string` | optional |  |
-| package_name | `string` | optional |  |
-| package_version | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-participantauthorizationadded"></a>
-**Message `com.daml.ledger.api.v2.ParticipantAuthorizationAdded`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party_id | `string` | optional |  |
-| participant_id | `string` | optional |  |
-| participant_permission | [`com.daml.ledger.api.v2.ParticipantPermission`](#type-com-daml-ledger-api-v2-participantpermission) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-participantauthorizationchanged"></a>
-**Message `com.daml.ledger.api.v2.ParticipantAuthorizationChanged`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party_id | `string` | optional |  |
-| participant_id | `string` | optional |  |
-| participant_permission | [`com.daml.ledger.api.v2.ParticipantPermission`](#type-com-daml-ledger-api-v2-participantpermission) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-participantauthorizationrevoked"></a>
-**Message `com.daml.ledger.api.v2.ParticipantAuthorizationRevoked`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| party_id | `string` | optional |  |
-| participant_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-participantauthorizationtopologyformat"></a>
-**Message `com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| parties | `string` | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-partymanagementfeature"></a>
-**Message `com.daml.ledger.api.v2.PartyManagementFeature`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| max_parties_page_size | `int32` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-prefetchcontractkey"></a>
-**Message `com.daml.ledger.api.v2.PrefetchContractKey`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| contract_key | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-priortopologyserial"></a>
-**Message `com.daml.ledger.api.v2.PriorTopologySerial`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| prior | `uint32` | optional |  |
-| no_prior | `google.protobuf.Empty` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-reassignment"></a>
-**Message `com.daml.ledger.api.v2.Reassignment`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto)
-- Fields: 8
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| update_id | `string` | optional |  |
-| command_id | `string` | optional |  |
-| workflow_id | `string` | optional |  |
-| offset | `int64` | optional |  |
-| events | [`com.daml.ledger.api.v2.ReassignmentEvent`](#type-com-daml-ledger-api-v2-reassignmentevent) | repeated |  |
-| trace_context | [`com.daml.ledger.api.v2.TraceContext`](#type-com-daml-ledger-api-v2-tracecontext) | optional |  |
-| record_time | `google.protobuf.Timestamp` | optional |  |
-| synchronizer_id | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-reassignmentcommand"></a>
-**Message `com.daml.ledger.api.v2.ReassignmentCommand`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| unassign_command | [`com.daml.ledger.api.v2.UnassignCommand`](#type-com-daml-ledger-api-v2-unassigncommand) | optional |  |
-| assign_command | [`com.daml.ledger.api.v2.AssignCommand`](#type-com-daml-ledger-api-v2-assigncommand) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-reassignmentcommands"></a>
-**Message `com.daml.ledger.api.v2.ReassignmentCommands`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto)
-- Fields: 6
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| workflow_id | `string` | optional |  |
-| user_id | `string` | optional |  |
-| command_id | `string` | optional |  |
-| submitter | `string` | optional |  |
-| submission_id | `string` | optional |  |
-| commands | [`com.daml.ledger.api.v2.ReassignmentCommand`](#type-com-daml-ledger-api-v2-reassignmentcommand) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-reassignmentevent"></a>
-**Message `com.daml.ledger.api.v2.ReassignmentEvent`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| unassigned | [`com.daml.ledger.api.v2.UnassignedEvent`](#type-com-daml-ledger-api-v2-unassignedevent) | optional |  |
-| assigned | [`com.daml.ledger.api.v2.AssignedEvent`](#type-com-daml-ledger-api-v2-assignedevent) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-record"></a>
-**Message `com.daml.ledger.api.v2.Record`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| record_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| fields | [`com.daml.ledger.api.v2.RecordField`](#type-com-daml-ledger-api-v2-recordfield) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-recordfield"></a>
-**Message `com.daml.ledger.api.v2.RecordField`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| label | `string` | optional |  |
-| value | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-signature"></a>
-**Message `com.daml.ledger.api.v2.Signature`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| format | [`com.daml.ledger.api.v2.SignatureFormat`](#type-com-daml-ledger-api-v2-signatureformat) | optional |  |
-| signature | `bytes` | optional |  |
-| signed_by | `string` | optional |  |
-| signing_algorithm_spec | [`com.daml.ledger.api.v2.SigningAlgorithmSpec`](#type-com-daml-ledger-api-v2-signingalgorithmspec) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-signingpublickey"></a>
-**Message `com.daml.ledger.api.v2.SigningPublicKey`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| format | [`com.daml.ledger.api.v2.CryptoKeyFormat`](#type-com-daml-ledger-api-v2-cryptokeyformat) | optional |  |
-| key_data | `bytes` | optional |  |
-| key_spec | [`com.daml.ledger.api.v2.SigningKeySpec`](#type-com-daml-ledger-api-v2-signingkeyspec) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest"></a>
-**Message `com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| reassignment_commands | [`com.daml.ledger.api.v2.ReassignmentCommands`](#type-com-daml-ledger-api-v2-reassignmentcommands) | optional |  |
-| event_format | [`com.daml.ledger.api.v2.EventFormat`](#type-com-daml-ledger-api-v2-eventformat) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse"></a>
-**Message `com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| reassignment | [`com.daml.ledger.api.v2.Reassignment`](#type-com-daml-ledger-api-v2-reassignment) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-submitandwaitfortransactionrequest"></a>
-**Message `com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| commands | [`com.daml.ledger.api.v2.Commands`](#type-com-daml-ledger-api-v2-commands) | optional |  |
-| transaction_format | [`com.daml.ledger.api.v2.TransactionFormat`](#type-com-daml-ledger-api-v2-transactionformat) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-submitandwaitfortransactionresponse"></a>
-**Message `com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| transaction | [`com.daml.ledger.api.v2.Transaction`](#type-com-daml-ledger-api-v2-transaction) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-submitandwaitrequest"></a>
-**Message `com.daml.ledger.api.v2.SubmitAndWaitRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| commands | [`com.daml.ledger.api.v2.Commands`](#type-com-daml-ledger-api-v2-commands) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-submitandwaitresponse"></a>
-**Message `com.daml.ledger.api.v2.SubmitAndWaitResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| update_id | `string` | optional |  |
-| completion_offset | `int64` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-submitreassignmentrequest"></a>
-**Message `com.daml.ledger.api.v2.SubmitReassignmentRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| reassignment_commands | [`com.daml.ledger.api.v2.ReassignmentCommands`](#type-com-daml-ledger-api-v2-reassignmentcommands) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-submitreassignmentresponse"></a>
-**Message `com.daml.ledger.api.v2.SubmitReassignmentResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-submitrequest"></a>
-**Message `com.daml.ledger.api.v2.SubmitRequest`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| commands | [`com.daml.ledger.api.v2.Commands`](#type-com-daml-ledger-api-v2-commands) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-submitresponse"></a>
-**Message `com.daml.ledger.api.v2.SubmitResponse`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto)
-- Fields: 0
-
-_No description._
-
-<a id="type-com-daml-ledger-api-v2-synchronizertime"></a>
-**Message `com.daml.ledger.api.v2.SynchronizerTime`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| synchronizer_id | `string` | optional |  |
-| record_time | `google.protobuf.Timestamp` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-templatefilter"></a>
-**Message `com.daml.ledger.api.v2.TemplateFilter`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| include_created_event_blob | `bool` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-textmap"></a>
-**Message `com.daml.ledger.api.v2.TextMap`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| entries | [`com.daml.ledger.api.v2.TextMap.Entry`](#type-com-daml-ledger-api-v2-textmap-entry) | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-textmap-entry"></a>
-**Message `com.daml.ledger.api.v2.TextMap.Entry`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| key | `string` | optional |  |
-| value | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-topologyevent"></a>
-**Message `com.daml.ledger.api.v2.TopologyEvent`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| participant_authorization_changed | [`com.daml.ledger.api.v2.ParticipantAuthorizationChanged`](#type-com-daml-ledger-api-v2-participantauthorizationchanged) | optional |  |
-| participant_authorization_revoked | [`com.daml.ledger.api.v2.ParticipantAuthorizationRevoked`](#type-com-daml-ledger-api-v2-participantauthorizationrevoked) | optional |  |
-| participant_authorization_added | [`com.daml.ledger.api.v2.ParticipantAuthorizationAdded`](#type-com-daml-ledger-api-v2-participantauthorizationadded) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-topologyformat"></a>
-**Message `com.daml.ledger.api.v2.TopologyFormat`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| include_participant_authorization_events | [`com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat`](#type-com-daml-ledger-api-v2-participantauthorizationtopologyformat) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-topologystatefilter"></a>
-**Message `com.daml.ledger.api.v2.TopologyStateFilter`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| participant_ids | `string` | repeated |  |
-| synchronizer_ids | `string` | repeated |  |
-
-<a id="type-com-daml-ledger-api-v2-topologytransaction"></a>
-**Message `com.daml.ledger.api.v2.TopologyTransaction`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto)
-- Fields: 6
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| update_id | `string` | optional |  |
-| offset | `int64` | optional |  |
-| synchronizer_id | `string` | optional |  |
-| record_time | `google.protobuf.Timestamp` | optional |  |
-| events | [`com.daml.ledger.api.v2.TopologyEvent`](#type-com-daml-ledger-api-v2-topologyevent) | repeated |  |
-| trace_context | [`com.daml.ledger.api.v2.TraceContext`](#type-com-daml-ledger-api-v2-tracecontext) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-tracecontext"></a>
-**Message `com.daml.ledger.api.v2.TraceContext`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| traceparent | `string` | optional |  |
-| tracestate | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-transaction"></a>
-**Message `com.daml.ledger.api.v2.Transaction`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto)
-- Fields: 10
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| update_id | `string` | optional |  |
-| command_id | `string` | optional |  |
-| workflow_id | `string` | optional |  |
-| effective_at | `google.protobuf.Timestamp` | optional |  |
-| events | [`com.daml.ledger.api.v2.Event`](#type-com-daml-ledger-api-v2-event) | repeated |  |
-| offset | `int64` | optional |  |
-| synchronizer_id | `string` | optional |  |
-| trace_context | [`com.daml.ledger.api.v2.TraceContext`](#type-com-daml-ledger-api-v2-tracecontext) | optional |  |
-| record_time | `google.protobuf.Timestamp` | optional |  |
-| external_transaction_hash | `bytes` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-transactionformat"></a>
-**Message `com.daml.ledger.api.v2.TransactionFormat`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
-- Fields: 2
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| event_format | [`com.daml.ledger.api.v2.EventFormat`](#type-com-daml-ledger-api-v2-eventformat) | optional |  |
-| transaction_shape | [`com.daml.ledger.api.v2.TransactionShape`](#type-com-daml-ledger-api-v2-transactionshape) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-unassigncommand"></a>
-**Message `com.daml.ledger.api.v2.UnassignCommand`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| contract_id | `string` | optional |  |
-| source | `string` | optional |  |
-| target | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-unassignedevent"></a>
-**Message `com.daml.ledger.api.v2.UnassignedEvent`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto)
-- Fields: 12
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| reassignment_id | `string` | optional |  |
-| contract_id | `string` | optional |  |
-| template_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| source | `string` | optional |  |
-| target | `string` | optional |  |
-| submitter | `string` | optional |  |
-| reassignment_counter | `uint64` | optional |  |
-| assignment_exclusivity | `google.protobuf.Timestamp` | optional |  |
-| witness_parties | `string` | repeated |  |
-| package_name | `string` | optional |  |
-| offset | `int64` | optional |  |
-| node_id | `int32` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-updateformat"></a>
-**Message `com.daml.ledger.api.v2.UpdateFormat`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| include_transactions | [`com.daml.ledger.api.v2.TransactionFormat`](#type-com-daml-ledger-api-v2-transactionformat) | optional |  |
-| include_reassignments | [`com.daml.ledger.api.v2.EventFormat`](#type-com-daml-ledger-api-v2-eventformat) | optional |  |
-| include_topology_events | [`com.daml.ledger.api.v2.TopologyFormat`](#type-com-daml-ledger-api-v2-topologyformat) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-usermanagementfeature"></a>
-**Message `com.daml.ledger.api.v2.UserManagementFeature`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| supported | `bool` | optional |  |
-| max_rights_per_user | `int32` | optional |  |
-| max_users_page_size | `int32` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-value"></a>
-**Message `com.daml.ledger.api.v2.Value`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 16
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| unit | `google.protobuf.Empty` | optional |  |
-| bool | `bool` | optional |  |
-| int64 | `sint64` | optional |  |
-| date | `int32` | optional |  |
-| timestamp | `sfixed64` | optional |  |
-| numeric | `string` | optional |  |
-| party | `string` | optional |  |
-| text | `string` | optional |  |
-| contract_id | `string` | optional |  |
-| optional | [`com.daml.ledger.api.v2.Optional`](#type-com-daml-ledger-api-v2-optional) | optional |  |
-| list | [`com.daml.ledger.api.v2.List`](#type-com-daml-ledger-api-v2-list) | optional |  |
-| text_map | [`com.daml.ledger.api.v2.TextMap`](#type-com-daml-ledger-api-v2-textmap) | optional |  |
-| gen_map | [`com.daml.ledger.api.v2.GenMap`](#type-com-daml-ledger-api-v2-genmap) | optional |  |
-| record | [`com.daml.ledger.api.v2.Record`](#type-com-daml-ledger-api-v2-record) | optional |  |
-| variant | [`com.daml.ledger.api.v2.Variant`](#type-com-daml-ledger-api-v2-variant) | optional |  |
-| enum | [`com.daml.ledger.api.v2.Enum`](#type-com-daml-ledger-api-v2-enum) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-variant"></a>
-**Message `com.daml.ledger.api.v2.Variant`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto)
-- Fields: 3
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| variant_id | [`com.daml.ledger.api.v2.Identifier`](#type-com-daml-ledger-api-v2-identifier) | optional |  |
-| constructor | `string` | optional |  |
-| value | [`com.daml.ledger.api.v2.Value`](#type-com-daml-ledger-api-v2-value) | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-vettedpackage"></a>
-**Message `com.daml.ledger.api.v2.VettedPackage`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto)
-- Fields: 5
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| package_id | `string` | optional |  |
-| valid_from_inclusive | `google.protobuf.Timestamp` | optional |  |
-| valid_until_exclusive | `google.protobuf.Timestamp` | optional |  |
-| package_name | `string` | optional |  |
-| package_version | `string` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-vettedpackages"></a>
-**Message `com.daml.ledger.api.v2.VettedPackages`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto)
-- Fields: 4
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| packages | [`com.daml.ledger.api.v2.VettedPackage`](#type-com-daml-ledger-api-v2-vettedpackage) | repeated |  |
-| participant_id | `string` | optional |  |
-| synchronizer_id | `string` | optional |  |
-| topology_serial | `uint32` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-wildcardfilter"></a>
-**Message `com.daml.ledger.api.v2.WildcardFilter`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
-- Fields: 1
-
-_No description._
-
-| Field | Type | Label | Description |
-| --- | --- | --- | --- |
-| include_created_event_blob | `bool` | optional |  |
-
-<a id="type-com-daml-ledger-api-v2-cryptokeyformat"></a>
-**Enum `com.daml.ledger.api.v2.CryptoKeyFormat`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| CRYPTO_KEY_FORMAT_UNSPECIFIED | `0` |
-| CRYPTO_KEY_FORMAT_DER | `1` |
-| CRYPTO_KEY_FORMAT_RAW | `2` |
-| CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO | `3` |
-
-<a id="type-com-daml-ledger-api-v2-hashfunction"></a>
-**Enum `com.daml.ledger.api.v2.HashFunction`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| HASH_FUNCTION_SHA256 | `0` |
-
-<a id="type-com-daml-ledger-api-v2-packagestatus"></a>
-**Enum `com.daml.ledger.api.v2.PackageStatus`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| PACKAGE_STATUS_UNSPECIFIED | `0` |
-| PACKAGE_STATUS_REGISTERED | `1` |
-
-<a id="type-com-daml-ledger-api-v2-participantpermission"></a>
-**Enum `com.daml.ledger.api.v2.ParticipantPermission`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| PARTICIPANT_PERMISSION_UNSPECIFIED | `0` |
-| PARTICIPANT_PERMISSION_SUBMISSION | `1` |
-| PARTICIPANT_PERMISSION_CONFIRMATION | `2` |
-| PARTICIPANT_PERMISSION_OBSERVATION | `3` |
-
-<a id="type-com-daml-ledger-api-v2-signatureformat"></a>
-**Enum `com.daml.ledger.api.v2.SignatureFormat`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| SIGNATURE_FORMAT_UNSPECIFIED | `0` |
-| SIGNATURE_FORMAT_RAW | `1` |
-| SIGNATURE_FORMAT_DER | `2` |
-| SIGNATURE_FORMAT_CONCAT | `3` |
-| SIGNATURE_FORMAT_SYMBOLIC | `10000` |
-
-<a id="type-com-daml-ledger-api-v2-signingalgorithmspec"></a>
-**Enum `com.daml.ledger.api.v2.SigningAlgorithmSpec`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| SIGNING_ALGORITHM_SPEC_UNSPECIFIED | `0` |
-| SIGNING_ALGORITHM_SPEC_ED25519 | `1` |
-| SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256 | `2` |
-| SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384 | `3` |
-
-<a id="type-com-daml-ledger-api-v2-signingkeyspec"></a>
-**Enum `com.daml.ledger.api.v2.SigningKeySpec`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| SIGNING_KEY_SPEC_UNSPECIFIED | `0` |
-| SIGNING_KEY_SPEC_EC_CURVE25519 | `1` |
-| SIGNING_KEY_SPEC_EC_P256 | `2` |
-| SIGNING_KEY_SPEC_EC_P384 | `3` |
-| SIGNING_KEY_SPEC_EC_SECP256K1 | `4` |
-
-<a id="type-com-daml-ledger-api-v2-transactionshape"></a>
-**Enum `com.daml.ledger.api.v2.TransactionShape`**
-
-- Source: [community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto](https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto)
-
-_No description._
-
-| Name | Number |
-| --- | --- |
-| TRANSACTION_SHAPE_UNSPECIFIED | `0` |
-| TRANSACTION_SHAPE_ACS_DELTA | `1` |
-| TRANSACTION_SHAPE_LEDGER_EFFECTS | `2` |
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>2</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>6</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>4</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>8</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/commands.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/completion.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>2</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>2</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>4</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/crypto.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>5</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>4</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>4</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/experimental_features.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>2</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/offset_checkpoint.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>4</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_reference.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>10</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>2</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>4</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>4</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/reassignment_commands.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>11</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>5</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/topology_transaction.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/trace_context.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>10</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/transaction_filter.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>5</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>10</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/value.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+  
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</h3>
+      
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">Current source file in the latest published descriptor snapshot.</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Services</dt>
+    <dd>1</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Messages</dt>
+    <dd>7</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Enums</dt>
+    <dd>0</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</a></dd>
+  </div>
+  
+</dl>
+
+  
+  </div>
+  
+  
+</div>
+
+
+
+
+
+## CommandCompletionService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_completion_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>1</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>CommandCompletionService.CompletionStream</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc CommandCompletionService.CompletionStream(com.daml.ledger.api.v2.CompletionStreamRequest) returns (stream com.daml.ledger.api.v2.CompletionStreamResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.CompletionStreamRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.CompletionStreamResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>Yes</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## CommandService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>3</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandservice/submitandwait">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>CommandService.SubmitAndWait</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc CommandService.SubmitAndWait(com.daml.ledger.api.v2.SubmitAndWaitRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>CommandService.SubmitAndWaitForReassignment</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc CommandService.SubmitAndWaitForReassignment(com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>CommandService.SubmitAndWaitForTransaction</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc CommandService.SubmitAndWaitForTransaction(com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest) returns (com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## CommandSubmissionService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/command_submission_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>2</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandsubmissionservice/submit">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>CommandSubmissionService.Submit</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc CommandSubmissionService.Submit(com.daml.ledger.api.v2.SubmitRequest) returns (com.daml.ledger.api.v2.SubmitResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.SubmitRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.SubmitResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>CommandSubmissionService.SubmitReassignment</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc CommandSubmissionService.SubmitReassignment(com.daml.ledger.api.v2.SubmitReassignmentRequest) returns (com.daml.ledger.api.v2.SubmitReassignmentResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.SubmitReassignmentRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.SubmitReassignmentResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## ContractService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/contract_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>1</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/contractservice/getcontract">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>ContractService.GetContract</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.11</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc ContractService.GetContract(com.daml.ledger.api.v2.GetContractRequest) returns (com.daml.ledger.api.v2.GetContractResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetContractRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetContractResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## EventQueryService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/event_query_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>1</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>EventQueryService.GetEventsByContractId</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc EventQueryService.GetEventsByContractId(com.daml.ledger.api.v2.GetEventsByContractIdRequest) returns (com.daml.ledger.api.v2.GetEventsByContractIdResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetEventsByContractIdRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetEventsByContractIdResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## PackageService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/package_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>4</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/getpackage">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PackageService.GetPackage</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PackageService.GetPackage(com.daml.ledger.api.v2.GetPackageRequest) returns (com.daml.ledger.api.v2.GetPackageResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetPackageRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetPackageResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/getpackagestatus">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PackageService.GetPackageStatus</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PackageService.GetPackageStatus(com.daml.ledger.api.v2.GetPackageStatusRequest) returns (com.daml.ledger.api.v2.GetPackageStatusResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetPackageStatusRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetPackageStatusResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/listpackages">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PackageService.ListPackages</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PackageService.ListPackages(com.daml.ledger.api.v2.ListPackagesRequest) returns (com.daml.ledger.api.v2.ListPackagesResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.ListPackagesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.ListPackagesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/packageservice/listvettedpackages">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>PackageService.ListVettedPackages</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc PackageService.ListVettedPackages(com.daml.ledger.api.v2.ListVettedPackagesRequest) returns (com.daml.ledger.api.v2.ListVettedPackagesResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.ListVettedPackagesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.ListVettedPackagesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## StateService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/state_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>4</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getactivecontracts">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>StateService.GetActiveContracts</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc StateService.GetActiveContracts(com.daml.ledger.api.v2.GetActiveContractsRequest) returns (stream com.daml.ledger.api.v2.GetActiveContractsResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetActiveContractsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetActiveContractsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>Yes</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>StateService.GetConnectedSynchronizers</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc StateService.GetConnectedSynchronizers(com.daml.ledger.api.v2.GetConnectedSynchronizersRequest) returns (com.daml.ledger.api.v2.GetConnectedSynchronizersResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>StateService.GetLatestPrunedOffsets</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc StateService.GetLatestPrunedOffsets(com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest) returns (com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/stateservice/getledgerend">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>StateService.GetLedgerEnd</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc StateService.GetLedgerEnd(com.daml.ledger.api.v2.GetLedgerEndRequest) returns (com.daml.ledger.api.v2.GetLedgerEndResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetLedgerEndRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetLedgerEndResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## UpdateService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/update_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>3</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/updateservice/getupdatebyid">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UpdateService.GetUpdateById</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UpdateService.GetUpdateById(com.daml.ledger.api.v2.GetUpdateByIdRequest) returns (com.daml.ledger.api.v2.GetUpdateResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdateByIdRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UpdateService.GetUpdateByOffset</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UpdateService.GetUpdateByOffset(com.daml.ledger.api.v2.GetUpdateByOffsetRequest) returns (com.daml.ledger.api.v2.GetUpdateResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdateByOffsetRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdateResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/updateservice/getupdates">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>UpdateService.GetUpdates</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc UpdateService.GetUpdates(com.daml.ledger.api.v2.GetUpdatesRequest) returns (stream com.daml.ledger.api.v2.GetUpdatesResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdatesRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetUpdatesResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>Yes</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## VersionService
+
+
+
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source file</dt>
+    <dd><a href="https://github.com/DACH-NY/canton/blob/v3.4.11/community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto">community/ledger-api/src/main/protobuf/com/daml/ledger/api/v2/version_service.proto</a></dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>1</dd>
+  </div>
+  
+</dl>
+
+
+<div class="x2mdx-ref-card-grid">
+  
+  
+  <a class="x2mdx-ref-card" href="../operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion">
+  
+    <div class="x2mdx-ref-card-head">
+      <h3>VersionService.GetLedgerApiVersion</h3>
+      
+<div class="x2mdx-ref-badges">
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">gRPC</span>
+  
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.4</span>
+  
+</div>
+
+    </div>
+    
+    <p class="x2mdx-ref-card-summary">rpc VersionService.GetLedgerApiVersion(com.daml.ledger.api.v2.GetLedgerApiVersionRequest) returns (com.daml.ledger.api.v2.GetLedgerApiVersionResponse);</p>
+    
+    
+<dl class="x2mdx-ref-meta-grid">
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Request</dt>
+    <dd>com.daml.ledger.api.v2.GetLedgerApiVersionRequest</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Response</dt>
+    <dd>com.daml.ledger.api.v2.GetLedgerApiVersionResponse</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Client stream</dt>
+    <dd>No</dd>
+  </div>
+  
+  <div class="x2mdx-ref-meta-item">
+    <dt>Server stream</dt>
+    <dd>No</dd>
+  </div>
+  
+</dl>
+
+  
+  </a>
+  
+  
+</div>
+
+
+
+
+
+## Type Inventory
+
+
+These are the package-level message and enum shapes in the publish-version snapshot.
+
+
+
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-activecontract">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ActiveContract</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createdevent">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CreatedEvent</h3>
+    
+    <p class="x2mdx-ref-schema-summary">15 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_views</code>
+      <span class="x2mdx-ref-type-badge">repeated InterfaceView</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signatories</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">observers</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">representative_package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-identifier">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Identifier</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">module_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entity_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-value">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Value</h3>
+    
+    <p class="x2mdx-ref-schema-summary">16 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unit</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">bool</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">int64</code>
+      <span class="x2mdx-ref-type-badge">sint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">date</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">timestamp</code>
+      <span class="x2mdx-ref-type-badge">sfixed64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">numeric</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">optional</code>
+      <span class="x2mdx-ref-type-badge">Optional</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">list</code>
+      <span class="x2mdx-ref-type-badge">List</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">text_map</code>
+      <span class="x2mdx-ref-type-badge">TextMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">gen_map</code>
+      <span class="x2mdx-ref-type-badge">GenMap</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant</code>
+      <span class="x2mdx-ref-type-badge">Variant</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum</code>
+      <span class="x2mdx-ref-type-badge">Enum</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-optional">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Optional</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-list">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.List</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">elements</code>
+      <span class="x2mdx-ref-type-badge">repeated Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TextMap</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-textmap-entry">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TextMap.Entry</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GenMap</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">entries</code>
+      <span class="x2mdx-ref-type-badge">repeated Entry</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-genmap-entry">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GenMap.Entry</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-record">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Record</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">fields</code>
+      <span class="x2mdx-ref-type-badge">repeated RecordField</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-recordfield">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.RecordField</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">label</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-variant">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Variant</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">variant_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">value</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-enum">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Enum</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">enum_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">constructor</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfaceview">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.InterfaceView</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">view_value</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archived">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Archived</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived_event</code>
+      <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-archivedevent">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ArchivedEvent</h3>
+    
+    <p class="x2mdx-ref-schema-summary">7 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assigncommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.AssignCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-assignedevent">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.AssignedEvent</h3>
+    
+    <p class="x2mdx-ref-schema-summary">6 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-command">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Command</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create</code>
+      <span class="x2mdx-ref-type-badge">CreateCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise</code>
+      <span class="x2mdx-ref-type-badge">ExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_by_key</code>
+      <span class="x2mdx-ref-type-badge">ExerciseByKeyCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_and_exercise</code>
+      <span class="x2mdx-ref-type-badge">CreateAndExerciseCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createcommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CreateCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisecommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExerciseCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisebykeycommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExerciseByKeyCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-createandexercisecommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CreateAndExerciseCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">create_arguments</code>
+      <span class="x2mdx-ref-type-badge">Record</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-commands">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Commands</h3>
+    
+    <p class="x2mdx-ref-schema-summary">15 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated Command</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_abs</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">min_ledger_time_rel</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">read_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">disclosed_contracts</code>
+      <span class="x2mdx-ref-type-badge">repeated DisclosedContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id_selection_preference</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prefetch_contract_keys</code>
+      <span class="x2mdx-ref-type-badge">repeated PrefetchContractKey</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-disclosedcontract">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.DisclosedContract</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-prefetchcontractkey">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.PrefetchContractKey</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_key</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completion">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Completion</h3>
+    
+    <p class="x2mdx-ref-schema-summary">11 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">status</code>
+      <span class="x2mdx-ref-type-badge">Status</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">act_as</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">deduplication_duration</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_time</code>
+      <span class="x2mdx-ref-type-badge">SynchronizerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-tracecontext">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TraceContext</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">traceparent</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">tracestate</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-synchronizertime">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SynchronizerTime</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CompletionStreamRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">begin_exclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-completionstreamresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CompletionStreamResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completion</code>
+      <span class="x2mdx-ref-type-badge">Completion</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset_checkpoint</code>
+      <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpoint">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.OffsetCheckpoint</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_times</code>
+      <span class="x2mdx-ref-type-badge">repeated SynchronizerTime</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-created">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Created</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cumulativefilter">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CumulativeFilter</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">wildcard_filter</code>
+      <span class="x2mdx-ref-type-badge">WildcardFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_filter</code>
+      <span class="x2mdx-ref-type-badge">InterfaceFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_filter</code>
+      <span class="x2mdx-ref-type-badge">TemplateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-wildcardfilter">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.WildcardFilter</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-interfacefilter">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.InterfaceFilter</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_interface_view</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-templatefilter">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TemplateFilter</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_created_event_blob</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-event">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Event</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">ArchivedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercised</code>
+      <span class="x2mdx-ref-type-badge">ExercisedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-exercisedevent">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExercisedEvent</h3>
+    
+    <p class="x2mdx-ref-schema-summary">15 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">interface_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">choice_argument</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acting_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">consuming</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">last_descendant_node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">exercise_result</code>
+      <span class="x2mdx-ref-type-badge">Value</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">implemented_interfaces</code>
+      <span class="x2mdx-ref-type-badge">repeated Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">acs_delta</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-eventformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.EventFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_by_party</code>
+      <span class="x2mdx-ref-type-badge">repeated map</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">filters_for_any_party</code>
+      <span class="x2mdx-ref-type-badge">Filters</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">verbose</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-filters">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Filters</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">cumulative</code>
+      <span class="x2mdx-ref-type-badge">repeated CumulativeFilter</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalcommandinspectionservice">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExperimentalCommandInspectionService</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">supported</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalfeatures">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExperimentalFeatures</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">static_time</code>
+      <span class="x2mdx-ref-type-badge">ExperimentalStaticTime</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_inspection_service</code>
+      <span class="x2mdx-ref-type-badge">ExperimentalCommandInspectionService</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalstatictime">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExperimentalStaticTime</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">supported</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-experimentalpartytopologyevents">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ExperimentalPartyTopologyEvents</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">supported</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-featuresdescriptor">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.FeaturesDescriptor</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">experimental</code>
+      <span class="x2mdx-ref-type-badge">ExperimentalFeatures</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_management</code>
+      <span class="x2mdx-ref-type-badge">UserManagementFeature</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_management</code>
+      <span class="x2mdx-ref-type-badge">PartyManagementFeature</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset_checkpoint</code>
+      <span class="x2mdx-ref-type-badge">OffsetCheckpointFeature</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_feature</code>
+      <span class="x2mdx-ref-type-badge">PackageFeature</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-usermanagementfeature">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.UserManagementFeature</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">supported</code>
+      <span class="x2mdx-ref-type-badge">bool</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_rights_per_user</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_users_page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-partymanagementfeature">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.PartyManagementFeature</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_parties_page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-offsetcheckpointfeature">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.OffsetCheckpointFeature</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_offset_checkpoint_emission_delay</code>
+      <span class="x2mdx-ref-type-badge">Duration</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagefeature">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.PackageFeature</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">max_vetted_packages_page_size</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractsrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetActiveContractsRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">active_at_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getactivecontractsresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetActiveContractsResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">active_contract</code>
+      <span class="x2mdx-ref-type-badge">ActiveContract</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">incomplete_unassigned</code>
+      <span class="x2mdx-ref-type-badge">IncompleteUnassigned</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">incomplete_assigned</code>
+      <span class="x2mdx-ref-type-badge">IncompleteAssigned</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteunassigned">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.IncompleteUnassigned</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unassigned_event</code>
+      <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassignedevent">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.UnassignedEvent</h3>
+    
+    <p class="x2mdx-ref-schema-summary">12 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">template_id</code>
+      <span class="x2mdx-ref-type-badge">Identifier</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_counter</code>
+      <span class="x2mdx-ref-type-badge">uint64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assignment_exclusivity</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">witness_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">node_id</code>
+      <span class="x2mdx-ref-type-badge">int32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-incompleteassigned">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.IncompleteAssigned</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assigned_event</code>
+      <span class="x2mdx-ref-type-badge">AssignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetConnectedSynchronizersRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">identity_provider_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">connected_synchronizers</code>
+      <span class="x2mdx-ref-type-badge">repeated ConnectedSynchronizer</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getconnectedsynchronizersresponse-connectedsynchronizer">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetConnectedSynchronizersResponse.ConnectedSynchronizer</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_alias</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">permission</code>
+      <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantpermission">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ParticipantPermission</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>PARTICIPANT_PERMISSION_UNSPECIFIED</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_SUBMISSION</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_CONFIRMATION</code></li>
+    
+    <li><code>PARTICIPANT_PERMISSION_OBSERVATION</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetContractRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">querying_parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getcontractresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetContractResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created_event</code>
+      <span class="x2mdx-ref-type-badge">CreatedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetEventsByContractIdRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-geteventsbycontractidresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetEventsByContractIdResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">created</code>
+      <span class="x2mdx-ref-type-badge">Created</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archived</code>
+      <span class="x2mdx-ref-type-badge">Archived</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetLatestPrunedOffsetsRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getlatestprunedoffsetsresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetLatestPrunedOffsetsResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_pruned_up_to_inclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">all_divulged_contracts_pruned_up_to_inclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetLedgerApiVersionRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerapiversionresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetLedgerApiVersionResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">features</code>
+      <span class="x2mdx-ref-type-badge">FeaturesDescriptor</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetLedgerEndRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getledgerendresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetLedgerEndResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagerequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetPackageRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackageresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetPackageResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hash_function</code>
+      <span class="x2mdx-ref-type-badge">HashFunction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">archive_payload</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">hash</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-hashfunction">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.HashFunction</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>HASH_FUNCTION_SHA256</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetPackageStatusRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getpackagestatusresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetPackageStatusResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_status</code>
+      <span class="x2mdx-ref-type-badge">PackageStatus</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagestatus">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.PackageStatus</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>PACKAGE_STATUS_UNSPECIFIED</code></li>
+    
+    <li><code>PACKAGE_STATUS_REGISTERED</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyidrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetUpdateByIdRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_format</code>
+      <span class="x2mdx-ref-type-badge">UpdateFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-updateformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.UpdateFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_transactions</code>
+      <span class="x2mdx-ref-type-badge">TransactionFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_reassignments</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_topology_events</code>
+      <span class="x2mdx-ref-type-badge">TopologyFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TransactionFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_shape</code>
+      <span class="x2mdx-ref-type-badge">TransactionShape</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transactionshape">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TransactionShape</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>TRANSACTION_SHAPE_UNSPECIFIED</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_ACS_DELTA</code></li>
+    
+    <li><code>TRANSACTION_SHAPE_LEDGER_EFFECTS</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TopologyFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">include_participant_authorization_events</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationTopologyFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationtopologyformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ParticipantAuthorizationTopologyFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">parties</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatebyoffsetrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetUpdateByOffsetRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_format</code>
+      <span class="x2mdx-ref-type-badge">UpdateFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdateresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetUpdateResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment</code>
+      <span class="x2mdx-ref-type-badge">Reassignment</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_transaction</code>
+      <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-transaction">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Transaction</h3>
+    
+    <p class="x2mdx-ref-schema-summary">10 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">effective_at</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated Event</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">external_transaction_hash</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignment">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Reassignment</h3>
+    
+    <p class="x2mdx-ref-schema-summary">8 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated ReassignmentEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentevent">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ReassignmentEvent</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unassigned</code>
+      <span class="x2mdx-ref-type-badge">UnassignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assigned</code>
+      <span class="x2mdx-ref-type-badge">AssignedEvent</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologytransaction">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TopologyTransaction</h3>
+    
+    <p class="x2mdx-ref-schema-summary">6 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">record_time</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">events</code>
+      <span class="x2mdx-ref-type-badge">repeated TopologyEvent</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">trace_context</code>
+      <span class="x2mdx-ref-type-badge">TraceContext</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologyevent">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TopologyEvent</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_changed</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationChanged</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_revoked</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationRevoked</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_authorization_added</code>
+      <span class="x2mdx-ref-type-badge">ParticipantAuthorizationAdded</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationchanged">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ParticipantAuthorizationChanged</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_permission</code>
+      <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationrevoked">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ParticipantAuthorizationRevoked</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-participantauthorizationadded">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ParticipantAuthorizationAdded</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">party_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_permission</code>
+      <span class="x2mdx-ref-type-badge">ParticipantPermission</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetUpdatesRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">begin_exclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">end_inclusive</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_format</code>
+      <span class="x2mdx-ref-type-badge">UpdateFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-getupdatesresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.GetUpdatesResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment</code>
+      <span class="x2mdx-ref-type-badge">Reassignment</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">offset_checkpoint</code>
+      <span class="x2mdx-ref-type-badge">OffsetCheckpoint</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_transaction</code>
+      <span class="x2mdx-ref-type-badge">TopologyTransaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ListPackagesRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listpackagesresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ListPackagesResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_ids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ListVettedPackagesRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_metadata_filter</code>
+      <span class="x2mdx-ref-type-badge">PackageMetadataFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_state_filter</code>
+      <span class="x2mdx-ref-type-badge">TopologyStateFilter</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">page_size</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagemetadatafilter">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.PackageMetadataFilter</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_ids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name_prefixes</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-topologystatefilter">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.TopologyStateFilter</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_ids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_ids</code>
+      <span class="x2mdx-ref-type-badge">repeated string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-listvettedpackagesresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ListVettedPackagesResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">vetted_packages</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackages</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">next_page_token</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackages">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.VettedPackages</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">packages</code>
+      <span class="x2mdx-ref-type-badge">repeated VettedPackage</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">participant_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">synchronizer_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">topology_serial</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-vettedpackage">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.VettedPackage</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">valid_from_inclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">valid_until_exclusive</code>
+      <span class="x2mdx-ref-type-badge">Timestamp</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-packagereference">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.PackageReference</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_name</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">package_version</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-priortopologyserial">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.PriorTopologySerial</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">prior</code>
+      <span class="x2mdx-ref-type-badge">uint32</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">no_prior</code>
+      <span class="x2mdx-ref-type-badge">Empty</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ReassignmentCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">unassign_command</code>
+      <span class="x2mdx-ref-type-badge">UnassignCommand</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">assign_command</code>
+      <span class="x2mdx-ref-type-badge">AssignCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-unassigncommand">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.UnassignCommand</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">contract_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">source</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">target</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-reassignmentcommands">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.ReassignmentCommands</h3>
+    
+    <p class="x2mdx-ref-schema-summary">6 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">workflow_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">user_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">command_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submitter</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">submission_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">repeated ReassignmentCommand</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signature">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.Signature</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">format</code>
+      <span class="x2mdx-ref-type-badge">SignatureFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signature</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signed_by</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">signing_algorithm_spec</code>
+      <span class="x2mdx-ref-type-badge">SigningAlgorithmSpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signatureformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SignatureFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNATURE_FORMAT_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_RAW</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_DER</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_CONCAT</code></li>
+    
+    <li><code>SIGNATURE_FORMAT_SYMBOLIC</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingalgorithmspec">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SigningAlgorithmSpec</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_ED25519</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_256</code></li>
+    
+    <li><code>SIGNING_ALGORITHM_SPEC_EC_DSA_SHA_384</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingpublickey">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SigningPublicKey</h3>
+    
+    <p class="x2mdx-ref-schema-summary">3 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">format</code>
+      <span class="x2mdx-ref-type-badge">CryptoKeyFormat</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key_data</code>
+      <span class="x2mdx-ref-type-badge">bytes</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">key_spec</code>
+      <span class="x2mdx-ref-type-badge">SigningKeySpec</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-cryptokeyformat">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.CryptoKeyFormat</h3>
+    
+    <p class="x2mdx-ref-schema-summary">4 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>CRYPTO_KEY_FORMAT_UNSPECIFIED</code></li>
+    
+    <li><code>CRYPTO_KEY_FORMAT_DER</code></li>
+    
+    <li><code>CRYPTO_KEY_FORMAT_RAW</code></li>
+    
+    <li><code>CRYPTO_KEY_FORMAT_DER_X509_SUBJECT_PUBLIC_KEY_INFO</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-signingkeyspec">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SigningKeySpec</h3>
+    
+    <p class="x2mdx-ref-schema-summary">5 values</p>
+    
+  </div>
+  
+  
+  
+  <ul class="x2mdx-ref-enum-list">
+    
+    <li><code>SIGNING_KEY_SPEC_UNSPECIFIED</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_CURVE25519</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_P256</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_P384</code></li>
+    
+    <li><code>SIGNING_KEY_SPEC_EC_SECP256K1</code></li>
+    
+  </ul>
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_commands</code>
+      <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">event_format</code>
+      <span class="x2mdx-ref-type-badge">EventFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitforreassignmentresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SubmitAndWaitForReassignmentResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment</code>
+      <span class="x2mdx-ref-type-badge">Reassignment</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SubmitAndWaitForTransactionRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">Commands</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction_format</code>
+      <span class="x2mdx-ref-type-badge">TransactionFormat</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitfortransactionresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SubmitAndWaitForTransactionResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">transaction</code>
+      <span class="x2mdx-ref-type-badge">Transaction</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SubmitAndWaitRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">Commands</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitandwaitresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SubmitAndWaitResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">2 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">update_id</code>
+      <span class="x2mdx-ref-type-badge">string</span>
+      
+    </div>
+    
+  </div>
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">completion_offset</code>
+      <span class="x2mdx-ref-type-badge">int64</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SubmitReassignmentRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">reassignment_commands</code>
+      <span class="x2mdx-ref-type-badge">ReassignmentCommands</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitreassignmentresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SubmitReassignmentResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitrequest">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SubmitRequest</h3>
+    
+    <p class="x2mdx-ref-schema-summary">1 fields</p>
+    
+  </div>
+  
+  
+<div class="x2mdx-ref-fields">
+  
+  <div class="x2mdx-ref-field-row">
+    <div class="x2mdx-ref-field-main">
+      <code class="x2mdx-ref-field-name">commands</code>
+      <span class="x2mdx-ref-type-badge">Commands</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+  
+  
+</div>
+
+<div class="x2mdx-ref-schema" id="schema-com-daml-ledger-api-v2-submitresponse">
+  <div class="x2mdx-ref-schema-head">
+    <h3>com.daml.ledger.api.v2.SubmitResponse</h3>
+    
+    <p class="x2mdx-ref-schema-summary">0 fields</p>
+    
+  </div>
+  
+  
+  
+  
+</div>

--- a/docs-main/reference/wallet-gateway-json-rpc/index.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/index.mdx
@@ -32,7 +32,7 @@ description: "Versioned OpenRPC reference docs."
   
   <div class="x2mdx-ref-meta-item">
     <dt>Versions compared</dt>
-    <dd>0.23.1, 0.24.0, 0.25.0</dd>
+    <dd>0.24.0, 0.25.0</dd>
   </div>
   
   <div class="x2mdx-ref-meta-item">
@@ -69,7 +69,7 @@ Choose a spec page to browse its methods, then drill into operation pages for re
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -111,7 +111,7 @@ Choose a spec page to browse its methods, then drill into operation pages for re
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -153,7 +153,7 @@ Choose a spec page to browse its methods, then drill into operation pages for re
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -195,7 +195,7 @@ Choose a spec page to browse its methods, then drill into operation pages for re
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/accountschanged.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/accountschanged.mdx
@@ -45,7 +45,7 @@ title: "accountsChanged"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/connect.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/connect.mdx
@@ -45,7 +45,7 @@ title: "connect"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/disconnect.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/disconnect.mdx
@@ -45,7 +45,7 @@ title: "disconnect"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/getactivenetwork.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/getactivenetwork.mdx
@@ -45,7 +45,7 @@ title: "getActiveNetwork"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/getprimaryaccount.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/getprimaryaccount.mdx
@@ -45,7 +45,7 @@ title: "getPrimaryAccount"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/ledgerapi.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/ledgerapi.mdx
@@ -45,7 +45,7 @@ title: "ledgerApi"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/listaccounts.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/listaccounts.mdx
@@ -45,7 +45,7 @@ title: "listAccounts"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/prepareexecute.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/prepareexecute.mdx
@@ -45,7 +45,7 @@ title: "prepareExecute"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/prepareexecuteandwait.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/prepareexecuteandwait.mdx
@@ -45,7 +45,7 @@ title: "prepareExecuteAndWait"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/signmessage.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/signmessage.mdx
@@ -45,7 +45,7 @@ title: "signMessage"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/status.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/status.mdx
@@ -45,7 +45,7 @@ title: "status"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/txchanged.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-api/txchanged.mdx
@@ -45,7 +45,7 @@ title: "txChanged"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/accountschanged.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/accountschanged.mdx
@@ -45,7 +45,7 @@ title: "accountsChanged"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/connect.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/connect.mdx
@@ -45,7 +45,7 @@ title: "connect"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/connected.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/connected.mdx
@@ -45,7 +45,7 @@ title: "connected"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/disconnect.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/disconnect.mdx
@@ -45,7 +45,7 @@ title: "disconnect"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/getactivenetwork.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/getactivenetwork.mdx
@@ -45,7 +45,7 @@ title: "getActiveNetwork"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/getprimaryaccount.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/getprimaryaccount.mdx
@@ -45,7 +45,7 @@ title: "getPrimaryAccount"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/ledgerapi.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/ledgerapi.mdx
@@ -45,7 +45,7 @@ title: "ledgerApi"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/listaccounts.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/listaccounts.mdx
@@ -45,7 +45,7 @@ title: "listAccounts"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/onstatuschanged.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/onstatuschanged.mdx
@@ -45,7 +45,7 @@ title: "onStatusChanged"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/prepareexecute.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/prepareexecute.mdx
@@ -45,7 +45,7 @@ title: "prepareExecute"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/signmessage.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/signmessage.mdx
@@ -45,7 +45,7 @@ title: "signMessage"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/status.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/status.mdx
@@ -45,7 +45,7 @@ title: "status"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/txchanged.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/dapp-remote-api/txchanged.mdx
@@ -45,7 +45,7 @@ title: "txChanged"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/createkey.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/createkey.mdx
@@ -45,7 +45,7 @@ title: "createKey"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/getconfiguration.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/getconfiguration.mdx
@@ -45,7 +45,7 @@ title: "getConfiguration"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/getkeys.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/getkeys.mdx
@@ -45,7 +45,7 @@ title: "getKeys"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/gettransaction.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/gettransaction.mdx
@@ -45,7 +45,7 @@ title: "getTransaction"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/gettransactions.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/gettransactions.mdx
@@ -45,7 +45,7 @@ title: "getTransactions"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/setconfiguration.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/setconfiguration.mdx
@@ -45,7 +45,7 @@ title: "setConfiguration"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/signtransaction.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/signtransaction.mdx
@@ -45,7 +45,7 @@ title: "signTransaction"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/subscribetransactions.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/signing-api/subscribetransactions.mdx
@@ -45,7 +45,7 @@ title: "subscribeTransactions"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/addidp.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/addidp.mdx
@@ -45,7 +45,7 @@ title: "addIdp"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/addnetwork.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/addnetwork.mdx
@@ -45,7 +45,7 @@ title: "addNetwork"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/addsession.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/addsession.mdx
@@ -45,7 +45,7 @@ title: "addSession"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/allocatepartyforwallet.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/allocatepartyforwallet.mdx
@@ -45,7 +45,7 @@ title: "allocatePartyForWallet"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/createwallet.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/createwallet.mdx
@@ -45,7 +45,7 @@ title: "createWallet"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/deletetransaction.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/deletetransaction.mdx
@@ -45,7 +45,7 @@ title: "deleteTransaction"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/execute.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/execute.mdx
@@ -45,7 +45,7 @@ title: "execute"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/gettransaction.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/gettransaction.mdx
@@ -45,7 +45,7 @@ title: "getTransaction"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/getuser.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/getuser.mdx
@@ -45,7 +45,7 @@ title: "getUser"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/iswalletsyncneeded.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/iswalletsyncneeded.mdx
@@ -45,7 +45,7 @@ title: "isWalletSyncNeeded"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/listidps.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/listidps.mdx
@@ -45,7 +45,7 @@ title: "listIdps"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/listnetworks.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/listnetworks.mdx
@@ -45,7 +45,7 @@ title: "listNetworks"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/listsessions.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/listsessions.mdx
@@ -45,7 +45,7 @@ title: "listSessions"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/listtransactions.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/listtransactions.mdx
@@ -45,7 +45,7 @@ title: "listTransactions"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/listwallets.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/listwallets.mdx
@@ -45,7 +45,7 @@ title: "listWallets"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/removeidp.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/removeidp.mdx
@@ -45,7 +45,7 @@ title: "removeIdp"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/removenetwork.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/removenetwork.mdx
@@ -45,7 +45,7 @@ title: "removeNetwork"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/removesession.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/removesession.mdx
@@ -45,7 +45,7 @@ title: "removeSession"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/removewallet.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/removewallet.mdx
@@ -45,7 +45,7 @@ title: "removeWallet"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/setprimarywallet.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/setprimarywallet.mdx
@@ -45,7 +45,7 @@ title: "setPrimaryWallet"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/sign.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/sign.mdx
@@ -45,7 +45,7 @@ title: "sign"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/syncwallets.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/operations/user-api/syncwallets.mdx
@@ -45,7 +45,7 @@ title: "syncWallets"
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-api.mdx
@@ -20,7 +20,7 @@ description: "An OpenRPC specification for the dapp to interact with a Wallet Pr
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -71,7 +71,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -106,7 +106,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -143,7 +143,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -180,7 +180,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -217,7 +217,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -254,7 +254,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -291,7 +291,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -328,7 +328,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -365,7 +365,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -402,7 +402,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -439,7 +439,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -476,7 +476,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-remote-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/dapp-remote-api.mdx
@@ -20,7 +20,7 @@ description: "An OpenRPC specification for remotely hosted Wallet Providers. Due
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -71,7 +71,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -106,7 +106,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -143,7 +143,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -180,7 +180,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -217,7 +217,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -254,7 +254,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -291,7 +291,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -328,7 +328,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -363,7 +363,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -398,7 +398,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -435,7 +435,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -472,7 +472,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -509,7 +509,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/signing-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/signing-api.mdx
@@ -20,7 +20,7 @@ description: "An OpenRPC specification for the Signing API which allows the Wall
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -71,7 +71,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -108,7 +108,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -143,7 +143,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -180,7 +180,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -217,7 +217,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -254,7 +254,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -291,7 +291,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -328,7 +328,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/docs-main/reference/wallet-gateway-json-rpc/specs/user-api.mdx
+++ b/docs-main/reference/wallet-gateway-json-rpc/specs/user-api.mdx
@@ -20,7 +20,7 @@ description: "An OpenRPC specification for the user to interact with the Wallet 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -71,7 +71,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -108,7 +108,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -145,7 +145,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -182,7 +182,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -219,7 +219,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -256,7 +256,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -293,7 +293,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -330,7 +330,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -365,7 +365,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -402,7 +402,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -439,7 +439,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -474,7 +474,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -509,7 +509,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -544,7 +544,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -579,7 +579,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -616,7 +616,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -653,7 +653,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -690,7 +690,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -727,7 +727,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -764,7 +764,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -801,7 +801,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 
@@ -838,7 +838,7 @@ Method pages are the primary reference surface. This spec page stays focused on 
   
   <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">JSON-RPC</span>
   
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.23.1</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 0.24.0</span>
   
 </div>
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "generate:canton-protobuf-history": "python3 scripts/generate_canton_protobuf_history.py",
     "generate:wallet-gateway-openrpc-reference": "python3 scripts/generate_wallet_gateway_openrpc_reference.py",
     "generate:splice-mintlify-openapi": "python3 scripts/generate_splice_mintlify_openapi.py",
+    "validate:splice-mintlify-openapi-nav": "python3 scripts/validate_splice_mintlify_openapi_nav.py",
     "generate:typescript-bindings-reference": "python3 scripts/generate_typescript_bindings_reference.py"
   },
   "dependencies": {

--- a/scripts/generate_all_reference_docs.py
+++ b/scripts/generate_all_reference_docs.py
@@ -15,6 +15,7 @@ from typing import Any, Literal
 
 from docs_env import ensure_repo_direnv, repo_direnv_command
 import reference_nav
+from validate_splice_mintlify_openapi_nav import validate_splice_nav
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -284,6 +285,7 @@ def consolidate_docs_json() -> None:
         docs_json_path=DOCS_JSON_PATH,
         dropdown_label=API_REFERENCE_DROPDOWN,
     )
+    validate_splice_nav(docs_json_path=DOCS_JSON_PATH)
 
 
 def main() -> int:

--- a/scripts/generate_json_api_reference.py
+++ b/scripts/generate_json_api_reference.py
@@ -131,7 +131,8 @@ def update_docs_navigation(
 
     group = _find_group(parent_pages, group_label)
     if group is None:
-        raise ValueError(f"Group not found in docs.json: {group_label}")
+        group = {}
+        parent_pages.append(group)
 
     group.clear()
     group["group"] = group_label

--- a/scripts/generate_splice_mintlify_openapi.py
+++ b/scripts/generate_splice_mintlify_openapi.py
@@ -13,6 +13,8 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from validate_splice_mintlify_openapi_nav import validate_splice_nav
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 USER_AGENT = "digital-asset-docs-mintlify-openapi/1.0"
 DEFAULT_SOURCE_CONFIG = REPO_ROOT / "config" / "mintlify-openapi" / "splice-openapi" / "source-artifacts.json"
@@ -468,6 +470,10 @@ def main() -> int:
         docs_json_path=docs_json_path,
         source_config=source_config,
         families=families,
+    )
+    validate_splice_nav(
+        source_config_path=Path(args.source_config).resolve(),
+        docs_json_path=docs_json_path,
     )
     print(f"Updated docs navigation: {docs_json_path}")
     return 0

--- a/scripts/reference_nav.py
+++ b/scripts/reference_nav.py
@@ -96,80 +96,93 @@ def _append_unique(items: list[str], values: list[str]) -> None:
             items.append(value)
 
 
-def _absorb_known_item(item: Any, collected: dict[str, dict[str, Any]]) -> None:
+def _absorb_known_item(item: Any, collected: dict[str, dict[str, Any]]) -> bool:
     if isinstance(item, str):
         if item == OPENAPI_PAGE_REF:
             _merge_group_entries(_upsert_group(collected, OPENAPI_GROUP), {"group": OPENAPI_GROUP, "pages": [item]})
+            return True
         elif item == ASYNCAPI_PAGE_REF:
             _merge_group_entries(_upsert_group(collected, ASYNCAPI_GROUP), {"group": ASYNCAPI_GROUP, "pages": [item]})
+            return True
         elif item == GRPC_OVERVIEW_PAGE_REF:
             _merge_group_entries(_upsert_group(collected, GRPC_GROUP), {"group": GRPC_GROUP, "pages": [item]})
+            return True
         elif item.startswith(GRPC_PACKAGES_PREFIX):
             _merge_group_entries(
                 _upsert_group(collected, GRPC_GROUP),
                 {"group": GRPC_GROUP, "pages": [{"group": "Packages", "pages": [item]}]},
             )
+            return True
         elif item == PROTOBUF_OVERVIEW_PAGE_REF:
             _merge_group_entries(_upsert_group(collected, PROTOBUF_GROUP), {"group": PROTOBUF_GROUP, "pages": [item]})
+            return True
         elif item == BINDINGS_OVERVIEW_PAGE_REF:
             _merge_group_entries(_upsert_group(collected, BINDINGS_GROUP), {"group": BINDINGS_GROUP, "pages": [item]})
+            return True
         elif item.startswith(SCALADOC_PREFIX):
             _merge_group_entries(
                 _upsert_group(collected, BINDINGS_GROUP),
                 {"group": BINDINGS_GROUP, "pages": [{"group": "Scaladocs", "pages": [item]}]},
             )
+            return True
         elif item.startswith(JAVADOC_PREFIX):
             _merge_group_entries(
                 _upsert_group(collected, BINDINGS_GROUP),
                 {"group": BINDINGS_GROUP, "pages": [{"group": "Javadocs", "pages": [item]}]},
             )
-        return
+            return True
+        return False
 
     if not isinstance(item, dict):
-        return
+        return False
 
     label = item.get("group")
     if not isinstance(label, str) or not label:
-        return
+        return False
 
     if label == LEDGER_API_PARENT_GROUP:
+        absorbed = False
         nested_pages = item.get("pages")
         if isinstance(nested_pages, list):
             for nested in nested_pages:
-                _absorb_known_item(nested, collected)
-        return
+                absorbed = _absorb_known_item(nested, collected) or absorbed
+        return absorbed
 
     if label == LEGACY_ENDPOINTS_GROUP:
+        absorbed = False
         pages = item.get("pages")
         if isinstance(pages, list):
             for page_ref in pages:
-                _absorb_known_item(page_ref, collected)
-        return
+                absorbed = _absorb_known_item(page_ref, collected) or absorbed
+        return absorbed
 
     if label in {OPENAPI_GROUP, ASYNCAPI_GROUP, GRPC_GROUP}:
         _merge_group_entries(_upsert_group(collected, label), item)
-        return
+        return True
 
     if label in PROTOBUF_GROUP_ALIASES:
         normalized = {"group": PROTOBUF_GROUP, "pages": []}
         _merge_group_entries(normalized, item)
         _merge_group_entries(_upsert_group(collected, PROTOBUF_GROUP), normalized)
-        return
+        return True
 
     if label in BINDINGS_GROUP_ALIASES:
         normalized = {"group": BINDINGS_GROUP, "pages": []}
         _merge_group_entries(normalized, item)
         _merge_group_entries(_upsert_group(collected, BINDINGS_GROUP), normalized)
-        return
+        return True
 
     if label == "Packages":
         pages = item.get("pages")
         if isinstance(pages, list) and all(isinstance(page, str) and page.startswith(GRPC_PACKAGES_PREFIX) for page in pages):
             _merge_group_entries(_upsert_group(collected, GRPC_GROUP), {"group": GRPC_GROUP, "pages": [item]})
-            return
+            return True
 
     if label in LANGUAGE_GROUPS:
         _merge_group_entries(_upsert_group(collected, BINDINGS_GROUP), {"group": BINDINGS_GROUP, "pages": [item]})
+        return True
+
+    return False
 
 
 def regroup_ledger_api_nav(*, docs_json_path: Path, dropdown_label: str) -> None:
@@ -201,10 +214,20 @@ def regroup_ledger_api_nav(*, docs_json_path: Path, dropdown_label: str) -> None
         *BINDINGS_GROUP_ALIASES,
     }
     collected: dict[str, dict[str, Any]] = {}
+    preserved_ledger_children: list[Any] = []
     remaining: list[Any] = []
     insert_at: int | None = None
 
     for index, item in enumerate(pages):
+        if isinstance(item, dict) and item.get("group") == LEDGER_API_PARENT_GROUP:
+            if insert_at is None:
+                insert_at = index
+            nested_pages = item.get("pages")
+            if isinstance(nested_pages, list):
+                for nested in nested_pages:
+                    if not _absorb_known_item(nested, collected):
+                        preserved_ledger_children.append(nested)
+            continue
         if isinstance(item, dict) and item.get("group") in known_labels:
             if insert_at is None:
                 insert_at = index
@@ -217,7 +240,10 @@ def regroup_ledger_api_nav(*, docs_json_path: Path, dropdown_label: str) -> None
 
     parent_group = {
         "group": LEDGER_API_PARENT_GROUP,
-        "pages": [collected[label] for label in LEDGER_API_CHILD_ORDER if label in collected],
+        "pages": [
+            *preserved_ledger_children,
+            *[collected[label] for label in LEDGER_API_CHILD_ORDER if label in collected],
+        ],
     }
 
     if insert_at is None:

--- a/scripts/validate_splice_mintlify_openapi_nav.py
+++ b/scripts/validate_splice_mintlify_openapi_nav.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SOURCE_CONFIG = REPO_ROOT / "config" / "mintlify-openapi" / "splice-openapi" / "source-artifacts.json"
+DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def navigation_dropdown_pages(docs: dict[str, Any], dropdown_label: str, docs_json_path: Path) -> list[Any]:
+    navigation = docs.get("navigation")
+    if not isinstance(navigation, dict):
+        raise ValueError(f"docs.json missing navigation object: {docs_json_path}")
+    dropdowns = navigation.get("dropdowns")
+    if not isinstance(dropdowns, list):
+        raise ValueError(f"docs.json navigation.dropdowns must be a list: {docs_json_path}")
+    dropdown = next(
+        (item for item in dropdowns if isinstance(item, dict) and item.get("dropdown") == dropdown_label),
+        None,
+    )
+    if dropdown is None:
+        raise ValueError(f"Dropdown not found in docs.json: {dropdown_label}")
+    pages = dropdown.get("pages")
+    if not isinstance(pages, list):
+        raise ValueError(f"Dropdown does not expose a pages list: {dropdown_label}")
+    return pages
+
+
+def find_group(items: list[Any], label: str) -> dict[str, Any] | None:
+    for item in items:
+        if isinstance(item, dict) and item.get("group") == label:
+            return item
+    return None
+
+
+def enabled_specs(source_config: dict[str, Any]) -> set[str] | None:
+    enabled = source_config.get("enabled_nav_specs")
+    if enabled is None:
+        return None
+    if not isinstance(enabled, list):
+        raise ValueError("enabled_nav_specs must be a list when set")
+    specs: set[str] = set()
+    for item in enabled:
+        if not isinstance(item, str) or not item:
+            raise ValueError("enabled_nav_specs entries must be non-empty strings")
+        specs.add(item)
+    return specs
+
+
+def expected_openapi_entries(source_config: dict[str, Any]) -> list[tuple[str, str]]:
+    selected = enabled_specs(source_config)
+    families = source_config.get("families")
+    if not isinstance(families, list):
+        raise ValueError("Source config must define families")
+    entries: list[tuple[str, str]] = []
+    for family in families:
+        if not isinstance(family, dict):
+            raise ValueError("Each source config family must be an object")
+        specs = family.get("specs")
+        if not isinstance(specs, list):
+            raise ValueError("Each source config family must define specs")
+        for spec in specs:
+            if not isinstance(spec, dict):
+                raise ValueError("Each source config spec must be an object")
+            filename = spec.get("filename")
+            source = spec.get("source")
+            directory = spec.get("directory")
+            if not all(isinstance(item, str) and item for item in (filename, source, directory)):
+                raise ValueError("Each source config spec must define filename, source, and directory")
+            if selected is None or filename in selected:
+                entries.append((source, directory))
+    return entries
+
+
+def collect_openapi_entries(node: Any, entries: set[tuple[str, str]]) -> None:
+    if isinstance(node, list):
+        for item in node:
+            collect_openapi_entries(item, entries)
+        return
+    if not isinstance(node, dict):
+        return
+    openapi = node.get("openapi")
+    if isinstance(openapi, dict):
+        source = openapi.get("source")
+        directory = openapi.get("directory")
+        if isinstance(source, str) and isinstance(directory, str):
+            entries.add((source, directory))
+    pages = node.get("pages")
+    if isinstance(pages, list):
+        collect_openapi_entries(pages, entries)
+
+
+def validate_splice_nav(*, source_config_path: Path = DEFAULT_SOURCE_CONFIG, docs_json_path: Path = DEFAULT_DOCS_JSON) -> None:
+    source_config = load_json(source_config_path)
+    docs = load_json(docs_json_path)
+    dropdown_label = source_config.get("nav_dropdown") or "API Reference"
+    if not isinstance(dropdown_label, str):
+        raise ValueError("nav_dropdown must be a string")
+    top_level_group_label = source_config.get("top_level_group_label") or "Splice APIs"
+    if not isinstance(top_level_group_label, str):
+        raise ValueError("top_level_group_label must be a string")
+
+    pages = navigation_dropdown_pages(docs, dropdown_label, docs_json_path)
+    top_group = find_group(pages, top_level_group_label)
+    if top_group is None:
+        raise ValueError(f"Configured Splice OpenAPI nav group is missing: {top_level_group_label}")
+
+    actual_entries: set[tuple[str, str]] = set()
+    collect_openapi_entries(top_group, actual_entries)
+    missing = [entry for entry in expected_openapi_entries(source_config) if entry not in actual_entries]
+    if missing:
+        details = "\n".join(f"- source={source} directory={directory}" for source, directory in missing)
+        raise ValueError(f"Splice OpenAPI nav is missing configured entries:\n{details}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate configured Splice OpenAPI specs are wired into docs.json.")
+    parser.add_argument("--source-config", default=str(DEFAULT_SOURCE_CONFIG))
+    parser.add_argument("--docs-json", default=str(DEFAULT_DOCS_JSON))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    validate_splice_nav(
+        source_config_path=Path(args.source_config).resolve(),
+        docs_json_path=Path(args.docs_json).resolve(),
+    )
+    print("Validated Splice OpenAPI navigation.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Restores:
1. splice APIs
2. ledger API HTTP JSON 
3. some gRPC
## Summary

- restores the generated `API Reference -> Splice APIs` Mintlify OpenAPI nav from the checked-in Splice source config
- runs the full `scripts/generate_all_reference_docs.py` regeneration from current `origin/main`
- makes generated nav consolidation preserve manual Ledger API children such as the PQS SQL reference
- adds a Splice OpenAPI nav validator and calls it from the Splice wrapper plus the all-reference-docs consolidation path

## Validation

- `direnv exec /Users/danielporter/control/.worktrees/docs-restore-splice-api-nav python3 scripts/generate_all_reference_docs.py`
- `direnv exec /Users/danielporter/control/.worktrees/docs-restore-splice-api-nav python3 scripts/validate_splice_mintlify_openapi_nav.py`
- `python3 -m py_compile scripts/generate_all_reference_docs.py scripts/generate_json_api_reference.py scripts/generate_splice_mintlify_openapi.py scripts/reference_nav.py scripts/validate_splice_mintlify_openapi_nav.py`