### PR TITLE
Refresh details and history reference pages

### DIFF
--- a/docs-main/appdev/reference/daml-standard-library/index.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/index.mdx
@@ -3,94 +3,1945 @@ title: "Details and history"
 description: "Reference documentation for Daml Standard Library modules."
 ---
 
-# Daml Standard Library
+<div class="x2mdx-ref-hero">
 
-This page is generated from versioned Daml docs JSON snapshots.
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-## Table of Contents
 
-| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`DA.Action`](/appdev/reference/daml-standard-library/da-action) | `Module` | Action | `3.4.9` | - | - | - |
-| [`DA.Action.State`](/appdev/reference/daml-standard-library/da-action-state) | `Module` | DA.Action.State | `3.4.9` | - | - | - |
-| [`DA.Action.State.Class`](/appdev/reference/daml-standard-library/da-action-state-class) | `Module` | DA.Action.State.Class | `3.4.9` | - | - | - |
-| [`DA.Assert`](/appdev/reference/daml-standard-library/da-assert) | `Module` | - | `3.4.9` | - | - | - |
-| [`DA.Bifunctor`](/appdev/reference/daml-standard-library/da-bifunctor) | `Module` | - | `3.4.9` | - | - | - |
-| [`DA.Crypto.Text`](/appdev/reference/daml-standard-library/da-crypto-text) | `Module` | Functions for working with Crypto builtins. | `3.4.9` | - | - | - |
-| [`DA.Date`](/appdev/reference/daml-standard-library/da-date) | `Module` | This module provides a set of functions to manipulate Date values. | `3.4.9` | - | - | - |
-| [`DA.Either`](/appdev/reference/daml-standard-library/da-either) | `Module` | The Either type represents values with two possibilities. | `3.4.9` | - | - | - |
-| [`DA.Exception`](/appdev/reference/daml-standard-library/da-exception) | `Module` | Exception handling in Daml. | `3.4.9` | - | `3.4.9` | - |
-| [`DA.Fail`](/appdev/reference/daml-standard-library/da-fail) | `Module` | Fail, for FailureStatus | `3.4.9` | - | - | - |
-| [`DA.Foldable`](/appdev/reference/daml-standard-library/da-foldable) | `Module` | Class of data structures that can be folded to a summary value. | `3.4.9` | - | - | - |
-| [`DA.Functor`](/appdev/reference/daml-standard-library/da-functor) | `Module` | The Functor class is used for types that can be mapped over. | `3.4.9` | - | - | - |
-| [`DA.Internal.Interface.AnyView`](/appdev/reference/daml-standard-library/da-internal-interface-anyview) | `Module` | - | `3.4.9` | - | - | - |
-| [`DA.Internal.Interface.AnyView.Types`](/appdev/reference/daml-standard-library/da-internal-interface-anyview-types) | `Module` | - | `3.4.9` | - | - | - |
-| [`DA.List`](/appdev/reference/daml-standard-library/da-list) | `Module` | List | `3.4.9` | - | - | - |
-| [`DA.List.BuiltinOrder`](/appdev/reference/daml-standard-library/da-list-builtinorder) | `Module` | Note: This is only supported in Daml-LF 1.11 or later. | `3.4.9` | - | - | - |
-| [`DA.List.Total`](/appdev/reference/daml-standard-library/da-list-total) | `Module` | - | `3.4.9` | - | - | - |
-| [`DA.Logic`](/appdev/reference/daml-standard-library/da-logic) | `Module` | Logic - Propositional calculus. | `3.4.9` | - | - | - |
-| [`DA.Map`](/appdev/reference/daml-standard-library/da-map) | `Module` | Note: This is only supported in Daml-LF 1.11 or later. | `3.4.9` | - | - | - |
-| [`DA.Math`](/appdev/reference/daml-standard-library/da-math) | `Module` | Math - Utility Math functions for Decimal | `3.4.9` | - | - | - |
-| [`DA.Monoid`](/appdev/reference/daml-standard-library/da-monoid) | `Module` | - | `3.4.9` | - | - | - |
-| [`DA.NonEmpty`](/appdev/reference/daml-standard-library/da-nonempty) | `Module` | Type and functions for non-empty lists. This module re-exports many functions with | `3.4.9` | - | - | - |
-| [`DA.NonEmpty.Types`](/appdev/reference/daml-standard-library/da-nonempty-types) | `Module` | This module contains the type for non-empty lists so we can give it a stable package id. | `3.4.9` | - | - | - |
-| [`DA.Numeric`](/appdev/reference/daml-standard-library/da-numeric) | `Module` | - | `3.4.9` | - | - | - |
-| [`DA.Optional`](/appdev/reference/daml-standard-library/da-optional) | `Module` | The Optional type encapsulates an optional value. A value of type | `3.4.9` | - | - | - |
-| [`DA.Record`](/appdev/reference/daml-standard-library/da-record) | `Module` | Exports the record machinery necessary to allow one to annotate | `3.4.9` | - | - | - |
-| [`DA.Semigroup`](/appdev/reference/daml-standard-library/da-semigroup) | `Module` | - | `3.4.9` | - | - | - |
-| [`DA.Set`](/appdev/reference/daml-standard-library/da-set) | `Module` | Note: This is only supported in Daml-LF 1.11 or later. | `3.4.9` | - | - | - |
-| [`DA.Stack`](/appdev/reference/daml-standard-library/da-stack) | `Module` | - | `3.4.9` | - | - | - |
-| [`DA.Text`](/appdev/reference/daml-standard-library/da-text) | `Module` | Functions for working with Text. | `3.4.9` | - | - | - |
-| [`DA.TextMap`](/appdev/reference/daml-standard-library/da-textmap) | `Module` | TextMap - A map is an associative array data type composed of a | `3.4.9` | - | - | - |
-| [`DA.Time`](/appdev/reference/daml-standard-library/da-time) | `Module` | This module provides a set of functions to manipulate Time values. | `3.4.9` | - | - | - |
-| [`DA.Traversable`](/appdev/reference/daml-standard-library/da-traversable) | `Module` | Class of data structures that can be traversed from left to right, performing an action on each element. | `3.4.9` | - | - | - |
-| [`DA.Tuple`](/appdev/reference/daml-standard-library/da-tuple) | `Module` | Tuple - Ubiquitous functions of tuples. | `3.4.9` | - | - | - |
-| [`DA.Validation`](/appdev/reference/daml-standard-library/da-validation) | `Module` | Validation type and associated functions. | `3.4.9` | - | - | - |
-| [`Prelude`](/appdev/reference/daml-standard-library/prelude) | `Module` | The pieces that make up the Daml language. | `3.4.9` | - | - | - |
+  <h1 class="x2mdx-ref-title">Daml Standard Library</h1>
 
-## Version Change Summary
 
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `3.4.9` | 38 | 0 | 0 |
-| `3.4.10` | 0 | 0 | 0 |
-| `3.4.11` | 0 | 0 | 0 |
+  <p class="x2mdx-ref-summary">Generated module overview for the Daml Standard Library, built from versioned docs JSON snapshots.</p>
 
-## Reference
 
-- [DA.Action](/appdev/reference/daml-standard-library/da-action)
-- [DA.Action.State](/appdev/reference/daml-standard-library/da-action-state)
-- [DA.Action.State.Class](/appdev/reference/daml-standard-library/da-action-state-class)
-- [DA.Assert](/appdev/reference/daml-standard-library/da-assert)
-- [DA.Bifunctor](/appdev/reference/daml-standard-library/da-bifunctor)
-- [DA.Crypto.Text](/appdev/reference/daml-standard-library/da-crypto-text)
-- [DA.Date](/appdev/reference/daml-standard-library/da-date)
-- [DA.Either](/appdev/reference/daml-standard-library/da-either)
-- [DA.Exception](/appdev/reference/daml-standard-library/da-exception)
-- [DA.Fail](/appdev/reference/daml-standard-library/da-fail)
-- [DA.Foldable](/appdev/reference/daml-standard-library/da-foldable)
-- [DA.Functor](/appdev/reference/daml-standard-library/da-functor)
-- [DA.Internal.Interface.AnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview)
-- [DA.Internal.Interface.AnyView.Types](/appdev/reference/daml-standard-library/da-internal-interface-anyview-types)
-- [DA.List](/appdev/reference/daml-standard-library/da-list)
-- [DA.List.BuiltinOrder](/appdev/reference/daml-standard-library/da-list-builtinorder)
-- [DA.List.Total](/appdev/reference/daml-standard-library/da-list-total)
-- [DA.Logic](/appdev/reference/daml-standard-library/da-logic)
-- [DA.Map](/appdev/reference/daml-standard-library/da-map)
-- [DA.Math](/appdev/reference/daml-standard-library/da-math)
-- [DA.Monoid](/appdev/reference/daml-standard-library/da-monoid)
-- [DA.NonEmpty](/appdev/reference/daml-standard-library/da-nonempty)
-- [DA.NonEmpty.Types](/appdev/reference/daml-standard-library/da-nonempty-types)
-- [DA.Numeric](/appdev/reference/daml-standard-library/da-numeric)
-- [DA.Optional](/appdev/reference/daml-standard-library/da-optional)
-- [DA.Record](/appdev/reference/daml-standard-library/da-record)
-- [DA.Semigroup](/appdev/reference/daml-standard-library/da-semigroup)
-- [DA.Set](/appdev/reference/daml-standard-library/da-set)
-- [DA.Stack](/appdev/reference/daml-standard-library/da-stack)
-- [DA.Text](/appdev/reference/daml-standard-library/da-text)
-- [DA.TextMap](/appdev/reference/daml-standard-library/da-textmap)
-- [DA.Time](/appdev/reference/daml-standard-library/da-time)
-- [DA.Traversable](/appdev/reference/daml-standard-library/da-traversable)
-- [DA.Tuple](/appdev/reference/daml-standard-library/da-tuple)
-- [DA.Validation](/appdev/reference/daml-standard-library/da-validation)
-- [Prelude](/appdev/reference/daml-standard-library/prelude)
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">3.4.11</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>3.4.11</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Daml Standard Library docs JSON from local SDK artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>configured Daml SDK artifact versions</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-action">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Action</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Action</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-action-state">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Action.State</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">DA.Action.State</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-action-state-class">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Action.State.Class</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">DA.Action.State.Class</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-assert">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Assert</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-bifunctor">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Bifunctor</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-crypto-text">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Crypto.Text</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Functions for working with Crypto builtins.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-date">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Date</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">This module provides a set of functions to manipulate Date values.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-either">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Either</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">The Either type represents values with two possibilities.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-exception">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Exception</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Exception handling in Daml.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-fail">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Fail</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Fail, for FailureStatus</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-foldable">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Foldable</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Class of data structures that can be folded to a summary value.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-functor">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Functor</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">The Functor class is used for types that can be mapped over.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-internal-interface-anyview">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Internal.Interface.AnyView</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-internal-interface-anyview-types">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Internal.Interface.AnyView.Types</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-list">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.List</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">List</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-list-builtinorder">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.List.BuiltinOrder</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Note: This is only supported in Daml-LF 1.11 or later.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-list-total">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.List.Total</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-logic">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Logic</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Logic - Propositional calculus.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-map">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Map</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Note: This is only supported in Daml-LF 1.11 or later.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-math">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Math</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Math - Utility Math functions for Decimal</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-monoid">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Monoid</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-nonempty">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.NonEmpty</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Type and functions for non-empty lists. This module re-exports many functions with</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-nonempty-types">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.NonEmpty.Types</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">This module contains the type for non-empty lists so we can give it a stable package id.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-numeric">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Numeric</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-optional">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Optional</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">The Optional type encapsulates an optional value. A value of type</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-record">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Record</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Exports the record machinery necessary to allow one to annotate</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-semigroup">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Semigroup</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-set">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Set</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Note: This is only supported in Daml-LF 1.11 or later.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-stack">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Stack</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-text">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Text</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Functions for working with Text.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-textmap">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.TextMap</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">TextMap - A map is an associative array data type composed of a</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-time">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Time</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">This module provides a set of functions to manipulate Time values.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-traversable">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Traversable</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Class of data structures that can be traversed from left to right, performing an action on each element.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-tuple">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Tuple</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Tuple - Ubiquitous functions of tuples.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-validation">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Validation</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Validation type and associated functions.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/prelude">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Prelude</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.9</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">The pieces that make up the Daml language.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.9</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.9</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 38</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.10</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.11</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/docs-main/reference/json-api-reference/details.mdx
+++ b/docs-main/reference/json-api-reference/details.mdx
@@ -3,2850 +3,2119 @@ title: "Details and history"
 description: "JSON Ledger API OpenAPI endpoint details and version history."
 ---
 
