### PR TITLE
Bump Mintlify Node heap to 12GB

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -25,9 +25,9 @@ pkgs.mkShell {
       *" --max-old-space-size="*) ;;
       *)
         if [ -z "$NODE_OPTIONS" ]; then
-          export NODE_OPTIONS="--max-old-space-size=8192"
+          export NODE_OPTIONS="--max-old-space-size=12288"
         else
-          export NODE_OPTIONS="$NODE_OPTIONS --max-old-space-size=8192"
+          export NODE_OPTIONS="$NODE_OPTIONS --max-old-space-size=12288"
         fi
         ;;
     esac


### PR DESCRIPTION
## Summary

- Increase the default Node old-space heap setting in `shell.nix` from 8 GB to 12 GB.
- Preserve the existing behavior that leaves a caller-provided `--max-old-space-size` untouched.

## Validation

- `direnv exec /Users/danielporter/control/.worktrees/docs-nix-mintlify-memory-12gb env | rg ^NODE_OPTIONS=`\n- `direnv exec /Users/danielporter/control/.worktrees/docs-nix-mintlify-memory-12gb node -e 'console.log(process.env.NODE_OPTIONS)'`\n- `git diff --check`