### PR TITLE
add GA Measurement ID

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -35,6 +35,11 @@
       }
     }
   },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-F2G1L137JX"
+    }
+  },
   "navigation": {
     "dropdowns": [
       {


### PR DESCRIPTION
Osano reports: osano.js:2 Error: Google tag G-F2G1L137JX loaded before Consent Mode update. Please review and resolve Google Consent Mode sequencing.

-> need to check proper consent mode resolve