### PR TITLE
Raise Mintlify dev Node heap in Nix shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,7 @@ This repo manages the contents of the docs.canton.network website.
 ### Running the dev server
 
 ```bash
-# Install Mintlify CLI (first time only)
-npm i -g mintlify
-
-# Start local dev server
+direnv allow
 cd docs-main && mintlify dev
 ```
 
@@ -61,7 +58,7 @@ Then run:
 
 ```bash
 direnv allow
-mintlify dev
+cd docs-main && mintlify dev
 ```
 
 ### Run all generated reference docs

--- a/shell.nix
+++ b/shell.nix
@@ -38,6 +38,17 @@ pkgs.mkShell {
   shellHook = ''
     export PATH="$HOME/.dpm/bin:$HOME/.daml/bin:$PWD/node_modules/.bin:$PATH"
 
+    case " $NODE_OPTIONS " in
+      *" --max-old-space-size="*) ;;
+      *)
+        if [ -z "$NODE_OPTIONS" ]; then
+          export NODE_OPTIONS="--max-old-space-size=8192"
+        else
+          export NODE_OPTIONS="$NODE_OPTIONS --max-old-space-size=8192"
+        fi
+        ;;
+    esac
+
     if [ -f package.json ] && [ ! -d node_modules ]; then
       echo "Installing npm dependencies..."
       if [ -f package-lock.json ]; then


### PR DESCRIPTION
## Summary
- set a default Node old-space limit for the repo Nix/direnv shell so local Mintlify preview has more heap headroom
- preserve explicit developer NODE_OPTIONS overrides
- route README local-preview commands through the repo direnv toolchain

## Verification
- confirmed Node exposes --max-old-space-size via node --v8-options
- confirmed the reported 4096 MB suggestion is effectively the current Node 22 limit, so this PR defaults to 8192 MB instead
- direnv exec . sh -lc 'printf "NODE_OPTIONS=%s\n" ""; node -e ...; mintlify --version'
- NODE_OPTIONS=--max-old-space-size=4096 direnv exec . sh -lc 'printf "NODE_OPTIONS=%s\n" ""; node -e ...'
- NODE_OPTIONS=--trace-warnings direnv exec . sh -lc 'printf "NODE_OPTIONS=%s\n" ""; node -e ...'
- git diff --check