### PR TITLE
Use brand kit logo assets

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -19,8 +19,8 @@
   },
   "favicon": "/images/canton-logo-dark.svg",
   "logo": {
-    "light": "/images/canton-nav-logo-dark.svg",
-    "dark": "/images/canton-nav-logo-white.svg",
+    "light": "/images/canton-logo-dark.svg",
+    "dark": "/images/canton-logo-white.svg",
     "href": "/"
   },
   "appearance": {

--- a/docs-main/images/canton-nav-logo-dark.svg
+++ b/docs-main/images/canton-nav-logo-dark.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="150" height="40" viewBox="0 0 150 40" role="img" aria-label="Canton">
-  <g fill="none" stroke="#030206" stroke-linecap="round" stroke-linejoin="round">
-    <path stroke-width="4" d="M31 10a14 14 0 1 0 0 20" />
-    <path stroke-width="3.2" d="M25 6.5 33 10l-8 3.5M25 26.5 33 30l-8 3.5" />
-  </g>
-  <text x="48" y="27" fill="#030206" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">Canton</text>
-</svg>

--- a/docs-main/images/canton-nav-logo-white.svg
+++ b/docs-main/images/canton-nav-logo-white.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="150" height="40" viewBox="0 0 150 40" role="img" aria-label="Canton">
-  <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round">
-    <path stroke-width="4" d="M31 10a14 14 0 1 0 0 20" />
-    <path stroke-width="3.2" d="M25 6.5 33 10l-8 3.5M25 26.5 33 30l-8 3.5" />
-  </g>
-  <text x="48" y="27" fill="#ffffff" font-family="Inter, Arial, sans-serif" font-size="24" font-weight="700">Canton</text>
-</svg>

--- a/tests/test_api_reference_navigation.py
+++ b/tests/test_api_reference_navigation.py
@@ -31,16 +31,17 @@ def test_product_selector_has_visible_accent_line() -> None:
     assert "box-shadow: inset 0 0 0 2px var(--canton-product-selector-line-active)" in styles
 
 
-def test_site_uses_small_nav_logo_assets() -> None:
+def test_site_uses_brand_kit_logo_assets() -> None:
     docs = json.loads((REPO_ROOT / "docs-main" / "docs.json").read_text(encoding="utf-8"))
 
     assert docs["favicon"] == "/images/canton-logo-dark.svg"
-    assert docs["logo"]["light"] == "/images/canton-nav-logo-dark.svg"
-    assert docs["logo"]["dark"] == "/images/canton-nav-logo-white.svg"
+    assert docs["logo"]["light"] == "/images/canton-logo-dark.svg"
+    assert docs["logo"]["dark"] == "/images/canton-logo-white.svg"
 
     for logo_path in docs["logo"]["light"], docs["logo"]["dark"]:
         svg_path = REPO_ROOT / "docs-main" / logo_path.removeprefix("/")
         assert svg_path.exists()
         svg = svg_path.read_text(encoding="utf-8")
-        assert 'width="150"' in svg
-        assert "<text" in svg
+        assert 'width="1432"' in svg
+        assert 'height="369"' in svg
+        assert "<text" not in svg


### PR DESCRIPTION
## Summary
- Points Mintlify `logo.light`/`logo.dark` at the official Canton brand-kit SVGs already checked into `docs-main/images`.
- Removes the handmade nav-only SVG logo variants so the site uses the same source assets as the [Canton brand kit](https://www.canton.network/brand-kit-trademark-use).
- Updates the navigation logo test to assert the brand-kit asset dimensions and ensure text-rendered SVG variants do not return.

## Brand kit source check
- Brand kit black logo download: `https://www.canton.network/hubfs/canton-logo-black.svg`
- Brand kit white logo download: `https://www.canton.network/hubfs/canton-logo-white.svg`
- Checked-in `/images/canton-logo-dark.svg` matches the brand-kit black logo (`sha256 ed8540a4f61f5025eb0074766f84a0167b69c4281ae351c59f398a912be794d2`).
- Checked-in `/images/canton-logo-white.svg` matches the brand-kit white logo (`sha256 720413e5861a911b495ed957c3d1884a2a8a288d79228194ffa2b1bc6c565694`).

## Screenshots
| Light mode | Dark mode |
| --- | --- |
| ![Light mode nav logo](https://raw.githubusercontent.com/canton-network/cf-docs/bc14babe1d1a228be79dabc80d0e82f2e3ccaefa/.github/pr-screenshots/brand-kit-logo/logo-light.png) | ![Dark mode nav logo](https://raw.githubusercontent.com/canton-network/cf-docs/bc14babe1d1a228be79dabc80d0e82f2e3ccaefa/.github/pr-screenshots/brand-kit-logo/logo-dark.png) |

## Validation
- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-brand-kit-logo python3 -m pytest tests/test_api_reference_navigation.py`
- `git diff --check`
- Local Mintlify preview at `http://localhost:3073/api-reference` for the light/dark screenshots above.

Note: the local preview still emits the existing Global Synchronizer MDX parse/nav warnings from `origin/main`; they are unrelated to this logo change.
