### PR TITLE
Add Java Bindings Details and history page

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1635,7 +1635,8 @@
                         ]
                       }
                     ]
-                  }
+                  },
+                  "reference/java-bindings"
                 ]
               }
             ]

--- a/docs-main/reference/java-bindings.mdx
+++ b/docs-main/reference/java-bindings.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Java Bindings"
+title: "Details and history"
 description: "Generated lifecycle timeline and reference pages for local Javadoc artifacts"
 ---
 

--- a/scripts/generate_ledger_bindings_api_reference.py
+++ b/scripts/generate_ledger_bindings_api_reference.py
@@ -41,6 +41,7 @@ LANGUAGE_DIRS = {
     "java": "java",
 }
 REMOVED_LANGUAGE_DIRS = {"scala"}
+DETAILS_LABEL = "Details and history"
 ARTIFACT_PAGE_DESCRIPTIONS = {
     "java": "Generated package reference and version summary from local Javadoc snapshots",
 }
@@ -307,7 +308,11 @@ def update_docs_navigation(
         docs_json_path=docs_json_path,
         group_label=group_label,
     )
-    generated_refs.add(docs_json_page_ref(overview_file, docs_json_path))
+    overview_ref = docs_json_page_ref(overview_file, docs_json_path)
+    generated_refs.add(overview_ref)
+    jvm_pages = jvm_group.setdefault("pages", [])
+    if isinstance(jvm_pages, list) and overview_ref not in jvm_pages:
+        jvm_pages.append(overview_ref)
     dropdown["pages"] = prune_nav_items(
         pages,
         page_refs=generated_refs,
@@ -569,6 +574,21 @@ def rewrite_java_only_generated_text(text: str) -> str:
         if line.strip() != "- Scala deprecation is not inferred from Scaladoc indexes in this initial implementation."
     ]
     return "\n".join(filtered_lines).rstrip() + "\n"
+
+
+def rewrite_overview_as_details_page(text: str) -> str:
+    frontmatter, body = split_frontmatter(text)
+    updated_frontmatter: list[str] = []
+    title_written = False
+    for line in frontmatter:
+        if line.startswith("title: "):
+            updated_frontmatter.append(f'title: "{DETAILS_LABEL}"')
+            title_written = True
+        else:
+            updated_frontmatter.append(line)
+    if not title_written:
+        updated_frontmatter.insert(0, f'title: "{DETAILS_LABEL}"')
+    return "\n".join(["---", *updated_frontmatter, "---", "", body.rstrip(), ""])
 
 
 def parse_markdown_table(lines: list[str]) -> tuple[list[str], list[list[str]]]:
@@ -908,6 +928,10 @@ def publish_rendered_pages(
         publish_overview_file,
         replacements=overview_replacements,
         rewrite_java_only_text=True,
+    )
+    publish_overview_file.write_text(
+        rewrite_overview_as_details_page(publish_overview_file.read_text(encoding="utf-8")),
+        encoding="utf-8",
     )
     generated_refs.add(docs_json_page_ref(publish_overview_file, DEFAULT_DOCS_JSON))
     return publish_overview_file, generated_refs

--- a/tests/test_ledger_bindings_nav.py
+++ b/tests/test_ledger_bindings_nav.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_script(name: str):
+    scripts_dir = str(REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / f"{name}.py")
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_mdx(path: Path, title: str, body: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'---\ntitle: "{title}"\n---\n{body}', encoding="utf-8")
+
+
+def test_java_bindings_nav_includes_details_and_history_page(tmp_path: Path) -> None:
+    generate_ledger_bindings_api_reference = load_script("generate_ledger_bindings_api_reference")
+    reference_nav = load_script("reference_nav")
+    docs_json = tmp_path / "docs-main" / "docs.json"
+    docs_json.parent.mkdir(parents=True)
+    docs_json.write_text(
+        json.dumps(
+            {
+                "navigation": {
+                    "dropdowns": [
+                        {
+                            "dropdown": "API Reference",
+                            "pages": [
+                                {"group": "Ledger API", "pages": [{"group": "OpenAPI", "pages": []}]},
+                                {"group": "Splice APIs", "pages": []},
+                            ],
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    publish_root = docs_json.parent / "reference"
+    overview_file = publish_root / "java-bindings.mdx"
+    write_mdx(overview_file, "Details and history")
+    write_mdx(publish_root / "java" / "index.mdx", "Javadocs")
+    write_mdx(
+        publish_root / "java" / "com-example" / "index.mdx",
+        "com.example",
+        "## Package `com.example`\n",
+    )
+    write_mdx(publish_root / "java" / "com-example" / "Client.mdx", "Client")
+
+    generate_ledger_bindings_api_reference.update_docs_navigation(
+        docs_json_path=docs_json,
+        dropdown_label="API Reference",
+        parent_groups=[],
+        group_label="Java Bindings",
+        overview_file=overview_file,
+        publish_root=publish_root,
+    )
+    reference_nav.regroup_ledger_api_nav(docs_json_path=docs_json, dropdown_label="API Reference")
+
+    docs = json.loads(docs_json.read_text(encoding="utf-8"))
+    ledger_pages = docs["navigation"]["dropdowns"][0]["pages"][0]["pages"]
+    assert ledger_pages[-1] == {
+        "group": "Java Bindings",
+        "pages": [
+            {
+                "group": "Javadocs",
+                "pages": [{"group": "com.example", "pages": ["reference/java/com-example/Client"]}],
+            },
+            "reference/java-bindings",
+        ],
+    }
+
+
+def test_java_bindings_overview_is_published_as_details_and_history() -> None:
+    generate_ledger_bindings_api_reference = load_script("generate_ledger_bindings_api_reference")
+
+    assert (
+        generate_ledger_bindings_api_reference.rewrite_overview_as_details_page(
+            '---\ntitle: "Java Bindings"\ndescription: "Generated lifecycle timeline"\n---\nBody\n'
+        )
+        == '---\ntitle: "Details and history"\ndescription: "Generated lifecycle timeline"\n---\n\nBody\n'
+    )


### PR DESCRIPTION
## Summary

Closes #360.

- publishes the generated Java Bindings overview as `Details and history`
- adds that page to the `Ledger API > Java Bindings` sidebar group after `Javadocs`
- adds focused generator/nav coverage so future Java Bindings regeneration keeps the details page visible

## Screenshot

Java Bindings now includes a `Details and history` page under `Ledger API > Java Bindings`, matching the other Ledger API reference groups.

![Java Bindings Details and history nav](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issue-360-screenshots/pr-assets/issue-360/java-bindings-details-nav.png)

## Validation

- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-360-java-bindings-details python3 scripts/generate_ledger_bindings_api_reference.py`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-360-java-bindings-details python3 -m pytest tests/test_ledger_bindings_nav.py`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-360-java-bindings-details npx mintlify validate` from `docs-main/`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-360-java-bindings-details git diff --check`
