### PR TITLE
Triage batch: address open issues #240, #325, #357, #370, #374

### DIFF
--- a/docs-main/devnet/appdev/deep-dives/external-signing-transactions.mdx
+++ b/docs-main/devnet/appdev/deep-dives/external-signing-transactions.mdx
@@ -1677,7 +1677,7 @@ def get_active_contracts(party: str):
 ``` none
 ping_created_event: event_pb2.CreatedEvent
 initiator_active_contracts = get_active_contracts(initiator)
-# Find the contract in the active contract store
+# Find the contract in the active contract set
 for active_contract_response in initiator_active_contracts:
     if (
         active_contract_response.HasField("active_contract")

--- a/docs-main/devnet/overview/reference/pruning.mdx
+++ b/docs-main/devnet/overview/reference/pruning.mdx
@@ -22,12 +22,6 @@ As a synchronizer orchestrates the execution of commands, the sequencers, mediat
 
 Because these nodes operate continuously for an indefinite amount of time, the stored data they accumulate, or put differently, the history of the ledger, keeps growing.
 
-<div className="todo">
-
-Add a link to the data they actually accumulate, probably in one of Raf's section \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 Accumulating and storing history forever on nodes is problematic for several reasons:
 
 - First, nodes have a limited amount of storage that they will eventually exhaust if the stored data keeps growing
@@ -65,12 +59,6 @@ A participant node's snapshot at t consists of the following:
 
 - The set of active contracts at time t that have stakeholders hosted on that participant. This set is fundamental for the participant node in order to participate correctly in Canton's transaction processing, e.g., the participant safeguards double spending by rejecting such transactions.
 - The in-flight reassignments at time t. A participant that is a reassigning participant for a contract must retain reassignment data while the reassignment is in-flight, i.e., while either the unassign or the assign commands did not complete. Otherwise, the participant would not be able to approve or reject reassignments correctly. For more details on reassignments, refer to the reassignments section. For now, participants do not prune their reassignment data, however, this is planned for the future.
-
-<div className="todo">
-
-Add link to reassignments section. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
 
 - The participant's private keys. For now, the participant requires all key material, not just the keys valid at time t. The participant uses these keys to authenticate the messages it sends to other nodes by signing these messages.
 - All past topology snapshots up to and including t. The past topology snapshots are necessary because the participant may need to serve them in order to validate future requests, e.g., validating the target timestamp in an unassignment request. The topology snapshot at t is necessary because it informs the participant of which nodes are present (mediators, sequencers, participants), which restrictions each synchronizer imposes on participants (e.g. the maximum number of parties a participant may host), which parties are hosted on which participants, etc. Thus, all nodes participating in the Canton transaction protocol know which participants are involved in a transaction at time t, which keys they use, etc.
@@ -197,12 +185,6 @@ Participant nodes need to efficiently summarize the ACS state into commitments, 
 
 Instead, each participant node summarizes ACS changes as they happen during the interval, maintains a running hash of the ACS per stakeholder group. The grouping per stakeholders ensures that each ACS change is processed only once. Specifically, per ACS change, the hash adds or removes the contract id, which authenticates the contents, and the contract's reassignment counter, which identifies the exact (de)activation of this contract: either creation, archival, or the reassignment instance for a contract that was reassigned between synchronizers. The hash function is homomorphic in the sense that contract deactivations cancel out activations, thus the running hash can be updated incrementally.
 
-<div className="todo">
-
-Add a link to contract id in daml when that page exists. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 The final commitment computation at the end of a period is as follows. For each counter-participant, the participant node collects all non-empty running hashes of stakeholder groups it shares with the counter-participant, and adds them into a homomorphic hash. The commitment essentially contains a two-level homomorphic hashing: first the hashing of ACS changes into stakeholder group hashes, and then the hashing of stakeholder group hashes into the commitment hash. The reason for this two-level hashing is that it enables optimizations for updating commitments and investigating mismatches, which we describe later. Afterwards, the participant node significantly reduces the size of the homomorphic hash by applying a cryptographic hash for compression purposes.
 
 Commitments are cryptographic hashes that are signed by the participant node, with the following properties:
@@ -221,12 +203,6 @@ If a period has resulted in a mismatch between two participant nodes, then we ha
 
 This intervention would require all involved participant node operators to look at their shared active contracts and find the cause of the mismatch. We provide tooling for mismatch inspection, which allows participant nodes to identify which contracts cause the mismatch. However, the tooling does not automatically resolve the mismatch, as the participant node operators need to decide, perhaps through out-of-band communication, what the correct end state is, and then apply the changes.
 
-<div className="todo">
-
-Add link to tooling page \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 As long as a mismatch is ongoing then the affected participant nodes would not be able to prune data prior to the initial mismatch. Once a period is matched with all counter-participant nodes then all previous periods are implicitly safe to prune: Even though initially the states showed a mismatch, a fork no longer exists.
 
 ### Optimizations
@@ -235,21 +211,9 @@ Computing a large number of hashes for commitments can be performance-heavy, and
 
 First, participant nodes that do not share active contracts neither compute, nor send commitments or expect to receive commitments. If one of the participant nodes thinks otherwise, however, the participant node sends a commitments, which causes the other participant node to output a warning `ACS_MISMATCH_NO_SHARED_CONTRACTS: Received a commitment where we have no shared contract with the sender`. The participant node then replies with an empty commitment, which triggers mismatch inspection based on the non-empty state of the counter-participant. This optimization produces significant performance improvements for a participant node that has many counter-participant nodes without shared active contracts. Moreover, if a participant node believes its shared state with a counter-participant to be empty, it can prune without establishing that the counter-participant agrees that the state is empty.
 
-<div className="todo">
-
-Add a link to the error code doc page (tooling). \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 Second, regarding bandwidth, participant nodes only exchange commitments periodically, which bounds the amount of bandwidth consumed regardless of the contract activity within a period. Also, periods are aggregated when there is no activity. Instead of constantly sending the same commitment, each participant node simply aggregates periods and send a commitment once it notices activity. Still, aggregation does not happen if the participants observe any possibly unrelated synchronizer activity, because activity triggers ticks, and in that case the participant nodes do exchange the same commitment hashes repeatedly, albeit with different timestamps. Moreover, there is a lower bound for exchanging commitments even when there is no synchronizer activity, by default every 24 hours.
 
 Additionally, to avoid a spike in network activity at the end of every period, each participant node sends commitments with jittered delay. The delay is a random amount uniformly distributed between 0 and 2/3 of the period length, therefore the sequencer is not getting flooded with commitments.
-
-<div className="todo">
-
-Change the hard-coded amount when we make it configurable in the code. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
 
 Commitments are sent best-effort, without a guaranteed delivery, which saves network resources. This means that a participant node might miss commitments from a counter-participant. However, this is not a problem because each commitment is stand-alone with respect to semantics, thus missing a commitment has no effect on the usefulness of future incoming commitments. A participant nodes might miss some commitments for some timestamps in the past, but as long as it agrees with its counter-participants on the present state, it can prune history. In other words, even though the participant node may not know whether a prior fork existed, it can still prune history up to timestamps where certainly no forks exist.
 
@@ -260,12 +224,6 @@ Moreover, this structure allows for efficient updates when few stakeholder group
 Also, the two-level homomorphic hash structure allows for efficient mismatch inspection. A participant node inspecting a mismatch does not require the entire set of shared contracts ids: The participant node can perform matching per level, keeps blinded those stakeholder commitments that match, and only requires the set of shared contracts ids of the stakeholder hashes that do not match.
 
 Fourth, in periods with high load, a participant node that lags behind with transaction processing reduces the overhead caused by commitments. A participant node lags behind when its observed sequencer time is behind some of its counter-participants; the participant can infer the sequencer time of a counter-participant from the periods in the received commitments. A lagging participant node automatically triggers a so-called catch-up mode, where it skips computing and sending commitments for some periods. The synchronizer operator can control the catch-up behavior through a synchronizer configuration. The catch-up mode brings a participant node up to date with transaction throughput, while still detecting forks.
-
-<div className="todo">
-
-Add a link to the how-to guide in the above. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
 
 Fifth, for multi-hosted parties, a participant node only requires threshold-many counter-participants to send matching commitments, instead of all counter-participants. Such an optimization is natural, given that we only need threshold-many counter-participants to approve a transaction, and therefore deem a contract active. This allows for pruning even if some commitments are outstanding, as long as each multi-hosted party is hosted on at least threshold-many counter-participants that send matching commitments. This is especially relevant for decentralized parties, some of whose participant nodes may be malicious / faulty.
 

--- a/docs-main/devnet/overview/reference/validator-node-components.mdx
+++ b/docs-main/devnet/overview/reference/validator-node-components.mdx
@@ -34,7 +34,7 @@ flowchart TB
         LAPI[Ledger API &#40;gRPC&#41;]
         AAPI[Admin API]
         ENGINE[Daml Engine]
-        ACS[(Active Contract Store)]
+        ACS[(Active Contract Set)]
         PROTO[Protocol Layer<br>preparation &#8226; validation &#8226; confirmation]
     end
 
@@ -144,7 +144,7 @@ The Daml engine interprets and executes Daml smart contract code. When an applic
 2. Evaluates the Daml code to produce a transaction tree -- the root action plus all its consequences
 3. Computes the view decomposition for privacy (each party sees only the sub-views they are entitled to)
 
-### Active Contract Store (ACS)
+### Active Contract Set (ACS)
 
 The ACS is the participant's local projection of active contracts. It contains only contracts where a party hosted on that participant is a stakeholder (signatory or observer). The ACS is stored in the participant's PostgreSQL database.
 

--- a/docs-main/devnet/overview/understand/core-concepts.mdx
+++ b/docs-main/devnet/overview/understand/core-concepts.mdx
@@ -89,7 +89,7 @@ flowchart TB
 
 ### Key Characteristics
 
-- Each validator maintains a **localized, private view** of the ledger (called the _Active Contract Store_)
+- Each validator maintains a **localized, private view** of the ledger (called the _Active Contract Set_)
 - Validators only store contracts where their hosted parties are stakeholders
 - Multiple parties can be hosted on a single validator
 - Validators can connect to multiple synchronizers

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -897,124 +897,128 @@
           {
             "group": "Ledger API",
             "pages": [
-              "appdev/reference/pqs-sql-reference",
               {
-                "group": "OpenAPI",
-                "openapi": {
-                  "source": "openapi/json-ledger-api/openapi.yaml",
-                  "directory": "reference/json-api-reference"
-                },
-                "pages": [
-                  "POST /v2/commands/submit-and-wait",
-                  "POST /v2/commands/submit-and-wait-for-transaction",
-                  "POST /v2/commands/submit-and-wait-for-reassignment",
-                  "POST /v2/commands/submit-and-wait-for-transaction-tree",
-                  "POST /v2/commands/async/submit",
-                  "POST /v2/commands/async/submit-reassignment",
-                  "POST /v2/commands/completions",
-                  "POST /v2/events/events-by-contract-id",
-                  "GET /v2/version",
-                  "POST /v2/dars/validate",
-                  "POST /v2/dars",
-                  "GET /v2/packages",
-                  "POST /v2/packages",
-                  "GET /v2/packages/{package-id}",
-                  "GET /v2/packages/{package-id}/status",
-                  "GET /v2/package-vetting",
-                  "POST /v2/package-vetting",
-                  "POST /v2/package-vetting/list",
-                  "POST /v2/package-vetting/update",
-                  "GET /v2/parties",
-                  "POST /v2/parties",
-                  "POST /v2/parties/external/allocate",
-                  "GET /v2/parties/participant-id",
-                  "GET /v2/parties/{party}",
-                  "PATCH /v2/parties/{party}",
-                  "POST /v2/parties/external/generate-topology",
-                  "POST /v2/state/active-contracts",
-                  "GET /v2/state/connected-synchronizers",
-                  "GET /v2/state/ledger-end",
-                  "GET /v2/state/latest-pruned-offsets",
-                  "POST /v2/updates",
-                  "POST /v2/updates/flats",
-                  "POST /v2/updates/trees",
-                  "GET /v2/updates/transaction-tree-by-offset/{offset}",
-                  "POST /v2/updates/transaction-by-offset",
-                  "POST /v2/updates/update-by-offset",
-                  "POST /v2/updates/transaction-by-id",
-                  "POST /v2/updates/update-by-id",
-                  "GET /v2/updates/transaction-tree-by-id/{update-id}",
-                  "GET /v2/users",
-                  "POST /v2/users",
-                  "GET /v2/users/{user-id}",
-                  "DELETE /v2/users/{user-id}",
-                  "PATCH /v2/users/{user-id}",
-                  "GET /v2/authenticated-user",
-                  "GET /v2/users/{user-id}/rights",
-                  "POST /v2/users/{user-id}/rights",
-                  "PATCH /v2/users/{user-id}/rights",
-                  "PATCH /v2/users/{user-id}/identity-provider-id",
-                  "GET /v2/idps",
-                  "POST /v2/idps",
-                  "GET /v2/idps/{idp-id}",
-                  "DELETE /v2/idps/{idp-id}",
-                  "PATCH /v2/idps/{idp-id}",
-                  "POST /v2/interactive-submission/prepare",
-                  "POST /v2/interactive-submission/execute",
-                  "POST /v2/interactive-submission/executeAndWait",
-                  "POST /v2/interactive-submission/executeAndWaitForTransaction",
-                  "GET /v2/interactive-submission/preferred-package-version",
-                  "POST /v2/interactive-submission/preferred-packages",
-                  "GET /livez",
-                  "GET /readyz",
-                  "POST /v2/contracts/contract-by-id",
-                  "reference/json-api-reference/details"
-                ]
-              },
-              {
-                "group": "AsyncAPI",
+                "group": "HTTP API",
                 "pages": [
                   {
-                    "group": "/v2/commands/completions",
+                    "group": "OpenAPI",
+                    "openapi": {
+                      "source": "openapi/json-ledger-api/openapi.yaml",
+                      "directory": "reference/json-api-reference"
+                    },
                     "pages": [
-                      "reference/json-api-asyncapi-reference/operations/v2-commands-completions/publish",
-                      "reference/json-api-asyncapi-reference/operations/v2-commands-completions/subscribe",
-                      "reference/json-api-asyncapi-reference/operations/v2-commands-completions/details"
+                      "POST /v2/commands/submit-and-wait",
+                      "POST /v2/commands/submit-and-wait-for-transaction",
+                      "POST /v2/commands/submit-and-wait-for-reassignment",
+                      "POST /v2/commands/submit-and-wait-for-transaction-tree",
+                      "POST /v2/commands/async/submit",
+                      "POST /v2/commands/async/submit-reassignment",
+                      "POST /v2/commands/completions",
+                      "POST /v2/events/events-by-contract-id",
+                      "GET /v2/version",
+                      "POST /v2/dars/validate",
+                      "POST /v2/dars",
+                      "GET /v2/packages",
+                      "POST /v2/packages",
+                      "GET /v2/packages/{package-id}",
+                      "GET /v2/packages/{package-id}/status",
+                      "GET /v2/package-vetting",
+                      "POST /v2/package-vetting",
+                      "POST /v2/package-vetting/list",
+                      "POST /v2/package-vetting/update",
+                      "GET /v2/parties",
+                      "POST /v2/parties",
+                      "POST /v2/parties/external/allocate",
+                      "GET /v2/parties/participant-id",
+                      "GET /v2/parties/{party}",
+                      "PATCH /v2/parties/{party}",
+                      "POST /v2/parties/external/generate-topology",
+                      "POST /v2/state/active-contracts",
+                      "GET /v2/state/connected-synchronizers",
+                      "GET /v2/state/ledger-end",
+                      "GET /v2/state/latest-pruned-offsets",
+                      "POST /v2/updates",
+                      "POST /v2/updates/flats",
+                      "POST /v2/updates/trees",
+                      "GET /v2/updates/transaction-tree-by-offset/{offset}",
+                      "POST /v2/updates/transaction-by-offset",
+                      "POST /v2/updates/update-by-offset",
+                      "POST /v2/updates/transaction-by-id",
+                      "POST /v2/updates/update-by-id",
+                      "GET /v2/updates/transaction-tree-by-id/{update-id}",
+                      "GET /v2/users",
+                      "POST /v2/users",
+                      "GET /v2/users/{user-id}",
+                      "DELETE /v2/users/{user-id}",
+                      "PATCH /v2/users/{user-id}",
+                      "GET /v2/authenticated-user",
+                      "GET /v2/users/{user-id}/rights",
+                      "POST /v2/users/{user-id}/rights",
+                      "PATCH /v2/users/{user-id}/rights",
+                      "PATCH /v2/users/{user-id}/identity-provider-id",
+                      "GET /v2/idps",
+                      "POST /v2/idps",
+                      "GET /v2/idps/{idp-id}",
+                      "DELETE /v2/idps/{idp-id}",
+                      "PATCH /v2/idps/{idp-id}",
+                      "POST /v2/interactive-submission/prepare",
+                      "POST /v2/interactive-submission/execute",
+                      "POST /v2/interactive-submission/executeAndWait",
+                      "POST /v2/interactive-submission/executeAndWaitForTransaction",
+                      "GET /v2/interactive-submission/preferred-package-version",
+                      "POST /v2/interactive-submission/preferred-packages",
+                      "GET /livez",
+                      "GET /readyz",
+                      "POST /v2/contracts/contract-by-id",
+                      "reference/json-api-reference/details"
                     ]
                   },
                   {
-                    "group": "/v2/state/active-contracts",
+                    "group": "AsyncAPI",
                     "pages": [
-                      "reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/publish",
-                      "reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/subscribe",
-                      "reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/details"
+                      {
+                        "group": "/v2/commands/completions",
+                        "pages": [
+                          "reference/json-api-asyncapi-reference/operations/v2-commands-completions/publish",
+                          "reference/json-api-asyncapi-reference/operations/v2-commands-completions/subscribe",
+                          "reference/json-api-asyncapi-reference/operations/v2-commands-completions/details"
+                        ]
+                      },
+                      {
+                        "group": "/v2/state/active-contracts",
+                        "pages": [
+                          "reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/publish",
+                          "reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/subscribe",
+                          "reference/json-api-asyncapi-reference/operations/v2-state-active-contracts/details"
+                        ]
+                      },
+                      {
+                        "group": "/v2/updates",
+                        "pages": [
+                          "reference/json-api-asyncapi-reference/operations/v2-updates/publish",
+                          "reference/json-api-asyncapi-reference/operations/v2-updates/subscribe",
+                          "reference/json-api-asyncapi-reference/operations/v2-updates/details"
+                        ]
+                      },
+                      {
+                        "group": "/v2/updates/flats",
+                        "pages": [
+                          "reference/json-api-asyncapi-reference/operations/v2-updates-flats/publish",
+                          "reference/json-api-asyncapi-reference/operations/v2-updates-flats/subscribe",
+                          "reference/json-api-asyncapi-reference/operations/v2-updates-flats/details"
+                        ]
+                      },
+                      {
+                        "group": "/v2/updates/trees",
+                        "pages": [
+                          "reference/json-api-asyncapi-reference/operations/v2-updates-trees/publish",
+                          "reference/json-api-asyncapi-reference/operations/v2-updates-trees/subscribe",
+                          "reference/json-api-asyncapi-reference/operations/v2-updates-trees/details"
+                        ]
+                      },
+                      "reference/json-api-asyncapi-reference/operations/details"
                     ]
-                  },
-                  {
-                    "group": "/v2/updates",
-                    "pages": [
-                      "reference/json-api-asyncapi-reference/operations/v2-updates/publish",
-                      "reference/json-api-asyncapi-reference/operations/v2-updates/subscribe",
-                      "reference/json-api-asyncapi-reference/operations/v2-updates/details"
-                    ]
-                  },
-                  {
-                    "group": "/v2/updates/flats",
-                    "pages": [
-                      "reference/json-api-asyncapi-reference/operations/v2-updates-flats/publish",
-                      "reference/json-api-asyncapi-reference/operations/v2-updates-flats/subscribe",
-                      "reference/json-api-asyncapi-reference/operations/v2-updates-flats/details"
-                    ]
-                  },
-                  {
-                    "group": "/v2/updates/trees",
-                    "pages": [
-                      "reference/json-api-asyncapi-reference/operations/v2-updates-trees/publish",
-                      "reference/json-api-asyncapi-reference/operations/v2-updates-trees/subscribe",
-                      "reference/json-api-asyncapi-reference/operations/v2-updates-trees/details"
-                    ]
-                  },
-                  "reference/json-api-asyncapi-reference/operations/details"
+                  }
                 ]
               },
               {
@@ -1216,217 +1220,222 @@
                       }
                     ]
                   },
-                  "reference/grpc-ledger-api-reference/details"
-                ]
-              },
-              {
-                "group": "Protobufs",
-                "pages": [
+                  "reference/grpc-ledger-api-reference/details",
                   {
-                    "group": "Packages",
+                    "group": "Protobufs",
                     "pages": [
                       {
-                        "group": "com.daml.ledger.api",
+                        "group": "Packages",
                         "pages": [
-                          "reference/protobuf/packages/com-daml-ledger-api"
-                        ]
-                      },
-                      {
-                        "group": "com.daml.ledger.api.v2",
-                        "pages": [
-                          "reference/protobuf/packages/com-daml-ledger-api-v2",
                           {
-                            "group": "Services",
+                            "group": "com.daml.ledger.api",
                             "pages": [
+                              "reference/protobuf/packages/com-daml-ledger-api"
+                            ]
+                          },
+                          {
+                            "group": "com.daml.ledger.api.v2",
+                            "pages": [
+                              "reference/protobuf/packages/com-daml-ledger-api-v2",
                               {
-                                "group": "CommandCompletionService",
+                                "group": "Services",
                                 "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream"
+                                  {
+                                    "group": "CommandCompletionService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/commandcompletionservice/completionstream"
+                                    ]
+                                  },
+                                  {
+                                    "group": "CommandService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwait",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction"
+                                    ]
+                                  },
+                                  {
+                                    "group": "CommandSubmissionService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/commandsubmissionservice/submit",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment"
+                                    ]
+                                  },
+                                  {
+                                    "group": "ContractService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/contractservice/getcontract"
+                                    ]
+                                  },
+                                  {
+                                    "group": "EventQueryService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid"
+                                    ]
+                                  },
+                                  {
+                                    "group": "PackageService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/getpackage",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/getpackagestatus",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/listpackages",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/listvettedpackages"
+                                    ]
+                                  },
+                                  {
+                                    "group": "StateService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getactivecontracts",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getledgerend"
+                                    ]
+                                  },
+                                  {
+                                    "group": "UpdateService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdatebyid",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdates"
+                                    ]
+                                  },
+                                  {
+                                    "group": "VersionService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion"
+                                    ]
+                                  }
                                 ]
-                              },
+                              }
+                            ]
+                          },
+                          {
+                            "group": "com.daml.ledger.api.v2.admin",
+                            "pages": [
+                              "reference/protobuf/packages/com-daml-ledger-api-v2-admin",
                               {
-                                "group": "CommandService",
+                                "group": "Services",
                                 "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwait",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwaitforreassignment",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/commandservice/submitandwaitfortransaction"
+                                  {
+                                    "group": "CommandInspectionService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus"
+                                    ]
+                                  },
+                                  {
+                                    "group": "IdentityProviderConfigService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig"
+                                    ]
+                                  },
+                                  {
+                                    "group": "PackageManagementService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile"
+                                    ]
+                                  },
+                                  {
+                                    "group": "ParticipantPruningService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune"
+                                    ]
+                                  },
+                                  {
+                                    "group": "PartyManagementService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid"
+                                    ]
+                                  },
+                                  {
+                                    "group": "UserManagementService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid"
+                                    ]
+                                  }
                                 ]
-                              },
+                              }
+                            ]
+                          },
+                          {
+                            "group": "com.daml.ledger.api.v2.interactive",
+                            "pages": [
+                              "reference/protobuf/packages/com-daml-ledger-api-v2-interactive",
                               {
-                                "group": "CommandSubmissionService",
+                                "group": "Services",
                                 "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/commandsubmissionservice/submit",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/commandsubmissionservice/submitreassignment"
+                                  {
+                                    "group": "InteractiveSubmissionService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission"
+                                    ]
+                                  }
                                 ]
-                              },
+                              }
+                            ]
+                          },
+                          {
+                            "group": "com.daml.ledger.api.v2.interactive.transaction.v1",
+                            "pages": [
+                              "reference/protobuf/packages/com-daml-ledger-api-v2-interactive-transaction-v1"
+                            ]
+                          },
+                          {
+                            "group": "com.daml.ledger.api.v2.testing",
+                            "pages": [
+                              "reference/protobuf/packages/com-daml-ledger-api-v2-testing",
                               {
-                                "group": "ContractService",
+                                "group": "Services",
                                 "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/contractservice/getcontract"
-                                ]
-                              },
-                              {
-                                "group": "EventQueryService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/eventqueryservice/geteventsbycontractid"
-                                ]
-                              },
-                              {
-                                "group": "PackageService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/getpackage",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/getpackagestatus",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/listpackages",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/packageservice/listvettedpackages"
-                                ]
-                              },
-                              {
-                                "group": "StateService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getactivecontracts",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getconnectedsynchronizers",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getlatestprunedoffsets",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/stateservice/getledgerend"
-                                ]
-                              },
-                              {
-                                "group": "UpdateService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdatebyid",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdatebyoffset",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/updateservice/getupdates"
-                                ]
-                              },
-                              {
-                                "group": "VersionService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2/versionservice/getledgerapiversion"
+                                  {
+                                    "group": "TimeService",
+                                    "pages": [
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-testing/timeservice/gettime",
+                                      "reference/protobuf/operations/com-daml-ledger-api-v2-testing/timeservice/settime"
+                                    ]
+                                  }
                                 ]
                               }
                             ]
                           }
                         ]
                       },
-                      {
-                        "group": "com.daml.ledger.api.v2.admin",
-                        "pages": [
-                          "reference/protobuf/packages/com-daml-ledger-api-v2-admin",
-                          {
-                            "group": "Services",
-                            "pages": [
-                              {
-                                "group": "CommandInspectionService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/commandinspectionservice/getcommandstatus"
-                                ]
-                              },
-                              {
-                                "group": "IdentityProviderConfigService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/createidentityproviderconfig",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/deleteidentityproviderconfig",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/getidentityproviderconfig",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/listidentityproviderconfigs",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/identityproviderconfigservice/updateidentityproviderconfig"
-                                ]
-                              },
-                              {
-                                "group": "PackageManagementService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/listknownpackages",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/updatevettedpackages",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/uploaddarfile",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/packagemanagementservice/validatedarfile"
-                                ]
-                              },
-                              {
-                                "group": "ParticipantPruningService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/participantpruningservice/prune"
-                                ]
-                              },
-                              {
-                                "group": "PartyManagementService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateexternalparty",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/allocateparty",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/generateexternalpartytopology",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparticipantid",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/getparties",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/listknownparties",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartydetails",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/partymanagementservice/updatepartyidentityproviderid"
-                                ]
-                              },
-                              {
-                                "group": "UserManagementService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/createuser",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/deleteuser",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/getuser",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/grantuserrights",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listuserrights",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/listusers",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/revokeuserrights",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuser",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-admin/usermanagementservice/updateuseridentityproviderid"
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "com.daml.ledger.api.v2.interactive",
-                        "pages": [
-                          "reference/protobuf/packages/com-daml-ledger-api-v2-interactive",
-                          {
-                            "group": "Services",
-                            "pages": [
-                              {
-                                "group": "InteractiveSubmissionService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmission",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwait",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/executesubmissionandwaitfortransaction",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackageversion",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/getpreferredpackages",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-interactive/interactivesubmissionservice/preparesubmission"
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "group": "com.daml.ledger.api.v2.interactive.transaction.v1",
-                        "pages": [
-                          "reference/protobuf/packages/com-daml-ledger-api-v2-interactive-transaction-v1"
-                        ]
-                      },
-                      {
-                        "group": "com.daml.ledger.api.v2.testing",
-                        "pages": [
-                          "reference/protobuf/packages/com-daml-ledger-api-v2-testing",
-                          {
-                            "group": "Services",
-                            "pages": [
-                              {
-                                "group": "TimeService",
-                                "pages": [
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-testing/timeservice/gettime",
-                                  "reference/protobuf/operations/com-daml-ledger-api-v2-testing/timeservice/settime"
-                                ]
-                              }
-                            ]
-                          }
-                        ]
-                      }
+                      "reference/protobuf/index"
                     ]
-                  },
-                  "reference/protobuf/index"
+                  }
                 ]
-              },
+              }
+            ]
+          },
+          {
+            "group": "Ledger API clients",
+            "pages": [
               {
                 "group": "Java Bindings",
                 "pages": [
@@ -1636,7 +1645,14 @@
                     ]
                   }
                 ]
-              }
+              },
+              {
+                "group": "TypeScript",
+                "pages": [
+                  "reference/typescript"
+                ]
+              },
+              "appdev/reference/pqs-sql-reference"
             ]
           },
           {
@@ -1684,12 +1700,6 @@
                 ]
               },
               "appdev/reference/daml-standard-library/index"
-            ]
-          },
-          {
-            "group": "TypeScript",
-            "pages": [
-              "reference/typescript"
             ]
           },
           {
@@ -1790,7 +1800,7 @@
             "group": "Splice APIs",
             "pages": [
               {
-                "group": "Scan APIs",
+                "group": "Scan API",
                 "pages": [
                   {
                     "group": "Scan API",
@@ -1885,7 +1895,7 @@
                 ]
               },
               {
-                "group": "Validator APIs",
+                "group": "Validator API",
                 "pages": [
                   {
                     "group": "Wallet API (External)",
@@ -1938,7 +1948,7 @@
                 ]
               },
               {
-                "group": "Token Standard APIs",
+                "group": "Token Standard API",
                 "pages": [
                   {
                     "group": "Token Metadata Service",

--- a/docs-main/mainnet/appdev/deep-dives/external-signing-transactions.mdx
+++ b/docs-main/mainnet/appdev/deep-dives/external-signing-transactions.mdx
@@ -1677,7 +1677,7 @@ def get_active_contracts(party: str):
 ``` none
 ping_created_event: event_pb2.CreatedEvent
 initiator_active_contracts = get_active_contracts(initiator)
