### PR TITLE
Flatten Admin API gRPC package navigation

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -1999,331 +1999,326 @@
                 "group": "gRPC API",
                 "pages": [
                   {
-                    "group": "Protobufs",
+                    "group": "Packages",
                     "pages": [
                       {
-                        "group": "Packages",
+                        "group": "com.digitalasset.canton.admin",
                         "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin"
+                        ]
+                      },
+                      {
+                        "group": "com.digitalasset.canton.admin.crypto.v30",
+                        "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-crypto-v30"
+                        ]
+                      },
+                      {
+                        "group": "com.digitalasset.canton.admin.health.v30",
+                        "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-health-v30",
                           {
-                            "group": "com.digitalasset.canton.admin",
+                            "group": "Services",
                             "pages": [
-                              "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin"
-                            ]
-                          },
-                          {
-                            "group": "com.digitalasset.canton.admin.crypto.v30",
-                            "pages": [
-                              "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-crypto-v30"
-                            ]
-                          },
-                          {
-                            "group": "com.digitalasset.canton.admin.health.v30",
-                            "pages": [
-                              "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-health-v30",
                               {
-                                "group": "Services",
+                                "group": "StatusService",
                                 "pages": [
-                                  {
-                                    "group": "StatusService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-health-v30/statusservice/getlasterrortrace",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-health-v30/statusservice/getlasterrors",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-health-v30/statusservice/healthdump",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-health-v30/statusservice/setloglevel"
-                                    ]
-                                  }
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-health-v30/statusservice/getlasterrortrace",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-health-v30/statusservice/getlasterrors",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-health-v30/statusservice/healthdump",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-health-v30/statusservice/setloglevel"
                                 ]
                               }
                             ]
-                          },
+                          }
+                        ]
+                      },
+                      {
+                        "group": "com.digitalasset.canton.admin.mediator.v30",
+                        "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-mediator-v30",
                           {
-                            "group": "com.digitalasset.canton.admin.mediator.v30",
+                            "group": "Services",
                             "pages": [
-                              "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-mediator-v30",
                               {
-                                "group": "Services",
+                                "group": "MediatorStatusService",
                                 "pages": [
-                                  {
-                                    "group": "MediatorStatusService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-mediator-v30/mediatorstatusservice/mediatorstatus"
-                                    ]
-                                  }
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-mediator-v30/mediatorstatusservice/mediatorstatus"
                                 ]
                               }
                             ]
-                          },
+                          }
+                        ]
+                      },
+                      {
+                        "group": "com.digitalasset.canton.admin.participant.v30",
+                        "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-participant-v30",
                           {
-                            "group": "com.digitalasset.canton.admin.participant.v30",
+                            "group": "Services",
                             "pages": [
-                              "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-participant-v30",
                               {
-                                "group": "Services",
+                                "group": "EnterpriseParticipantReplicationService",
                                 "pages": [
-                                  {
-                                    "group": "EnterpriseParticipantReplicationService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/enterpriseparticipantreplicationservice/setpassive"
-                                    ]
-                                  },
-                                  {
-                                    "group": "PackageService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/getdar",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/getdarcontents",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/getpackagecontents",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/getpackagereferences",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/listdars",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/listpackages",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/removedar",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/removepackage",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/unvetdar",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/uploaddar",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/validatedar",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/vetdar"
-                                    ]
-                                  },
-                                  {
-                                    "group": "ParticipantInspectionService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/countinflight",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/getconfigforslowcounterparticipants",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/getintervalsbehindforcounterparticipants",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/inspectcommitmentcontracts",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/lookupoffsetbytime",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/lookupreceivedacscommitments",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/lookupsentacscommitments",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/opencommitment",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/setconfigforslowcounterparticipants"
-                                    ]
-                                  },
-                                  {
-                                    "group": "ParticipantRepairService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/changeassignation",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/exportacs",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/exportacsold",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/ignoreevents",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/importacs",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/importacsold",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/migratesynchronizer",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/purgecontracts",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/purgedeactivatedsynchronizer",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/repaircommitmentsusingacs",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/rollbackunassignment",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/unignoreevents"
-                                    ]
-                                  },
-                                  {
-                                    "group": "ParticipantStatusService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantstatusservice/participantstatus"
-                                    ]
-                                  },
-                                  {
-                                    "group": "PartyManagementService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/addpartyasync",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/clearpartyonboardingflag",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/exportpartyacs",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/getaddpartystatus",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/gethighestoffsetbytimestamp",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/importpartyacs"
-                                    ]
-                                  },
-                                  {
-                                    "group": "PingService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pingservice/ping"
-                                    ]
-                                  },
-                                  {
-                                    "group": "PruningService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/clearschedule",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/getnowaitcommitmentsfrom",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/getparticipantschedule",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/getsafepruningoffset",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/getschedule",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/prune",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/resetnowaitcommitmentsfrom",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setcron",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setmaxduration",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setnowaitcommitmentsfrom",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setparticipantschedule",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setretention",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setschedule"
-                                    ]
-                                  },
-                                  {
-                                    "group": "ResourceManagementService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/resourcemanagementservice/getresourcelimits",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/resourcemanagementservice/setresourcelimits"
-                                    ]
-                                  },
-                                  {
-                                    "group": "SynchronizerConnectivityService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/connectsynchronizer",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/disconnectallsynchronizers",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/disconnectsynchronizer",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/getsynchronizerid",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/listconnectedsynchronizers",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/listregisteredsynchronizers",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/logout",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/modifysynchronizer",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/reconnectsynchronizer",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/reconnectsynchronizers",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/registersynchronizer"
-                                    ]
-                                  },
-                                  {
-                                    "group": "TrafficControlService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/trafficcontrolservice/trafficcontrolstate"
-                                    ]
-                                  }
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/enterpriseparticipantreplicationservice/setpassive"
+                                ]
+                              },
+                              {
+                                "group": "PackageService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/getdar",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/getdarcontents",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/getpackagecontents",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/getpackagereferences",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/listdars",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/listpackages",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/removedar",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/removepackage",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/unvetdar",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/uploaddar",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/validatedar",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/packageservice/vetdar"
+                                ]
+                              },
+                              {
+                                "group": "ParticipantInspectionService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/countinflight",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/getconfigforslowcounterparticipants",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/getintervalsbehindforcounterparticipants",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/inspectcommitmentcontracts",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/lookupoffsetbytime",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/lookupreceivedacscommitments",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/lookupsentacscommitments",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/opencommitment",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantinspectionservice/setconfigforslowcounterparticipants"
+                                ]
+                              },
+                              {
+                                "group": "ParticipantRepairService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/changeassignation",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/exportacs",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/exportacsold",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/ignoreevents",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/importacs",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/importacsold",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/migratesynchronizer",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/purgecontracts",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/purgedeactivatedsynchronizer",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/repaircommitmentsusingacs",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/rollbackunassignment",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantrepairservice/unignoreevents"
+                                ]
+                              },
+                              {
+                                "group": "ParticipantStatusService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/participantstatusservice/participantstatus"
+                                ]
+                              },
+                              {
+                                "group": "PartyManagementService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/addpartyasync",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/clearpartyonboardingflag",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/exportpartyacs",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/getaddpartystatus",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/gethighestoffsetbytimestamp",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/partymanagementservice/importpartyacs"
+                                ]
+                              },
+                              {
+                                "group": "PingService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pingservice/ping"
+                                ]
+                              },
+                              {
+                                "group": "PruningService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/clearschedule",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/getnowaitcommitmentsfrom",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/getparticipantschedule",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/getsafepruningoffset",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/getschedule",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/prune",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/resetnowaitcommitmentsfrom",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setcron",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setmaxduration",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setnowaitcommitmentsfrom",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setparticipantschedule",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setretention",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/pruningservice/setschedule"
+                                ]
+                              },
+                              {
+                                "group": "ResourceManagementService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/resourcemanagementservice/getresourcelimits",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/resourcemanagementservice/setresourcelimits"
+                                ]
+                              },
+                              {
+                                "group": "SynchronizerConnectivityService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/connectsynchronizer",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/disconnectallsynchronizers",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/disconnectsynchronizer",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/getsynchronizerid",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/listconnectedsynchronizers",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/listregisteredsynchronizers",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/logout",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/modifysynchronizer",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/reconnectsynchronizer",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/reconnectsynchronizers",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/synchronizerconnectivityservice/registersynchronizer"
+                                ]
+                              },
+                              {
+                                "group": "TrafficControlService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-participant-v30/trafficcontrolservice/trafficcontrolstate"
                                 ]
                               }
                             ]
