### PR TITLE
GS Production Operations: Super Validator sub-grouping

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -8429,9 +8429,6 @@
                   "global-synchronizer/production-operations/key-metrics",
                   "global-synchronizer/production-operations/logging",
                   "global-synchronizer/production-operations/backup-and-recovery",
-                  "global-synchronizer/production-operations/disaster-recovery",
-                  "global-synchronizer/production-operations/pruning",
-                  "global-synchronizer/production-operations/security-hardening",
                   "global-synchronizer/production-operations/security-operations",
                   "global-synchronizer/production-operations/upgrade-procedures",
                   "global-synchronizer/production-operations/performance-optimization",
@@ -8446,7 +8443,15 @@
                   "global-synchronizer/deployment/identity-management",
                   "global-synchronizer/deployment/docker",
                   "global-synchronizer/reference/metrics-reference",
-                  "global-synchronizer/troubleshooting-guide/runbooks"
+                  "global-synchronizer/troubleshooting-guide/runbooks",
+                  {
+                    "group": "Super Validator only",
+                    "pages": [
+                      "global-synchronizer/production-operations/disaster-recovery",
+                      "global-synchronizer/production-operations/pruning",
+                      "global-synchronizer/production-operations/security-hardening"
+                    ]
+                  }
                 ]
               },
               {
@@ -8571,9 +8576,6 @@
                   "global-synchronizer/production-operations/key-metrics",
                   "global-synchronizer/production-operations/logging",
                   "global-synchronizer/production-operations/backup-and-recovery",
-                  "global-synchronizer/production-operations/disaster-recovery",
-                  "global-synchronizer/production-operations/pruning",
-                  "global-synchronizer/production-operations/security-hardening",
                   "global-synchronizer/production-operations/security-operations",
                   "global-synchronizer/production-operations/upgrade-procedures",
                   "global-synchronizer/production-operations/performance-optimization",
@@ -8588,7 +8590,15 @@
                   "global-synchronizer/deployment/identity-management",
                   "global-synchronizer/deployment/docker",
                   "global-synchronizer/reference/metrics-reference",
-                  "global-synchronizer/troubleshooting-guide/runbooks"
+                  "global-synchronizer/troubleshooting-guide/runbooks",
+                  {
+                    "group": "Super Validator only",
+                    "pages": [
+                      "global-synchronizer/production-operations/disaster-recovery",
+                      "global-synchronizer/production-operations/pruning",
+                      "global-synchronizer/production-operations/security-hardening"
+                    ]
+                  }
                 ]
               },
               {
@@ -8713,9 +8723,6 @@
                   "global-synchronizer/production-operations/key-metrics",
                   "global-synchronizer/production-operations/logging",
                   "global-synchronizer/production-operations/backup-and-recovery",
-                  "global-synchronizer/production-operations/disaster-recovery",
-                  "global-synchronizer/production-operations/pruning",
-                  "global-synchronizer/production-operations/security-hardening",
                   "global-synchronizer/production-operations/security-operations",
                   "global-synchronizer/production-operations/upgrade-procedures",
                   "global-synchronizer/production-operations/performance-optimization",
@@ -8730,7 +8737,15 @@
                   "global-synchronizer/deployment/identity-management",
                   "global-synchronizer/deployment/docker",
                   "global-synchronizer/reference/metrics-reference",
-                  "global-synchronizer/troubleshooting-guide/runbooks"
+                  "global-synchronizer/troubleshooting-guide/runbooks",
+                  {
+                    "group": "Super Validator only",
+                    "pages": [
+                      "global-synchronizer/production-operations/disaster-recovery",
+                      "global-synchronizer/production-operations/pruning",
+                      "global-synchronizer/production-operations/security-hardening"
+                    ]
+                  }
                 ]
               },
               {


### PR DESCRIPTION
## Summary

Continuing through the 2026-04-27 review. The reviewer flagged that several pages in the Global Synchronizer **Production Operations** group are SV-only and should be visually separated from validator-or-shared content in the sidebar.

**1 file changed, +27 / -12 lines** — pure `docs.json` nav restructure. No content files touched, no page deletions, no link rewrites.

### Change

Added a `Super Validator only` sub-group at the bottom of the Production Operations group in each version block (MainNet × TestNet × DevNet). Three SV-only pages moved from the flat list into the sub-group:

| Slug | Reviewer's note | Item |
|------|-----------------|------|
| `global-synchronizer/production-operations/disaster-recovery` | "It has no validator content" | F-054 / item 55 |
| `global-synchronizer/production-operations/pruning` | "It is only SV content" | F-058 / item 62 |
| `global-synchronizer/production-operations/security-hardening` | "should be under the SV TOC" | F-059 / item 63 |