-# Find the contract in the active contract store
+# Find the contract in the active contract set
 for active_contract_response in initiator_active_contracts:
     if (
         active_contract_response.HasField("active_contract")

--- a/docs-main/mainnet/overview/reference/pruning.mdx
+++ b/docs-main/mainnet/overview/reference/pruning.mdx
@@ -22,12 +22,6 @@ As a synchronizer orchestrates the execution of commands, the sequencers, mediat
 
 Because these nodes operate continuously for an indefinite amount of time, the stored data they accumulate, or put differently, the history of the ledger, keeps growing.
 
-<div className="todo">
-
-Add a link to the data they actually accumulate, probably in one of Raf's section \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 Accumulating and storing history forever on nodes is problematic for several reasons:
 
 - First, nodes have a limited amount of storage that they will eventually exhaust if the stored data keeps growing
@@ -65,12 +59,6 @@ A participant node's snapshot at t consists of the following:
 
 - The set of active contracts at time t that have stakeholders hosted on that participant. This set is fundamental for the participant node in order to participate correctly in Canton's transaction processing, e.g., the participant safeguards double spending by rejecting such transactions.
 - The in-flight reassignments at time t. A participant that is a reassigning participant for a contract must retain reassignment data while the reassignment is in-flight, i.e., while either the unassign or the assign commands did not complete. Otherwise, the participant would not be able to approve or reject reassignments correctly. For more details on reassignments, refer to the reassignments section. For now, participants do not prune their reassignment data, however, this is planned for the future.
-
-<div className="todo">
-
-Add link to reassignments section. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
 
 - The participant's private keys. For now, the participant requires all key material, not just the keys valid at time t. The participant uses these keys to authenticate the messages it sends to other nodes by signing these messages.
 - All past topology snapshots up to and including t. The past topology snapshots are necessary because the participant may need to serve them in order to validate future requests, e.g., validating the target timestamp in an unassignment request. The topology snapshot at t is necessary because it informs the participant of which nodes are present (mediators, sequencers, participants), which restrictions each synchronizer imposes on participants (e.g. the maximum number of parties a participant may host), which parties are hosted on which participants, etc. Thus, all nodes participating in the Canton transaction protocol know which participants are involved in a transaction at time t, which keys they use, etc.
@@ -197,12 +185,6 @@ Participant nodes need to efficiently summarize the ACS state into commitments, 
 
 Instead, each participant node summarizes ACS changes as they happen during the interval, maintains a running hash of the ACS per stakeholder group. The grouping per stakeholders ensures that each ACS change is processed only once. Specifically, per ACS change, the hash adds or removes the contract id, which authenticates the contents, and the contract's reassignment counter, which identifies the exact (de)activation of this contract: either creation, archival, or the reassignment instance for a contract that was reassigned between synchronizers. The hash function is homomorphic in the sense that contract deactivations cancel out activations, thus the running hash can be updated incrementally.
 
-<div className="todo">
-
-Add a link to contract id in daml when that page exists. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 The final commitment computation at the end of a period is as follows. For each counter-participant, the participant node collects all non-empty running hashes of stakeholder groups it shares with the counter-participant, and adds them into a homomorphic hash. The commitment essentially contains a two-level homomorphic hashing: first the hashing of ACS changes into stakeholder group hashes, and then the hashing of stakeholder group hashes into the commitment hash. The reason for this two-level hashing is that it enables optimizations for updating commitments and investigating mismatches, which we describe later. Afterwards, the participant node significantly reduces the size of the homomorphic hash by applying a cryptographic hash for compression purposes.
 
 Commitments are cryptographic hashes that are signed by the participant node, with the following properties:
@@ -221,12 +203,6 @@ If a period has resulted in a mismatch between two participant nodes, then we ha
 
 This intervention would require all involved participant node operators to look at their shared active contracts and find the cause of the mismatch. We provide tooling for mismatch inspection, which allows participant nodes to identify which contracts cause the mismatch. However, the tooling does not automatically resolve the mismatch, as the participant node operators need to decide, perhaps through out-of-band communication, what the correct end state is, and then apply the changes.
 
-<div className="todo">
-
-Add link to tooling page \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 As long as a mismatch is ongoing then the affected participant nodes would not be able to prune data prior to the initial mismatch. Once a period is matched with all counter-participant nodes then all previous periods are implicitly safe to prune: Even though initially the states showed a mismatch, a fork no longer exists.
 
 ### Optimizations
@@ -235,21 +211,9 @@ Computing a large number of hashes for commitments can be performance-heavy, and
 
 First, participant nodes that do not share active contracts neither compute, nor send commitments or expect to receive commitments. If one of the participant nodes thinks otherwise, however, the participant node sends a commitments, which causes the other participant node to output a warning `ACS_MISMATCH_NO_SHARED_CONTRACTS: Received a commitment where we have no shared contract with the sender`. The participant node then replies with an empty commitment, which triggers mismatch inspection based on the non-empty state of the counter-participant. This optimization produces significant performance improvements for a participant node that has many counter-participant nodes without shared active contracts. Moreover, if a participant node believes its shared state with a counter-participant to be empty, it can prune without establishing that the counter-participant agrees that the state is empty.
 
-<div className="todo">
-
-Add a link to the error code doc page (tooling). \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 Second, regarding bandwidth, participant nodes only exchange commitments periodically, which bounds the amount of bandwidth consumed regardless of the contract activity within a period. Also, periods are aggregated when there is no activity. Instead of constantly sending the same commitment, each participant node simply aggregates periods and send a commitment once it notices activity. Still, aggregation does not happen if the participants observe any possibly unrelated synchronizer activity, because activity triggers ticks, and in that case the participant nodes do exchange the same commitment hashes repeatedly, albeit with different timestamps. Moreover, there is a lower bound for exchanging commitments even when there is no synchronizer activity, by default every 24 hours.
 
 Additionally, to avoid a spike in network activity at the end of every period, each participant node sends commitments with jittered delay. The delay is a random amount uniformly distributed between 0 and 2/3 of the period length, therefore the sequencer is not getting flooded with commitments.
-
-<div className="todo">
-
-Change the hard-coded amount when we make it configurable in the code. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
 
 Commitments are sent best-effort, without a guaranteed delivery, which saves network resources. This means that a participant node might miss commitments from a counter-participant. However, this is not a problem because each commitment is stand-alone with respect to semantics, thus missing a commitment has no effect on the usefulness of future incoming commitments. A participant nodes might miss some commitments for some timestamps in the past, but as long as it agrees with its counter-participants on the present state, it can prune history. In other words, even though the participant node may not know whether a prior fork existed, it can still prune history up to timestamps where certainly no forks exist.
 
@@ -260,12 +224,6 @@ Moreover, this structure allows for efficient updates when few stakeholder group
 Also, the two-level homomorphic hash structure allows for efficient mismatch inspection. A participant node inspecting a mismatch does not require the entire set of shared contracts ids: The participant node can perform matching per level, keeps blinded those stakeholder commitments that match, and only requires the set of shared contracts ids of the stakeholder hashes that do not match.
 
 Fourth, in periods with high load, a participant node that lags behind with transaction processing reduces the overhead caused by commitments. A participant node lags behind when its observed sequencer time is behind some of its counter-participants; the participant can infer the sequencer time of a counter-participant from the periods in the received commitments. A lagging participant node automatically triggers a so-called catch-up mode, where it skips computing and sending commitments for some periods. The synchronizer operator can control the catch-up behavior through a synchronizer configuration. The catch-up mode brings a participant node up to date with transaction throughput, while still detecting forks.
-
-<div className="todo">
-
-Add a link to the how-to guide in the above. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
 
 Fifth, for multi-hosted parties, a participant node only requires threshold-many counter-participants to send matching commitments, instead of all counter-participants. Such an optimization is natural, given that we only need threshold-many counter-participants to approve a transaction, and therefore deem a contract active. This allows for pruning even if some commitments are outstanding, as long as each multi-hosted party is hosted on at least threshold-many counter-participants that send matching commitments. This is especially relevant for decentralized parties, some of whose participant nodes may be malicious / faulty.
 

--- a/docs-main/mainnet/overview/reference/validator-node-components.mdx
+++ b/docs-main/mainnet/overview/reference/validator-node-components.mdx
@@ -34,7 +34,7 @@ flowchart TB
         LAPI[Ledger API &#40;gRPC&#41;]
         AAPI[Admin API]
         ENGINE[Daml Engine]
-        ACS[(Active Contract Store)]
+        ACS[(Active Contract Set)]
         PROTO[Protocol Layer<br>preparation &#8226; validation &#8226; confirmation]
     end
 
@@ -144,7 +144,7 @@ The Daml engine interprets and executes Daml smart contract code. When an applic
 2. Evaluates the Daml code to produce a transaction tree -- the root action plus all its consequences
 3. Computes the view decomposition for privacy (each party sees only the sub-views they are entitled to)
 
-### Active Contract Store (ACS)
+### Active Contract Set (ACS)
 
 The ACS is the participant's local projection of active contracts. It contains only contracts where a party hosted on that participant is a stakeholder (signatory or observer). The ACS is stored in the participant's PostgreSQL database.
 

--- a/docs-main/mainnet/overview/understand/core-concepts.mdx
+++ b/docs-main/mainnet/overview/understand/core-concepts.mdx
@@ -89,7 +89,7 @@ flowchart TB
 
 ### Key Characteristics
 
-- Each validator maintains a **localized, private view** of the ledger (called the _Active Contract Store_)
+- Each validator maintains a **localized, private view** of the ledger (called the _Active Contract Set_)
 - Validators only store contracts where their hosted parties are stakeholders
 - Multiple parties can be hosted on a single validator
 - Validators can connect to multiple synchronizers

--- a/docs-main/styles.css
+++ b/docs-main/styles.css
@@ -240,53 +240,44 @@ table tbody tr:hover {
   --canton-text-secondary: #B0B0B0;
 }
 
-/* Version dropdown - match product dropdown style */
-button[aria-haspopup="menu"]:not(.nav-dropdown-trigger) {
+/* Version dropdown - match product dropdown style.
+   The :not(#page-context-menu *) exclusion keeps these overrides from leaking
+   into the Copy page split button's chevron, which Mintlify already styles via
+   Tailwind (rounded-r-xl, etc.). */
+button[aria-haspopup="menu"]:not(.nav-dropdown-trigger):not(#page-context-menu *) {
   background-color: transparent !important;
   border: 1px solid rgba(209, 213, 219, 0.7) !important;
   border-radius: 0.85rem !important;
   padding: 0.375rem 0.875rem 0.375rem 0.5rem !important;
 }
 
-button[aria-haspopup="menu"]:not(.nav-dropdown-trigger):hover {
+button[aria-haspopup="menu"]:not(.nav-dropdown-trigger):not(#page-context-menu *):hover {
   background-color: rgba(75, 85, 99, 0.05) !important;
 }
 
-[data-theme="dark"] button[aria-haspopup="menu"]:not(.nav-dropdown-trigger) {
+[data-theme="dark"] button[aria-haspopup="menu"]:not(.nav-dropdown-trigger):not(#page-context-menu *) {
   border-color: rgba(255, 255, 255, 0.07) !important;
 }
 
 /* Version dropdown chevron icon */
-button[aria-haspopup="menu"]:not(.nav-dropdown-trigger) svg {
+button[aria-haspopup="menu"]:not(.nav-dropdown-trigger):not(#page-context-menu *) svg {
   color: rgb(156, 163, 175) !important;
   stroke: rgb(156, 163, 175) !important;
 }
 
-button[aria-haspopup="menu"]:not(.nav-dropdown-trigger):hover svg {
+button[aria-haspopup="menu"]:not(.nav-dropdown-trigger):not(#page-context-menu *):hover svg {
   color: rgb(75, 85, 99) !important;
   stroke: rgb(75, 85, 99) !important;
 }
 
-[data-theme="dark"] button[aria-haspopup="menu"]:not(.nav-dropdown-trigger) svg {
+[data-theme="dark"] button[aria-haspopup="menu"]:not(.nav-dropdown-trigger):not(#page-context-menu *) svg {
   color: rgb(75, 85, 99) !important;
   stroke: rgb(75, 85, 99) !important;
 }
 
-[data-theme="dark"] button[aria-haspopup="menu"]:not(.nav-dropdown-trigger):hover svg {
+[data-theme="dark"] button[aria-haspopup="menu"]:not(.nav-dropdown-trigger):not(#page-context-menu *):hover svg {
   color: rgb(156, 163, 175) !important;
   stroke: rgb(156, 163, 175) !important;
-}
-
-/* Prevent version dropdown styling from affecting the contextual menu (Copy page) chevron */
-#page-context-menu-button + button[aria-haspopup="menu"] {
-  background-color: unset !important;
-  border: unset !important;
-  border-radius: unset !important;
-  padding: unset !important;
-}
-#page-context-menu-button + button[aria-haspopup="menu"] svg {
-  color: unset !important;
-  stroke: unset !important;
 }
 
 /* ============================================

--- a/docs-main/testnet/appdev/deep-dives/external-signing-transactions.mdx
+++ b/docs-main/testnet/appdev/deep-dives/external-signing-transactions.mdx
@@ -1677,7 +1677,7 @@ def get_active_contracts(party: str):
 ``` none
 ping_created_event: event_pb2.CreatedEvent
 initiator_active_contracts = get_active_contracts(initiator)
-# Find the contract in the active contract store
+# Find the contract in the active contract set
 for active_contract_response in initiator_active_contracts:
     if (
         active_contract_response.HasField("active_contract")

--- a/docs-main/testnet/overview/reference/pruning.mdx
+++ b/docs-main/testnet/overview/reference/pruning.mdx
@@ -22,12 +22,6 @@ As a synchronizer orchestrates the execution of commands, the sequencers, mediat
 
 Because these nodes operate continuously for an indefinite amount of time, the stored data they accumulate, or put differently, the history of the ledger, keeps growing.
 
-<div className="todo">
-
-Add a link to the data they actually accumulate, probably in one of Raf's section \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 Accumulating and storing history forever on nodes is problematic for several reasons:
 
 - First, nodes have a limited amount of storage that they will eventually exhaust if the stored data keeps growing
@@ -65,12 +59,6 @@ A participant node's snapshot at t consists of the following:
 
 - The set of active contracts at time t that have stakeholders hosted on that participant. This set is fundamental for the participant node in order to participate correctly in Canton's transaction processing, e.g., the participant safeguards double spending by rejecting such transactions.
 - The in-flight reassignments at time t. A participant that is a reassigning participant for a contract must retain reassignment data while the reassignment is in-flight, i.e., while either the unassign or the assign commands did not complete. Otherwise, the participant would not be able to approve or reject reassignments correctly. For more details on reassignments, refer to the reassignments section. For now, participants do not prune their reassignment data, however, this is planned for the future.
-
-<div className="todo">
-
-Add link to reassignments section. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
 
 - The participant's private keys. For now, the participant requires all key material, not just the keys valid at time t. The participant uses these keys to authenticate the messages it sends to other nodes by signing these messages.
 - All past topology snapshots up to and including t. The past topology snapshots are necessary because the participant may need to serve them in order to validate future requests, e.g., validating the target timestamp in an unassignment request. The topology snapshot at t is necessary because it informs the participant of which nodes are present (mediators, sequencers, participants), which restrictions each synchronizer imposes on participants (e.g. the maximum number of parties a participant may host), which parties are hosted on which participants, etc. Thus, all nodes participating in the Canton transaction protocol know which participants are involved in a transaction at time t, which keys they use, etc.
@@ -197,12 +185,6 @@ Participant nodes need to efficiently summarize the ACS state into commitments, 
 
 Instead, each participant node summarizes ACS changes as they happen during the interval, maintains a running hash of the ACS per stakeholder group. The grouping per stakeholders ensures that each ACS change is processed only once. Specifically, per ACS change, the hash adds or removes the contract id, which authenticates the contents, and the contract's reassignment counter, which identifies the exact (de)activation of this contract: either creation, archival, or the reassignment instance for a contract that was reassigned between synchronizers. The hash function is homomorphic in the sense that contract deactivations cancel out activations, thus the running hash can be updated incrementally.
 
-<div className="todo">
-
-Add a link to contract id in daml when that page exists. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 The final commitment computation at the end of a period is as follows. For each counter-participant, the participant node collects all non-empty running hashes of stakeholder groups it shares with the counter-participant, and adds them into a homomorphic hash. The commitment essentially contains a two-level homomorphic hashing: first the hashing of ACS changes into stakeholder group hashes, and then the hashing of stakeholder group hashes into the commitment hash. The reason for this two-level hashing is that it enables optimizations for updating commitments and investigating mismatches, which we describe later. Afterwards, the participant node significantly reduces the size of the homomorphic hash by applying a cryptographic hash for compression purposes.
 
 Commitments are cryptographic hashes that are signed by the participant node, with the following properties:
@@ -221,12 +203,6 @@ If a period has resulted in a mismatch between two participant nodes, then we ha
 
 This intervention would require all involved participant node operators to look at their shared active contracts and find the cause of the mismatch. We provide tooling for mismatch inspection, which allows participant nodes to identify which contracts cause the mismatch. However, the tooling does not automatically resolve the mismatch, as the participant node operators need to decide, perhaps through out-of-band communication, what the correct end state is, and then apply the changes.
 
-<div className="todo">
-
-Add link to tooling page \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 As long as a mismatch is ongoing then the affected participant nodes would not be able to prune data prior to the initial mismatch. Once a period is matched with all counter-participant nodes then all previous periods are implicitly safe to prune: Even though initially the states showed a mismatch, a fork no longer exists.
 
 ### Optimizations
@@ -235,21 +211,9 @@ Computing a large number of hashes for commitments can be performance-heavy, and
 
 First, participant nodes that do not share active contracts neither compute, nor send commitments or expect to receive commitments. If one of the participant nodes thinks otherwise, however, the participant node sends a commitments, which causes the other participant node to output a warning `ACS_MISMATCH_NO_SHARED_CONTRACTS: Received a commitment where we have no shared contract with the sender`. The participant node then replies with an empty commitment, which triggers mismatch inspection based on the non-empty state of the counter-participant. This optimization produces significant performance improvements for a participant node that has many counter-participant nodes without shared active contracts. Moreover, if a participant node believes its shared state with a counter-participant to be empty, it can prune without establishing that the counter-participant agrees that the state is empty.
 
-<div className="todo">
-
-Add a link to the error code doc page (tooling). \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
-
 Second, regarding bandwidth, participant nodes only exchange commitments periodically, which bounds the amount of bandwidth consumed regardless of the contract activity within a period. Also, periods are aggregated when there is no activity. Instead of constantly sending the same commitment, each participant node simply aggregates periods and send a commitment once it notices activity. Still, aggregation does not happen if the participants observe any possibly unrelated synchronizer activity, because activity triggers ticks, and in that case the participant nodes do exchange the same commitment hashes repeatedly, albeit with different timestamps. Moreover, there is a lower bound for exchanging commitments even when there is no synchronizer activity, by default every 24 hours.
 
 Additionally, to avoid a spike in network activity at the end of every period, each participant node sends commitments with jittered delay. The delay is a random amount uniformly distributed between 0 and 2/3 of the period length, therefore the sequencer is not getting flooded with commitments.
-
-<div className="todo">
-
-Change the hard-coded amount when we make it configurable in the code. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
 
 Commitments are sent best-effort, without a guaranteed delivery, which saves network resources. This means that a participant node might miss commitments from a counter-participant. However, this is not a problem because each commitment is stand-alone with respect to semantics, thus missing a commitment has no effect on the usefulness of future incoming commitments. A participant nodes might miss some commitments for some timestamps in the past, but as long as it agrees with its counter-participants on the present state, it can prune history. In other words, even though the participant node may not know whether a prior fork existed, it can still prune history up to timestamps where certainly no forks exist.
 
@@ -260,12 +224,6 @@ Moreover, this structure allows for efficient updates when few stakeholder group
 Also, the two-level homomorphic hash structure allows for efficient mismatch inspection. A participant node inspecting a mismatch does not require the entire set of shared contracts ids: The participant node can perform matching per level, keeps blinded those stakeholder commitments that match, and only requires the set of shared contracts ids of the stakeholder hashes that do not match.
 
 Fourth, in periods with high load, a participant node that lags behind with transaction processing reduces the overhead caused by commitments. A participant node lags behind when its observed sequencer time is behind some of its counter-participants; the participant can infer the sequencer time of a counter-participant from the periods in the received commitments. A lagging participant node automatically triggers a so-called catch-up mode, where it skips computing and sending commitments for some periods. The synchronizer operator can control the catch-up behavior through a synchronizer configuration. The catch-up mode brings a participant node up to date with transaction throughput, while still detecting forks.
-
-<div className="todo">
-
-Add a link to the how-to guide in the above. \<[https://github.com/DACH-NY/canton/issues/26154](https://github.com/DACH-NY/canton/issues/26154)\>
-
-</div>
 
 Fifth, for multi-hosted parties, a participant node only requires threshold-many counter-participants to send matching commitments, instead of all counter-participants. Such an optimization is natural, given that we only need threshold-many counter-participants to approve a transaction, and therefore deem a contract active. This allows for pruning even if some commitments are outstanding, as long as each multi-hosted party is hosted on at least threshold-many counter-participants that send matching commitments. This is especially relevant for decentralized parties, some of whose participant nodes may be malicious / faulty.
 

--- a/docs-main/testnet/overview/reference/validator-node-components.mdx
+++ b/docs-main/testnet/overview/reference/validator-node-components.mdx
@@ -34,7 +34,7 @@ flowchart TB
         LAPI[Ledger API &#40;gRPC&#41;]
         AAPI[Admin API]
         ENGINE[Daml Engine]
-        ACS[(Active Contract Store)]
+        ACS[(Active Contract Set)]
         PROTO[Protocol Layer<br>preparation &#8226; validation &#8226; confirmation]
     end
 
@@ -144,7 +144,7 @@ The Daml engine interprets and executes Daml smart contract code. When an applic
 2. Evaluates the Daml code to produce a transaction tree -- the root action plus all its consequences
 3. Computes the view decomposition for privacy (each party sees only the sub-views they are entitled to)
 
-### Active Contract Store (ACS)
+### Active Contract Set (ACS)
 
 The ACS is the participant's local projection of active contracts. It contains only contracts where a party hosted on that participant is a stakeholder (signatory or observer). The ACS is stored in the participant's PostgreSQL database.
 

--- a/docs-main/testnet/overview/understand/core-concepts.mdx
+++ b/docs-main/testnet/overview/understand/core-concepts.mdx
@@ -89,7 +89,7 @@ flowchart TB
 
 ### Key Characteristics
 
-- Each validator maintains a **localized, private view** of the ledger (called the _Active Contract Store_)
+- Each validator maintains a **localized, private view** of the ledger (called the _Active Contract Set_)
 - Validators only store contracts where their hosted parties are stakeholders
 - Multiple parties can be hosted on a single validator
 - Validators can connect to multiple synchronizers


### PR DESCRIPTION
## Summary

Addresses 5 actionable issues from the open issues triage. Closes:

- Closes #240 — author TODO blocks in pruning.mdx
- Closes #325 — Ledger API section reorganization
- Closes #357 — drop trailing "s" from API titles
- Closes #370 — Copy page chevron missing right radius
- Closes #374 — Active Contract "Store" → Set

## What changed

### Issue #240
Removed all seven `<div className="todo">…</div>` blocks from `overview/reference/pruning.mdx` (mainnet/testnet/devnet). They referenced `DACH-NY/canton/issues/26154` and were leaking author notes into rendered docs. Files changed: 3.

### Issue #325
Restructured the API Reference → Ledger API group per the reporter's proposal:

- New `HTTP API` sub-group wraps `OpenAPI` + `AsyncAPI`
- `Protobufs` moved inside `gRPC API` (was a sibling)
- `pqs-sql-reference` and `Java Bindings` pulled out of Ledger API
- Top-level `TypeScript` group pulled out
- New sibling group `Ledger API clients` contains Java Bindings, TypeScript, PQS SQL

Result:
```
- Ledger API
  - HTTP API
    - OpenAPI
    - AsyncAPI
  - gRPC API
    - Packages
    - Protobufs
- Ledger API clients
  - Java Bindings
  - TypeScript (@daml/types)
  - PQS SQL
```

### Issue #357
In `docs.json`: `Scan APIs` → `Scan API`, `Validator APIs` → `Validator API`, `Token Standard APIs` → `Token Standard API`.

### Issue #370
The Copy page chevron's right border-radius was wrong. Root cause: the version-dropdown rule (styles.css:244) used a broad `button[aria-haspopup="menu"]:not(.nav-dropdown-trigger)` selector that also matched the chevron, overriding Tailwind's `rounded-r-xl` (0.75rem) with a uniform `0.85rem !important` on all four corners. The previous patch tried to neutralize that with `border-radius: unset !important; padding: unset !important;` on the chevron, which set padding to 0 and produced an off-size right radius.

Fix: added `:not(#page-context-menu *)` to every version-dropdown selector and deleted the chevron-override hack. Tailwind's native `rounded-r-xl` now applies cleanly.

Browser support note: `:not()` with descendant combinators is CSS Selectors Level 4 — Chrome 88+, Firefox 84+, Safari 15.4+. All evergreen.

### Issue #374
Replaced "Active Contract Store" with "Active Contract Set" across 9 files (3× `validator-node-components`, 3× `core-concepts`, 3× `external-signing-transactions`). Reporter flagged one occurrence; the typo was systemic, so all 12 instances are fixed for consistency.