-                          },
+                          }
+                        ]
+                      },
+                      {
+                        "group": "com.digitalasset.canton.admin.pruning.v30",
+                        "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-pruning-v30"
+                        ]
+                      },
+                      {
+                        "group": "com.digitalasset.canton.admin.sequencer.v30",
+                        "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-sequencer-v30",
                           {
-                            "group": "com.digitalasset.canton.admin.pruning.v30",
+                            "group": "Services",
                             "pages": [
-                              "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-pruning-v30"
-                            ]
-                          },
-                          {
-                            "group": "com.digitalasset.canton.admin.sequencer.v30",
-                            "pages": [
-                              "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-sequencer-v30",
                               {
-                                "group": "Services",
+                                "group": "SequencerStatusService",
                                 "pages": [
-                                  {
-                                    "group": "SequencerStatusService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-sequencer-v30/sequencerstatusservice/sequencerstatus"
-                                    ]
-                                  }
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-admin-sequencer-v30/sequencerstatusservice/sequencerstatus"
                                 ]
                               }
                             ]
-                          },
+                          }
+                        ]
+                      },
+                      {
+                        "group": "com.digitalasset.canton.admin.time.v30",
+                        "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-time-v30"
+                        ]
+                      },
+                      {
+                        "group": "com.digitalasset.canton.crypto.admin.v30",
+                        "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-crypto-admin-v30",
                           {
-                            "group": "com.digitalasset.canton.admin.time.v30",
+                            "group": "Services",
                             "pages": [
-                              "reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-time-v30"
-                            ]
-                          },
-                          {
-                            "group": "com.digitalasset.canton.crypto.admin.v30",
-                            "pages": [
-                              "reference/admin-api/protobuf/packages/com-digitalasset-canton-crypto-admin-v30",
                               {
-                                "group": "Services",
+                                "group": "VaultService",
                                 "pages": [
-                                  {
-                                    "group": "VaultService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/deletekeypair",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/exportkeypair",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/generateencryptionkey",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/generatesigningkey",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/getwrapperkeyid",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/importkeypair",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/importpublickey",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/listmykeys",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/listpublickeys",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/registerkmsencryptionkey",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/registerkmssigningkey",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/rotatewrapperkey"
-                                    ]
-                                  }
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/deletekeypair",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/exportkeypair",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/generateencryptionkey",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/generatesigningkey",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/getwrapperkeyid",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/importkeypair",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/importpublickey",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/listmykeys",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/listpublickeys",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/registerkmsencryptionkey",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/registerkmssigningkey",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-crypto-admin-v30/vaultservice/rotatewrapperkey"
                                 ]
                               }
                             ]
-                          },
+                          }
+                        ]
+                      },
+                      {
+                        "group": "com.digitalasset.canton.time.admin.v30",
+                        "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-time-admin-v30",
                           {
-                            "group": "com.digitalasset.canton.time.admin.v30",
+                            "group": "Services",
                             "pages": [
-                              "reference/admin-api/protobuf/packages/com-digitalasset-canton-time-admin-v30",
                               {
-                                "group": "Services",
+                                "group": "SynchronizerTimeService",
                                 "pages": [
-                                  {
-                                    "group": "SynchronizerTimeService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-time-admin-v30/synchronizertimeservice/awaittime",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-time-admin-v30/synchronizertimeservice/fetchtime"
-                                    ]
-                                  }
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-time-admin-v30/synchronizertimeservice/awaittime",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-time-admin-v30/synchronizertimeservice/fetchtime"
                                 ]
                               }
                             ]
-                          },
+                          }
+                        ]
+                      },
+                      {
+                        "group": "com.digitalasset.canton.topology.admin.v30",
+                        "pages": [
+                          "reference/admin-api/protobuf/packages/com-digitalasset-canton-topology-admin-v30",
                           {
-                            "group": "com.digitalasset.canton.topology.admin.v30",
+                            "group": "Services",
                             "pages": [
-                              "reference/admin-api/protobuf/packages/com-digitalasset-canton-topology-admin-v30",
                               {
-                                "group": "Services",
+                                "group": "IdentityInitializationService",
                                 "pages": [
-                                  {
-                                    "group": "IdentityInitializationService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/identityinitializationservice/currenttime",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/identityinitializationservice/getid",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/identityinitializationservice/initid"
-                                    ]
-                                  },
-                                  {
-                                    "group": "TopologyAggregationService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologyaggregationservice/listkeyowners",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologyaggregationservice/listparties"
-                                    ]
-                                  },
-                                  {
-                                    "group": "TopologyManagerReadService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/exporttopologysnapshot",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/exporttopologysnapshotv2",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/genesisstate",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/genesisstatev2",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listall",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listavailablestores",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listdecentralizednamespacedefinition",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listmediatorsynchronizerstate",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listnamespacedelegation",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listownertokeymapping",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listparticipantsynchronizerpermission",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listpartyhostinglimits",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listpartytokeymapping",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listpartytoparticipant",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listsequencerconnectionsuccessor",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listsequencersynchronizerstate",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listsynchronizerparametersstate",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listsynchronizertrustcertificate",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listsynchronizerupgradeannouncement",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listvettedpackages",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/logicalupgradestate"
-                                    ]
-                                  },
-                                  {
-                                    "group": "TopologyManagerWriteService",
-                                    "pages": [
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/addtransactions",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/authorize",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/createtemporarytopologystore",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/droptemporarytopologystore",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/generatetransactions",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/importtopologysnapshot",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/importtopologysnapshotv2",
-                                      "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/signtransactions"
-                                    ]
-                                  }
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/identityinitializationservice/currenttime",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/identityinitializationservice/getid",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/identityinitializationservice/initid"
+                                ]
+                              },
+                              {
+                                "group": "TopologyAggregationService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologyaggregationservice/listkeyowners",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologyaggregationservice/listparties"
+                                ]
+                              },
+                              {
+                                "group": "TopologyManagerReadService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/exporttopologysnapshot",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/exporttopologysnapshotv2",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/genesisstate",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/genesisstatev2",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listall",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listavailablestores",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listdecentralizednamespacedefinition",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listmediatorsynchronizerstate",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listnamespacedelegation",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listownertokeymapping",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listparticipantsynchronizerpermission",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listpartyhostinglimits",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listpartytokeymapping",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listpartytoparticipant",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listsequencerconnectionsuccessor",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listsequencersynchronizerstate",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listsynchronizerparametersstate",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listsynchronizertrustcertificate",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listsynchronizerupgradeannouncement",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/listvettedpackages",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerreadservice/logicalupgradestate"
+                                ]
+                              },
+                              {
+                                "group": "TopologyManagerWriteService",
+                                "pages": [
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/addtransactions",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/authorize",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/createtemporarytopologystore",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/droptemporarytopologystore",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/generatetransactions",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/importtopologysnapshot",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/importtopologysnapshotv2",
+                                  "reference/admin-api/protobuf/operations/com-digitalasset-canton-topology-admin-v30/topologymanagerwriteservice/signtransactions"
                                 ]
                               }
                             ]