-## Table of Contents
-
-🟢 Active Since  🔵 Changed  🔴 Removed
-
-| NAME | STATUS | SUMMARY |
-| --- | --- | --- |
-| [`/livez`](#endpoint-path-livez) | 🟢 `v3.5` | Checks if the service is alive |
-| [`/readyz`](#endpoint-path-readyz) | 🟢 `v3.5` | Checks if the service is ready to serve requests |
-| [`/v2/authenticated-user`](#endpoint-path-v2-authenticated-user) | 🟢 `v3.4` 🔵 `v3.5` | Get the user data of the current authenticated user. |
-| [`/v2/commands/async/submit`](#endpoint-path-v2-commands-async-submit) | 🟢 `v3.4` 🔵 `v3.5` | Submit a single composite command. |
-| [`/v2/commands/async/submit-reassignment`](#endpoint-path-v2-commands-async-submit-reassignment) | 🟢 `v3.4` 🔵 `v3.5` | Submit a single reassignment. |
-| [`/v2/commands/completions`](#endpoint-path-v2-commands-completions) | 🟢 `v3.4` 🔵 `v3.5` | Query completions list (blocking call)  Subscribe to command completion events. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. |
-| [`/v2/commands/submit-and-wait`](#endpoint-path-v2-commands-submit-and-wait) | 🟢 `v3.4` 🔵 `v3.5` | Submits a single composite command and waits for its result. Propagates the gRPC error of failed submissions including Daml interpretation errors. |
-| [`/v2/commands/submit-and-wait-for-reassignment`](#endpoint-path-v2-commands-submit-and-wait-for-reassignment) | 🟢 `v3.4` 🔵 `v3.5` | Submits a single composite reassignment command, waits for its result, and returns the reassignment. Propagates the gRPC error of failed submission. |
-| [`/v2/commands/submit-and-wait-for-transaction`](#endpoint-path-v2-commands-submit-and-wait-for-transaction) | 🟢 `v3.4` 🔵 `v3.5` | Submits a single composite command, waits for its result, and returns the transaction. Propagates the gRPC error of failed submissions including Daml interpretation errors. |
-| [`/v2/commands/submit-and-wait-for-transaction-tree`](#endpoint-path-v2-commands-submit-and-wait-for-transaction-tree) | 🟢 `v3.4` 🔵 `v3.5` | Submit a batch of commands and wait for the transaction trees response. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use submit-and-wait-for-transaction instead. |
-| [`/v2/contracts/contract-by-id`](#endpoint-path-v2-contracts-contract-by-id) | 🟢 `v3.4` 🔵 `v3.5` | Looking up contract data by contract ID. This endpoint is experimental / alpha, therefore no backwards compatibility is guaranteed. This endpoint must not be used to look up contracts which entered the participant via party replication or repair service. |
-| [`/v2/dars`](#endpoint-path-v2-dars) | 🟢 `v3.4` 🔵 `v3.5` | Upload a DAR to the participant node |
-| [`/v2/dars/validate`](#endpoint-path-v2-dars-validate) | 🟢 `v3.4` 🔵 `v3.5` | Validates the DAR and checks the upgrade compatibility of the DAR's packages with the set of the already vetted packages on the target vetting synchronizer. See ValidateDarFileRequest for details regarding the target vetting synchronizer.  The operation has no effect on the state of the participant or the Canton ledger: the DAR payload and its packages are not persisted neither are the packages vetted. |
-| [`/v2/events/events-by-contract-id`](#endpoint-path-v2-events-events-by-contract-id) | 🟢 `v3.4` 🔵 `v3.5` | Get the create and the consuming exercise event for the contract with the provided ID. No events will be returned for contracts that have been pruned because they have already been archived before the latest pruning offset. If the contract cannot be found for the request, or all the contract-events are filtered, a CONTRACT_EVENTS_NOT_FOUND error will be raised. |
-| [`/v2/idps`](#endpoint-path-v2-idps) | 🟢 `v3.4` 🔵 `v3.5` | GET: List all existing identity provider configurations.; POST: Create a new identity provider configuration. The request will fail if the maximum allowed number of separate configurations is reached. |
-| [`/v2/idps/{idp-id}`](#endpoint-path-v2-idps-idp-id) | 🟢 `v3.4` 🔵 `v3.5` | DELETE: Delete an existing identity provider configuration.; GET: Get the identity provider configuration data by id.; PATCH: Update selected modifiable attribute of an identity provider config resource described by the ``IdentityProviderConfig`` message. |
-| [`/v2/interactive-submission/execute`](#endpoint-path-v2-interactive-submission-execute) | 🟢 `v3.4` 🔵 `v3.5` | Execute a prepared submission _asynchronously_ on the ledger. Requires a signature of the transaction from the submitting external party. |
-| [`/v2/interactive-submission/executeAndWait`](#endpoint-path-v2-interactive-submission-executeandwait) | 🟢 `v3.4` 🔵 `v3.5` | Similar to ExecuteSubmission but _synchronously_ wait for the completion of the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appeared failed and vice versa |
-| [`/v2/interactive-submission/executeAndWaitForTransaction`](#endpoint-path-v2-interactive-submission-executeandwaitfortransaction) | 🟢 `v3.4` 🔵 `v3.5` | Similar to ExecuteSubmissionAndWait but additionally returns the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appear as failed and vice versa |
-| [`/v2/interactive-submission/preferred-package-version`](#endpoint-path-v2-interactive-submission-preferred-package-version) | 🟢 `v3.4` 🔵 `v3.5` | A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred package, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Provided for backwards compatibility, it will be removed in the Canton version 3.4.0 |
-| [`/v2/interactive-submission/preferred-packages`](#endpoint-path-v2-interactive-submission-preferred-packages) | 🟢 `v3.4` 🔵 `v3.5` | Compute the preferred packages for the vetting requirements in the request. A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred packages, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  If the package preferences could not be computed due to no selection satisfying the requirements, a `FAILED_PRECONDITION` error will be returned.  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Experimental API: this endpoint is not guaranteed to provide backwards compatibility in future releases |
-| [`/v2/interactive-submission/prepare`](#endpoint-path-v2-interactive-submission-prepare) | 🟢 `v3.4` 🔵 `v3.5` | Requires `readAs` scope for the submitting party when LAPI User authorization is enabled |
-| [`/v2/package-vetting`](#endpoint-path-v2-package-vetting) | 🟢 `v3.4` 🔵 `v3.5` | GET: Lists which participant node vetted what packages on which synchronizer. This endpoint (GET /package-vetting) is deprecated and will be removed in a future release. Please use POST /package-vetting/list instead.; POST: Update the vetted packages of this participant This endpoint (POST /package-vetting) is deprecated and will be removed in a future release. Please use POST /package-vetting/update instead. |
-| [`/v2/package-vetting/list`](#endpoint-path-v2-package-vetting-list) | 🟢 `v3.4` 🔵 `v3.5` | Lists which participant node vetted what packages on which synchronizer. Can be called by any authenticated user. |
-| [`/v2/package-vetting/update`](#endpoint-path-v2-package-vetting-update) | 🟢 `v3.4` 🔵 `v3.5` | Update the vetted packages of this participant |
-| [`/v2/packages`](#endpoint-path-v2-packages) | 🟢 `v3.4` 🔵 `v3.5` | GET: Returns the identifiers of all supported packages.; POST: Behaves the same as /dars. This endpoint will be deprecated and removed in a future release. Upload a DAR file to the participant.  If vetting is enabled in the request, the DAR is checked for upgrade compatibility with the set of the already vetted packages on the target vetting synchronizer See UploadDarFileRequest for details regarding vetting and the target vetting synchronizer. |
-| [`/v2/packages/{package-id}`](#endpoint-path-v2-packages-package-id) | 🟢 `v3.4` 🔵 `v3.5` | Returns the contents of a single package. |
-| [`/v2/packages/{package-id}/status`](#endpoint-path-v2-packages-package-id-status) | 🟢 `v3.4` 🔵 `v3.5` | Returns the status of a single package. |
-| [`/v2/parties`](#endpoint-path-v2-parties) | 🟢 `v3.4` 🔵 `v3.5` | GET: List the parties known by the participant. The list returned contains parties whose ledger access is facilitated by the participant and the ones maintained elsewhere.; POST: Allocates a new party on a ledger and adds it to the set managed by the participant. Caller specifies a party identifier suggestion, the actual identifier allocated might be different and is implementation specific. Caller can specify party metadata that is stored locally on the participant. This call may:  - Succeed, in which case the actual allocated identifier is visible in   the response. - Respond with a gRPC error  daml-on-kv-ledger: suggestion's uniqueness is checked by the validators in the consensus layer and call rejected if the identifier is already present. canton: completely different globally unique identifier is allocated. Behind the scenes calls to an internal protocol are made. As that protocol is richer than the surface protocol, the arguments take implicit values The party identifier suggestion must be a valid party name. Party names are required to be non-empty US-ASCII strings built from letters, digits, space, colon, minus and underscore limited to 255 chars |
-| [`/v2/parties/external/allocate`](#endpoint-path-v2-parties-external-allocate) | 🟢 `v3.4` 🔵 `v3.5` | Alpha 3.3: Endpoint to allocate a new external party on a synchronizer  Expected to be stable in 3.5  The external party must be hosted (at least) on this node with either confirmation or observation permissions It can optionally be hosted on other nodes (then called a multi-hosted party). If hosted on additional nodes, explicit authorization of the hosting relationship must be performed on those nodes before the party can be used. Decentralized namespaces are supported but must be provided fully authorized by their owners. The individual owner namespace transactions can be submitted in the same call (fully authorized as well). In the simple case of a non-multi hosted, non-decentralized party, the RPC will return once the party is effectively allocated and ready to use, similarly to the AllocateParty behavior. For more complex scenarios applications may need to query the party status explicitly (only through the admin API as of now). |
-| [`/v2/parties/external/generate-topology`](#endpoint-path-v2-parties-external-generate-topology) | 🟢 `v3.4` 🔵 `v3.5` | Alpha 3.3: Convenience endpoint to generate topology transactions for external signing  Expected to be stable in 3.5  You may use this endpoint to generate the common external topology transactions which can be signed externally and uploaded as part of the allocate party process  Note that this request will create a normal namespace using the same key for the identity as for signing. More elaborate schemes such as multi-signature or decentralized parties require you to construct the topology transactions yourself. |
-| [`/v2/parties/participant-id`](#endpoint-path-v2-parties-participant-id) | 🟢 `v3.4` 🔵 `v3.5` | Return the identifier of the participant. All horizontally scaled replicas should return the same id. daml-on-kv-ledger: returns an identifier supplied on command line at launch time canton: returns globally unique identifier of the participant |
-| [`/v2/parties/{party}`](#endpoint-path-v2-parties-party) | 🟢 `v3.4` 🔵 `v3.5` | GET: Get the party details of the given parties. Only known parties will be returned in the list.; PATCH: Update selected modifiable participant-local attributes of a party details resource. Can update the participant's local information for local parties. |
-| [`/v2/state/active-contracts`](#endpoint-path-v2-state-active-contracts) | 🟢 `v3.4` 🔵 `v3.5` | Query active contracts list (blocking call). Querying active contracts is an expensive operation and if possible should not be repeated often. Consider querying active contracts initially (for a given offset) and then repeatedly call one of `/v2/updates/...`endpoints  to get subsequent modifications. You can also use websockets to get updates with better performance.  Returns a stream of the snapshot of the active contracts and incomplete (un)assignments at a ledger offset. Once the stream of GetActiveContractsResponses completes, the client SHOULD begin streaming updates from the update service, starting at the GetActiveContractsRequest.active_at_offset specified in this request. Clients SHOULD NOT assume that the set of active contracts they receive reflects the state at the ledger end.  Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. |
-| [`/v2/state/connected-synchronizers`](#endpoint-path-v2-state-connected-synchronizers) | 🟢 `v3.4` 🔵 `v3.5` | Get the list of connected synchronizers at the time of the query. |
-| [`/v2/state/latest-pruned-offsets`](#endpoint-path-v2-state-latest-pruned-offsets) | 🟢 `v3.4` 🔵 `v3.5` | Get the latest successfully pruned ledger offsets |
-| [`/v2/state/ledger-end`](#endpoint-path-v2-state-ledger-end) | 🟢 `v3.4` 🔵 `v3.5` | Get the current ledger end. Subscriptions started with the returned offset will serve events after this RPC was called. |
-| [`/v2/updates`](#endpoint-path-v2-updates) | 🟢 `v3.4` 🔵 `v3.5` | Read the ledger's filtered update stream for the specified contents and filters. It returns the event types in accordance with the stream contents selected. Also the selection criteria for individual events depends on the transaction shape chosen.  - ACS delta: a requesting party must be a stakeholder of an event for it to be included. - ledger effects: a requesting party must be a witness of an event for it to be included. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. |
-| [`/v2/updates/flats`](#endpoint-path-v2-updates-flats) | 🟢 `v3.4` 🔵 `v3.5` | Query flat transactions update list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. |
-| [`/v2/updates/transaction-by-id`](#endpoint-path-v2-updates-transaction-by-id) | 🟢 `v3.4` 🔵 `v3.5` | Get transaction by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead. |
-| [`/v2/updates/transaction-by-offset`](#endpoint-path-v2-updates-transaction-by-offset) | 🟢 `v3.4` 🔵 `v3.5` | Get transaction by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead. |
-| [`/v2/updates/transaction-tree-by-id/{update-id}`](#endpoint-path-v2-updates-transaction-tree-by-id-update-id) | 🟢 `v3.4` 🔵 `v3.5` | Get transaction tree by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead. |
-| [`/v2/updates/transaction-tree-by-offset/{offset}`](#endpoint-path-v2-updates-transaction-tree-by-offset-offset) | 🟢 `v3.4` 🔵 `v3.5` | Get transaction tree by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead. |
-| [`/v2/updates/trees`](#endpoint-path-v2-updates-trees) | 🟢 `v3.4` 🔵 `v3.5` | Query update transactions tree list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results. |
-| [`/v2/updates/update-by-id`](#endpoint-path-v2-updates-update-by-id) | 🟢 `v3.4` 🔵 `v3.5` | Lookup an update by its ID. If there is no update with this ID, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised. |
-| [`/v2/updates/update-by-offset`](#endpoint-path-v2-updates-update-by-offset) | 🟢 `v3.4` 🔵 `v3.5` | Lookup an update by its offset. If there is no update with this offset, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised. |
-| [`/v2/users`](#endpoint-path-v2-users) | 🟢 `v3.4` 🔵 `v3.5` | GET: List all existing users.; POST: Create a new user. |
-| [`/v2/users/{user-id}`](#endpoint-path-v2-users-user-id) | 🟢 `v3.4` 🔵 `v3.5` | DELETE: Delete an existing user and all its rights.; GET: Get the user data of a specific user or the authenticated user.; PATCH: Update selected modifiable attribute of a user resource described by the ``User`` message. |
-| [`/v2/users/{user-id}/identity-provider-id`](#endpoint-path-v2-users-user-id-identity-provider-id) | 🟢 `v3.4` 🔵 `v3.5` | Update the assignment of a user from one IDP to another. |
-| [`/v2/users/{user-id}/rights`](#endpoint-path-v2-users-user-id-rights) | 🟢 `v3.4` 🔵 `v3.5` | GET: List the set of all rights granted to a user.; PATCH: Revoke rights from a user. Revoking rights does not affect the resource version of the corresponding user.; POST: Grant rights to a user. Granting rights does not affect the resource version of the corresponding user. |
-| [`/v2/version`](#endpoint-path-v2-version) | 🟢 `v3.4` 🔵 `v3.5` | Read the Ledger API version |
-## Endpoint Reference (Latest)
-
-<span id="endpoint-path-livez"></span>
-
-### `/livez`
-
-<span id="endpoint-get-livez"></span>
-
-- Method: `GET`
-
-- Operation ID: `getLivez`
-- Description: Checks if the service is alive
-
-**Responses**
-
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | OK: service is alive | `-` | `-` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
-
-<span id="endpoint-path-readyz"></span>
-
-### `/readyz`
-
-<span id="endpoint-get-readyz"></span>
-
-- Method: `GET`
-
-- Operation ID: `getReadyz`
-- Description: Checks if the service is ready to serve requests
-
-**Responses**
-
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | OK: readiness message | `text/plain` | `text/plain:string` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
-
-<span id="endpoint-path-v2-authenticated-user"></span>
-
-### `/v2/authenticated-user`
-
-<span id="endpoint-get-v2-authenticated-user"></span>
+<div class="x2mdx-ref-hero">
 
-- Method: `GET`
+  <p class="x2mdx-ref-eyebrow">OpenAPI Reference</p>
 
-- Operation ID: `getV2Authenticated-user`
-- Description: Get the user data of the current authenticated user.
 
-**Parameters**
+  <h1 class="x2mdx-ref-title">Details and history</h1>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `identity-provider-id` | `query` | `no` | `string` | - |
 
-**Responses**
+  <p class="x2mdx-ref-summary">Endpoint overview for the JSON Ledger API OpenAPI surface, built from versioned release snapshots.</p>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: query parameter identity-provider-id | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-commands-async-submit"></span>
+<div class="x2mdx-ref-badges">
 
-### `/v2/commands/async/submit`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">OpenAPI</span>
 
-<span id="endpoint-post-v2-commands-async-submit"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">3.5</span>
 
-- Method: `POST`
+</div>
 
-- Operation ID: `postV2CommandsAsyncSubmit`
-- Description: Submit a single composite command.
 
-**Request Body**
+<dl class="x2mdx-ref-meta-grid">
 
-- Required: `yes`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>3.5</dd>
+  </div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `actAs`, `commandId`, `commands` |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Canton release bundle JSON Ledger API specifications</dd>
+  </div>
 
-**Request Example: `application/json`**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>3.4, 3.5</dd>
+  </div>
 
-```json
-{
-  "commands": [
-    {
-      "CreateAndExerciseCommand": {
-        "templateId": "<string>",
-        "createArguments": "<value>",
-        "choice": "<string>",
-        "choiceArgument": "<value>"
-      }
-    }
-  ],
-  "commandId": "<string>",
-  "actAs": [
-    "<string>"
-  ]
-}
-```
+</dl>
 
-**Responses**
+</div>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-commands-async-submit-reassignment"></span>
+## Endpoints
 
-### `/v2/commands/async/submit-reassignment`
 
-<span id="endpoint-post-v2-commands-async-submit-reassignment"></span>
+Select an OpenAPI operation from the sidebar for request and response details. This page summarizes endpoint lifecycle changes across the configured Ledger API versions.
 
-- Method: `POST`
 
-- Operation ID: `postV2CommandsAsyncSubmit-reassignment`
-- Description: Submit a single reassignment.
 
-**Request Body**
+<div class="x2mdx-ref-card-grid">
 
-- Required: `yes`
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `reassignmentCommands` |
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**Request Example: `application/json`**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/commands/submit-and-wait</h3>
 
-```json
-{
-  "reassignmentCommands": {
-    "commandId": "<string>",
-    "submitter": "<string>",
-    "commands": [
-      {
-        "command": "<object>"
-      }
-    ]
-  }
-}
-```
+<div class="x2mdx-ref-badges">
 
-**Responses**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-<span id="endpoint-path-v2-commands-completions"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-### `/v2/commands/completions`
+</div>
 
-<span id="endpoint-post-v2-commands-completions"></span>
+    </div>
 
-- Method: `POST`
+    <p class="x2mdx-ref-card-summary">POST: Submits a single composite command and waits for its result. Propagates the gRPC error of failed submissions including Daml interpretation errors.</p>
 
-- Operation ID: `postV2CommandsCompletions`
-- Description: Query completions list (blocking call)  Subscribe to command completion events. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
 
-**Parameters**
+<dl class="x2mdx-ref-meta-grid">
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `limit` | `query` | `no` | `integer` | maximum number of elements to return, this param is ignored if is bigger than server setting |
-| `stream_idle_timeout_ms` | `query` | `no` | `integer` | timeout to complete and send result if no new elements are received (for open ended streams) |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-**Request Body**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-- Required: `yes`
+</dl>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `parties` |
 
-**Request Example: `application/json`**
+  </div>
 
-```json
-{
-  "parties": [
-    "<string>"
-  ]
-}
-```
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:array[object]` |
-| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-<span id="endpoint-path-v2-commands-submit-and-wait"></span>
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/commands/submit-and-wait-for-transaction</h3>
 
-### `/v2/commands/submit-and-wait`
+<div class="x2mdx-ref-badges">
 
-<span id="endpoint-post-v2-commands-submit-and-wait"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-- Method: `POST`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-- Operation ID: `postV2CommandsSubmit-and-wait`
-- Description: Submits a single composite command and waits for its result. Propagates the gRPC error of failed submissions including Daml interpretation errors.
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-**Request Body**
+</div>
 
-- Required: `yes`
+    </div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `actAs`, `commandId`, `commands` |
+    <p class="x2mdx-ref-card-summary">POST: Submits a single composite command, waits for its result, and returns the transaction. Propagates the gRPC error of failed submissions including Daml interpretation errors.</p>
 
-**Request Example: `application/json`**
 
-```json
-{
-  "commands": [
-    {
-      "CreateAndExerciseCommand": {
-        "templateId": "<string>",
-        "createArguments": "<value>",
-        "choice": "<string>",
-        "choiceArgument": "<value>"
-      }
-    }
-  ],
-  "commandId": "<string>",
-  "actAs": [
-    "<string>"
-  ]
-}
-```
+<dl class="x2mdx-ref-meta-grid">
 
-**Responses**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-<span id="endpoint-path-v2-commands-submit-and-wait-for-reassignment"></span>
+</dl>
 
-### `/v2/commands/submit-and-wait-for-reassignment`
 
-<span id="endpoint-post-v2-commands-submit-and-wait-for-reassignment"></span>
+  </div>
 
-- Method: `POST`
 
-- Operation ID: `postV2CommandsSubmit-and-wait-for-reassignment`
-- Description: Submits a single composite reassignment command, waits for its result, and returns the reassignment. Propagates the gRPC error of failed submission.
 
-**Request Body**
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-- Required: `yes`
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/commands/submit-and-wait-for-reassignment</h3>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `reassignmentCommands` |
+<div class="x2mdx-ref-badges">
 
-**Request Example: `application/json`**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-```json
-{
-  "reassignmentCommands": {
-    "commandId": "<string>",
-    "submitter": "<string>",
-    "commands": [
-      {
-        "command": "<object>"
-      }
-    ]
-  }
-}
-```
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**Responses**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+</div>
 
-<span id="endpoint-path-v2-commands-submit-and-wait-for-transaction"></span>
+    </div>
 
-### `/v2/commands/submit-and-wait-for-transaction`
+    <p class="x2mdx-ref-card-summary">POST: Submits a single composite reassignment command, waits for its result, and returns the reassignment. Propagates the gRPC error of failed submission.</p>
 
-<span id="endpoint-post-v2-commands-submit-and-wait-for-transaction"></span>
 
-- Method: `POST`
+<dl class="x2mdx-ref-meta-grid">
 
-- Operation ID: `postV2CommandsSubmit-and-wait-for-transaction`
-- Description: Submits a single composite command, waits for its result, and returns the transaction. Propagates the gRPC error of failed submissions including Daml interpretation errors.
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-**Request Body**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-- Required: `yes`
+</dl>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `commands` |
 
-**Request Example: `application/json`**
+  </div>
 
-```json
-{
-  "commands": {
-    "commands": [
-      {
-        "CreateAndExerciseCommand": "<object>"
-      }
-    ],
-    "commandId": "<string>",
-    "actAs": [
-      "<string>"
-    ]
-  }
-}
-```
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-<span id="endpoint-path-v2-commands-submit-and-wait-for-transaction-tree"></span>
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/commands/submit-and-wait-for-transaction-tree</h3>
 
-### `/v2/commands/submit-and-wait-for-transaction-tree`
+<div class="x2mdx-ref-badges">
 
-<span id="endpoint-post-v2-commands-submit-and-wait-for-transaction-tree"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-- Method: `POST`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-- Operation ID: `postV2CommandsSubmit-and-wait-for-transaction-tree`
-- Description: Submit a batch of commands and wait for the transaction trees response. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use submit-and-wait-for-transaction instead.
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-**Request Body**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated</span>
 
-- Required: `yes`
+</div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `actAs`, `commandId`, `commands` |
+    </div>
 
-**Request Example: `application/json`**
+    <p class="x2mdx-ref-card-summary">POST: Submit a batch of commands and wait for the transaction trees response. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use submit-and-wait-for...</p>
 
-```json
-{
-  "commands": [
-    {
-      "CreateAndExerciseCommand": {
-        "templateId": "<string>",
-        "createArguments": "<value>",
-        "choice": "<string>",
-        "choiceArgument": "<value>"
-      }
-    }
-  ],
-  "commandId": "<string>",
-  "actAs": [
-    "<string>"
-  ]
-}
-```
 
-**Responses**
+<dl class="x2mdx-ref-meta-grid">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-<span id="endpoint-path-v2-contracts-contract-by-id"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-### `/v2/contracts/contract-by-id`
+</dl>
 
-<span id="endpoint-post-v2-contracts-contract-by-id"></span>
 
-- Method: `POST`
+  </div>
 
-- Operation ID: `postV2ContractsContract-by-id`
-- Description: Looking up contract data by contract ID. This endpoint is experimental / alpha, therefore no backwards compatibility is guaranteed. This endpoint must not be used to look up contracts which entered the participant via party replication or repair service.
 
-**Request Body**
 
-- Required: `yes`
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `contractId` |
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/commands/async/submit</h3>
 
-**Request Example: `application/json`**
+<div class="x2mdx-ref-badges">
 
-```json
-{
-  "contractId": "<string>"
-}
-```
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-**Responses**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-<span id="endpoint-path-v2-dars"></span>
+</div>
 
-### `/v2/dars`
+    </div>
 
-<span id="endpoint-post-v2-dars"></span>
+    <p class="x2mdx-ref-card-summary">POST: Submit a single composite command.</p>
 
-- Method: `POST`
 
-- Operation ID: `postV2Dars`
-- Description: Upload a DAR to the participant node
+<dl class="x2mdx-ref-meta-grid">
 
-**Parameters**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `vetAllPackages` | `query` | `no` | `boolean` | - |
-| `synchronizerId` | `query` | `no` | `string` | - |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-**Request Body**
+</dl>
 
-- Required: `yes`
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/octet-stream` | `string` | - |
+  </div>
 
-**Request Example: `application/octet-stream`**
 
-```json
-"<string>"
-```
 
-**Responses**
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter vetAllPackages, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/commands/async/submit-reassignment</h3>
 
-<span id="endpoint-path-v2-dars-validate"></span>
+<div class="x2mdx-ref-badges">
 
-### `/v2/dars/validate`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-<span id="endpoint-post-v2-dars-validate"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-- Method: `POST`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Operation ID: `postV2DarsValidate`
-- Description: Validates the DAR and checks the upgrade compatibility of the DAR's packages with the set of the already vetted packages on the target vetting synchronizer. See ValidateDarFileRequest for details regarding the target vetting synchronizer.  The operation has no effect on the state of the participant or the Canton ledger: the DAR payload and its packages are not persisted neither are the packages vetted.
+</div>
 
-**Parameters**
+    </div>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `synchronizerId` | `query` | `no` | `string` | - |
+    <p class="x2mdx-ref-card-summary">POST: Submit a single reassignment.</p>
 
-**Request Body**
 
-- Required: `yes`
+<dl class="x2mdx-ref-meta-grid">
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/octet-stream` | `string` | - |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-**Request Example: `application/octet-stream`**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-```json
-"<string>"
-```
+</dl>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `-` | `-` |
-| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  </div>
 
-<span id="endpoint-path-v2-events-events-by-contract-id"></span>
 
-### `/v2/events/events-by-contract-id`
 
-<span id="endpoint-post-v2-events-events-by-contract-id"></span>
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-- Method: `POST`
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/commands/completions</h3>
 
-- Operation ID: `postV2EventsEvents-by-contract-id`
-- Description: Get the create and the consuming exercise event for the contract with the provided ID. No events will be returned for contracts that have been pruned because they have already been archived before the latest pruning offset. If the contract cannot be found for the request, or all the contract-events are filtered, a CONTRACT_EVENTS_NOT_FOUND error will be raised.
+<div class="x2mdx-ref-badges">
 
-**Request Body**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-- Required: `yes`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `contractId`, `eventFormat` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-**Request Example: `application/json`**
+</div>
 
-```json
-{
-  "contractId": "<string>",
-  "eventFormat": {
-    "filtersByParty": {},
-    "filtersForAnyParty": {
-      "cumulative": [
-        "<object>"
-      ]
-    },
-    "verbose": "<boolean>"
-  }
-}
-```
+    </div>
 
-**Responses**
+    <p class="x2mdx-ref-card-summary">POST: Query completions list (blocking call) Subscribe to command completion events. Notice: This endpoint should be used for small results set. When number of results exceeded node confi...</p>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-idps"></span>
+<dl class="x2mdx-ref-meta-grid">
 
-### `/v2/idps`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-- Methods: `GET`, `POST`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-<span id="endpoint-get-v2-idps"></span>
+</dl>
 
-**GET**
 
-- Operation ID: `getV2Idps`
-- Description: List all existing identity provider configurations.
+  </div>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-post-v2-idps"></span>
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**POST**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/events/events-by-contract-id</h3>
 
-- Operation ID: `postV2Idps`
-- Description: Create a new identity provider configuration. The request will fail if the maximum allowed number of separate configurations is reached.
+<div class="x2mdx-ref-badges">
 
-**Request Body**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-- Required: `yes`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `identityProviderConfig` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-**Request Example: `application/json`**
+</div>
 
-```json
-{
-  "identityProviderConfig": {
-    "identityProviderId": "<string>",
-    "issuer": "<string>",
-    "jwksUrl": "<string>"
-  }
-}
-```
+    </div>
 
-**Responses**
+    <p class="x2mdx-ref-card-summary">POST: Get the create and the consuming exercise event for the contract with the provided ID. No events will be returned for contracts that have been pruned because they have already been...</p>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-idps-idp-id"></span>
+<dl class="x2mdx-ref-meta-grid">
 
-### `/v2/idps/{idp-id}`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-- Methods: `DELETE`, `GET`, `PATCH`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-<span id="endpoint-delete-v2-idps-idp-id"></span>
+</dl>
 
-**DELETE**
 
-- Operation ID: `deleteV2IdpsIdp-id`
-- Description: Delete an existing identity provider configuration.
+  </div>
 
-**Parameters**
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `idp-id` | `path` | `yes` | `string` | - |
 
-**Responses**
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/version</h3>
 
-<span id="endpoint-get-v2-idps-idp-id"></span>
+<div class="x2mdx-ref-badges">
 
-**GET**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
 
-- Operation ID: `getV2IdpsIdp-id`
-- Description: Get the identity provider configuration data by id.
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**Parameters**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `idp-id` | `path` | `yes` | `string` | - |
+</div>
 
-**Responses**
+    </div>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+    <p class="x2mdx-ref-card-summary">GET: Read the Ledger API version</p>
 
-<span id="endpoint-patch-v2-idps-idp-id"></span>
 
-**PATCH**
+<dl class="x2mdx-ref-meta-grid">
 
-- Operation ID: `patchV2IdpsIdp-id`
-- Description: Update selected modifiable attribute of an identity provider config resource described by the ``IdentityProviderConfig`` message.
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
 
-**Parameters**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `idp-id` | `path` | `yes` | `string` | - |
+</dl>
 
-**Request Body**
 
-- Required: `yes`
+  </div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `identityProviderConfig`, `updateMask` |
 
-**Request Example: `application/json`**
 
-```json
-{
-  "identityProviderConfig": {
-    "identityProviderId": "<string>",
-    "issuer": "<string>",
-    "jwksUrl": "<string>"
-  },
-  "updateMask": {
-    "unknownFields": {
-      "fields": {}
-    }
-  }
-}
-```
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**Responses**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/dars/validate</h3>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+<div class="x2mdx-ref-badges">
 
-<span id="endpoint-path-v2-interactive-submission-execute"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-### `/v2/interactive-submission/execute`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-<span id="endpoint-post-v2-interactive-submission-execute"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Method: `POST`
+</div>
 
-- Operation ID: `postV2Interactive-submissionExecute`
-- Description: Execute a prepared submission _asynchronously_ on the ledger. Requires a signature of the transaction from the submitting external party.
+    </div>
 
-**Request Body**
+    <p class="x2mdx-ref-card-summary">POST: Validates the DAR and checks the upgrade compatibility of the DAR&#x27;s packages with the set of the already vetted packages on the target vetting synchronizer. See ValidateDarFileReque...</p>
 
-- Required: `yes`
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `hashingSchemeVersion`, `partySignatures`, `preparedTransaction`, `submissionId` |
+<dl class="x2mdx-ref-meta-grid">
 
-**Request Example: `application/json`**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-```json
-{
-  "preparedTransaction": "<string>",
-  "partySignatures": {
-    "signatures": [
-      {
-        "party": "<string>",
-        "signatures": [
-          "<object>"
-        ]
-      }
-    ]
-  },
-  "submissionId": "<string>",
-  "hashingSchemeVersion": "<string>"
-}
-```
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-**Responses**
+</dl>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-interactive-submission-executeandwait"></span>
+  </div>
 
-### `/v2/interactive-submission/executeAndWait`
 
-<span id="endpoint-post-v2-interactive-submission-executeandwait"></span>
 
-- Method: `POST`
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-- Operation ID: `postV2Interactive-submissionExecuteandwait`
-- Description: Similar to ExecuteSubmission but _synchronously_ wait for the completion of the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appeared failed and vice versa
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/dars</h3>
 
-**Request Body**
+<div class="x2mdx-ref-badges">
 
-- Required: `yes`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `hashingSchemeVersion`, `partySignatures`, `preparedTransaction`, `submissionId` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**Request Example: `application/json`**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-```json
-{
-  "preparedTransaction": "<string>",
-  "partySignatures": {
-    "signatures": [
-      {
-        "party": "<string>",
-        "signatures": [
-          "<object>"
-        ]
-      }
-    ]
-  },
-  "submissionId": "<string>",
-  "hashingSchemeVersion": "<string>"
-}
-```
+</div>
 
-**Responses**
+    </div>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+    <p class="x2mdx-ref-card-summary">POST: Upload a DAR to the participant node</p>
 
-<span id="endpoint-path-v2-interactive-submission-executeandwaitfortransaction"></span>
 
-### `/v2/interactive-submission/executeAndWaitForTransaction`
+<dl class="x2mdx-ref-meta-grid">
 
-<span id="endpoint-post-v2-interactive-submission-executeandwaitfortransaction"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-- Method: `POST`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-- Operation ID: `postV2Interactive-submissionExecuteandwaitfortransaction`
-- Description: Similar to ExecuteSubmissionAndWait but additionally returns the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be honest. A malicious node could make a successfully committed request appear as failed and vice versa
+</dl>
 
-**Request Body**
 
-- Required: `yes`
+  </div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `hashingSchemeVersion`, `partySignatures`, `preparedTransaction`, `submissionId` |
 
-**Request Example: `application/json`**
 
-```json
-{
-  "preparedTransaction": "<string>",
-  "partySignatures": {
-    "signatures": [
-      {
-        "party": "<string>",
-        "signatures": [
-          "<object>"
-        ]
-      }
-    ]
-  },
-  "submissionId": "<string>",
-  "hashingSchemeVersion": "<string>"
-}
-```
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**Responses**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/packages</h3>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+<div class="x2mdx-ref-badges">
 
-<span id="endpoint-path-v2-interactive-submission-preferred-package-version"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET, POST</span>
 
-### `/v2/interactive-submission/preferred-package-version`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-<span id="endpoint-get-v2-interactive-submission-preferred-package-version"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Method: `GET`
+</div>
 
-- Operation ID: `getV2Interactive-submissionPreferred-package-version`
-- Description: A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred package, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Provided for backwards compatibility, it will be removed in the Canton version 3.4.0
+    </div>
 
-**Parameters**
+    <p class="x2mdx-ref-card-summary">GET: Returns the identifiers of all supported packages.; POST: Behaves the same as /dars. This endpoint will be deprecated and removed in a future release. Upload a DAR file to the partic...</p>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `parties` | `query` | `no` | `array[string]` | - |
-| `package-name` | `query` | `yes` | `string` | - |
-| `vetting_valid_at` | `query` | `no` | `string` | - |
-| `synchronizer-id` | `query` | `no` | `string` | - |
 
-**Responses**
+<dl class="x2mdx-ref-meta-grid">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: query parameter parties, Invalid value for: query parameter package-name, Invalid value for: query parameter vetting_valid_at, Invalid value for: query parameter synchronizer-id | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET, POST</dd>
+  </div>
 
-<span id="endpoint-path-v2-interactive-submission-preferred-packages"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-### `/v2/interactive-submission/preferred-packages`
+</dl>
 
-<span id="endpoint-post-v2-interactive-submission-preferred-packages"></span>
 
-- Method: `POST`
+  </div>
 
-- Operation ID: `postV2Interactive-submissionPreferred-packages`
-- Description: Compute the preferred packages for the vetting requirements in the request. A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties.  Ledger API clients should use this endpoint for constructing command submissions that are compatible with the provided preferred packages, by making informed decisions on: - which are the compatible packages that can be used to create contracts - which contract or exercise choice argument version can be used in the command - which choices can be executed on a template or interface of a contract  If the package preferences could not be computed due to no selection satisfying the requirements, a `FAILED_PRECONDITION` error will be returned.  Can be accessed by any Ledger API client with a valid token when Ledger API authorization is enabled.  Experimental API: this endpoint is not guaranteed to provide backwards compatibility in future releases
 
-**Request Body**
 
-- Required: `yes`
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `packageVettingRequirements` |
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/packages/&#123;package-id&#125;</h3>
 
-**Request Example: `application/json`**
+<div class="x2mdx-ref-badges">
 
-```json
-{
-  "packageVettingRequirements": [
-    {
-      "parties": [
-        "<string>"
-      ],
-      "packageName": "<string>"
-    }
-  ]
-}
-```
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
 
-**Responses**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-<span id="endpoint-path-v2-interactive-submission-prepare"></span>
+</div>
 
-### `/v2/interactive-submission/prepare`
+    </div>
 
-<span id="endpoint-post-v2-interactive-submission-prepare"></span>
+    <p class="x2mdx-ref-card-summary">GET: Returns the contents of a single package.</p>
 
-- Method: `POST`
 
-- Operation ID: `postV2Interactive-submissionPrepare`
-- Description: Requires `readAs` scope for the submitting party when LAPI User authorization is enabled
+<dl class="x2mdx-ref-meta-grid">
 
-**Request Body**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
 
-- Required: `yes`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `actAs`, `commandId`, `commands` |
+</dl>
 
-**Request Example: `application/json`**
 
-```json
-{
-  "commandId": "<string>",
-  "commands": [
-    {
-      "CreateAndExerciseCommand": {
-        "templateId": "<string>",
-        "createArguments": "<value>",
-        "choice": "<string>",
-        "choiceArgument": "<value>"
-      }
-    }
-  ],
-  "actAs": [
-    "<string>"
-  ]
-}
-```
+  </div>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-package-vetting"></span>
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-### `/v2/package-vetting`
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/packages/&#123;package-id&#125;/status</h3>
 
-- Methods: `GET`, `POST`
+<div class="x2mdx-ref-badges">
 
-<span id="endpoint-get-v2-package-vetting"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
 
-**GET**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-- Operation ID: `getV2Package-vetting`
-- Description: Lists which participant node vetted what packages on which synchronizer. This endpoint (GET /package-vetting) is deprecated and will be removed in a future release. Please use POST /package-vetting/list instead.
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-**Request Body**
+</div>
 
-- Required: `yes`
+    </div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | - |
+    <p class="x2mdx-ref-card-summary">GET: Returns the status of a single package.</p>
 
-**Request Example: `application/json`**
 
-```json
-{
-  "packageMetadataFilter": {
-    "packageIds": [
-      "<string>"
-    ],
-    "packageNamePrefixes": [
-      "<string>"
-    ]
-  },
-  "topologyStateFilter": {
-    "participantIds": [
-      "<string>"
-    ],
-    "synchronizerIds": [
-      "<string>"
-    ]
-  },
-  "pageToken": "<string>",
-  "pageSize": "<integer>"
-}
-```
+<dl class="x2mdx-ref-meta-grid">
 
-**Responses**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-<span id="endpoint-post-v2-package-vetting"></span>
+</dl>
 
-**POST**
 
-- Operation ID: `postV2Package-vetting`
-- Description: Update the vetted packages of this participant This endpoint (POST /package-vetting) is deprecated and will be removed in a future release. Please use POST /package-vetting/update instead.
+  </div>
 
-**Request Body**
 
-- Required: `yes`
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `changes` |
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**Request Example: `application/json`**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/package-vetting</h3>
 
-```json
-{
-  "changes": [
-    {
-      "operation": {
-        "Empty": "<object>"
-      }
-    }
-  ]
-}
-```
+<div class="x2mdx-ref-badges">
 
-**Responses**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET, POST</span>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-<span id="endpoint-path-v2-package-vetting-list"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-### `/v2/package-vetting/list`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated</span>
 
-<span id="endpoint-post-v2-package-vetting-list"></span>
+</div>
 
-- Method: `POST`
+    </div>
 
-- Operation ID: `postV2Package-vettingList`
-- Description: Lists which participant node vetted what packages on which synchronizer. Can be called by any authenticated user.
+    <p class="x2mdx-ref-card-summary">GET: Lists which participant node vetted what packages on which synchronizer. This endpoint (GET /package-vetting) is deprecated and will be removed in a future release. Please use POST /...</p>
 
-**Request Body**
 
-- Required: `yes`
+<dl class="x2mdx-ref-meta-grid">
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | - |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET, POST</dd>
+  </div>
 
-**Request Example: `application/json`**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-```json
-{
-  "packageMetadataFilter": {
-    "packageIds": [
-      "<string>"
-    ],
-    "packageNamePrefixes": [
-      "<string>"
-    ]
-  },
-  "topologyStateFilter": {
-    "participantIds": [
-      "<string>"
-    ],
-    "synchronizerIds": [
-      "<string>"
-    ]
-  },
-  "pageToken": "<string>",
-  "pageSize": "<integer>"
-}
-```
+</dl>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  </div>
 
-<span id="endpoint-path-v2-package-vetting-update"></span>
 
-### `/v2/package-vetting/update`
 
-<span id="endpoint-post-v2-package-vetting-update"></span>
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-- Method: `POST`
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/package-vetting/list</h3>
 
-- Operation ID: `postV2Package-vettingUpdate`
-- Description: Update the vetted packages of this participant
+<div class="x2mdx-ref-badges">
 
-**Request Body**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-- Required: `yes`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `changes` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-**Request Example: `application/json`**
+</div>
 
-```json
-{
-  "changes": [
-    {
-      "operation": {
-        "Empty": "<object>"
-      }
-    }
-  ]
-}
-```
+    </div>
 
-**Responses**
+    <p class="x2mdx-ref-card-summary">POST: Lists which participant node vetted what packages on which synchronizer. Can be called by any authenticated user.</p>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-packages"></span>
+<dl class="x2mdx-ref-meta-grid">
 
-### `/v2/packages`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-- Methods: `GET`, `POST`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-<span id="endpoint-get-v2-packages"></span>
+</dl>
 
-**GET**
 
-- Operation ID: `getV2Packages`
-- Description: Returns the identifiers of all supported packages.
+  </div>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-post-v2-packages"></span>
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**POST**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/package-vetting/update</h3>
 
-- Operation ID: `postV2Packages`
-- Description: Behaves the same as /dars. This endpoint will be deprecated and removed in a future release. Upload a DAR file to the participant.  If vetting is enabled in the request, the DAR is checked for upgrade compatibility with the set of the already vetted packages on the target vetting synchronizer See UploadDarFileRequest for details regarding vetting and the target vetting synchronizer.
+<div class="x2mdx-ref-badges">
 
-**Parameters**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `vetAllPackages` | `query` | `no` | `boolean` | - |
-| `synchronizerId` | `query` | `no` | `string` | - |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**Request Body**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Required: `yes`
+</div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/octet-stream` | `string` | - |
+    </div>
 
-**Request Example: `application/octet-stream`**
+    <p class="x2mdx-ref-card-summary">POST: Update the vetted packages of this participant</p>
 
-```json
-"<string>"
-```
 
-**Responses**
+<dl class="x2mdx-ref-meta-grid">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter vetAllPackages, Invalid value for: query parameter synchronizerId | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-<span id="endpoint-path-v2-packages-package-id"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-### `/v2/packages/{package-id}`
+</dl>
 
-<span id="endpoint-get-v2-packages-package-id"></span>
 
-- Method: `GET`
+  </div>
 
-- Operation ID: `getV2PackagesPackage-id`
-- Description: Returns the contents of a single package.
 
-**Parameters**
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `package-id` | `path` | `yes` | `string` | - |
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**Responses**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/parties</h3>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/octet-stream` | `application/octet-stream:string` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+<div class="x2mdx-ref-badges">
 
-<span id="endpoint-path-v2-packages-package-id-status"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET, POST</span>
 
-### `/v2/packages/{package-id}/status`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-<span id="endpoint-get-v2-packages-package-id-status"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Method: `GET`
+</div>
 
-- Operation ID: `getV2PackagesPackage-idStatus`
-- Description: Returns the status of a single package.
+    </div>
 
-**Parameters**
+    <p class="x2mdx-ref-card-summary">GET: List the parties known by the participant. The list returned contains parties whose ledger access is facilitated by the participant and the ones maintained elsewhere.; POST: Allocate...</p>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `package-id` | `path` | `yes` | `string` | - |
 
-**Responses**
+<dl class="x2mdx-ref-meta-grid">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET, POST</dd>
+  </div>
 
-<span id="endpoint-path-v2-parties"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-### `/v2/parties`
+</dl>
 
-- Methods: `GET`, `POST`
 
-<span id="endpoint-get-v2-parties"></span>
+  </div>
 
-**GET**
 
-- Operation ID: `getV2Parties`
-- Description: List the parties known by the participant. The list returned contains parties whose ledger access is facilitated by the participant and the ones maintained elsewhere.
 
-**Parameters**
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `identity-provider-id` | `query` | `no` | `string` | - |
-| `filter-party` | `query` | `no` | `string` | - |
-| `pageSize` | `query` | `no` | `integer` | maximum number of elements in a returned page |
-| `pageToken` | `query` | `no` | `string` | token - to continue results from a given page, leave empty to start from the beginning of the list, obtain token from the result of previous page |
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/parties/external/allocate</h3>
 
-**Responses**
+<div class="x2mdx-ref-badges">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: query parameter identity-provider-id, Invalid value for: query parameter filter-party, Invalid value for: query parameter pageSize, Invalid value for: query parameter pageToken | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-<span id="endpoint-post-v2-parties"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**POST**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Operation ID: `postV2Parties`
-- Description: Allocates a new party on a ledger and adds it to the set managed by the participant. Caller specifies a party identifier suggestion, the actual identifier allocated might be different and is implementation specific. Caller can specify party metadata that is stored locally on the participant. This call may:  - Succeed, in which case the actual allocated identifier is visible in   the response. - Respond with a gRPC error  daml-on-kv-ledger: suggestion's uniqueness is checked by the validators in the consensus layer and call rejected if the identifier is already present. canton: completely different globally unique identifier is allocated. Behind the scenes calls to an internal protocol are made. As that protocol is richer than the surface protocol, the arguments take implicit values The party identifier suggestion must be a valid party name. Party names are required to be non-empty US-ASCII strings built from letters, digits, space, colon, minus and underscore limited to 255 chars
+</div>
 
-**Request Body**
+    </div>
 
-- Required: `yes`
+    <p class="x2mdx-ref-card-summary">POST: Alpha 3.3: Endpoint to allocate a new external party on a synchronizer Expected to be stable in 3.5 The external party must be hosted (at least) on this node with either confirmatio...</p>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | - |
 
-**Request Example: `application/json`**
+<dl class="x2mdx-ref-meta-grid">
 
-```json
-{
-  "partyIdHint": "<string>",
-  "localMetadata": {
-    "resourceVersion": "<string>",
-    "annotations": {}
-  },
-  "identityProviderId": "<string>",
-  "synchronizerId": "<string>",
-  "userId": "<string>"
-}
-```
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-**Responses**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+</dl>
 
-<span id="endpoint-path-v2-parties-external-allocate"></span>
 
-### `/v2/parties/external/allocate`
+  </div>
 
-<span id="endpoint-post-v2-parties-external-allocate"></span>
 
-- Method: `POST`
 
-- Operation ID: `postV2PartiesExternalAllocate`
-- Description: Alpha 3.3: Endpoint to allocate a new external party on a synchronizer  Expected to be stable in 3.5  The external party must be hosted (at least) on this node with either confirmation or observation permissions It can optionally be hosted on other nodes (then called a multi-hosted party). If hosted on additional nodes, explicit authorization of the hosting relationship must be performed on those nodes before the party can be used. Decentralized namespaces are supported but must be provided fully authorized by their owners. The individual owner namespace transactions can be submitted in the same call (fully authorized as well). In the simple case of a non-multi hosted, non-decentralized party, the RPC will return once the party is effectively allocated and ready to use, similarly to the AllocateParty behavior. For more complex scenarios applications may need to query the party status explicitly (only through the admin API as of now).
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**Request Body**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/parties/participant-id</h3>
 
-- Required: `yes`
+<div class="x2mdx-ref-badges">
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `onboardingTransactions`, `synchronizer` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
 
-**Request Example: `application/json`**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-```json
-{
-  "synchronizer": "<string>",
-  "onboardingTransactions": [
-    {
-      "transaction": "<string>"
-    }
-  ]
-}
-```
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-**Responses**
+</div>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+    </div>
 
-<span id="endpoint-path-v2-parties-external-generate-topology"></span>
+    <p class="x2mdx-ref-card-summary">GET: Return the identifier of the participant. All horizontally scaled replicas should return the same id. daml-on-kv-ledger: returns an identifier supplied on command line at launch time...</p>
 
-### `/v2/parties/external/generate-topology`
 
-<span id="endpoint-post-v2-parties-external-generate-topology"></span>
+<dl class="x2mdx-ref-meta-grid">
 
-- Method: `POST`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
 
-- Operation ID: `postV2PartiesExternalGenerate-topology`
-- Description: Alpha 3.3: Convenience endpoint to generate topology transactions for external signing  Expected to be stable in 3.5  You may use this endpoint to generate the common external topology transactions which can be signed externally and uploaded as part of the allocate party process  Note that this request will create a normal namespace using the same key for the identity as for signing. More elaborate schemes such as multi-signature or decentralized parties require you to construct the topology transactions yourself.
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-**Request Body**
+</dl>
 
-- Required: `yes`
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `partyHint`, `publicKey`, `synchronizer` |
+  </div>
 
-**Request Example: `application/json`**
 
-```json
-{
-  "synchronizer": "<string>",
-  "partyHint": "<string>",
-  "publicKey": {
-    "format": "<string>",
-    "keyData": "<string>",
-    "keySpec": "<string>"
-  }
-}
-```
 
-**Responses**
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/parties/&#123;party&#125;</h3>
 
-<span id="endpoint-path-v2-parties-participant-id"></span>
+<div class="x2mdx-ref-badges">
 
-### `/v2/parties/participant-id`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET, PATCH</span>
 
-<span id="endpoint-get-v2-parties-participant-id"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-- Method: `GET`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Operation ID: `getV2PartiesParticipant-id`
-- Description: Return the identifier of the participant. All horizontally scaled replicas should return the same id. daml-on-kv-ledger: returns an identifier supplied on command line at launch time canton: returns globally unique identifier of the participant
+</div>
 
-**Responses**
+    </div>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+    <p class="x2mdx-ref-card-summary">GET: Get the party details of the given parties. Only known parties will be returned in the list.; PATCH: Update selected modifiable participant-local attributes of a party details resour...</p>
 
-<span id="endpoint-path-v2-parties-party"></span>
 
-### `/v2/parties/{party}`
+<dl class="x2mdx-ref-meta-grid">
 
-- Methods: `GET`, `PATCH`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET, PATCH</dd>
+  </div>
 
-<span id="endpoint-get-v2-parties-party"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-**GET**
+</dl>
 
-- Operation ID: `getV2PartiesParty`
-- Description: Get the party details of the given parties. Only known parties will be returned in the list.
 
-**Parameters**
+  </div>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `party` | `path` | `yes` | `string` | - |
-| `identity-provider-id` | `query` | `no` | `string` | - |
-| `parties` | `query` | `no` | `array[string]` | - |
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: query parameter identity-provider-id, Invalid value for: query parameter parties | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-<span id="endpoint-patch-v2-parties-party"></span>
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/parties/external/generate-topology</h3>
 
-**PATCH**
+<div class="x2mdx-ref-badges">
 
-- Operation ID: `patchV2PartiesParty`
-- Description: Update selected modifiable participant-local attributes of a party details resource. Can update the participant's local information for local parties.
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-**Parameters**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `party` | `path` | `yes` | `string` | - |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-**Request Body**
+</div>
 
-- Required: `yes`
+    </div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `partyDetails`, `updateMask` |
+    <p class="x2mdx-ref-card-summary">POST: Alpha 3.3: Convenience endpoint to generate topology transactions for external signing Expected to be stable in 3.5 You may use this endpoint to generate the common external topolog...</p>
 
-**Request Example: `application/json`**
 
-```json
-{
-  "partyDetails": {
-    "party": "<string>"
-  },
-  "updateMask": {
-    "unknownFields": {
-      "fields": {}
-    }
-  }
-}
-```
+<dl class="x2mdx-ref-meta-grid">
 
-**Responses**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-<span id="endpoint-path-v2-state-active-contracts"></span>
+</dl>
 
-### `/v2/state/active-contracts`
 
-<span id="endpoint-post-v2-state-active-contracts"></span>
+  </div>
 
-- Method: `POST`
 
-- Operation ID: `postV2StateActive-contracts`
-- Description: Query active contracts list (blocking call). Querying active contracts is an expensive operation and if possible should not be repeated often. Consider querying active contracts initially (for a given offset) and then repeatedly call one of `/v2/updates/...`endpoints  to get subsequent modifications. You can also use websockets to get updates with better performance.  Returns a stream of the snapshot of the active contracts and incomplete (un)assignments at a ledger offset. Once the stream of GetActiveContractsResponses completes, the client SHOULD begin streaming updates from the update service, starting at the GetActiveContractsRequest.active_at_offset specified in this request. Clients SHOULD NOT assume that the set of active contracts they receive reflects the state at the ledger end.  Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
 
-**Parameters**
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `limit` | `query` | `no` | `integer` | maximum number of elements to return, this param is ignored if is bigger than server setting |
-| `stream_idle_timeout_ms` | `query` | `no` | `integer` | timeout to complete and send result if no new elements are received (for open ended streams) |
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/state/active-contracts</h3>
 
-**Request Body**
+<div class="x2mdx-ref-badges">
 
-- Required: `yes`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `activeAtOffset` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**Request Example: `application/json`**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-```json
-{
-  "activeAtOffset": "<integer>"
-}
-```
+</div>
 
-**Responses**
+    </div>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:array[object]` |
-| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+    <p class="x2mdx-ref-card-summary">POST: Query active contracts list (blocking call). Querying active contracts is an expensive operation and if possible should not be repeated often. Consider querying active contracts ini...</p>
 
-<span id="endpoint-path-v2-state-connected-synchronizers"></span>
 
-### `/v2/state/connected-synchronizers`
+<dl class="x2mdx-ref-meta-grid">
 
-<span id="endpoint-get-v2-state-connected-synchronizers"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-- Method: `GET`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-- Operation ID: `getV2StateConnected-synchronizers`
-- Description: Get the list of connected synchronizers at the time of the query.
+</dl>
 
-**Parameters**
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `party` | `query` | `no` | `string` | - |
-| `participantId` | `query` | `no` | `string` | - |
-| `identityProviderId` | `query` | `no` | `string` | - |
+  </div>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: query parameter party, Invalid value for: query parameter participantId, Invalid value for: query parameter identityProviderId | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-state-latest-pruned-offsets"></span>
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-### `/v2/state/latest-pruned-offsets`
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/state/connected-synchronizers</h3>
 
-<span id="endpoint-get-v2-state-latest-pruned-offsets"></span>
+<div class="x2mdx-ref-badges">
 
-- Method: `GET`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
 
-- Operation ID: `getV2StateLatest-pruned-offsets`
-- Description: Get the latest successfully pruned ledger offsets
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**Responses**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+</div>
 
-<span id="endpoint-path-v2-state-ledger-end"></span>
+    </div>
 
-### `/v2/state/ledger-end`
+    <p class="x2mdx-ref-card-summary">GET: Get the list of connected synchronizers at the time of the query.</p>
 
-<span id="endpoint-get-v2-state-ledger-end"></span>
 
-- Method: `GET`
+<dl class="x2mdx-ref-meta-grid">
 
-- Operation ID: `getV2StateLedger-end`
-- Description: Get the current ledger end. Subscriptions started with the returned offset will serve events after this RPC was called.
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
 
-**Responses**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+</dl>
 
-<span id="endpoint-path-v2-updates"></span>
 
-### `/v2/updates`
+  </div>
 
-<span id="endpoint-post-v2-updates"></span>
 
-- Method: `POST`
 
-- Operation ID: `postV2Updates`
-- Description: Read the ledger's filtered update stream for the specified contents and filters. It returns the event types in accordance with the stream contents selected. Also the selection criteria for individual events depends on the transaction shape chosen.  - ACS delta: a requesting party must be a stakeholder of an event for it to be included. - ledger effects: a requesting party must be a witness of an event for it to be included. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**Parameters**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/state/ledger-end</h3>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `limit` | `query` | `no` | `integer` | maximum number of elements to return, this param is ignored if is bigger than server setting |
-| `stream_idle_timeout_ms` | `query` | `no` | `integer` | timeout to complete and send result if no new elements are received (for open ended streams) |
+<div class="x2mdx-ref-badges">
 
-**Request Body**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
 
-- Required: `yes`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `beginExclusive` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-**Request Example: `application/json`**
+</div>
 
-```json
-{
-  "beginExclusive": "<integer>"
-}
-```
+    </div>
 
-**Responses**
+    <p class="x2mdx-ref-card-summary">GET: Get the current ledger end. Subscriptions started with the returned offset will serve events after this RPC was called.</p>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:array[object]` |
-| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-updates-flats"></span>
+<dl class="x2mdx-ref-meta-grid">
 
-### `/v2/updates/flats`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
 
-<span id="endpoint-post-v2-updates-flats"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-- Method: `POST`
+</dl>
 
-- Operation ID: `postV2UpdatesFlats`
-- Description: Query flat transactions update list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
 
-**Parameters**
+  </div>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `limit` | `query` | `no` | `integer` | maximum number of elements to return, this param is ignored if is bigger than server setting |
-| `stream_idle_timeout_ms` | `query` | `no` | `integer` | timeout to complete and send result if no new elements are received (for open ended streams) |
 
-**Request Body**
 
-- Required: `yes`
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `beginExclusive` |
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/state/latest-pruned-offsets</h3>
 
-**Request Example: `application/json`**
+<div class="x2mdx-ref-badges">
 
-```json
-{
-  "beginExclusive": "<integer>"
-}
-```
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
 
-**Responses**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:array[object]` |
-| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-<span id="endpoint-path-v2-updates-transaction-by-id"></span>
+</div>
 
-### `/v2/updates/transaction-by-id`
+    </div>
 
-<span id="endpoint-post-v2-updates-transaction-by-id"></span>
+    <p class="x2mdx-ref-card-summary">GET: Get the latest successfully pruned ledger offsets</p>
 
-- Method: `POST`
 
-- Operation ID: `postV2UpdatesTransaction-by-id`
-- Description: Get transaction by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.
+<dl class="x2mdx-ref-meta-grid">
 
-**Request Body**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
 
-- Required: `yes`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `updateId` |
+</dl>
 
-**Request Example: `application/json`**
 
-```json
-{
-  "updateId": "<string>"
-}
-```
+  </div>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-updates-transaction-by-offset"></span>
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-### `/v2/updates/transaction-by-offset`
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/updates</h3>
 
-<span id="endpoint-post-v2-updates-transaction-by-offset"></span>
+<div class="x2mdx-ref-badges">
 
-- Method: `POST`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-- Operation ID: `postV2UpdatesTransaction-by-offset`
-- Description: Get transaction by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead.
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**Request Body**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Required: `yes`
+</div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `offset` |
+    </div>
 
-**Request Example: `application/json`**
+    <p class="x2mdx-ref-card-summary">POST: Read the ledger&#x27;s filtered update stream for the specified contents and filters. It returns the event types in accordance with the stream contents selected. Also the selection crite...</p>
 
-```json
-{
-  "offset": "<integer>"
-}
-```
 
-**Responses**
+<dl class="x2mdx-ref-meta-grid">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-<span id="endpoint-path-v2-updates-transaction-tree-by-id-update-id"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-### `/v2/updates/transaction-tree-by-id/{update-id}`
+</dl>
 
-<span id="endpoint-get-v2-updates-transaction-tree-by-id-update-id"></span>
 
-- Method: `GET`
+  </div>
 
-- Operation ID: `getV2UpdatesTransaction-tree-by-idUpdate-id`
-- Description: Get transaction tree by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.
 
-**Parameters**
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `update-id` | `path` | `yes` | `string` | - |
-| `parties` | `query` | `no` | `array[string]` | - |
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**Responses**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/updates/flats</h3>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: query parameter parties | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+<div class="x2mdx-ref-badges">
 
-<span id="endpoint-path-v2-updates-transaction-tree-by-offset-offset"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-### `/v2/updates/transaction-tree-by-offset/{offset}`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-<span id="endpoint-get-v2-updates-transaction-tree-by-offset-offset"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Method: `GET`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated</span>
 
-- Operation ID: `getV2UpdatesTransaction-tree-by-offsetOffset`
-- Description: Get transaction tree by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead.
+</div>
 
-**Parameters**
+    </div>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `offset` | `path` | `yes` | `integer` | - |
-| `parties` | `query` | `no` | `array[string]` | - |
+    <p class="x2mdx-ref-card-summary">POST: Query flat transactions update list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpo...</p>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: path parameter offset, Invalid value for: query parameter parties | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+<dl class="x2mdx-ref-meta-grid">
 
-<span id="endpoint-path-v2-updates-trees"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-### `/v2/updates/trees`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-<span id="endpoint-post-v2-updates-trees"></span>
+</dl>
 
-- Method: `POST`
 
-- Operation ID: `postV2UpdatesTrees`
-- Description: Query update transactions tree list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpoint should be used for small results set. When number of results exceeded node configuration limit (`http-list-max-elements-limit`) there will be an error (`413 Content Too Large`) returned. Increasing this limit may lead to performance issues and high memory consumption. Consider using websockets (asyncapi) for better efficiency with larger results.
+  </div>
 
-**Parameters**
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `limit` | `query` | `no` | `integer` | maximum number of elements to return, this param is ignored if is bigger than server setting |
-| `stream_idle_timeout_ms` | `query` | `no` | `integer` | timeout to complete and send result if no new elements are received (for open ended streams) |
 
-**Request Body**
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-- Required: `yes`
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/updates/trees</h3>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `beginExclusive` |
+<div class="x2mdx-ref-badges">
 
-**Request Example: `application/json`**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-```json
-{
-  "beginExclusive": "<integer>"
-}
-```
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**Responses**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:array[object]` |
-| `400` | Invalid value, Invalid value for: body, Invalid value for: query parameter limit, Invalid value for: query parameter stream_idle_timeout_ms | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated</span>
 
-<span id="endpoint-path-v2-updates-update-by-id"></span>
+</div>
 
-### `/v2/updates/update-by-id`
+    </div>
 
-<span id="endpoint-post-v2-updates-update-by-id"></span>
+    <p class="x2mdx-ref-card-summary">POST: Query update transactions tree list (blocking call). Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates instead. Notice: This endpo...</p>
 
-- Method: `POST`
 
-- Operation ID: `postV2UpdatesUpdate-by-id`
-- Description: Lookup an update by its ID. If there is no update with this ID, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
+<dl class="x2mdx-ref-meta-grid">
 
-**Request Body**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-- Required: `yes`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `updateFormat`, `updateId` |
+</dl>
 
-**Request Example: `application/json`**
 
-```json
-{
-  "updateId": "<string>",
-  "updateFormat": {
-    "includeTransactions": {
-      "eventFormat": {
-        "filtersByParty": "<object>",
-        "filtersForAnyParty": "<object>",
-        "verbose": "<boolean>"
-      },
-      "transactionShape": "<string>"
-    },
-    "includeReassignments": {
-      "filtersByParty": {},
-      "filtersForAnyParty": {
-        "cumulative": [
-          "<object>"
-        ]
-      },
-      "verbose": "<boolean>"
-    },
-    "includeTopologyEvents": {
-      "includeParticipantAuthorizationEvents": {
-        "parties": [
-          "<string>"
-        ]
-      }
-    }
-  }
-}
-```
+  </div>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-updates-update-by-offset"></span>
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-### `/v2/updates/update-by-offset`
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/updates/transaction-tree-by-offset/&#123;offset&#125;</h3>
 
-<span id="endpoint-post-v2-updates-update-by-offset"></span>
+<div class="x2mdx-ref-badges">
 
-- Method: `POST`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
 
-- Operation ID: `postV2UpdatesUpdate-by-offset`
-- Description: Lookup an update by its offset. If there is no update with this offset, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**Request Body**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Required: `yes`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated</span>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `offset`, `updateFormat` |
+</div>
 
-**Request Example: `application/json`**
+    </div>
 
-```json
-{
-  "offset": "<integer>",
-  "updateFormat": {
-    "includeTransactions": {
-      "eventFormat": {
-        "filtersByParty": "<object>",
-        "filtersForAnyParty": "<object>",
-        "verbose": "<boolean>"
-      },
-      "transactionShape": "<string>"
-    },
-    "includeReassignments": {
-      "filtersByParty": {},
-      "filtersForAnyParty": {
-        "cumulative": [
-          "<object>"
-        ]
-      },
-      "verbose": "<boolean>"
-    },
-    "includeTopologyEvents": {
-      "includeParticipantAuthorizationEvents": {
-        "parties": [
-          "<string>"
-        ]
-      }
-    }
-  }
-}
-```
+    <p class="x2mdx-ref-card-summary">GET: Get transaction tree by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead.</p>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+<dl class="x2mdx-ref-meta-grid">
 
-<span id="endpoint-path-v2-users"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
 
-### `/v2/users`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-- Methods: `GET`, `POST`
+</dl>
 
-<span id="endpoint-get-v2-users"></span>
 
-**GET**
+  </div>
 
-- Operation ID: `getV2Users`
-- Description: List all existing users.
 
-**Parameters**
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `pageSize` | `query` | `no` | `integer` | maximum number of elements in a returned page |
-| `pageToken` | `query` | `no` | `string` | token - to continue results from a given page, leave empty to start from the beginning of the list, obtain token from the result of previous page |
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**Responses**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/updates/transaction-by-offset</h3>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: query parameter pageSize, Invalid value for: query parameter pageToken | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+<div class="x2mdx-ref-badges">
 
-<span id="endpoint-post-v2-users"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-**POST**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-- Operation ID: `postV2Users`
-- Description: Create a new user.
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-**Request Body**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated</span>
 
-- Required: `yes`
+</div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `user` |
+    </div>
 
-**Request Example: `application/json`**
+    <p class="x2mdx-ref-card-summary">POST: Get transaction by offset. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-offset instead.</p>
 
-```json
-{
-  "user": {
-    "id": "<string>"
-  }
-}
-```
 
-**Responses**
+<dl class="x2mdx-ref-meta-grid">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-<span id="endpoint-path-v2-users-user-id"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-### `/v2/users/{user-id}`
+</dl>
 
-- Methods: `DELETE`, `GET`, `PATCH`
 
-<span id="endpoint-delete-v2-users-user-id"></span>
+  </div>
 
-**DELETE**
 
-- Operation ID: `deleteV2UsersUser-id`
-- Description: Delete an existing user and all its rights.
 
-**Parameters**
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `user-id` | `path` | `yes` | `string` | - |
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/updates/update-by-offset</h3>
 
-**Responses**
+<div class="x2mdx-ref-badges">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-<span id="endpoint-get-v2-users-user-id"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**GET**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Operation ID: `getV2UsersUser-id`
-- Description: Get the user data of a specific user or the authenticated user.
+</div>
 
-**Parameters**
+    </div>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `user-id` | `path` | `yes` | `string` | - |
-| `identity-provider-id` | `query` | `no` | `string` | - |
+    <p class="x2mdx-ref-card-summary">POST: Lookup an update by its offset. If there is no update with this offset, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.</p>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: query parameter identity-provider-id | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+<dl class="x2mdx-ref-meta-grid">
 
-<span id="endpoint-patch-v2-users-user-id"></span>
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-**PATCH**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-- Operation ID: `patchV2UsersUser-id`
-- Description: Update selected modifiable attribute of a user resource described by the ``User`` message.
+</dl>
 
-**Parameters**
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `user-id` | `path` | `yes` | `string` | - |
+  </div>
 
-**Request Body**
 
-- Required: `yes`
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `updateMask`, `user` |
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-**Request Example: `application/json`**
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/updates/transaction-by-id</h3>
 
-```json
-{
-  "user": {
-    "id": "<string>"
-  },
-  "updateMask": {
-    "unknownFields": {
-      "fields": {}
-    }
-  }
-}
-```
+<div class="x2mdx-ref-badges">
 
-**Responses**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-<span id="endpoint-path-v2-users-user-id-identity-provider-id"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-### `/v2/users/{user-id}/identity-provider-id`
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated</span>
 
-<span id="endpoint-patch-v2-users-user-id-identity-provider-id"></span>
+</div>
 
-- Method: `PATCH`
+    </div>
 
-- Operation ID: `patchV2UsersUser-idIdentity-provider-id`
-- Description: Update the assignment of a user from one IDP to another.
+    <p class="x2mdx-ref-card-summary">POST: Get transaction by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.</p>
 
-**Parameters**
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `user-id` | `path` | `yes` | `string` | - |
+<dl class="x2mdx-ref-meta-grid">
 
-**Request Body**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-- Required: `yes`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `userId` |
+</dl>
 
-**Request Example: `application/json`**
 
-```json
-{
-  "userId": "<string>"
-}
-```
+  </div>
 
-**Responses**
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-users-user-id-rights"></span>
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-### `/v2/users/{user-id}/rights`
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/updates/update-by-id</h3>
 
-- Methods: `GET`, `PATCH`, `POST`
+<div class="x2mdx-ref-badges">
 
-<span id="endpoint-get-v2-users-user-id-rights"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
 
-**GET**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-- Operation ID: `getV2UsersUser-idRights`
-- Description: List the set of all rights granted to a user.
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-**Parameters**
+</div>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `user-id` | `path` | `yes` | `string` | - |
+    </div>
 
-**Responses**
+    <p class="x2mdx-ref-card-summary">POST: Lookup an update by its ID. If there is no update with this ID, or all the events are filtered, an UPDATE_NOT_FOUND error will be raised.</p>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-patch-v2-users-user-id-rights"></span>
+<dl class="x2mdx-ref-meta-grid">
 
-**PATCH**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
 
-- Operation ID: `patchV2UsersUser-idRights`
-- Description: Revoke rights from a user. Revoking rights does not affect the resource version of the corresponding user.
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-**Parameters**
+</dl>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `user-id` | `path` | `yes` | `string` | - |
 
-**Request Body**
+  </div>
 
-- Required: `yes`
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `userId` |
 
-**Request Example: `application/json`**
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-```json
-{
-  "userId": "<string>"
-}
-```
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/updates/transaction-tree-by-id/&#123;update-id&#125;</h3>
 
-**Responses**
+<div class="x2mdx-ref-badges">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
 
-<span id="endpoint-post-v2-users-user-id-rights"></span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-**POST**
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-- Operation ID: `postV2UsersUser-idRights`
-- Description: Grant rights to a user. Granting rights does not affect the resource version of the corresponding user.
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated</span>
 
-**Parameters**
+</div>
 
-| Name | In | Required | Schema | Description |
-| --- | --- | --- | --- | --- |
-| `user-id` | `path` | `yes` | `string` | - |
+    </div>
 
-**Request Body**
+    <p class="x2mdx-ref-card-summary">GET: Get transaction tree by id. Provided for backwards compatibility, it will be removed in the Canton version 3.5.0, use v2/updates/update-by-id instead.</p>
 
-- Required: `yes`
 
-| Content Type | Schema | Required Fields |
-| --- | --- | --- |
-| `application/json` | `object` | `userId` |
+<dl class="x2mdx-ref-meta-grid">
 
-**Request Example: `application/json`**
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
 
-```json
-{
-  "userId": "<string>"
-}
-```
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
 
-**Responses**
+</dl>
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value, Invalid value for: body | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
 
-<span id="endpoint-path-v2-version"></span>
+  </div>
 
-### `/v2/version`
 
-<span id="endpoint-get-v2-version"></span>
 
-- Method: `GET`
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
 
-- Operation ID: `getV2Version`
-- Description: Read the Ledger API version
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/users</h3>
 
-**Responses**
+<div class="x2mdx-ref-badges">
 
-| Code | Description | Content Types | Schemas |
-| --- | --- | --- | --- |
-| `200` | - | `application/json` | `application/json:object` |
-| `400` | Invalid value | `text/plain` | `text/plain:string` |
-| `default` | - | `application/json` | `application/json:object` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET, POST</span>
 
-## Version Change Timeline
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
 
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `3.4` | `361` | `0` | `0` |
-| `3.5` | `6` | `152` | `1` |
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
 
-## Changed Entities
+</div>
 
-| Entity | Type | Introduced | Changed In | Changes | Removed |
-| --- | --- | --- | --- | --- | --- |
-| `schemas.AllocateExternalPartyRequest` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.AllocatePartyRequest` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.ArchivedEvent` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.CanActAs1` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.CanExecuteAs1` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.CanExecuteAsAnyParty` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.CanExecuteAsAnyParty1` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.CanReadAs1` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.CanReadAsAnyParty` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.CanReadAsAnyParty1` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.Completion1` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.ConnectedSynchronizer` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.CostEstimationHints` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.CreatedEvent` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.ExercisedEvent` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.GetActiveContractsRequest` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.GetPartiesResponse` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.GetPreferredPackagesRequest` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.GetUpdatesRequest` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.Identifier` | `component` | `3.4` | - | - | ❌ `3.5` |
-| `schemas.IdentifierFilter` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.IdentityProviderAdmin` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.IdentityProviderAdmin1` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.JsExecuteSubmissionAndWaitForTransactionRequest` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.JsExecuteSubmissionAndWaitRequest` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.JsExecuteSubmissionRequest` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.JsGetActiveContractsResponse` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.JsInterfaceView` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.JsPrepareSubmissionRequest` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.JsPrepareSubmissionResponse` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.JsReassignment` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.JsTransaction` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.ParticipantAdmin` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.ParticipantAdmin1` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.ParticipantAuthorizationOnboarding` | `component` | `3.5` | - | - | - |
-| `schemas.ParticipantAuthorizationOnboarding1` | `component` | `3.5` | - | - | - |
-| `schemas.PrefetchContractKey` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.ReassignmentCommands` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.SignedTransaction` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.TopologyEventEvent` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.TraceContext` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.Unvet` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.Unvet1` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.Vet` | `component` | `3.4` | `3.5` | - | - |
-| `schemas.Vet1` | `component` | `3.4` | `3.5` | - | - |
-| `DELETE /v2/idps/{idp-id}` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `DELETE /v2/users/{user-id}` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /livez` | `operation` | `3.5` | - | - | - |
-| `GET /readyz` | `operation` | `3.5` | - | - | - |
-| `GET /v2/authenticated-user` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/idps` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/idps/{idp-id}` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/interactive-submission/preferred-package-version` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/package-vetting` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/packages` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/packages/{package-id}` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/packages/{package-id}/status` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/parties` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/parties/participant-id` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/parties/{party}` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/state/connected-synchronizers` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/state/latest-pruned-offsets` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/state/ledger-end` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/updates/transaction-tree-by-id/{update-id}` | `operation` | `3.4` | `3.5` | 3.5: response `400` description updated | - |
-| `GET /v2/updates/transaction-tree-by-offset/{offset}` | `operation` | `3.4` | `3.5` | 3.5: response `400` description updated | - |
-| `GET /v2/users` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/users/{user-id}` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/users/{user-id}/rights` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `GET /v2/version` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `PATCH /v2/idps/{idp-id}` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `PATCH /v2/parties/{party}` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `PATCH /v2/users/{user-id}` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `PATCH /v2/users/{user-id}/identity-provider-id` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `PATCH /v2/users/{user-id}/rights` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/commands/async/submit` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/commands/async/submit-reassignment` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/commands/completions` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/commands/submit-and-wait` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/commands/submit-and-wait-for-reassignment` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/commands/submit-and-wait-for-transaction` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/commands/submit-and-wait-for-transaction-tree` | `operation` | `3.4` | `3.5` | 3.5: response `400` description updated | - |
-| `POST /v2/contracts/contract-by-id` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/dars` | `operation` | `3.4` | `3.5` | 3.5: response `400` description updated | - |
-| `POST /v2/dars/validate` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/events/events-by-contract-id` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/idps` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/interactive-submission/execute` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/interactive-submission/executeAndWait` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/interactive-submission/executeAndWaitForTransaction` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/interactive-submission/preferred-packages` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/interactive-submission/prepare` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/package-vetting` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/package-vetting/list` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/package-vetting/update` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/packages` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/parties` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/parties/external/allocate` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/parties/external/generate-topology` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/state/active-contracts` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/updates` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/updates/flats` | `operation` | `3.4` | `3.5` | 3.5: response `400` description updated | - |
-| `POST /v2/updates/transaction-by-id` | `operation` | `3.4` | `3.5` | 3.5: response `400` description updated | - |
-| `POST /v2/updates/transaction-by-offset` | `operation` | `3.4` | `3.5` | 3.5: response `400` description updated | - |
-| `POST /v2/updates/trees` | `operation` | `3.4` | `3.5` | 3.5: response `400` description updated | - |
-| `POST /v2/updates/update-by-id` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/updates/update-by-offset` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/users` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `POST /v2/users/{user-id}/rights` | `operation` | `3.4` | `3.5` | 3.5: description updated; response `400` description updated | - |
-| `/livez` | `path` | `3.5` | - | - | - |
-| `/readyz` | `path` | `3.5` | - | - | - |
-| `/v2/authenticated-user` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/commands/async/submit` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/commands/async/submit-reassignment` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/commands/completions` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/commands/submit-and-wait` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/commands/submit-and-wait-for-reassignment` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/commands/submit-and-wait-for-transaction` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/commands/submit-and-wait-for-transaction-tree` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/contracts/contract-by-id` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/dars` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/dars/validate` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/events/events-by-contract-id` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/idps` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/idps/{idp-id}` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/interactive-submission/execute` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/interactive-submission/executeAndWait` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/interactive-submission/executeAndWaitForTransaction` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/interactive-submission/preferred-package-version` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/interactive-submission/preferred-packages` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/interactive-submission/prepare` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/package-vetting` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/package-vetting/list` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/package-vetting/update` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/packages` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/packages/{package-id}` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/packages/{package-id}/status` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/parties` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/parties/external/allocate` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/parties/external/generate-topology` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/parties/participant-id` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/parties/{party}` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/state/active-contracts` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/state/connected-synchronizers` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/state/latest-pruned-offsets` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/state/ledger-end` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/updates` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/updates/flats` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/updates/transaction-by-id` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/updates/transaction-by-offset` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/updates/transaction-tree-by-id/{update-id}` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/updates/transaction-tree-by-offset/{offset}` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/updates/trees` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/updates/update-by-id` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/updates/update-by-offset` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/users` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/users/{user-id}` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/users/{user-id}/identity-provider-id` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/users/{user-id}/rights` | `path` | `3.4` | `3.5` | - | - |
-| `/v2/version` | `path` | `3.4` | `3.5` | - | - |
+    </div>
 
-## Latest Operations
+    <p class="x2mdx-ref-card-summary">GET: List all existing users.; POST: Create a new user.</p>
 
-| Operation | Introduced | Changed In | Removed |
-| --- | --- | --- | --- |
-| `DELETE /v2/idps/{idp-id}` | `3.4` | `3.5` | - |
-| `DELETE /v2/users/{user-id}` | `3.4` | `3.5` | - |
-| `GET /livez` | `3.5` | - | - |
-| `GET /readyz` | `3.5` | - | - |
-| `GET /v2/authenticated-user` | `3.4` | `3.5` | - |
-| `GET /v2/idps` | `3.4` | `3.5` | - |
-| `GET /v2/idps/{idp-id}` | `3.4` | `3.5` | - |
-| `GET /v2/interactive-submission/preferred-package-version` | `3.4` | `3.5` | - |
-| `GET /v2/package-vetting` | `3.4` | `3.5` | - |
-| `GET /v2/packages` | `3.4` | `3.5` | - |
-| `GET /v2/packages/{package-id}` | `3.4` | `3.5` | - |
-| `GET /v2/packages/{package-id}/status` | `3.4` | `3.5` | - |
-| `GET /v2/parties` | `3.4` | `3.5` | - |
-| `GET /v2/parties/participant-id` | `3.4` | `3.5` | - |
-| `GET /v2/parties/{party}` | `3.4` | `3.5` | - |
-| `GET /v2/state/connected-synchronizers` | `3.4` | `3.5` | - |
-| `GET /v2/state/latest-pruned-offsets` | `3.4` | `3.5` | - |
-| `GET /v2/state/ledger-end` | `3.4` | `3.5` | - |
-| `GET /v2/updates/transaction-tree-by-id/{update-id}` | `3.4` | `3.5` | - |
-| `GET /v2/updates/transaction-tree-by-offset/{offset}` | `3.4` | `3.5` | - |
-| `GET /v2/users` | `3.4` | `3.5` | - |
-| `GET /v2/users/{user-id}` | `3.4` | `3.5` | - |
-| `GET /v2/users/{user-id}/rights` | `3.4` | `3.5` | - |
-| `GET /v2/version` | `3.4` | `3.5` | - |
-| `PATCH /v2/idps/{idp-id}` | `3.4` | `3.5` | - |
-| `PATCH /v2/parties/{party}` | `3.4` | `3.5` | - |
-| `PATCH /v2/users/{user-id}` | `3.4` | `3.5` | - |
-| `PATCH /v2/users/{user-id}/identity-provider-id` | `3.4` | `3.5` | - |
-| `PATCH /v2/users/{user-id}/rights` | `3.4` | `3.5` | - |
-| `POST /v2/commands/async/submit` | `3.4` | `3.5` | - |
-| `POST /v2/commands/async/submit-reassignment` | `3.4` | `3.5` | - |
-| `POST /v2/commands/completions` | `3.4` | `3.5` | - |
-| `POST /v2/commands/submit-and-wait` | `3.4` | `3.5` | - |
-| `POST /v2/commands/submit-and-wait-for-reassignment` | `3.4` | `3.5` | - |
-| `POST /v2/commands/submit-and-wait-for-transaction` | `3.4` | `3.5` | - |
-| `POST /v2/commands/submit-and-wait-for-transaction-tree` | `3.4` | `3.5` | - |
-| `POST /v2/contracts/contract-by-id` | `3.4` | `3.5` | - |
-| `POST /v2/dars` | `3.4` | `3.5` | - |
-| `POST /v2/dars/validate` | `3.4` | `3.5` | - |
-| `POST /v2/events/events-by-contract-id` | `3.4` | `3.5` | - |
-| `POST /v2/idps` | `3.4` | `3.5` | - |
-| `POST /v2/interactive-submission/execute` | `3.4` | `3.5` | - |
-| `POST /v2/interactive-submission/executeAndWait` | `3.4` | `3.5` | - |
-| `POST /v2/interactive-submission/executeAndWaitForTransaction` | `3.4` | `3.5` | - |
-| `POST /v2/interactive-submission/preferred-packages` | `3.4` | `3.5` | - |
-| `POST /v2/interactive-submission/prepare` | `3.4` | `3.5` | - |
-| `POST /v2/package-vetting` | `3.4` | `3.5` | - |
-| `POST /v2/package-vetting/list` | `3.4` | `3.5` | - |
-| `POST /v2/package-vetting/update` | `3.4` | `3.5` | - |
-| `POST /v2/packages` | `3.4` | `3.5` | - |
-| `POST /v2/parties` | `3.4` | `3.5` | - |
-| `POST /v2/parties/external/allocate` | `3.4` | `3.5` | - |
-| `POST /v2/parties/external/generate-topology` | `3.4` | `3.5` | - |
-| `POST /v2/state/active-contracts` | `3.4` | `3.5` | - |
-| `POST /v2/updates` | `3.4` | `3.5` | - |
-| `POST /v2/updates/flats` | `3.4` | `3.5` | - |
-| `POST /v2/updates/transaction-by-id` | `3.4` | `3.5` | - |
-| `POST /v2/updates/transaction-by-offset` | `3.4` | `3.5` | - |
-| `POST /v2/updates/trees` | `3.4` | `3.5` | - |
-| `POST /v2/updates/update-by-id` | `3.4` | `3.5` | - |
-| `POST /v2/updates/update-by-offset` | `3.4` | `3.5` | - |
-| `POST /v2/users` | `3.4` | `3.5` | - |
-| `POST /v2/users/{user-id}/rights` | `3.4` | `3.5` | - |
 
-## Latest Components
+<dl class="x2mdx-ref-meta-grid">
 
-| Component | Introduced | Changed In | Removed |
-| --- | --- | --- | --- |
-| `schemas.AllocateExternalPartyRequest` | `3.4` | `3.5` | - |
-| `schemas.AllocateExternalPartyResponse` | `3.4` | - | - |
-| `schemas.AllocatePartyRequest` | `3.4` | `3.5` | - |
-| `schemas.AllocatePartyResponse` | `3.4` | - | - |
-| `schemas.ArchivedEvent` | `3.4` | `3.5` | - |
-| `schemas.AssignCommand` | `3.4` | - | - |
-| `schemas.AssignCommand1` | `3.4` | - | - |
-| `schemas.CanActAs` | `3.4` | - | - |
-| `schemas.CanActAs1` | `3.4` | `3.5` | - |
-| `schemas.CanExecuteAs` | `3.4` | - | - |
-| `schemas.CanExecuteAs1` | `3.4` | `3.5` | - |
-| `schemas.CanExecuteAsAnyParty` | `3.4` | `3.5` | - |
-| `schemas.CanExecuteAsAnyParty1` | `3.4` | `3.5` | - |
-| `schemas.CanReadAs` | `3.4` | - | - |
-| `schemas.CanReadAs1` | `3.4` | `3.5` | - |
-| `schemas.CanReadAsAnyParty` | `3.4` | `3.5` | - |
-| `schemas.CanReadAsAnyParty1` | `3.4` | `3.5` | - |
-| `schemas.Command` | `3.4` | - | - |
-| `schemas.Command1` | `3.4` | - | - |
-| `schemas.Completion` | `3.4` | - | - |
-| `schemas.Completion1` | `3.4` | `3.5` | - |
-| `schemas.CompletionResponse` | `3.4` | - | - |
-| `schemas.CompletionStreamRequest` | `3.4` | - | - |
-| `schemas.CompletionStreamResponse` | `3.4` | - | - |
-| `schemas.ConnectedSynchronizer` | `3.4` | `3.5` | - |
-| `schemas.CostEstimation` | `3.4` | - | - |
-| `schemas.CostEstimationHints` | `3.4` | `3.5` | - |
-| `schemas.CreateAndExerciseCommand` | `3.4` | - | - |
-| `schemas.CreateCommand` | `3.4` | - | - |
-| `schemas.CreateIdentityProviderConfigRequest` | `3.4` | - | - |
-| `schemas.CreateIdentityProviderConfigResponse` | `3.4` | - | - |
-| `schemas.CreateUserRequest` | `3.4` | - | - |
-| `schemas.CreateUserResponse` | `3.4` | - | - |
-| `schemas.CreatedEvent` | `3.4` | `3.5` | - |
-| `schemas.CreatedTreeEvent` | `3.4` | - | - |
-| `schemas.CumulativeFilter` | `3.4` | - | - |
-| `schemas.DeduplicationDuration` | `3.4` | - | - |
-| `schemas.DeduplicationDuration1` | `3.4` | - | - |
-| `schemas.DeduplicationDuration2` | `3.4` | - | - |
-| `schemas.DeduplicationOffset` | `3.4` | - | - |
-| `schemas.DeduplicationOffset1` | `3.4` | - | - |
-| `schemas.DeduplicationOffset2` | `3.4` | - | - |
-| `schemas.DeduplicationPeriod` | `3.4` | - | - |
-| `schemas.DeduplicationPeriod1` | `3.4` | - | - |
-| `schemas.DeduplicationPeriod2` | `3.4` | - | - |
-| `schemas.DeleteIdentityProviderConfigResponse` | `3.4` | - | - |
-| `schemas.DisclosedContract` | `3.4` | - | - |
-| `schemas.Duration` | `3.4` | - | - |
-| `schemas.Empty` | `3.4` | - | - |
-| `schemas.Empty1` | `3.4` | - | - |
-| `schemas.Empty10` | `3.4` | - | - |
-| `schemas.Empty2` | `3.4` | - | - |
-| `schemas.Empty3` | `3.4` | - | - |
-| `schemas.Empty4` | `3.4` | - | - |
-| `schemas.Empty5` | `3.4` | - | - |
-| `schemas.Empty6` | `3.4` | - | - |
-| `schemas.Empty7` | `3.4` | - | - |
-| `schemas.Empty8` | `3.4` | - | - |
-| `schemas.Empty9` | `3.4` | - | - |
-| `schemas.Event` | `3.4` | - | - |
-| `schemas.EventFormat` | `3.4` | - | - |
-| `schemas.ExecuteSubmissionAndWaitResponse` | `3.4` | - | - |
-| `schemas.ExecuteSubmissionResponse` | `3.4` | - | - |
-| `schemas.ExerciseByKeyCommand` | `3.4` | - | - |
-| `schemas.ExerciseCommand` | `3.4` | - | - |
-| `schemas.ExercisedEvent` | `3.4` | `3.5` | - |
-| `schemas.ExercisedTreeEvent` | `3.4` | - | - |
-| `schemas.ExperimentalCommandInspectionService` | `3.4` | - | - |
-| `schemas.ExperimentalFeatures` | `3.4` | - | - |
-| `schemas.ExperimentalStaticTime` | `3.4` | - | - |
-| `schemas.FeaturesDescriptor` | `3.4` | - | - |
-| `schemas.Field` | `3.4` | - | - |
-| `schemas.FieldMask` | `3.4` | - | - |
-| `schemas.Filters` | `3.4` | - | - |
-| `schemas.GenerateExternalPartyTopologyRequest` | `3.4` | - | - |
-| `schemas.GenerateExternalPartyTopologyResponse` | `3.4` | - | - |
-| `schemas.GetActiveContractsRequest` | `3.4` | `3.5` | - |
-| `schemas.GetConnectedSynchronizersResponse` | `3.4` | - | - |
-| `schemas.GetContractRequest` | `3.4` | - | - |
-| `schemas.GetContractResponse` | `3.4` | - | - |
-| `schemas.GetEventsByContractIdRequest` | `3.4` | - | - |
-| `schemas.GetIdentityProviderConfigResponse` | `3.4` | - | - |
-| `schemas.GetLatestPrunedOffsetsResponse` | `3.4` | - | - |
-| `schemas.GetLedgerApiVersionResponse` | `3.4` | - | - |
-| `schemas.GetLedgerEndResponse` | `3.4` | - | - |
-| `schemas.GetPackageStatusResponse` | `3.4` | - | - |
-| `schemas.GetParticipantIdResponse` | `3.4` | - | - |
-| `schemas.GetPartiesResponse` | `3.4` | `3.5` | - |
-| `schemas.GetPreferredPackageVersionResponse` | `3.4` | - | - |
-| `schemas.GetPreferredPackagesRequest` | `3.4` | `3.5` | - |
-| `schemas.GetPreferredPackagesResponse` | `3.4` | - | - |
-| `schemas.GetTransactionByIdRequest` | `3.4` | - | - |
-| `schemas.GetTransactionByOffsetRequest` | `3.4` | - | - |
-| `schemas.GetUpdateByIdRequest` | `3.4` | - | - |
-| `schemas.GetUpdateByOffsetRequest` | `3.4` | - | - |
-| `schemas.GetUpdatesRequest` | `3.4` | `3.5` | - |
-| `schemas.GetUserResponse` | `3.4` | - | - |
-| `schemas.GrantUserRightsRequest` | `3.4` | - | - |
-| `schemas.GrantUserRightsResponse` | `3.4` | - | - |
-| `schemas.IdentifierFilter` | `3.4` | `3.5` | - |
-| `schemas.IdentityProviderAdmin` | `3.4` | `3.5` | - |
-| `schemas.IdentityProviderAdmin1` | `3.4` | `3.5` | - |
-| `schemas.IdentityProviderConfig` | `3.4` | - | - |
-| `schemas.InterfaceFilter` | `3.4` | - | - |
-| `schemas.InterfaceFilter1` | `3.4` | - | - |
-| `schemas.JsActiveContract` | `3.4` | - | - |
-| `schemas.JsArchived` | `3.4` | - | - |
-| `schemas.JsAssignedEvent` | `3.4` | - | - |
-| `schemas.JsAssignmentEvent` | `3.4` | - | - |
-| `schemas.JsCantonError` | `3.4` | - | - |
-| `schemas.JsCommands` | `3.4` | - | - |
-| `schemas.JsContractEntry` | `3.4` | - | - |
-| `schemas.JsCreated` | `3.4` | - | - |
-| `schemas.JsEmpty` | `3.4` | - | - |
-| `schemas.JsExecuteSubmissionAndWaitForTransactionRequest` | `3.4` | `3.5` | - |
-| `schemas.JsExecuteSubmissionAndWaitForTransactionResponse` | `3.4` | - | - |
-| `schemas.JsExecuteSubmissionAndWaitRequest` | `3.4` | `3.5` | - |
-| `schemas.JsExecuteSubmissionRequest` | `3.4` | `3.5` | - |
-| `schemas.JsGetActiveContractsResponse` | `3.4` | `3.5` | - |
-| `schemas.JsGetEventsByContractIdResponse` | `3.4` | - | - |
-| `schemas.JsGetTransactionResponse` | `3.4` | - | - |
-| `schemas.JsGetTransactionTreeResponse` | `3.4` | - | - |
-| `schemas.JsGetUpdateResponse` | `3.4` | - | - |
-| `schemas.JsGetUpdateTreesResponse` | `3.4` | - | - |
-| `schemas.JsGetUpdatesResponse` | `3.4` | - | - |
-| `schemas.JsIncompleteAssigned` | `3.4` | - | - |
-| `schemas.JsIncompleteUnassigned` | `3.4` | - | - |
-| `schemas.JsInterfaceView` | `3.4` | `3.5` | - |
-| `schemas.JsPrepareSubmissionRequest` | `3.4` | `3.5` | - |
-| `schemas.JsPrepareSubmissionResponse` | `3.4` | `3.5` | - |
-| `schemas.JsReassignment` | `3.4` | `3.5` | - |
-| `schemas.JsReassignmentEvent` | `3.4` | - | - |
-| `schemas.JsStatus` | `3.4` | - | - |
-| `schemas.JsSubmitAndWaitForReassignmentResponse` | `3.4` | - | - |
-| `schemas.JsSubmitAndWaitForTransactionRequest` | `3.4` | - | - |
-| `schemas.JsSubmitAndWaitForTransactionResponse` | `3.4` | - | - |
-| `schemas.JsSubmitAndWaitForTransactionTreeResponse` | `3.4` | - | - |
-| `schemas.JsTopologyTransaction` | `3.4` | - | - |
-| `schemas.JsTransaction` | `3.4` | `3.5` | - |
-| `schemas.JsTransactionTree` | `3.4` | - | - |
-| `schemas.JsUnassignedEvent` | `3.4` | - | - |
-| `schemas.Kind` | `3.4` | - | - |
-| `schemas.ListIdentityProviderConfigsResponse` | `3.4` | - | - |
-| `schemas.ListKnownPartiesResponse` | `3.4` | - | - |
-| `schemas.ListPackagesResponse` | `3.4` | - | - |
-| `schemas.ListUserRightsResponse` | `3.4` | - | - |
-| `schemas.ListUsersResponse` | `3.4` | - | - |
-| `schemas.ListVettedPackagesRequest` | `3.4` | - | - |
-| `schemas.ListVettedPackagesResponse` | `3.4` | - | - |
-| `schemas.Map_Filters` | `3.4` | - | - |
-| `schemas.Map_Int_Field` | `3.4` | - | - |
-| `schemas.Map_Int_TreeEvent` | `3.4` | - | - |
-| `schemas.Map_String` | `3.4` | - | - |
-| `schemas.MinLedgerTime` | `3.4` | - | - |
-| `schemas.MinLedgerTimeAbs` | `3.4` | - | - |
-| `schemas.MinLedgerTimeRel` | `3.4` | - | - |
-| `schemas.NoPrior` | `3.4` | - | - |
-| `schemas.ObjectMeta` | `3.4` | - | - |
-| `schemas.OffsetCheckpoint` | `3.4` | - | - |
-| `schemas.OffsetCheckpoint1` | `3.4` | - | - |
-| `schemas.OffsetCheckpoint2` | `3.4` | - | - |
-| `schemas.OffsetCheckpoint3` | `3.4` | - | - |
-| `schemas.OffsetCheckpointFeature` | `3.4` | - | - |
-| `schemas.Operation` | `3.4` | - | - |
-| `schemas.PackageFeature` | `3.4` | - | - |
-| `schemas.PackageMetadataFilter` | `3.4` | - | - |
-| `schemas.PackagePreference` | `3.4` | - | - |
-| `schemas.PackageReference` | `3.4` | - | - |
-| `schemas.PackageVettingRequirement` | `3.4` | - | - |
-| `schemas.ParticipantAdmin` | `3.4` | `3.5` | - |
-| `schemas.ParticipantAdmin1` | `3.4` | `3.5` | - |
-| `schemas.ParticipantAuthorizationAdded` | `3.4` | - | - |
-| `schemas.ParticipantAuthorizationAdded1` | `3.4` | - | - |
-| `schemas.ParticipantAuthorizationChanged` | `3.4` | - | - |
-| `schemas.ParticipantAuthorizationChanged1` | `3.4` | - | - |
-| `schemas.ParticipantAuthorizationOnboarding` | `3.5` | - | - |
-| `schemas.ParticipantAuthorizationOnboarding1` | `3.5` | - | - |
-| `schemas.ParticipantAuthorizationRevoked` | `3.4` | - | - |
-| `schemas.ParticipantAuthorizationRevoked1` | `3.4` | - | - |
-| `schemas.ParticipantAuthorizationTopologyFormat` | `3.4` | - | - |
-| `schemas.PartyDetails` | `3.4` | - | - |
-| `schemas.PartyManagementFeature` | `3.4` | - | - |
-| `schemas.PartySignatures` | `3.4` | - | - |
-| `schemas.PrefetchContractKey` | `3.4` | `3.5` | - |
-| `schemas.Prior` | `3.4` | - | - |
-| `schemas.PriorTopologySerial` | `3.4` | - | - |
-| `schemas.ProtoAny` | `3.4` | - | - |
-| `schemas.Reassignment` | `3.4` | - | - |
-| `schemas.Reassignment1` | `3.4` | - | - |
-| `schemas.ReassignmentCommand` | `3.4` | - | - |
-| `schemas.ReassignmentCommands` | `3.4` | `3.5` | - |
-| `schemas.RevokeUserRightsRequest` | `3.4` | - | - |
-| `schemas.RevokeUserRightsResponse` | `3.4` | - | - |
-| `schemas.Right` | `3.4` | - | - |
-| `schemas.Serial` | `3.4` | - | - |
-| `schemas.Signature` | `3.4` | - | - |
-| `schemas.SignedTransaction` | `3.4` | `3.5` | - |
-| `schemas.SigningPublicKey` | `3.4` | - | - |
-| `schemas.SinglePartySignatures` | `3.4` | - | - |
-| `schemas.SubmitAndWaitForReassignmentRequest` | `3.4` | - | - |
-| `schemas.SubmitAndWaitResponse` | `3.4` | - | - |
-| `schemas.SubmitReassignmentRequest` | `3.4` | - | - |
-| `schemas.SubmitReassignmentResponse` | `3.4` | - | - |
-| `schemas.SubmitResponse` | `3.4` | - | - |
-| `schemas.SynchronizerTime` | `3.4` | - | - |
-| `schemas.TemplateFilter` | `3.4` | - | - |
-| `schemas.TemplateFilter1` | `3.4` | - | - |
-| `schemas.Time` | `3.4` | - | - |
-| `schemas.TopologyEvent` | `3.4` | - | - |
-| `schemas.TopologyEventEvent` | `3.4` | `3.5` | - |
-| `schemas.TopologyFormat` | `3.4` | - | - |
-| `schemas.TopologyStateFilter` | `3.4` | - | - |
-| `schemas.TopologyTransaction` | `3.4` | - | - |
-| `schemas.TraceContext` | `3.4` | `3.5` | - |
-| `schemas.Transaction` | `3.4` | - | - |
-| `schemas.TransactionFilter` | `3.4` | - | - |
-| `schemas.TransactionFormat` | `3.4` | - | - |
-| `schemas.TransactionTree` | `3.4` | - | - |
-| `schemas.TreeEvent` | `3.4` | - | - |
-| `schemas.Tuple2_String_String` | `3.4` | - | - |
-| `schemas.UnassignCommand` | `3.4` | - | - |
-| `schemas.UnassignCommand1` | `3.4` | - | - |
-| `schemas.UnassignedEvent` | `3.4` | - | - |
-| `schemas.UnknownFieldSet` | `3.4` | - | - |
-| `schemas.Unvet` | `3.4` | `3.5` | - |
-| `schemas.Unvet1` | `3.4` | `3.5` | - |
-| `schemas.Update` | `3.4` | - | - |
-| `schemas.Update1` | `3.4` | - | - |
-| `schemas.UpdateFormat` | `3.4` | - | - |
-| `schemas.UpdateIdentityProviderConfigRequest` | `3.4` | - | - |
-| `schemas.UpdateIdentityProviderConfigResponse` | `3.4` | - | - |
-| `schemas.UpdatePartyDetailsRequest` | `3.4` | - | - |
-| `schemas.UpdatePartyDetailsResponse` | `3.4` | - | - |
-| `schemas.UpdateUserIdentityProviderIdRequest` | `3.4` | - | - |
-| `schemas.UpdateUserIdentityProviderIdResponse` | `3.4` | - | - |
-| `schemas.UpdateUserRequest` | `3.4` | - | - |
-| `schemas.UpdateUserResponse` | `3.4` | - | - |
-| `schemas.UpdateVettedPackagesRequest` | `3.4` | - | - |
-| `schemas.UpdateVettedPackagesResponse` | `3.4` | - | - |
-| `schemas.UploadDarFileResponse` | `3.4` | - | - |
-| `schemas.User` | `3.4` | - | - |
-| `schemas.UserManagementFeature` | `3.4` | - | - |
-| `schemas.Vet` | `3.4` | `3.5` | - |
-| `schemas.Vet1` | `3.4` | `3.5` | - |
-| `schemas.VettedPackage` | `3.4` | - | - |
-| `schemas.VettedPackages` | `3.4` | - | - |
-| `schemas.VettedPackagesChange` | `3.4` | - | - |
-| `schemas.VettedPackagesRef` | `3.4` | - | - |
-| `schemas.WildcardFilter` | `3.4` | - | - |
-| `schemas.WildcardFilter1` | `3.4` | - | - |
-| `securitySchemes.apiKeyAuth` | `3.4` | - | - |
-| `securitySchemes.httpAuth` | `3.4` | - | - |
-
-## Spec Metadata
-
-- Canonical spec id: `json-ledger-api/openapi.yaml`
-- Latest source path: `canton-release-bundle/json-ledger-api/openapi.yaml`
-- OpenAPI version (latest): `3.0.3`
-- Introduced: `3.4`
-- Changed in versions: `3.5`
-- Removed: -
-
-## Entity Summary
-
-- Total entities tracked: `367`
-- Entities introduced after spec introduction: `6`
-- Entities changed at least once: `152`
-- Entities removed: `1`
-- Latest operations: `63`
-- Latest paths: `51`
-- Latest components: `252`
-- Latest tags: `0`
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET, POST</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/users/&#123;user-id&#125;</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET, DELETE, PATCH</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">GET: Get the user data of a specific user or the authenticated user.; DELETE: Delete an existing user and all its rights.; PATCH: Update selected modifiable attribute of a user resource d...</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET, DELETE, PATCH</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/authenticated-user</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">GET: Get the user data of the current authenticated user.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/users/&#123;user-id&#125;/rights</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET, POST, PATCH</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">GET: List the set of all rights granted to a user.; POST: Grant rights to a user. Granting rights does not affect the resource version of the corresponding user.; PATCH: Revoke rights fro...</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET, POST, PATCH</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/users/&#123;user-id&#125;/identity-provider-id</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">PATCH</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">PATCH: Update the assignment of a user from one IDP to another.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>PATCH</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/idps</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET, POST</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">GET: List all existing identity provider configurations.; POST: Create a new identity provider configuration. The request will fail if the maximum allowed number of separate configuration...</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET, POST</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/idps/&#123;idp-id&#125;</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET, DELETE, PATCH</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">GET: Get the identity provider configuration data by id.; DELETE: Delete an existing identity provider configuration.; PATCH: Update selected modifiable attribute of an identity provider...</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET, DELETE, PATCH</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/interactive-submission/prepare</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">POST: Requires `readAs` scope for the submitting party when LAPI User authorization is enabled</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/interactive-submission/execute</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">POST: Execute a prepared submission _asynchronously_ on the ledger. Requires a signature of the transaction from the submitting external party.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/interactive-submission/executeAndWait</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">POST: Similar to ExecuteSubmission but _synchronously_ wait for the completion of the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant N...</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/interactive-submission/executeAndWaitForTransaction</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">POST: Similar to ExecuteSubmissionAndWait but additionally returns the transaction IMPORTANT: Relying on the response from this endpoint requires trusting the Participant Node to be hones...</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/interactive-submission/preferred-package-version</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">GET: A preferred package is the highest-versioned package for a provided package-name that is vetted by all the participants hosting the provided parties. Ledger API clients should use th...</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/interactive-submission/preferred-packages</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">POST: Compute the preferred packages for the vetting requirements in the request. A preferred package is the highest-versioned package for a provided package-name that is vetted by all th...</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/livez</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">GET: Checks if the service is alive</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/readyz</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">GET</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">GET: Checks if the service is ready to serve requests</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>GET</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>/v2/contracts/contract-by-id</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">POST</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 3.5</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">POST: Looking up contract data by contract ID. This endpoint is experimental / alpha, therefore no backwards compatibility is guaranteed. This endpoint must not be used to look up contrac...</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Operations</dt>
+    <dd>POST</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Last seen</dt>
+    <dd>3.5</dd>
+  </div>
+
+</dl>
+
+
+  </div>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 49</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint changes included in this release snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.5</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 2</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 49</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Endpoint changes included in this release snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/scripts/generate_json_api_reference.py
+++ b/scripts/generate_json_api_reference.py
@@ -13,11 +13,25 @@ from typing import Any
 import yaml
 
 from ledger_api_release_bundles import (
+    ensure_bundle_archive,
     load_json,
     materialize_bundle_spec,
+    read_bundle_spec_text,
     selected_versions,
 )
 import reference_nav
+from x2mdx.output import Page, RawMarkdown
+from x2mdx.reference_pages import (
+    ReferenceBadge,
+    ReferenceCard,
+    ReferenceCollectionPage,
+    ReferenceMetaItem,
+    ReferenceSection,
+    compact_text,
+    render_collection_page,
+    safe_markdown_text,
+)
+from x2mdx.render import write_page
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -274,6 +288,205 @@ def mintlify_openapi_page_refs(openapi_path: Path) -> list[str]:
     return openapi_operation_page_refs(spec)
 
 
+def operation_items(path_item: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+    return [
+        (method.lower(), operation)
+        for method, operation in path_item.items()
+        if method.lower() in HTTP_METHODS and isinstance(operation, dict)
+    ]
+
+
+def operation_summary(path: str, path_item: dict[str, Any]) -> str:
+    summaries: list[str] = []
+    for method, operation in operation_items(path_item):
+        summary = str(operation.get("summary") or "").strip()
+        description = str(operation.get("description") or "").strip()
+        label = summary if summary and summary != path else description
+        if label:
+            summaries.append(f"{method.upper()}: {label}")
+    if summaries:
+        return compact_text("; ".join(summaries), limit=190)
+    return "OpenAPI endpoint"
+
+
+def operation_methods(path_item: dict[str, Any]) -> list[str]:
+    return [method.upper() for method, _operation in operation_items(path_item)]
+
+
+def path_item_fingerprint(path_item: Any) -> str:
+    return json.dumps(path_item, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def versioned_openapi_specs(
+    *,
+    source_config: dict[str, Any],
+    cache_dir: Path,
+    versions: list[dict[str, str]],
+    spec_filename: str,
+    force_refresh: bool,
+) -> dict[str, dict[str, Any]]:
+    specs: dict[str, dict[str, Any]] = {}
+    for entry in versions:
+        archive_path = ensure_bundle_archive(
+            source_config=source_config,
+            cache_dir=cache_dir,
+            version_entry=entry,
+            force_refresh=force_refresh,
+        )
+        spec = yaml.safe_load(
+            add_missing_operation_summaries(
+                read_bundle_spec_text(
+                    archive_path,
+                    source_config=source_config,
+                    spec_filename=spec_filename,
+                )
+            )
+        )
+        if not isinstance(spec, dict):
+            raise ValueError(f"Expected OpenAPI spec for {entry['version']} to parse as an object")
+        specs[entry["version"]] = spec
+    return specs
+
+
+def strip_raw_markdown_trailing_whitespace(page: Page) -> Page:
+    return Page(
+        path=page.path,
+        title=page.title,
+        description=page.description,
+        blocks=[
+            RawMarkdown("\n".join(line.rstrip() for line in block.text.splitlines()))
+            if isinstance(block, RawMarkdown)
+            else block
+            for block in page.blocks
+        ],
+    )
+
+
+def build_openapi_details_page(
+    *,
+    specs_by_version: dict[str, dict[str, Any]],
+    versions: list[str],
+    publish_version: str,
+    details_page_ref: str,
+    source_name: str,
+) -> Any:
+    latest = specs_by_version[publish_version]
+    latest_paths = latest.get("paths")
+    if not isinstance(latest_paths, dict):
+        raise ValueError("Published OpenAPI spec must define a paths object")
+
+    version_path_items: dict[str, dict[str, Any]] = {}
+    for version in versions:
+        paths = specs_by_version[version].get("paths")
+        version_path_items[version] = paths if isinstance(paths, dict) else {}
+
+    endpoint_cards: list[ReferenceCard] = []
+    version_cards: list[ReferenceCard] = []
+    for path, path_item in latest_paths.items():
+        if not isinstance(path, str) or not isinstance(path_item, dict):
+            continue
+        present_versions = [
+            version
+            for version in versions
+            if isinstance(version_path_items[version].get(path), dict)
+        ]
+        if not present_versions:
+            continue
+        introduced = present_versions[0]
+        last_seen = present_versions[-1]
+        changed_versions: list[str] = []
+        previous_fingerprint: str | None = None
+        for version in present_versions:
+            fingerprint = path_item_fingerprint(version_path_items[version][path])
+            if previous_fingerprint is not None and fingerprint != previous_fingerprint:
+                changed_versions.append(version)
+            previous_fingerprint = fingerprint
+
+        badges = [
+            ReferenceBadge(", ".join(operation_methods(path_item)) or "Endpoint", tone="protocol"),
+            ReferenceBadge(f"Since {introduced}", tone="added"),
+        ]
+        if changed_versions:
+            badges.append(ReferenceBadge(f"Changed {changed_versions[-1]}", tone="changed"))
+        if any(bool(operation.get("deprecated")) for _method, operation in operation_items(path_item)):
+            badges.append(ReferenceBadge("Deprecated", tone="removed"))
+        endpoint_cards.append(
+            ReferenceCard(
+                title=path,
+                summary=operation_summary(path, path_item),
+                badges=badges,
+                meta_items=[
+                    ReferenceMetaItem("Operations", ", ".join(operation_methods(path_item)) or "-"),
+                    ReferenceMetaItem("Last seen", last_seen),
+                ],
+            )
+        )
+
+    for version in versions:
+        current_paths = version_path_items[version]
+        previous_index = versions.index(version) - 1
+        previous_paths = version_path_items[versions[previous_index]] if previous_index >= 0 else {}
+        current_keys = {key for key, value in current_paths.items() if isinstance(key, str) and isinstance(value, dict)}
+        previous_keys = {key for key, value in previous_paths.items() if isinstance(key, str) and isinstance(value, dict)}
+        changed = sum(
+            1
+            for key in current_keys & previous_keys
+            if path_item_fingerprint(current_paths[key]) != path_item_fingerprint(previous_paths[key])
+        )
+        version_cards.append(
+            ReferenceCard(
+                title=version,
+                summary="Endpoint changes included in this release snapshot.",
+                badges=[
+                    ReferenceBadge(f"Added {len(current_keys - previous_keys)}", tone="added"),
+                    ReferenceBadge(f"Changed {changed}", tone="changed"),
+                    ReferenceBadge(f"Removed {len(previous_keys - current_keys)}", tone="removed"),
+                ],
+            )
+        )
+
+    return strip_raw_markdown_trailing_whitespace(
+        render_collection_page(
+            ReferenceCollectionPage(
+                path=f"{details_page_ref}.mdx",
+                title="Details and history",
+                description="JSON Ledger API OpenAPI endpoint details and version history.",
+                eyebrow="OpenAPI Reference",
+                summary="Endpoint overview for the JSON Ledger API OpenAPI surface, built from versioned release snapshots.",
+                badges=[ReferenceBadge("OpenAPI", tone="protocol"), ReferenceBadge(publish_version, tone="neutral")],
+                meta_items=[
+                    ReferenceMetaItem("Publish version", publish_version),
+                    ReferenceMetaItem("Source", source_name),
+                    ReferenceMetaItem("Version filter", ", ".join(versions)),
+                ],
+                sections=[
+                    ReferenceSection(
+                        heading="Endpoints",
+                        body_markdown=safe_markdown_text(
+                            "Select an OpenAPI operation from the sidebar for request and response details. "
+                            "This page summarizes endpoint lifecycle changes across the configured Ledger API versions."
+                        ),
+                        cards=endpoint_cards,
+                    ),
+                    ReferenceSection(
+                        heading="Version Summary",
+                        cards=version_cards,
+                    ),
+                ],
+            )
+        )
+    )
+
+
+def write_openapi_details_page(
+    *,
+    docs_json_path: Path,
+    details_page_ref: str,
+    page: Any,
+) -> None:
+    write_page(page, docs_json_path.parent / f"{details_page_ref}.mdx")
+
+
 def main() -> int:
     args = parse_args()
     source_config = load_json(Path(args.source_config).resolve())
@@ -286,9 +499,10 @@ def main() -> int:
     )
 
     output_spec = Path(args.output_spec).resolve()
+    cache_dir = Path(args.cache_dir).resolve()
     materialize_bundle_spec(
         source_config=source_config,
-        cache_dir=Path(args.cache_dir).resolve(),
+        cache_dir=cache_dir,
         version_entry=publish_entry,
         spec_filename="openapi.yaml",
         output_path=output_spec,
@@ -311,6 +525,24 @@ def main() -> int:
         openapi_directory=args.openapi_directory,
         details_page_ref=args.details_page_ref,
         openapi_page_refs=mintlify_openapi_page_refs(output_spec),
+    )
+    specs_by_version = versioned_openapi_specs(
+        source_config=source_config,
+        cache_dir=cache_dir,
+        versions=versions,
+        spec_filename="openapi.yaml",
+        force_refresh=args.force_refresh,
+    )
+    write_openapi_details_page(
+        docs_json_path=docs_json_path,
+        details_page_ref=args.details_page_ref,
+        page=build_openapi_details_page(
+            specs_by_version=specs_by_version,
+            versions=[entry["version"] for entry in versions],
+            publish_version=publish_entry["version"],
+            details_page_ref=args.details_page_ref,
+            source_name=str(source_config.get("source") or "Canton release bundle JSON Ledger API OpenAPI fixtures"),
+        ),
     )
     remove_legacy_output(output_file=LEGACY_OUTPUT_FILE.resolve())
     return 0

--- a/src/x2mdx/daml_json/render.py
+++ b/src/x2mdx/daml_json/render.py
@@ -8,7 +8,16 @@ from pathlib import Path
 from typing import Any
 
 from x2mdx.daml_json.models import DamlDocsReport
-from x2mdx.output import Page
+from x2mdx.output import Page, RawMarkdown
+from x2mdx.reference_pages import (
+    ReferenceBadge,
+    ReferenceCard,
+    ReferenceCollectionPage,
+    ReferenceMetaItem,
+    ReferenceSection,
+    render_collection_page,
+    safe_markdown_text,
+)
 from x2mdx.templating import markdown_page, render_template
 
 EXCLUDED_MODULE_NAMES = frozenset(
@@ -630,6 +639,34 @@ def render_module_body(
     )
 
 
+def module_lifecycle_badges(
+    *,
+    lifecycle: dict[str, str | None],
+    deprecation_version: str | None,
+) -> list[ReferenceBadge]:
+    badges = [ReferenceBadge(f"Since {lifecycle.get('introduced_in') or '-'}", tone="added")]
+    if deprecation_version:
+        badges.append(ReferenceBadge(f"Deprecated {deprecation_version}", tone="removed"))
+    removed_in = lifecycle.get("removed_in")
+    if removed_in:
+        badges.append(ReferenceBadge(f"Removed {removed_in}", tone="removed"))
+    return badges
+
+
+def strip_raw_markdown_trailing_whitespace(page: Page) -> Page:
+    return Page(
+        path=page.path,
+        title=page.title,
+        description=page.description,
+        blocks=[
+            RawMarkdown("\n".join(line.rstrip() for line in block.text.splitlines()))
+            if isinstance(block, RawMarkdown)
+            else block
+            for block in page.blocks
+        ],
+    )
+
+
 def build_pages(
     report: DamlDocsReport,
     *,
@@ -640,6 +677,7 @@ def build_pages(
     root = output_dir.parent
     pages: list[Page] = []
     module_entries: list[tuple[str, str, str]] = []
+    module_cards: list[ReferenceCard] = []
     normalized_link_prefix = normalize_link_prefix(link_prefix) if link_prefix else None
     modules_sorted = sorted(
         report.modules,
@@ -669,57 +707,82 @@ def build_pages(
             )
         )
 
-    module_links: list[str] = []
-    module_toc_rows: list[list[str]] = []
     for source_name, display_name, target in module_entries:
-        status_suffix = ""
         lifecycle = report.module_lifecycle.get(source_name, {})
         deprecation_version = report.module_deprecation_first_seen.get(source_name)
-        if lifecycle.get("status") == "removed":
-            removed_in = lifecycle.get("removed_in")
-            if isinstance(removed_in, str) and removed_in.strip():
-                status_suffix = f" - removed in `{removed_in}`"
-            else:
-                status_suffix = " - removed"
         if normalized_link_prefix:
             module_link = f"{normalized_link_prefix}/{target}"
         else:
             module_link = (output_dir / target).relative_to(root).with_suffix("").as_posix()
-        module_links.append(f"[{display_name}]({module_link}){status_suffix}")
         module_doc = modules_by_name[source_name]
-        module_toc_rows.append(
-            [
-                f"[`{display_name}`]({module_link})",
-                "`Module`",
-                escape_md_cell(module_summary_preview(module_doc)),
-                f"`{lifecycle.get('introduced_in') or '-'}`",
-                "-",
-                f"`{deprecation_version}`" if deprecation_version else "-",
-                f"`{lifecycle.get('removed_in')}`" if lifecycle.get("removed_in") else "-",
-            ]
+        module_cards.append(
+            ReferenceCard(
+                title=display_name,
+                href=module_link,
+                summary=module_summary_preview(module_doc),
+                badges=module_lifecycle_badges(
+                    lifecycle=lifecycle,
+                    deprecation_version=deprecation_version,
+                ),
+                meta_items=[
+                    ReferenceMetaItem("Kind", "Module"),
+                    ReferenceMetaItem("Introduced", lifecycle.get("introduced_in") or "-"),
+                    ReferenceMetaItem("Changed", "-"),
+                    ReferenceMetaItem("Deprecated", deprecation_version or "-"),
+                    ReferenceMetaItem("Removed", lifecycle.get("removed_in") or "-"),
+                ],
+            )
         )
-
-    version_change_summary_rows = [
-        [
-            f"`{version}`",
-            str(sum(1 for lifecycle in report.module_lifecycle.values() if lifecycle.get("introduced_in") == version)),
-            "0",
-            str(sum(1 for lifecycle in report.module_lifecycle.values() if lifecycle.get("removed_in") == version)),
-        ]
+    version_cards = [
+        ReferenceCard(
+            title=version,
+            summary="Module changes included in this Daml docs JSON snapshot.",
+            badges=[
+                ReferenceBadge(
+                    f"Added {sum(1 for lifecycle in report.module_lifecycle.values() if lifecycle.get('introduced_in') == version)}",
+                    tone="added",
+                ),
+                ReferenceBadge("Changed 0", tone="changed"),
+                ReferenceBadge(
+                    f"Removed {sum(1 for lifecycle in report.module_lifecycle.values() if lifecycle.get('removed_in') == version)}",
+                    tone="removed",
+                ),
+            ],
+        )
         for version in report.versions
     ]
 
     pages.insert(
         0,
-        markdown_page(
-            path=(output_dir / "index.mdx").relative_to(root).as_posix(),
-            title=overview_title,
-            description=f"Reference documentation for {overview_title} modules.",
-            template_name="daml_json/index.md.j2",
-            overview_title=overview_title,
-            module_toc_rows=module_toc_rows,
-            version_change_summary_rows=version_change_summary_rows,
-            module_links=module_links,
+        strip_raw_markdown_trailing_whitespace(
+            render_collection_page(
+                ReferenceCollectionPage(
+                    path=(output_dir / "index.mdx").relative_to(root).as_posix(),
+                    title=overview_title,
+                    description=f"Reference documentation for {overview_title} modules.",
+                    eyebrow="Daml Reference",
+                    summary="Generated module overview for the Daml Standard Library, built from versioned docs JSON snapshots.",
+                    badges=[ReferenceBadge("Daml", tone="protocol"), ReferenceBadge(report.publish_version, tone="neutral")],
+                    meta_items=[
+                        ReferenceMetaItem("Publish version", report.publish_version),
+                        ReferenceMetaItem("Source", report.source_name),
+                        ReferenceMetaItem("Version filter", report.version_filter),
+                    ],
+                    sections=[
+                        ReferenceSection(
+                            heading="Modules",
+                            body_markdown=safe_markdown_text(
+                                "Open a module page for declarations, type signatures, warnings, and lifecycle details."
+                            ),
+                            cards=module_cards,
+                        ),
+                        ReferenceSection(
+                            heading="Version Summary",
+                            cards=version_cards,
+                        ),
+                    ],
+                )
+            )
         ),
     )
     return root, pages

--- a/src/x2mdx/templates/shared/reference_macros.md.j2
+++ b/src/x2mdx/templates/shared/reference_macros.md.j2
@@ -1,16 +1,16 @@
 {% macro header(eyebrow, title, summary, back_link, back_label, badges, meta_items, render_title=True, render_summary=True) -%}
 {% if back_link %}
-<p class="x2mdx-ref-back"><a href="{{ back_link }}">{{ escape_html(inline_text(back_label or "Back")) }}</a></p>
+<p class="x2mdx-ref-back"><a href="{{ back_link }}">{{ escape_mdx_html_text(inline_text(back_label or "Back")) }}</a></p>
 {% endif %}
 <div class="x2mdx-ref-hero">
   {% if eyebrow %}
-  <p class="x2mdx-ref-eyebrow">{{ escape_html(inline_text(eyebrow)) }}</p>
+  <p class="x2mdx-ref-eyebrow">{{ escape_mdx_html_text(inline_text(eyebrow)) }}</p>
   {% endif %}
   {% if render_title %}
-  <h1 class="x2mdx-ref-title">{{ escape_html(inline_text(title)) }}</h1>
+  <h1 class="x2mdx-ref-title">{{ escape_mdx_html_text(inline_text(title)) }}</h1>
   {% endif %}
   {% if render_summary and summary %}
-  <p class="x2mdx-ref-summary">{{ escape_html(inline_text(summary)) }}</p>
+  <p class="x2mdx-ref-summary">{{ escape_mdx_html_text(inline_text(summary)) }}</p>
   {% endif %}
   {{ badge_row(badges) }}
   {{ meta_grid(meta_items) }}
@@ -22,9 +22,9 @@
 <div class="x2mdx-ref-breadcrumbs" role="navigation" aria-label="Breadcrumb">
   {% for item in items %}
   {% if item.href %}
-  <a href="{{ item.href }}">{{ escape_html(inline_text(item.label)) }}</a>
+  <a href="{{ item.href }}">{{ escape_mdx_html_text(inline_text(item.label)) }}</a>
   {% else %}
-  <span>{{ escape_html(inline_text(item.label)) }}</span>
+  <span>{{ escape_mdx_html_text(inline_text(item.label)) }}</span>
   {% endif %}
   {% if not loop.last %}
   <span class="x2mdx-ref-breadcrumb-separator">›</span>
@@ -38,7 +38,7 @@
 {% if badges %}
 <div class="x2mdx-ref-badges">
   {% for badge in badges %}
-  <span class="x2mdx-ref-badge x2mdx-ref-badge--{{ escape_html(inline_text(badge.tone)) }}">{{ escape_html(inline_text(badge.label)) }}</span>
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--{{ escape_html(inline_text(badge.tone)) }}">{{ escape_mdx_html_text(inline_text(badge.label)) }}</span>
   {% endfor %}
 </div>
 {% endif %}
@@ -49,8 +49,8 @@
 <dl class="x2mdx-ref-meta-grid">
   {% for item in meta_items %}
   <div class="x2mdx-ref-meta-item">
-    <dt>{{ escape_html(inline_text(item.label)) }}</dt>
-    <dd>{% if item.href %}<a href="{{ item.href }}">{{ escape_html(inline_text(item.value)) }}</a>{% else %}{{ escape_html(inline_text(item.value)) }}{% endif %}</dd>
+    <dt>{{ escape_mdx_html_text(inline_text(item.label)) }}</dt>
+    <dd>{% if item.href %}<a href="{{ item.href }}">{{ escape_mdx_html_text(inline_text(item.value)) }}</a>{% else %}{{ escape_mdx_html_text(inline_text(item.value)) }}{% endif %}</dd>
   </div>
   {% endfor %}
 </dl>
@@ -67,11 +67,11 @@
   <div class="x2mdx-ref-card x2mdx-ref-card--static">
   {% endif %}
     <div class="x2mdx-ref-card-head">
-      <h3>{{ escape_html(inline_text(card.title)) }}</h3>
+      <h3>{{ escape_mdx_html_text(inline_text(card.title)) }}</h3>
       {{ badge_row(card.badges) }}
     </div>
     {% if card.summary %}
-    <p class="x2mdx-ref-card-summary">{{ escape_html(inline_text(card.summary)) }}</p>
+    <p class="x2mdx-ref-card-summary">{{ escape_mdx_html_text(inline_text(card.summary)) }}</p>
     {% endif %}
     {{ meta_grid(card.meta_items) }}
   {% if card.href %}
@@ -90,14 +90,14 @@
   {% for field in fields %}
   <div class="x2mdx-ref-field-row">
     <div class="x2mdx-ref-field-main">
-      <code class="x2mdx-ref-field-name">{{ escape_html(inline_text(field.name)) }}</code>
-      <span class="x2mdx-ref-type-badge">{{ escape_html(inline_text(field.type_label)) }}</span>
+      <code class="x2mdx-ref-field-name">{{ escape_mdx_html_text(inline_text(field.name)) }}</code>
+      <span class="x2mdx-ref-type-badge">{{ escape_mdx_html_text(inline_text(field.type_label)) }}</span>
       {% if field.required %}
       <span class="x2mdx-ref-required-badge">required</span>
       {% endif %}
     </div>
     {% if field.description and field.description != "-" %}
-    <div class="x2mdx-ref-field-description">{{ escape_html(inline_text(field.description or "-")) }}</div>
+    <div class="x2mdx-ref-field-description">{{ escape_mdx_html_text(inline_text(field.description or "-")) }}</div>
     {% endif %}
   </div>
   {% endfor %}
@@ -107,7 +107,7 @@
 
 {% macro example_block(example) -%}
 {% if example %}
-<div class="x2mdx-ref-example-heading">{{ escape_html(inline_text(example.title)) }}</div>
+<div class="x2mdx-ref-example-heading">{{ escape_mdx_html_text(inline_text(example.title)) }}</div>
 {{ code_block(example.language, example.body) }}
 {% endif %}
 {%- endmacro %}
@@ -115,9 +115,9 @@
 {% macro rail_example_card(example) -%}
 <div className="x2mdx-ref-rail-code{% if example.kind == "response" %} x2mdx-ref-rail-code--response{% endif %}">
 <div className="x2mdx-ref-rail-head">
-  <span className="x2mdx-ref-rail-heading">{{ escape_html(inline_text(example.title)) }}</span>
+  <span className="x2mdx-ref-rail-heading">{{ escape_mdx_html_text(inline_text(example.title)) }}</span>
   {% if example.kind == "response" and example.media_type %}
-  <span className="x2mdx-ref-response-label">{{ escape_html(inline_text(example.media_type)) }}</span>
+  <span className="x2mdx-ref-response-label">{{ escape_mdx_html_text(inline_text(example.media_type)) }}</span>
   {% endif %}
 </div>
 
@@ -131,9 +131,9 @@
 {% macro schema_block(schema) -%}
 <div class="x2mdx-ref-schema"{% if schema.anchor %} id="{{ schema.anchor }}"{% endif %}>
   <div class="x2mdx-ref-schema-head">
-    <h3>{{ escape_html(inline_text(schema.name)) }}</h3>
+    <h3>{{ escape_mdx_html_text(inline_text(schema.name)) }}</h3>
     {% if schema.summary %}
-    <p class="x2mdx-ref-schema-summary">{{ escape_html(inline_text(schema.summary)) }}</p>
+    <p class="x2mdx-ref-schema-summary">{{ escape_mdx_html_text(inline_text(schema.summary)) }}</p>
     {% endif %}
   </div>
   {{ schema_body(schema) }}
@@ -142,13 +142,13 @@
 
 {% macro schema_body(schema, render_example=True, render_description=True) -%}
   {% if render_description and schema.description %}
-  <p class="x2mdx-ref-schema-description">{{ escape_html(inline_text(schema.description)) }}</p>
+  <p class="x2mdx-ref-schema-description">{{ escape_mdx_html_text(inline_text(schema.description)) }}</p>
   {% endif %}
   {{ fields_table(schema.fields) }}
   {% if schema.enum_values %}
   <ul class="x2mdx-ref-enum-list">
     {% for value in schema.enum_values %}
-    <li><code>{{ escape_html(inline_text(value)) }}</code></li>
+    <li><code>{{ escape_mdx_html_text(inline_text(value)) }}</code></li>
     {% endfor %}
   </ul>
   {% endif %}
@@ -160,14 +160,14 @@
 {% macro panel_block(panel, render_text=True, render_schema_description=True) -%}
 <div class="x2mdx-ref-panel">
   <div class="x2mdx-ref-panel-head">
-    <h3>{{ escape_html(inline_text(panel.title)) }}</h3>
+    <h3>{{ escape_mdx_html_text(inline_text(panel.title)) }}</h3>
     {% if render_text and panel.summary %}
-    <p class="x2mdx-ref-panel-summary">{{ escape_html(inline_text(panel.summary)) }}</p>
+    <p class="x2mdx-ref-panel-summary">{{ escape_mdx_html_text(inline_text(panel.summary)) }}</p>
     {% endif %}
   </div>
   {{ badge_row(panel.badges) }}
   {% if render_text and panel.description %}
-  <p class="x2mdx-ref-panel-description">{{ escape_html(inline_text(panel.description)) }}</p>
+  <p class="x2mdx-ref-panel-description">{{ escape_mdx_html_text(inline_text(panel.description)) }}</p>
   {% endif %}
   {{ meta_grid(panel.meta_items) }}
   {% if panel.schema %}
@@ -197,7 +197,7 @@
   {% if operation.operation_method %}
   <span class="x2mdx-ref-operation-method x2mdx-ref-operation-method--{{ escape_html(inline_text(operation.operation_method)|lower|replace(' ', '-')|replace('/', '-')|replace('_', '-')) }}">{{ escape_html(inline_text(operation.operation_method)) }}</span>
   {% endif %}
-  <code>{{ escape_html(inline_text(operation.operation_target)) }}</code>
+  <code>{{ escape_mdx_html_text(inline_text(operation.operation_target)) }}</code>
 </div>
 {% endif %}
 {%- endmacro %}
@@ -233,8 +233,8 @@
 <div class="x2mdx-ref-change-list">
   {% for change in operation.lifecycle_changes %}
   <div class="x2mdx-ref-change-item">
-    <span class="x2mdx-ref-change-version">{{ escape_html(inline_text(change.version)) }}</span>
-    <span class="x2mdx-ref-change-detail">{{ escape_html(inline_text(change.details)) }}</span>
+    <span class="x2mdx-ref-change-version">{{ escape_mdx_html_text(inline_text(change.version)) }}</span>
+    <span class="x2mdx-ref-change-detail">{{ escape_mdx_html_text(inline_text(change.details)) }}</span>
   </div>
   {% endfor %}
 </div>

--- a/tests/fixtures/characterization/daml_json/expected/index.mdx
+++ b/tests/fixtures/characterization/daml_json/expected/index.mdx
@@ -3,93 +3,1920 @@ title: "Daml Standard Library"
 description: "Reference documentation for Daml Standard Library modules."
 ---
 
-# Daml Standard Library
+<div class="x2mdx-ref-hero">
 
-This page is generated from versioned Daml docs JSON snapshots.
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-## Table of Contents
 
-| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`DA.Action`](/appdev/reference/daml-standard-library/da-action) | `Module` | Action | `3.4.10` | - | - | - |
-| [`DA.Action.State`](/appdev/reference/daml-standard-library/da-action-state) | `Module` | DA.Action.State | `3.4.10` | - | - | - |
-| [`DA.Action.State.Class`](/appdev/reference/daml-standard-library/da-action-state-class) | `Module` | DA.Action.State.Class | `3.4.10` | - | - | - |
-| [`DA.Assert`](/appdev/reference/daml-standard-library/da-assert) | `Module` | - | `3.4.10` | - | - | - |
-| [`DA.Bifunctor`](/appdev/reference/daml-standard-library/da-bifunctor) | `Module` | - | `3.4.10` | - | - | - |
-| [`DA.Crypto.Text`](/appdev/reference/daml-standard-library/da-crypto-text) | `Module` | Functions for working with Crypto builtins. | `3.4.10` | - | - | - |
-| [`DA.Date`](/appdev/reference/daml-standard-library/da-date) | `Module` | This module provides a set of functions to manipulate Date values. | `3.4.10` | - | - | - |
-| [`DA.Either`](/appdev/reference/daml-standard-library/da-either) | `Module` | The Either type represents values with two possibilities. | `3.4.10` | - | - | - |
-| [`DA.Exception`](/appdev/reference/daml-standard-library/da-exception) | `Module` | Exception handling in Daml. | `3.4.10` | - | `3.4.10` | - |
-| [`DA.Fail`](/appdev/reference/daml-standard-library/da-fail) | `Module` | Fail, for FailureStatus | `3.4.10` | - | - | - |
-| [`DA.Foldable`](/appdev/reference/daml-standard-library/da-foldable) | `Module` | Class of data structures that can be folded to a summary value. | `3.4.10` | - | - | - |
-| [`DA.Functor`](/appdev/reference/daml-standard-library/da-functor) | `Module` | The Functor class is used for types that can be mapped over. | `3.4.10` | - | - | - |
-| [`DA.Internal.Interface.AnyView`](/appdev/reference/daml-standard-library/da-internal-interface-anyview) | `Module` | - | `3.4.10` | - | - | - |
-| [`DA.Internal.Interface.AnyView.Types`](/appdev/reference/daml-standard-library/da-internal-interface-anyview-types) | `Module` | - | `3.4.10` | - | - | - |
-| [`DA.List`](/appdev/reference/daml-standard-library/da-list) | `Module` | List | `3.4.10` | - | - | - |
-| [`DA.List.BuiltinOrder`](/appdev/reference/daml-standard-library/da-list-builtinorder) | `Module` | Note: This is only supported in Daml-LF 1.11 or later. | `3.4.10` | - | - | - |
-| [`DA.List.Total`](/appdev/reference/daml-standard-library/da-list-total) | `Module` | - | `3.4.10` | - | - | - |
-| [`DA.Logic`](/appdev/reference/daml-standard-library/da-logic) | `Module` | Logic - Propositional calculus. | `3.4.10` | - | - | - |
-| [`DA.Map`](/appdev/reference/daml-standard-library/da-map) | `Module` | Note: This is only supported in Daml-LF 1.11 or later. | `3.4.10` | - | - | - |
-| [`DA.Math`](/appdev/reference/daml-standard-library/da-math) | `Module` | Math - Utility Math functions for Decimal | `3.4.10` | - | - | - |
-| [`DA.Monoid`](/appdev/reference/daml-standard-library/da-monoid) | `Module` | - | `3.4.10` | - | - | - |
-| [`DA.NonEmpty`](/appdev/reference/daml-standard-library/da-nonempty) | `Module` | Type and functions for non-empty lists. This module re-exports many functions with | `3.4.10` | - | - | - |
-| [`DA.NonEmpty.Types`](/appdev/reference/daml-standard-library/da-nonempty-types) | `Module` | This module contains the type for non-empty lists so we can give it a stable package id. | `3.4.10` | - | - | - |
-| [`DA.Numeric`](/appdev/reference/daml-standard-library/da-numeric) | `Module` | - | `3.4.10` | - | - | - |
-| [`DA.Optional`](/appdev/reference/daml-standard-library/da-optional) | `Module` | The Optional type encapsulates an optional value. A value of type | `3.4.10` | - | - | - |
-| [`DA.Record`](/appdev/reference/daml-standard-library/da-record) | `Module` | Exports the record machinery necessary to allow one to annotate | `3.4.10` | - | - | - |
-| [`DA.Semigroup`](/appdev/reference/daml-standard-library/da-semigroup) | `Module` | - | `3.4.10` | - | - | - |
-| [`DA.Set`](/appdev/reference/daml-standard-library/da-set) | `Module` | Note: This is only supported in Daml-LF 1.11 or later. | `3.4.10` | - | - | - |
-| [`DA.Stack`](/appdev/reference/daml-standard-library/da-stack) | `Module` | - | `3.4.10` | - | - | - |
-| [`DA.Text`](/appdev/reference/daml-standard-library/da-text) | `Module` | Functions for working with Text. | `3.4.10` | - | - | - |
-| [`DA.TextMap`](/appdev/reference/daml-standard-library/da-textmap) | `Module` | TextMap - A map is an associative array data type composed of a | `3.4.10` | - | - | - |
-| [`DA.Time`](/appdev/reference/daml-standard-library/da-time) | `Module` | This module provides a set of functions to manipulate Time values. | `3.4.10` | - | - | - |
-| [`DA.Traversable`](/appdev/reference/daml-standard-library/da-traversable) | `Module` | Class of data structures that can be traversed from left to right, performing an action on each element. | `3.4.10` | - | - | - |
-| [`DA.Tuple`](/appdev/reference/daml-standard-library/da-tuple) | `Module` | Tuple - Ubiquitous functions of tuples. | `3.4.10` | - | - | - |
-| [`DA.Validation`](/appdev/reference/daml-standard-library/da-validation) | `Module` | Validation type and associated functions. | `3.4.10` | - | - | - |
-| [`Prelude`](/appdev/reference/daml-standard-library/prelude) | `Module` | The pieces that make up the Daml language. | `3.4.10` | - | - | - |
+  <h1 class="x2mdx-ref-title">Daml Standard Library</h1>
 
-## Version Change Summary
 
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `3.4.10` | 38 | 0 | 0 |
-| `3.4.11` | 0 | 0 | 0 |
+  <p class="x2mdx-ref-summary">Generated module overview for the Daml Standard Library, built from versioned docs JSON snapshots.</p>
 
-## Reference
 
-- [DA.Action](/appdev/reference/daml-standard-library/da-action)
-- [DA.Action.State](/appdev/reference/daml-standard-library/da-action-state)
-- [DA.Action.State.Class](/appdev/reference/daml-standard-library/da-action-state-class)
-- [DA.Assert](/appdev/reference/daml-standard-library/da-assert)
-- [DA.Bifunctor](/appdev/reference/daml-standard-library/da-bifunctor)
-- [DA.Crypto.Text](/appdev/reference/daml-standard-library/da-crypto-text)
-- [DA.Date](/appdev/reference/daml-standard-library/da-date)
-- [DA.Either](/appdev/reference/daml-standard-library/da-either)
-- [DA.Exception](/appdev/reference/daml-standard-library/da-exception)
-- [DA.Fail](/appdev/reference/daml-standard-library/da-fail)
-- [DA.Foldable](/appdev/reference/daml-standard-library/da-foldable)
-- [DA.Functor](/appdev/reference/daml-standard-library/da-functor)
-- [DA.Internal.Interface.AnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview)
-- [DA.Internal.Interface.AnyView.Types](/appdev/reference/daml-standard-library/da-internal-interface-anyview-types)
-- [DA.List](/appdev/reference/daml-standard-library/da-list)
-- [DA.List.BuiltinOrder](/appdev/reference/daml-standard-library/da-list-builtinorder)
-- [DA.List.Total](/appdev/reference/daml-standard-library/da-list-total)
-- [DA.Logic](/appdev/reference/daml-standard-library/da-logic)
-- [DA.Map](/appdev/reference/daml-standard-library/da-map)
-- [DA.Math](/appdev/reference/daml-standard-library/da-math)
-- [DA.Monoid](/appdev/reference/daml-standard-library/da-monoid)
-- [DA.NonEmpty](/appdev/reference/daml-standard-library/da-nonempty)
-- [DA.NonEmpty.Types](/appdev/reference/daml-standard-library/da-nonempty-types)
-- [DA.Numeric](/appdev/reference/daml-standard-library/da-numeric)
-- [DA.Optional](/appdev/reference/daml-standard-library/da-optional)
-- [DA.Record](/appdev/reference/daml-standard-library/da-record)
-- [DA.Semigroup](/appdev/reference/daml-standard-library/da-semigroup)
-- [DA.Set](/appdev/reference/daml-standard-library/da-set)
-- [DA.Stack](/appdev/reference/daml-standard-library/da-stack)
-- [DA.Text](/appdev/reference/daml-standard-library/da-text)
-- [DA.TextMap](/appdev/reference/daml-standard-library/da-textmap)
-- [DA.Time](/appdev/reference/daml-standard-library/da-time)
-- [DA.Traversable](/appdev/reference/daml-standard-library/da-traversable)
-- [DA.Tuple](/appdev/reference/daml-standard-library/da-tuple)
-- [DA.Validation](/appdev/reference/daml-standard-library/da-validation)
-- [Prelude](/appdev/reference/daml-standard-library/prelude)
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">3.4.11</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>3.4.11</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>Published Daml Standard Library docs JSON from local SDK artifacts</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>characterization fixture versions</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-action">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Action</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Action</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-action-state">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Action.State</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">DA.Action.State</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-action-state-class">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Action.State.Class</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">DA.Action.State.Class</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-assert">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Assert</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-bifunctor">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Bifunctor</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-crypto-text">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Crypto.Text</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Functions for working with Crypto builtins.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-date">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Date</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">This module provides a set of functions to manipulate Date values.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-either">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Either</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">The Either type represents values with two possibilities.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-exception">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Exception</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Exception handling in Daml.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-fail">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Fail</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Fail, for FailureStatus</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-foldable">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Foldable</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Class of data structures that can be folded to a summary value.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-functor">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Functor</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">The Functor class is used for types that can be mapped over.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-internal-interface-anyview">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Internal.Interface.AnyView</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-internal-interface-anyview-types">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Internal.Interface.AnyView.Types</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-list">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.List</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">List</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-list-builtinorder">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.List.BuiltinOrder</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Note: This is only supported in Daml-LF 1.11 or later.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-list-total">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.List.Total</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-logic">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Logic</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Logic - Propositional calculus.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-map">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Map</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Note: This is only supported in Daml-LF 1.11 or later.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-math">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Math</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Math - Utility Math functions for Decimal</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-monoid">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Monoid</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-nonempty">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.NonEmpty</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Type and functions for non-empty lists. This module re-exports many functions with</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-nonempty-types">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.NonEmpty.Types</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">This module contains the type for non-empty lists so we can give it a stable package id.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-numeric">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Numeric</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-optional">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Optional</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">The Optional type encapsulates an optional value. A value of type</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-record">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Record</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Exports the record machinery necessary to allow one to annotate</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-semigroup">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Semigroup</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-set">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Set</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Note: This is only supported in Daml-LF 1.11 or later.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-stack">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Stack</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">-</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-text">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Text</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Functions for working with Text.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-textmap">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.TextMap</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">TextMap - A map is an associative array data type composed of a</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-time">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Time</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">This module provides a set of functions to manipulate Time values.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-traversable">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Traversable</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Class of data structures that can be traversed from left to right, performing an action on each element.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-tuple">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Tuple</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Tuple - Ubiquitous functions of tuples.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-validation">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Validation</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Validation type and associated functions.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/prelude">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>Prelude</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 3.4.10</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">The pieces that make up the Daml language.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>3.4.10</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.10</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 38</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>3.4.11</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/tests/minimal_characterization/fixtures/expected/daml_json/beta_stable/index.mdx
+++ b/tests/minimal_characterization/fixtures/expected/daml_json/beta_stable/index.mdx
@@ -3,24 +3,193 @@ title: "Minimal Daml JSON Beta Stable"
 description: "Reference documentation for Minimal Daml JSON Beta Stable modules."
 ---
 
-# Minimal Daml JSON Beta Stable
+<div class="x2mdx-ref-hero">
 
-This page is generated from versioned Daml docs JSON snapshots.
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-## Table of Contents
 
-| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`DA.Beta`](daml-json-lifecycle/da-beta) | `Module` | Beta module. | `1.0.0` | - | - | - |
-| [`DA.Stable`](daml-json-lifecycle/da-stable) | `Module` | Stable module. | `1.0.0` | - | - | - |
+  <h1 class="x2mdx-ref-title">Minimal Daml JSON Beta Stable</h1>
 
-## Version Change Summary
 
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `1.0.0` | 2 | 0 | 0 |
+  <p class="x2mdx-ref-summary">Generated module overview for the Daml Standard Library, built from versioned docs JSON snapshots.</p>
 
-## Reference
 
-- [DA.Beta](daml-json-lifecycle/da-beta)
-- [DA.Stable](daml-json-lifecycle/da-stable)
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">1.0.0</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>1.0.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>minimal daml json beta stable fixtures</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>manifest versions</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="daml-json-lifecycle/da-beta">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Beta</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 1.0.0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Beta module.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>1.0.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="daml-json-lifecycle/da-stable">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Stable</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 1.0.0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Stable module.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>1.0.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>1.0.0</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 2</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/tests/minimal_characterization/fixtures/expected/daml_json/default/index.mdx
+++ b/tests/minimal_characterization/fixtures/expected/daml_json/default/index.mdx
@@ -3,29 +3,322 @@ title: "Minimal Daml JSON"
 description: "Reference documentation for Minimal Daml JSON modules."
 ---
 
-# Minimal Daml JSON
+<div class="x2mdx-ref-hero">
 
-This page is generated from versioned Daml docs JSON snapshots.
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-## Table of Contents
 
-| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`DA.Alpha`](/reference/daml-json/da-alpha) | `Module` | Alpha module. | `1.0.0` | - | - | - |
-| [`DA.Current`](/reference/daml-json/da-current) | `Module` | Current module. | `1.1.0` | - | - | - |
-| [`DA.Legacy`](/reference/daml-json/da-legacy) | `Module` | Legacy module. | `1.0.0` | - | `1.1.0` | - |
-| [`DA.LooseLegacy`](/reference/daml-json/da-looselegacy) | `Module` | Loose legacy module. | `1.0.0` | - | `1.1.0` | - |
+  <h1 class="x2mdx-ref-title">Minimal Daml JSON</h1>
 
-## Version Change Summary
 
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `1.0.0` | 3 | 0 | 0 |
-| `1.1.0` | 1 | 0 | 0 |
+  <p class="x2mdx-ref-summary">Generated module overview for the Daml Standard Library, built from versioned docs JSON snapshots.</p>
 
-## Reference
 
-- [DA.Alpha](/reference/daml-json/da-alpha)
-- [DA.Current](/reference/daml-json/da-current)
-- [DA.Legacy](/reference/daml-json/da-legacy)
-- [DA.LooseLegacy](/reference/daml-json/da-looselegacy)
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">1.1.0</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>1.1.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>minimal daml json lifecycle fixtures</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>minimal versions</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="/reference/daml-json/da-alpha">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Alpha</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 1.0.0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Alpha module.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>1.0.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/reference/daml-json/da-current">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Current</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 1.1.0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Current module.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>1.1.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/reference/daml-json/da-legacy">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Legacy</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 1.0.0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated 1.1.0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Legacy module.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>1.0.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>1.1.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="/reference/daml-json/da-looselegacy">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.LooseLegacy</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 1.0.0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated 1.1.0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Loose legacy module.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>1.0.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>1.1.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>1.0.0</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 3</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>1.1.0</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/tests/minimal_characterization/fixtures/expected/daml_json/prune/index.mdx
+++ b/tests/minimal_characterization/fixtures/expected/daml_json/prune/index.mdx
@@ -3,29 +3,322 @@ title: "Daml Standard Library"
 description: "Reference documentation for Daml Standard Library modules."
 ---
 
-# Daml Standard Library
+<div class="x2mdx-ref-hero">
 
-This page is generated from versioned Daml docs JSON snapshots.
+  <p class="x2mdx-ref-eyebrow">Daml Reference</p>
 
-## Table of Contents
 
-| Name | Kind | Summary | Introduced | Changed | Deprecated | Removed |
-| --- | --- | --- | --- | --- | --- | --- |
-| [`DA.Alpha`](daml-json-prune/da-alpha) | `Module` | Alpha module. | `1.0.0` | - | - | - |
-| [`DA.Current`](daml-json-prune/da-current) | `Module` | Current module. | `1.1.0` | - | - | - |
-| [`DA.Legacy`](daml-json-prune/da-legacy) | `Module` | Legacy module. | `1.0.0` | - | `1.1.0` | - |
-| [`DA.LooseLegacy`](daml-json-prune/da-looselegacy) | `Module` | Loose legacy module. | `1.0.0` | - | `1.1.0` | - |
+  <h1 class="x2mdx-ref-title">Daml Standard Library</h1>
 
-## Version Change Summary
 
-| Version | Added | Changed | Removed |
-| --- | --- | --- | --- |
-| `1.0.0` | 3 | 0 | 0 |
-| `1.1.0` | 1 | 0 | 0 |
+  <p class="x2mdx-ref-summary">Generated module overview for the Daml Standard Library, built from versioned docs JSON snapshots.</p>
 
-## Reference
 
-- [DA.Alpha](daml-json-prune/da-alpha)
-- [DA.Current](daml-json-prune/da-current)
-- [DA.Legacy](daml-json-prune/da-legacy)
-- [DA.LooseLegacy](daml-json-prune/da-looselegacy)
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--protocol">Daml</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--neutral">1.1.0</span>
+
+</div>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Publish version</dt>
+    <dd>1.1.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Source</dt>
+    <dd>minimal daml json lifecycle fixtures</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Version filter</dt>
+    <dd>manifest versions</dd>
+  </div>
+
+</dl>
+
+</div>
+
+
+## Modules
+
+
+Open a module page for declarations, type signatures, warnings, and lifecycle details.
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <a class="x2mdx-ref-card" href="daml-json-prune/da-alpha">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Alpha</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 1.0.0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Alpha module.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>1.0.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="daml-json-prune/da-current">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Current</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 1.1.0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Current module.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>1.1.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="daml-json-prune/da-legacy">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.Legacy</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 1.0.0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated 1.1.0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Legacy module.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>1.0.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>1.1.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+
+  <a class="x2mdx-ref-card" href="daml-json-prune/da-looselegacy">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>DA.LooseLegacy</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Since 1.0.0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Deprecated 1.1.0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Loose legacy module.</p>
+
+
+<dl class="x2mdx-ref-meta-grid">
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Kind</dt>
+    <dd>Module</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Introduced</dt>
+    <dd>1.0.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Changed</dt>
+    <dd>-</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Deprecated</dt>
+    <dd>1.1.0</dd>
+  </div>
+
+  <div class="x2mdx-ref-meta-item">
+    <dt>Removed</dt>
+    <dd>-</dd>
+  </div>
+
+</dl>
+
+
+  </a>
+
+
+</div>
+
+
+
+
+
+## Version Summary
+
+
+
+
+<div class="x2mdx-ref-card-grid">
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>1.0.0</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 3</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+
+  <div class="x2mdx-ref-card x2mdx-ref-card--static">
+
+    <div class="x2mdx-ref-card-head">
+      <h3>1.1.0</h3>
+
+<div class="x2mdx-ref-badges">
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--added">Added 1</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--changed">Changed 0</span>
+
+  <span class="x2mdx-ref-badge x2mdx-ref-badge--removed">Removed 0</span>
+
+</div>
+
+    </div>
+
+    <p class="x2mdx-ref-card-summary">Module changes included in this Daml docs JSON snapshot.</p>
+
+
+
+  </div>
+
+
+</div>

--- a/tests/minimal_characterization/test_daml_json_lifecycle.py
+++ b/tests/minimal_characterization/test_daml_json_lifecycle.py
@@ -179,9 +179,10 @@ class DamlJsonMinimalLifecycleTests(unittest.TestCase):
         assert_contains_all(
             overview,
             [
-                "[`DA.Alpha`](/reference/daml-json/da-alpha)",
-                "[`DA.Current`](/reference/daml-json/da-current)",
-                "`1.1.0`",
+                '<p class="x2mdx-ref-eyebrow">Daml Reference</p>',
+                '<a class="x2mdx-ref-card" href="/reference/daml-json/da-alpha">',
+                '<a class="x2mdx-ref-card" href="/reference/daml-json/da-current">',
+                "1.1.0",
             ],
         )
         assert_contains_all(alpha, ["Lifecycle", "Alpha (experimental).", "Alpha: experimental module.", "### `data Token`"])

--- a/tests/test_daml_json.py
+++ b/tests/test_daml_json.py
@@ -193,8 +193,10 @@ class DamlJsonTests(unittest.TestCase):
         legacy_text = (output_dir / "da-legacy.mdx").read_text(encoding="utf-8")
 
         self.assertIn("Utility Credential API", index_text)
-        self.assertIn("[DA.List](daml-standard-library/da-list)", index_text)
-        self.assertIn("removed in `1.1.0`", index_text)
+        self.assertIn('<div class="x2mdx-ref-hero">', index_text)
+        self.assertIn('<p class="x2mdx-ref-eyebrow">Daml Reference</p>', index_text)
+        self.assertIn('<a class="x2mdx-ref-card" href="daml-standard-library/da-list">', index_text)
+        self.assertIn("Removed 1.1.0", index_text)
         self.assertIn("Deprecated since: `1.1.0`", list_text)
         self.assertIn("historical reference", legacy_text)
 
@@ -264,4 +266,4 @@ class DamlJsonTests(unittest.TestCase):
 
         self.assertEqual(result, 0)
         index_text = (output_dir / "index.mdx").read_text(encoding="utf-8")
-        self.assertIn("[DA.List](/appdev/reference/daml-standard-library/da-list)", index_text)
+        self.assertIn('<a class="x2mdx-ref-card" href="/appdev/reference/daml-standard-library/da-list">', index_text)

--- a/tests/test_json_api_openapi.py
+++ b/tests/test_json_api_openapi.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+from x2mdx.render import render_page
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -81,3 +83,52 @@ def test_openapi_operation_page_refs_lists_endpoint_refs_in_source_order() -> No
         "POST /v2/packages",
         "GET /v2/version",
     ]
+
+
+def test_build_openapi_details_page_uses_reference_overview_layout() -> None:
+    module = load_script_module("generate_json_api_reference.py")
+    specs = {
+        "3.4": {
+            "paths": {
+                "/v2/version": {
+                    "get": {
+                        "summary": "/v2/version",
+                        "description": "Read the version.",
+                    }
+                }
+            }
+        },
+        "3.5": {
+            "paths": {
+                "/v2/version": {
+                    "get": {
+                        "summary": "/v2/version",
+                        "description": "Read the Ledger API version.",
+                    }
+                },
+                "/readyz": {
+                    "get": {
+                        "summary": "/readyz",
+                        "description": "Check readiness.",
+                    }
+                },
+            }
+        },
+    }
+
+    rendered = render_page(
+        module.build_openapi_details_page(
+            specs_by_version=specs,
+            versions=["3.4", "3.5"],
+            publish_version="3.5",
+            details_page_ref="reference/json-api-reference/details",
+            source_name="unit test OpenAPI fixtures",
+        )
+    )
+
+    assert '<div class="x2mdx-ref-hero">' in rendered
+    assert '<p class="x2mdx-ref-eyebrow">OpenAPI Reference</p>' in rendered
+    assert '<a class="x2mdx-ref-card"' not in rendered
+    assert '<div class="x2mdx-ref-card x2mdx-ref-card--static">' in rendered
+    assert "Changed 3.5" in rendered
+    assert "## Endpoint Reference (Latest)" not in rendered


### PR DESCRIPTION
Fixes #359

## Summary
- Rebuilds the OpenAPI `Details and history` page with the shared reference hero/card layout used by AsyncAPI.
- Adds generated endpoint cards and version summary cards from versioned OpenAPI snapshots.
- Updates the Daml Standard Library overview page to the same reference collection layout, including module cards and version summary cards.
- Escapes visible JSX text in the shared reference macros so OpenAPI paths with `{parameter}` segments validate under MDX.

## Screenshots
### OpenAPI Details and history
![OpenAPI Details and history card layout](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issues-359-364-screenshots/pr-assets/cf-docs-pr-372/openapi-details-history.png)

The OpenAPI Details and history page now uses the shared reference hero and card grid, with endpoint lifecycle badges visible in the main content.

### Daml Standard Library overview
![Daml Standard Library overview card layout](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issues-359-364-screenshots/pr-assets/cf-docs-pr-372/daml-standard-library-overview.png)

The Daml Standard Library overview now matches the same collection-page treatment: hero metadata, module cards, lifecycle badges, and the generated module index in the right rail.

## Validation
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-359 python3 -m pytest tests/test_json_api_openapi.py tests/test_daml_json.py`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-359 python3 -m pytest tests/minimal_characterization/test_daml_json_lifecycle.py -k 'not explicit_lifecycle_states'`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-359 git diff --check`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-359 npx mintlify validate`
- Local screenshots captured from `npx mintlify dev --port 3072 --no-open` with Playwright at `1440x1000`.

## Known Existing Gap
The excluded `test_cli_renders_explicit_lifecycle_states` assertion is the existing beta/stable lifecycle characterization gap. This PR updates the overview layout expectations but does not change that lifecycle-status behavior.