### PR TITLE
Reflect gRPC nav flattening in codegen

### DIFF
--- a/scripts/generate_grpc_ledger_api_reference.py
+++ b/scripts/generate_grpc_ledger_api_reference.py
@@ -37,8 +37,9 @@ DEFAULT_MANIFEST = REPO_ROOT / ".internal" / "generated" / "x2mdx" / "grpc-ledge
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "docs-main" / "reference" / "grpc-ledger-api-reference"
 DEFAULT_DOCS_JSON = REPO_ROOT / "docs-main" / "docs.json"
 DEFAULT_REPO_DIR = DEFAULT_CACHE_DIR / "repos" / "canton"
-GROUP_LABEL = "gRPC Ledger API Reference"
-PACKAGE_GROUP_LABEL = "Packages"
+GROUP_LABEL = "gRPC API"
+LEGACY_GROUP_LABEL = "gRPC Ledger API Reference"
+DETAILS_LABEL = "Details and history"
 DEFAULT_INSERT_AFTER_GROUP = "Ledger API Endpoints"
 DEFAULT_SOURCE_NAME = "Canton Ledger API protobuf release bundles"
 
@@ -213,7 +214,8 @@ def retitle_generated_pages(*, output_dir: Path) -> None:
         replace_text(
             overview_path,
             [
-                ("Canton Protobuf History", GROUP_LABEL),
+                ('title: "Canton Protobuf History"', f'title: "{DETAILS_LABEL}"'),
+                ('title: "Canton Protobuf Reference"', f'title: "{DETAILS_LABEL}"'),
                 (
                     'description: "Descriptor-backed protobuf API history grouped by package."',
                     'description: "Generated Ledger API gRPC reference grouped by package."',
@@ -229,21 +231,55 @@ def retitle_generated_pages(*, output_dir: Path) -> None:
         replace_text(package_page, [("Canton Protobuf History", GROUP_LABEL)])
 
 
+def flattened_page_path(path: Path, *, output_dir: Path) -> Path:
+    relative = path.resolve().relative_to(output_dir.resolve())
+    if relative == Path("index.mdx"):
+        return output_dir / "details.mdx"
+    if relative.parts and relative.parts[0] in {"packages", "operations"}:
+        return output_dir.joinpath(*relative.parts[1:])
+    return path
+
+
+def flatten_generated_tree(*, output_dir: Path, page_paths: list[Path]) -> list[Path]:
+    flattened_paths = [flattened_page_path(path, output_dir=output_dir) for path in page_paths]
+
+    index_path = output_dir / "index.mdx"
+    details_path = output_dir / "details.mdx"
+    if index_path.exists():
+        if details_path.exists():
+            details_path.unlink()
+        index_path.rename(details_path)
+
+    for source_dir_name in ("packages", "operations"):
+        source_dir = output_dir / source_dir_name
+        if not source_dir.is_dir():
+            continue
+        for source_path in sorted(source_dir.iterdir()):
+            destination = output_dir / source_path.name
+            if destination.exists():
+                if destination.is_dir():
+                    shutil.rmtree(destination)
+                else:
+                    destination.unlink()
+            source_path.rename(destination)
+        source_dir.rmdir()
+
+    return flattened_paths
+
+
 def build_nav_group(
     *,
     docs_json_path: Path,
-    overview_path: Path,
-    package_paths: list[Path],
+    details_path: Path,
+    page_paths: list[Path],
 ) -> tuple[dict[str, Any], set[str]]:
-    overview_ref = canton_protobuf_history.docs_json_page_ref(overview_path, docs_json_path)
-    package_refs = [
-        canton_protobuf_history.docs_json_page_ref(package_path, docs_json_path)
-        for package_path in package_paths
+    details_ref = canton_protobuf_history.docs_json_page_ref(details_path, docs_json_path)
+    page_refs = [
+        canton_protobuf_history.docs_json_page_ref(page_path, docs_json_path)
+        for page_path in page_paths
     ]
-    refs = {overview_ref, *package_refs}
-    pages: list[Any] = [overview_ref]
-    if package_refs:
-        pages.append({"group": PACKAGE_GROUP_LABEL, "pages": package_refs})
+    refs = {*page_refs, details_ref}
+    pages: list[Any] = [*page_refs, details_ref]
     return {"group": GROUP_LABEL, "pages": pages}, refs
 
 
@@ -262,8 +298,8 @@ def update_docs_navigation(
     dropdown_label: str,
     parent_groups: list[str],
     insert_after_group: str | None,
-    overview_path: Path,
-    package_paths: list[Path],
+    details_path: Path,
+    page_paths: list[Path],
 ) -> None:
     docs = load_json(docs_json_path)
     navigation = docs.get("navigation")
@@ -281,13 +317,13 @@ def update_docs_navigation(
 
     nav_group, generated_refs = build_nav_group(
         docs_json_path=docs_json_path,
-        overview_path=overview_path,
-        package_paths=package_paths,
+        details_path=details_path,
+        page_paths=page_paths,
     )
     dropdown["pages"] = canton_protobuf_history.prune_nav_items(
         pages,
         page_refs=generated_refs,
-        group_labels={GROUP_LABEL},
+        group_labels={GROUP_LABEL, LEGACY_GROUP_LABEL},
     )
     target_pages = canton_protobuf_history.ensure_group_path(dropdown["pages"], parent_groups)
     insert_group(target_pages, group=nav_group, after_group=insert_after_group)
@@ -401,16 +437,19 @@ def main() -> int:
     root, pages = build_pages(report, output_dir=output_dir)
     written_paths = write_pages(pages, root)
     retitle_generated_pages(output_dir=output_dir)
+    page_paths = flatten_generated_tree(
+        output_dir=output_dir,
+        page_paths=[root / page.path for page in pages[1:]],
+    )
 
-    overview_path = output_dir / "index.mdx"
-    package_paths = [root / page.path for page in pages[1:]]
+    details_path = output_dir / "details.mdx"
     update_docs_navigation(
         docs_json_path=Path(args.docs_json).resolve(),
         dropdown_label=args.nav_dropdown,
         parent_groups=args.nav_group or [],
         insert_after_group=args.insert_after_group,
-        overview_path=overview_path,
-        package_paths=package_paths,
+        details_path=details_path,
+        page_paths=page_paths,
     )
     reference_nav.regroup_ledger_api_nav(
         docs_json_path=Path(args.docs_json).resolve(),

--- a/scripts/reference_nav.py
+++ b/scripts/reference_nav.py
@@ -9,7 +9,8 @@ LEDGER_API_PARENT_GROUP = "Ledger API"
 LEGACY_ENDPOINTS_GROUP = "Ledger API Endpoints"
 OPENAPI_GROUP = "OpenAPI"
 ASYNCAPI_GROUP = "AsyncAPI"
-GRPC_GROUP = "gRPC Ledger API Reference"
+GRPC_GROUP = "gRPC API"
+GRPC_GROUP_ALIASES = {GRPC_GROUP, "gRPC Ledger API Reference"}
 PROTOBUF_GROUP = "Protobufs"
 PROTOBUF_GROUP_ALIASES = {"Canton Protobuf", "Canton Protobuf History", PROTOBUF_GROUP}
 BINDINGS_GROUP = "Java Bindings"
@@ -23,8 +24,11 @@ LEDGER_API_CHILD_ORDER = [
 ]
 OPENAPI_PAGE_REF = "reference/json-api-reference"
 ASYNCAPI_PAGE_REF = "reference/json-api-asyncapi-reference/index"
-GRPC_OVERVIEW_PAGE_REF = "reference/grpc-ledger-api-reference/index"
+GRPC_DETAILS_PAGE_REF = "reference/grpc-ledger-api-reference/details"
+GRPC_LEGACY_OVERVIEW_PAGE_REF = "reference/grpc-ledger-api-reference/index"
+GRPC_PREFIX = "reference/grpc-ledger-api-reference/"
 GRPC_PACKAGES_PREFIX = "reference/grpc-ledger-api-reference/packages/"
+GRPC_OPERATIONS_PREFIX = "reference/grpc-ledger-api-reference/operations/"
 PROTOBUF_OVERVIEW_PAGE_REF = "reference/protobuf/index"
 BINDINGS_OVERVIEW_PAGE_REF = "reference/ledger-api-jvm-bindings"
 LANGUAGE_GROUPS = {"Scaladocs", "Javadocs"}
@@ -96,22 +100,55 @@ def _append_unique(items: list[str], values: list[str]) -> None:
             items.append(value)
 
 
+def _normalized_grpc_ref(page_ref: str) -> str | None:
+    if page_ref == GRPC_LEGACY_OVERVIEW_PAGE_REF:
+        return GRPC_DETAILS_PAGE_REF
+    if page_ref == GRPC_DETAILS_PAGE_REF:
+        return page_ref
+    for prefix in (GRPC_PACKAGES_PREFIX, GRPC_OPERATIONS_PREFIX):
+        if page_ref.startswith(prefix):
+            return f"{GRPC_PREFIX}{page_ref.removeprefix(prefix)}"
+    if page_ref.startswith(GRPC_PREFIX):
+        return page_ref
+    return None
+
+
+def _absorb_grpc_pages(items: list[Any], collected: dict[str, dict[str, Any]]) -> bool:
+    absorbed = False
+    normalized_refs: list[str] = []
+    for item in items:
+        if isinstance(item, str):
+            normalized = _normalized_grpc_ref(item)
+            if normalized is not None:
+                normalized_refs.append(normalized)
+                absorbed = True
+            continue
+        if isinstance(item, dict):
+            pages = item.get("pages")
+            if isinstance(pages, list):
+                absorbed = _absorb_grpc_pages(pages, collected) or absorbed
+    if normalized_refs:
+        _merge_group_entries(
+            _upsert_group(collected, GRPC_GROUP),
+            {"group": GRPC_GROUP, "pages": normalized_refs},
+        )
+    return absorbed
+
+
 def _absorb_known_item(item: Any, collected: dict[str, dict[str, Any]]) -> bool:
     if isinstance(item, str):
+        normalized_grpc = _normalized_grpc_ref(item)
+        if normalized_grpc is not None:
+            _merge_group_entries(
+                _upsert_group(collected, GRPC_GROUP),
+                {"group": GRPC_GROUP, "pages": [normalized_grpc]},
+            )
+            return True
         if item == OPENAPI_PAGE_REF:
             _merge_group_entries(_upsert_group(collected, OPENAPI_GROUP), {"group": OPENAPI_GROUP, "pages": [item]})
             return True
         elif item == ASYNCAPI_PAGE_REF:
             _merge_group_entries(_upsert_group(collected, ASYNCAPI_GROUP), {"group": ASYNCAPI_GROUP, "pages": [item]})
-            return True
-        elif item == GRPC_OVERVIEW_PAGE_REF:
-            _merge_group_entries(_upsert_group(collected, GRPC_GROUP), {"group": GRPC_GROUP, "pages": [item]})
-            return True
-        elif item.startswith(GRPC_PACKAGES_PREFIX):
-            _merge_group_entries(
-                _upsert_group(collected, GRPC_GROUP),
-                {"group": GRPC_GROUP, "pages": [{"group": "Packages", "pages": [item]}]},
-            )
             return True
         elif item == PROTOBUF_OVERVIEW_PAGE_REF:
             _merge_group_entries(_upsert_group(collected, PROTOBUF_GROUP), {"group": PROTOBUF_GROUP, "pages": [item]})
@@ -156,8 +193,16 @@ def _absorb_known_item(item: Any, collected: dict[str, dict[str, Any]]) -> bool:
                 absorbed = _absorb_known_item(page_ref, collected) or absorbed
         return absorbed
 
-    if label in {OPENAPI_GROUP, ASYNCAPI_GROUP, GRPC_GROUP}:
+    if label in {OPENAPI_GROUP, ASYNCAPI_GROUP}:
         _merge_group_entries(_upsert_group(collected, label), item)
+        return True
+
+    if label in GRPC_GROUP_ALIASES:
+        pages = item.get("pages")
+        if isinstance(pages, list):
+            _absorb_grpc_pages(pages, collected)
+        else:
+            _upsert_group(collected, GRPC_GROUP)
         return True
 
     if label in PROTOBUF_GROUP_ALIASES:
@@ -174,9 +219,8 @@ def _absorb_known_item(item: Any, collected: dict[str, dict[str, Any]]) -> bool:
 
     if label == "Packages":
         pages = item.get("pages")
-        if isinstance(pages, list) and all(isinstance(page, str) and page.startswith(GRPC_PACKAGES_PREFIX) for page in pages):
-            _merge_group_entries(_upsert_group(collected, GRPC_GROUP), {"group": GRPC_GROUP, "pages": [item]})
-            return True
+        if isinstance(pages, list):
+            return _absorb_grpc_pages(pages, collected)
 
     if label in LANGUAGE_GROUPS:
         _merge_group_entries(_upsert_group(collected, BINDINGS_GROUP), {"group": BINDINGS_GROUP, "pages": [item]})
@@ -209,7 +253,7 @@ def regroup_ledger_api_nav(*, docs_json_path: Path, dropdown_label: str) -> None
     known_labels = {
         LEDGER_API_PARENT_GROUP,
         LEGACY_ENDPOINTS_GROUP,
-        GRPC_GROUP,
+        *GRPC_GROUP_ALIASES,
         *PROTOBUF_GROUP_ALIASES,
         *BINDINGS_GROUP_ALIASES,
     }


### PR DESCRIPTION
## Summary
- make the gRPC Ledger API generator emit the merged PR #285 nav label and flattened page paths
- write the generated overview as the final Details and history page instead of a top-level index page
- teach Ledger API nav regrouping to normalize legacy gRPC labels and paths to the new shape

## Validation
- `direnv exec /Users/danielporter/control/.worktrees/docs-pr-285-grpc-nav-codegen python3 -m py_compile scripts/generate_grpc_ledger_api_reference.py scripts/reference_nav.py scripts/generate_all_reference_docs.py`
- `direnv exec /Users/danielporter/control/.worktrees/docs-pr-285-grpc-nav-codegen python3 scripts/generate_grpc_ledger_api_reference.py --cache-dir /Users/danielporter/.cache/x2mdx/grpc-ledger-api-reference --repo-dir /Users/danielporter/.cache/x2mdx/grpc-ledger-api-reference/repos/canton` (no generated-file diff)
- `direnv exec /Users/danielporter/control/.worktrees/docs-pr-285-grpc-nav-codegen python3 scripts/generate_all_reference_docs.py` (completed; unrelated AsyncAPI generated churn was discarded from this PR)
- `git diff --check`
- synthetic legacy gRPC nav normalization assertion via `direnv exec ... python3 - <<'PY' ...`