--- a/scripts/generate_canton_protobuf_history.py
+++ b/scripts/generate_canton_protobuf_history.py
@@ -488,19 +488,19 @@ def update_split_protobuf_navigation(
 
     if admin_output_dir is not None:
         admin_details_page_ref = docs_json_page_ref(admin_output_dir / "index.mdx", docs_json_path)
-        admin_protobuf_group = generated_reference_nav.build_protobuf_nav_group(
+        admin_protobuf_group_pages = generated_reference_nav.build_protobuf_nav_group(
             output_dir=admin_output_dir,
             docs_json_path=docs_json_path,
             group_label=reference_nav.PROTOBUF_GROUP,
             include_details_page=False,
-        )
+        )["pages"]
         replace_group_at_path(
             dropdown["pages"],
             [reference_nav.ADMIN_API_PARENT_GROUP],
             {
                 "group": reference_nav.GRPC_GROUP,
                 "pages": [
-                    admin_protobuf_group,
+                    *admin_protobuf_group_pages,
                     admin_details_page_ref,
                 ],
             },

--- a/tests/test_canton_protobuf_generator.py
+++ b/tests/test_canton_protobuf_generator.py
@@ -69,7 +69,7 @@ class CantonProtobufGeneratorTests(unittest.TestCase):
         self.assertNotIn("com/digitalasset/canton/protocol/v30/common.proto", admin_mapping)
         self.assertNotIn("com/digitalasset/canton/participant/foo.proto", admin_mapping)
 
-    def test_split_protobuf_navigation_places_admin_details_beside_protobufs(self) -> None:
+    def test_split_protobuf_navigation_flattens_admin_packages_under_grpc(self) -> None:
         docs_root = self.root / "docs-main"
         docs_json = docs_root / "docs.json"
         docs_root.mkdir(parents=True)
@@ -115,10 +115,21 @@ class CantonProtobufGeneratorTests(unittest.TestCase):
         admin = next(item for item in pages if item["group"] == "Admin API")
         ledger_protobuf = next(item for item in ledger["pages"] if item["group"] == "Protobufs")
         admin_grpc = next(item for item in admin["pages"] if item["group"] == "gRPC API")
-        admin_protobuf = next(item for item in admin_grpc["pages"] if isinstance(item, dict) and item["group"] == "Protobufs")
+        admin_packages = next(item for item in admin_grpc["pages"] if isinstance(item, dict) and item["group"] == "Packages")
 
         self.assertIn("reference/protobuf/index", ledger_protobuf["pages"])
-        self.assertNotIn("reference/admin-api/protobuf/index", admin_protobuf["pages"])
+        self.assertEqual(
+            admin_packages["pages"],
+            [
+                {
+                    "group": "com.digitalasset.canton.admin.health.v30",
+                    "pages": ["reference/admin-api/protobuf/packages/com-digitalasset-canton-admin-health-v30"],
+                }
+            ],
+        )
+        self.assertFalse(
+            any(isinstance(item, dict) and item.get("group") == "Protobufs" for item in admin_grpc["pages"])
+        )
         self.assertEqual(admin_grpc["pages"][-1], "reference/admin-api/protobuf/index")
 
 


### PR DESCRIPTION
## Summary

Closes #355.

- removes the extra `Protobufs` wrapper under `Admin API > gRPC API`
- keeps `Packages` directly under `gRPC API`, matching the Ledger API gRPC shape
- keeps the Admin API `Details and history` page as the final item in the gRPC group
- updates focused protobuf nav coverage for the flattened Admin API shape

## Screenshot

Admin API gRPC now expands directly into `Packages`; there is no intermediate `Protobufs` layer.

![Admin API gRPC packages nav](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issue-355-screenshots/pr-assets/issue-355/admin-api-grpc-packages-nav.png)

## Validation

- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-355-admin-api-protobuf-nav python3 scripts/generate_canton_protobuf_history.py`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-355-admin-api-protobuf-nav python3 -m pytest tests/test_canton_protobuf_generator.py`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-355-admin-api-protobuf-nav npx mintlify validate` from `docs-main/`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-355-admin-api-protobuf-nav git diff --check`
