### PR TITLE
Remove redundant Wallet Gateway API nav entries

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1699,7 +1699,6 @@
               {
                 "group": "Sync dApp API",
                 "pages": [
-                  "reference/wallet-gateway-json-rpc/specs/dapp-api",
                   "reference/wallet-gateway-json-rpc/operations/dapp-api/accountschanged",
                   "reference/wallet-gateway-json-rpc/operations/dapp-api/connect",
                   "reference/wallet-gateway-json-rpc/operations/dapp-api/disconnect",
@@ -1718,7 +1717,6 @@
               {
                 "group": "Async dApp API",
                 "pages": [
-                  "reference/wallet-gateway-json-rpc/specs/dapp-remote-api",
                   "reference/wallet-gateway-json-rpc/operations/dapp-remote-api/accountschanged",
                   "reference/wallet-gateway-json-rpc/operations/dapp-remote-api/connect",
                   "reference/wallet-gateway-json-rpc/operations/dapp-remote-api/connected",
@@ -1743,7 +1741,6 @@
               {
                 "group": "User API",
                 "pages": [
-                  "reference/wallet-gateway-json-rpc/specs/user-api",
                   "reference/wallet-gateway-json-rpc/operations/user-api/addidp",
                   "reference/wallet-gateway-json-rpc/operations/user-api/addnetwork",
                   "reference/wallet-gateway-json-rpc/operations/user-api/addsession",
@@ -1772,7 +1769,6 @@
               {
                 "group": "Signing API",
                 "pages": [
-                  "reference/wallet-gateway-json-rpc/specs/signing-api",
                   "reference/wallet-gateway-json-rpc/operations/signing-api/createkey",
                   "reference/wallet-gateway-json-rpc/operations/signing-api/getconfiguration",
                   "reference/wallet-gateway-json-rpc/operations/signing-api/getkeys",

--- a/scripts/generated_reference_nav.py
+++ b/scripts/generated_reference_nav.py
@@ -107,7 +107,6 @@ def build_openrpc_nav_group(
         spec_page = output_dir / spec_dir_name / f"{slugify(spec_id)}.mdx"
         if not spec_page.exists():
             continue
-        spec_page_ref = docs_json_page_ref(spec_page, docs_json_path)
         operation_dir = output_dir / "operations" / slugify(spec_id)
         operation_refs = [
             docs_json_page_ref(path, docs_json_path)
@@ -122,14 +121,14 @@ def build_openrpc_nav_group(
             section_pages.setdefault(section, []).append(
                 {
                     "group": mdx_title(spec_page),
-                    "pages": [spec_page_ref, *operation_refs],
+                    "pages": operation_refs,
                 }
             )
         else:
             pages.append(
                 {
                     "group": mdx_title(spec_page),
-                    "pages": [spec_page_ref, *operation_refs],
+                    "pages": operation_refs,
                 }
             )
     if spec_group_sections:

--- a/tests/test_wallet_kernel_nav.py
+++ b/tests/test_wallet_kernel_nav.py
@@ -91,7 +91,6 @@ def test_openrpc_nav_uses_wallet_gateway_section_shape(tmp_path: Path) -> None:
                 {
                     "group": "Sync dApp API",
                     "pages": [
-                        "reference/wallet-gateway-json-rpc/specs/dapp-api",
                         "reference/wallet-gateway-json-rpc/operations/dapp-api/connect",
                         "reference/wallet-gateway-json-rpc/operations/dapp-api/details",
                     ],
@@ -99,7 +98,6 @@ def test_openrpc_nav_uses_wallet_gateway_section_shape(tmp_path: Path) -> None:
                 {
                     "group": "Async dApp API",
                     "pages": [
-                        "reference/wallet-gateway-json-rpc/specs/dapp-remote-api",
                         "reference/wallet-gateway-json-rpc/operations/dapp-remote-api/connect",
                         "reference/wallet-gateway-json-rpc/operations/dapp-remote-api/details",
                     ],
@@ -112,7 +110,6 @@ def test_openrpc_nav_uses_wallet_gateway_section_shape(tmp_path: Path) -> None:
                 {
                     "group": "User API",
                     "pages": [
-                        "reference/wallet-gateway-json-rpc/specs/user-api",
                         "reference/wallet-gateway-json-rpc/operations/user-api/createWallet",
                         "reference/wallet-gateway-json-rpc/operations/user-api/details",
                     ],
@@ -120,7 +117,6 @@ def test_openrpc_nav_uses_wallet_gateway_section_shape(tmp_path: Path) -> None:
                 {
                     "group": "Signing API",
                     "pages": [
-                        "reference/wallet-gateway-json-rpc/specs/signing-api",
                         "reference/wallet-gateway-json-rpc/operations/signing-api/signTransaction",
                         "reference/wallet-gateway-json-rpc/operations/signing-api/details",
                     ],
@@ -132,7 +128,7 @@ def test_openrpc_nav_uses_wallet_gateway_section_shape(tmp_path: Path) -> None:
     ]
 
 
-def test_openrpc_nav_group_helper_keeps_spec_pages_routable(tmp_path: Path) -> None:
+def test_openrpc_nav_group_helper_omits_redundant_spec_page_child(tmp_path: Path) -> None:
     generated_reference_nav = load_script("generated_reference_nav")
     docs_json = tmp_path / "docs-main" / "docs.json"
     docs_json.parent.mkdir(parents=True)
@@ -155,7 +151,6 @@ def test_openrpc_nav_group_helper_keeps_spec_pages_routable(tmp_path: Path) -> N
             {
                 "group": "Sync dApp API",
                 "pages": [
-                    "reference/wallet-gateway-json-rpc/specs/dapp-api",
                     "reference/wallet-gateway-json-rpc/operations/dapp-api/connect",
                 ],
             },


### PR DESCRIPTION
## Summary

Closes #358.

- removes the redundant OpenRPC spec overview page from nested sidebar groups for dApp API and Wallet Gateway specs
- keeps the operation pages and Details/history pages directly under each API group
- updates the generated navigation test fixture so future regenerations preserve the cleaner sidebar shape

## Screenshots

Sync dApp API now expands directly into operations. The duplicate `Sync dApp API` spec page row is gone.

![Sync dApp API nav](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issue-358-screenshots/pr-assets/issue-358/dapp-api-nav.png)

Wallet Gateway `User API` now expands directly into operations. The duplicate `User API` spec page row is gone.

![Wallet Gateway User API nav](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issue-358-screenshots/pr-assets/issue-358/wallet-gateway-user-nav.png)

## Validation

- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-358-openrpc-nav-cleanup python3 -m pytest tests/test_wallet_kernel_nav.py`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-358-openrpc-nav-cleanup npx mintlify validate` from `docs-main/`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-358-openrpc-nav-cleanup git diff --check`
