### PR TITLE
Add Admin API tile to API Reference landing page

### DIFF
--- a/docs-main/api-reference.mdx
+++ b/docs-main/api-reference.mdx
@@ -22,7 +22,7 @@ The API Reference covers every programmatic interface to Canton - review endpoin
     </Card>
 
     <Card title="dApp API" icon="bookmark" href="reference/wallet-gateway-json-rpc/specs/dapp-api">
-      An OpenRPC specification for the dApp to interact with a Wallet Provider. \
+      An OpenRPC specification for the dApp to interact with a Wallet Provider.
     </Card>
   </Column>
 </Columns>
@@ -34,8 +34,12 @@ The API Reference covers every programmatic interface to Canton - review endpoin
     </Card>
   </Column>
   <Column>
-    <Card title="Splice API" icon="bookmark" href="reference/splice-scan-api/common/readyz">
+    <Card title="Splice APIs" icon="bookmark" href="/reference/splice-scan-api/common/readyz">
       Developing with Canton Network's OpenAPI endpoints for: Canton Coin data, name service, token standard, and more.
+    </Card>
+
+    <Card title="Admin API" icon="bookmark" href="/reference/admin-api/protobuf/index">
+      Generated gRPC package reference for Canton Admin API services, messages, and lifecycle history.
     </Card>
   </Column>
 </Columns>


### PR DESCRIPTION
## Summary

Closes #356.

- adds an `Admin API` card to the API Reference landing page
- renames the landing-page card from `Splice API` to `Splice APIs` to match the sidebar/top-level group
- removes a visible stray backslash from the dApp API card copy

## Screenshot

The API Reference landing page now includes the requested top-level API surfaces, including `Splice APIs`, `dApp API`, `Wallet Gateway`, and `Admin API`.

![API Reference landing tiles](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issue-356-screenshots/pr-assets/issue-356/api-reference-tiles.png)

## Validation

- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-356-api-reference-tiles npx mintlify validate` from `docs-main/`
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-356-api-reference-tiles git diff --check`
