### PR TITLE
Rename Java bindings nav label

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1785,7 +1785,7 @@
                 ]
               },
               {
-                "group": "Ledger API Java Bindings",
+                "group": "Java Bindings",
                 "pages": [
                   {
                     "group": "Scaladocs",

--- a/scripts/reference_nav.py
+++ b/scripts/reference_nav.py
@@ -12,8 +12,8 @@ ASYNCAPI_GROUP = "AsyncAPI"
 GRPC_GROUP = "gRPC Ledger API Reference"
 PROTOBUF_GROUP = "Protobufs"
 PROTOBUF_GROUP_ALIASES = {"Canton Protobuf", "Canton Protobuf History", PROTOBUF_GROUP}
-BINDINGS_GROUP = "Ledger API Java Bindings"
-BINDINGS_GROUP_ALIASES = {BINDINGS_GROUP, "Ledger API JVM Bindings"}
+BINDINGS_GROUP = "Java Bindings"
+BINDINGS_GROUP_ALIASES = {BINDINGS_GROUP, "Ledger API Java Bindings", "Ledger API JVM Bindings"}
 LEDGER_API_CHILD_ORDER = [
     OPENAPI_GROUP,
     ASYNCAPI_GROUP,


### PR DESCRIPTION
## Summary
- rename the Ledger API Java Bindings nav group to Java Bindings
- keep the old longer group name as a nav-normalization alias for regeneration compatibility

## Validation
- direnv exec . python script confirmed docs-main/docs.json parses and reference_nav.regroup_ledger_api_nav keeps the Java Bindings label
- git diff --check

Closes #262