### PR TITLE
Add Version Dashboard to product dropdown

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -324,6 +324,308 @@
         ]
       },
       {
+        "product": "Global Synchronizer",
+        "icon": "server",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "global-synchronizer/understand/overview",
+              "global-synchronizer/understand/introduction",
+              "global-synchronizer/understand/validator-roles",
+              "global-synchronizer/extension-synchronizers/bft-orderer",
+              "global-synchronizer/understand/installing-daml-sdk",
+              "global-synchronizer/understand/local-testing"
+            ]
+          },
+          {
+            "group": "Validator Deployment",
+            "pages": [
+              "global-synchronizer/deployment/onboarding-process",
+              "global-synchronizer/deployment/prerequisites",
+              {
+                "group": "Deployment Options",
+                "pages": [
+                  "global-synchronizer/deployment/deployment-options",
+                  "global-synchronizer/deployment/validator-docker-compose",
+                  "global-synchronizer/deployment/validator-kubernetes"
+                ]
+              },
+              "global-synchronizer/deployment/configuration",
+              "global-synchronizer/deployment/validator-users",
+              "global-synchronizer/deployment/validator-network-resets",
+              "global-synchronizer/deployment/required-network-parameters",
+              "global-synchronizer/production-operations/validator-backups",
+              "global-synchronizer/production-operations/validator-disaster-recovery",
+              "global-synchronizer/production-operations/validator-security",
+              "global-synchronizer/deployment/validator-networking"
+            ]
+          },
+          {
+            "group": "Super Validator Deployment",
+            "pages": [
+              "global-synchronizer/deployment/kubernetes-deployment",
+              "global-synchronizer/deployment/sv-network-resets",
+              "global-synchronizer/production-operations/sv-security",
+              "global-synchronizer/production-operations/sv-upgrades",
+              "global-synchronizer/deployment/sv-operations",
+              "global-synchronizer/deployment/sv-scratchnet"
+            ]
+          },
+          {
+            "group": "Splice Fundamentals",
+            "pages": [
+              "global-synchronizer/splice-fundamentals/rewards-minting",
+              "global-synchronizer/deployment/synchronizer-traffic",
+              "global-synchronizer/splice-fundamentals/validator-development-fund",
+              "global-synchronizer/splice-fundamentals/sv-live-tokenomics",
+              "global-synchronizer/splice-fundamentals/validator-liveness",
+              "global-synchronizer/splice-fundamentals/glossary"
+            ]
+          },
+          {
+            "group": "Canton Console",
+            "pages": [
+              "global-synchronizer/canton-console/console-overview",
+              "global-synchronizer/canton-console/essential-commands",
+              "global-synchronizer/canton-console/scripting",
+              "global-synchronizer/canton-console/debugging-workflows",
+              "global-synchronizer/canton-console/advanced-operations",
+              "global-synchronizer/canton-console/getting-started-tutorial"
+            ]
+          },
+          {
+            "group": "Production Operations",
+            "pages": [
+              "global-synchronizer/production-operations/monitoring-setup",
+              "global-synchronizer/production-operations/key-metrics",
+              "global-synchronizer/production-operations/splice-metrics-overview",
+              "global-synchronizer/production-operations/validator-upgrades",
+              "global-synchronizer/production-operations/validator-major-upgrade",
+              "global-synchronizer/production-operations/sv-major-upgrade",
+              "global-synchronizer/production-operations/performance-optimization",
+              "global-synchronizer/production-operations/key-management",
+              "global-synchronizer/production-operations/party-management",
+              "global-synchronizer/production-operations/multi-sig",
+              "global-synchronizer/production-operations/kms-operations",
+              "global-synchronizer/production-operations/canton-console",
+              "global-synchronizer/production-operations/manage-packages",
+              "global-synchronizer/production-operations/upgrade-canton-nodes",
+              "global-synchronizer/production-operations/decommission-nodes",
+              "global-synchronizer/production-operations/node-backup-restore",
+              "global-synchronizer/deployment/identity-management",
+              "global-synchronizer/deployment/oidc-providers",
+              "global-synchronizer/deployment/docker",
+              "global-synchronizer/reference/metrics-reference",
+              "global-synchronizer/troubleshooting-guide/runbooks",
+              {
+                "group": "Super Validator only",
+                "pages": [
+                  "global-synchronizer/production-operations/disaster-recovery",
+                  "global-synchronizer/production-operations/pruning",
+                  "global-synchronizer/production-operations/logical-synchronizer-upgrade",
+                  "global-synchronizer/production-operations/sv-backup",
+                  "global-synchronizer/production-operations/sv-pruning"
+                ]
+              },
+              "global-synchronizer/production-operations/scalability"
+            ]
+          },
+          {
+            "group": "Extension Synchronizers",
+            "pages": [
+              "global-synchronizer/extension-synchronizers/private-synchronizers",
+              "global-synchronizer/extension-synchronizers/hybrid-synchronizer-pattern",
+              "global-synchronizer/extension-synchronizers/other-private-synchronizers",
+              "global-synchronizer/extension-synchronizers/deployment",
+              "global-synchronizer/extension-synchronizers/linking-validator-multi-sync",
+              "global-synchronizer/extension-synchronizers/private-validators",
+              "global-synchronizer/extension-synchronizers/synchronizer-operations",
+              "global-synchronizer/extension-synchronizers/synchronizer-monitoring"
+            ]
+          },
+          {
+            "group": "Troubleshooting",
+            "pages": [
+              "global-synchronizer/faq",
+              "global-synchronizer/troubleshooting-guide/troubleshooting-methodology",
+              "global-synchronizer/troubleshooting-guide/installation-issues",
+              "global-synchronizer/troubleshooting-guide/configuration-problems",
+              "global-synchronizer/troubleshooting-guide/connectivity-issues",
+              "global-synchronizer/troubleshooting-guide/transaction-failures",
+              "global-synchronizer/troubleshooting-guide/performance-issues",
+              "global-synchronizer/troubleshooting-guide/security-issues",
+              "global-synchronizer/troubleshooting-guide/common-questions",
+              "global-synchronizer/troubleshooting-guide/error-code-reference"
+            ]
+          },
+          {
+            "group": "Release Notes",
+            "pages": [
+              "global-synchronizer/release-notes/release-notes"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "global-synchronizer/reference/canton-console-reference",
+              "global-synchronizer/reference/canton-console-commands",
+              "global-synchronizer/reference/configuration-reference",
+              "global-synchronizer/reference/canton-configuration-guide",
+              "global-synchronizer/reference/api-configuration",
+              "global-synchronizer/reference/security-configuration",
+              "global-synchronizer/reference/observability-configuration",
+              "global-synchronizer/reference/crypto-schemes",
+              "global-synchronizer/reference/kms-driver-guide",
+              "global-synchronizer/reference/canton-metrics",
+              "global-synchronizer/reference/splice-metrics",
+              "global-synchronizer/reference/error-codes"
+            ]
+          },
+          {
+            "group": "Community Resources",
+            "pages": [
+              "global-synchronizer/deployment/community-docker-compose-helm",
+              "global-synchronizer/deployment/community-helm-templating",
+              "global-synchronizer/deployment/community-keycloak-config"
+            ]
+          }
+        ]
+      },
+      {
+        "product": "Integrations",
+        "icon": "plug",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "integrations/overview",
+              "integrations/integration-patterns"
+            ]
+          },
+          {
+            "group": "Wallet",
+            "pages": [
+              "integrations/wallet/sdk-download",
+              "integrations/wallet/configuration",
+              "integrations/wallet/guidance",
+              "integrations/wallet/release-notes"
+            ]
+          },
+          {
+            "group": "Exchanges",
+            "pages": [
+              "integrations/exchanges/sdk-download",
+              "integrations/exchanges/guidance",
+              "integrations/exchanges/node-operations"
+            ]
+          },
+          {
+            "group": "Ecosystem",
+            "pages": [
+              "integrations/ecosystem",
+              "integrations/apps/finding-apps",
+              "integrations/wallets/canton-vs-web3",
+              "integrations/wallets/for-users"
+            ]
+          }
+        ]
+      },
+      {
+        "product": "SDKs and Tools",
+        "icon": "wrench",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "sdks-tools/overview"
+            ]
+          },
+          {
+            "group": "SDKs",
+            "pages": [
+              "sdks-tools/sdks/daml-sdk",
+              "sdks-tools/sdks/wallet-sdk",
+              "sdks-tools/sdks/exchange-sdk"
+            ]
+          },
+          {
+            "group": "Language Bindings",
+            "pages": [
+              "sdks-tools/language-bindings/java",
+              "sdks-tools/language-bindings/java-client-libraries",
+              "sdks-tools/language-bindings/javascript",
+              "sdks-tools/language-bindings/community"
+            ]
+          },
+          {
+            "group": "CLI Tools",
+            "pages": [
+              "sdks-tools/cli-tools/dpm",
+              "sdks-tools/cli-tools/canton-console",
+              "sdks-tools/cli-tools/daml-script",
+              "sdks-tools/cli-tools/daml-shell"
+            ]
+          },
+          {
+            "group": "Development Tools",
+            "pages": [
+              "sdks-tools/development-tools/daml-studio",
+              "sdks-tools/development-tools/daml-compiler",
+              "sdks-tools/development-tools/localnet",
+              "sdks-tools/development-tools/sandbox",
+              "sdks-tools/development-tools/pqs"
+            ]
+          },
+          {
+            "group": "API Overview",
+            "pages": [
+              {
+                "group": "Ledger API",
+                "pages": [
+                  "sdks-tools/api-reference/ledger-api",
+                  "sdks-tools/api-reference/ledger-api-services",
+                  "sdks-tools/api-reference/json-api"
+                ]
+              },
+              "sdks-tools/api-reference/admin-api",
+              {
+                "group": "Splice APIs",
+                "pages": [
+                  "sdks-tools/api-reference/splice-apis",
+                  "sdks-tools/api-reference/splice-overview",
+                  "sdks-tools/api-reference/splice-http-apis",
+                  "sdks-tools/api-reference/splice-daml-apis",
+                  "sdks-tools/api-reference/splice-daml-models",
+                  "sdks-tools/api-reference/splice-architecture",
+                  {
+                    "group": "Scan APIs",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-scan-api",
+                      "sdks-tools/api-reference/splice-scan-aggregates-api",
+                      "sdks-tools/api-reference/splice-scan-bulk-data-api",
+                      "sdks-tools/api-reference/splice-scan-cc-reference-data-api",
+                      "sdks-tools/api-reference/splice-scan-current-state-api",
+                      "sdks-tools/api-reference/splice-scan-gs-connectivity-api",
+                      "sdks-tools/api-reference/splice-scan-gs-operations-api",
+                      "sdks-tools/api-reference/splice-scan-openapi"
+                    ]
+                  },
+                  "sdks-tools/api-reference/splice-validator-api"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Reference Projects",
+            "pages": [
+              "sdks-tools/reference-projects/cn-quickstart",
+              "sdks-tools/reference-projects/splice-reference-apps"
+            ]
+          }
+        ]
+      },
+      {
         "product": "API Reference",
         "icon": "book-open",
         "root": "api-reference",
@@ -1762,308 +2064,6 @@
                   "reference/admin-api/protobuf/index"
                 ]
               }
-            ]
-          }
-        ]
-      },
-      {
-        "product": "Global Synchronizer",
-        "icon": "server",
-        "groups": [
-          {
-            "group": "Overview",
-            "pages": [
-              "global-synchronizer/understand/overview",
-              "global-synchronizer/understand/introduction",
-              "global-synchronizer/understand/validator-roles",
-              "global-synchronizer/extension-synchronizers/bft-orderer",
-              "global-synchronizer/understand/installing-daml-sdk",
-              "global-synchronizer/understand/local-testing"
-            ]
-          },
-          {
-            "group": "Validator Deployment",
-            "pages": [
-              "global-synchronizer/deployment/onboarding-process",
-              "global-synchronizer/deployment/prerequisites",
-              {
-                "group": "Deployment Options",
-                "pages": [
-                  "global-synchronizer/deployment/deployment-options",
-                  "global-synchronizer/deployment/validator-docker-compose",
-                  "global-synchronizer/deployment/validator-kubernetes"
-                ]
-              },
-              "global-synchronizer/deployment/configuration",
-              "global-synchronizer/deployment/validator-users",
-              "global-synchronizer/deployment/validator-network-resets",
-              "global-synchronizer/deployment/required-network-parameters",
-              "global-synchronizer/production-operations/validator-backups",
-              "global-synchronizer/production-operations/validator-disaster-recovery",
-              "global-synchronizer/production-operations/validator-security",
-              "global-synchronizer/deployment/validator-networking"
-            ]
-          },
-          {
-            "group": "Super Validator Deployment",
-            "pages": [
-              "global-synchronizer/deployment/kubernetes-deployment",
-              "global-synchronizer/deployment/sv-network-resets",
-              "global-synchronizer/production-operations/sv-security",
-              "global-synchronizer/production-operations/sv-upgrades",
-              "global-synchronizer/deployment/sv-operations",
-              "global-synchronizer/deployment/sv-scratchnet"
-            ]
-          },
-          {
-            "group": "Splice Fundamentals",
-            "pages": [
-              "global-synchronizer/splice-fundamentals/rewards-minting",
-              "global-synchronizer/deployment/synchronizer-traffic",
-              "global-synchronizer/splice-fundamentals/validator-development-fund",
-              "global-synchronizer/splice-fundamentals/sv-live-tokenomics",
-              "global-synchronizer/splice-fundamentals/validator-liveness",
-              "global-synchronizer/splice-fundamentals/glossary"
-            ]
-          },
-          {
-            "group": "Canton Console",
-            "pages": [
-              "global-synchronizer/canton-console/console-overview",
-              "global-synchronizer/canton-console/essential-commands",
-              "global-synchronizer/canton-console/scripting",
-              "global-synchronizer/canton-console/debugging-workflows",
-              "global-synchronizer/canton-console/advanced-operations",
-              "global-synchronizer/canton-console/getting-started-tutorial"
-            ]
-          },
-          {
-            "group": "Production Operations",
-            "pages": [
-              "global-synchronizer/production-operations/monitoring-setup",
-              "global-synchronizer/production-operations/key-metrics",
-              "global-synchronizer/production-operations/splice-metrics-overview",
-              "global-synchronizer/production-operations/validator-upgrades",
-              "global-synchronizer/production-operations/validator-major-upgrade",
-              "global-synchronizer/production-operations/sv-major-upgrade",
-              "global-synchronizer/production-operations/performance-optimization",
-              "global-synchronizer/production-operations/key-management",
-              "global-synchronizer/production-operations/party-management",
-              "global-synchronizer/production-operations/multi-sig",
-              "global-synchronizer/production-operations/kms-operations",
-              "global-synchronizer/production-operations/canton-console",
-              "global-synchronizer/production-operations/manage-packages",
-              "global-synchronizer/production-operations/upgrade-canton-nodes",
-              "global-synchronizer/production-operations/decommission-nodes",
-              "global-synchronizer/production-operations/node-backup-restore",
-              "global-synchronizer/deployment/identity-management",
-              "global-synchronizer/deployment/oidc-providers",
-              "global-synchronizer/deployment/docker",
-              "global-synchronizer/reference/metrics-reference",
-              "global-synchronizer/troubleshooting-guide/runbooks",
-              {
-                "group": "Super Validator only",
-                "pages": [
-                  "global-synchronizer/production-operations/disaster-recovery",
-                  "global-synchronizer/production-operations/pruning",
-                  "global-synchronizer/production-operations/logical-synchronizer-upgrade",
-                  "global-synchronizer/production-operations/sv-backup",
-                  "global-synchronizer/production-operations/sv-pruning"
-                ]
-              },
-              "global-synchronizer/production-operations/scalability"
-            ]
-          },
-          {
-            "group": "Extension Synchronizers",
-            "pages": [
-              "global-synchronizer/extension-synchronizers/private-synchronizers",
-              "global-synchronizer/extension-synchronizers/hybrid-synchronizer-pattern",
-              "global-synchronizer/extension-synchronizers/other-private-synchronizers",
-              "global-synchronizer/extension-synchronizers/deployment",
-              "global-synchronizer/extension-synchronizers/linking-validator-multi-sync",
-              "global-synchronizer/extension-synchronizers/private-validators",
-              "global-synchronizer/extension-synchronizers/synchronizer-operations",
-              "global-synchronizer/extension-synchronizers/synchronizer-monitoring"
-            ]
-          },
-          {
-            "group": "Troubleshooting",
-            "pages": [
-              "global-synchronizer/faq",
-              "global-synchronizer/troubleshooting-guide/troubleshooting-methodology",
-              "global-synchronizer/troubleshooting-guide/installation-issues",
-              "global-synchronizer/troubleshooting-guide/configuration-problems",
-              "global-synchronizer/troubleshooting-guide/connectivity-issues",
-              "global-synchronizer/troubleshooting-guide/transaction-failures",
-              "global-synchronizer/troubleshooting-guide/performance-issues",
-              "global-synchronizer/troubleshooting-guide/security-issues",
-              "global-synchronizer/troubleshooting-guide/common-questions",
-              "global-synchronizer/troubleshooting-guide/error-code-reference"
-            ]
-          },
-          {
-            "group": "Release Notes",
-            "pages": [
-              "global-synchronizer/release-notes/release-notes"
-            ]
-          },
-          {
-            "group": "Reference",
-            "pages": [
-              "global-synchronizer/reference/canton-console-reference",
-              "global-synchronizer/reference/canton-console-commands",
-              "global-synchronizer/reference/configuration-reference",
-              "global-synchronizer/reference/canton-configuration-guide",
-              "global-synchronizer/reference/api-configuration",
-              "global-synchronizer/reference/security-configuration",
-              "global-synchronizer/reference/observability-configuration",
-              "global-synchronizer/reference/crypto-schemes",
-              "global-synchronizer/reference/kms-driver-guide",
-              "global-synchronizer/reference/canton-metrics",
-              "global-synchronizer/reference/splice-metrics",
-              "global-synchronizer/reference/error-codes"
-            ]
-          },
-          {
-            "group": "Community Resources",
-            "pages": [
-              "global-synchronizer/deployment/community-docker-compose-helm",
-              "global-synchronizer/deployment/community-helm-templating",
-              "global-synchronizer/deployment/community-keycloak-config"
-            ]
-          }
-        ]
-      },
-      {
-        "product": "Integrations",
-        "icon": "plug",
-        "groups": [
-          {
-            "group": "Overview",
-            "pages": [
-              "integrations/overview",
-              "integrations/integration-patterns"
-            ]
-          },
-          {
-            "group": "Wallet",
-            "pages": [
-              "integrations/wallet/sdk-download",
-              "integrations/wallet/configuration",
-              "integrations/wallet/guidance",
-              "integrations/wallet/release-notes"
-            ]
-          },
-          {
-            "group": "Exchanges",
-            "pages": [
-              "integrations/exchanges/sdk-download",
-              "integrations/exchanges/guidance",
-              "integrations/exchanges/node-operations"
-            ]
-          },
-          {
-            "group": "Ecosystem",
-            "pages": [
-              "integrations/ecosystem",
-              "integrations/apps/finding-apps",
-              "integrations/wallets/canton-vs-web3",
-              "integrations/wallets/for-users"
-            ]
-          }
-        ]
-      },
-      {
-        "product": "SDKs and Tools",
-        "icon": "wrench",
-        "groups": [
-          {
-            "group": "Overview",
-            "pages": [
-              "sdks-tools/overview"
-            ]
-          },
-          {
-            "group": "SDKs",
-            "pages": [
-              "sdks-tools/sdks/daml-sdk",
-              "sdks-tools/sdks/wallet-sdk",
-              "sdks-tools/sdks/exchange-sdk"
-            ]
-          },
-          {
-            "group": "Language Bindings",
-            "pages": [
-              "sdks-tools/language-bindings/java",
-              "sdks-tools/language-bindings/java-client-libraries",
-              "sdks-tools/language-bindings/javascript",
-              "sdks-tools/language-bindings/community"
-            ]
-          },
-          {
-            "group": "CLI Tools",
-            "pages": [
-              "sdks-tools/cli-tools/dpm",
-              "sdks-tools/cli-tools/canton-console",
-              "sdks-tools/cli-tools/daml-script",
-              "sdks-tools/cli-tools/daml-shell"
-            ]
-          },
-          {
-            "group": "Development Tools",
-            "pages": [
-              "sdks-tools/development-tools/daml-studio",
-              "sdks-tools/development-tools/daml-compiler",
-              "sdks-tools/development-tools/localnet",
-              "sdks-tools/development-tools/sandbox",
-              "sdks-tools/development-tools/pqs"
-            ]
-          },
-          {
-            "group": "API Overview",
-            "pages": [
-              {
-                "group": "Ledger API",
-                "pages": [
-                  "sdks-tools/api-reference/ledger-api",
-                  "sdks-tools/api-reference/ledger-api-services",
-                  "sdks-tools/api-reference/json-api"
-                ]
-              },
-              "sdks-tools/api-reference/admin-api",
-              {
-                "group": "Splice APIs",
-                "pages": [
-                  "sdks-tools/api-reference/splice-apis",
-                  "sdks-tools/api-reference/splice-overview",
-                  "sdks-tools/api-reference/splice-http-apis",
-                  "sdks-tools/api-reference/splice-daml-apis",
-                  "sdks-tools/api-reference/splice-daml-models",
-                  "sdks-tools/api-reference/splice-architecture",
-                  {
-                    "group": "Scan APIs",
-                    "pages": [
-                      "sdks-tools/api-reference/splice-scan-api",
-                      "sdks-tools/api-reference/splice-scan-aggregates-api",
-                      "sdks-tools/api-reference/splice-scan-bulk-data-api",
-                      "sdks-tools/api-reference/splice-scan-cc-reference-data-api",
-                      "sdks-tools/api-reference/splice-scan-current-state-api",
-                      "sdks-tools/api-reference/splice-scan-gs-connectivity-api",
-                      "sdks-tools/api-reference/splice-scan-gs-operations-api",
-                      "sdks-tools/api-reference/splice-scan-openapi"
-                    ]
-                  },
-                  "sdks-tools/api-reference/splice-validator-api"
-                ]
-              }
-            ]
-          },
-          {
-            "group": "Reference Projects",
-            "pages": [
-              "sdks-tools/reference-projects/cn-quickstart",
-              "sdks-tools/reference-projects/splice-reference-apps"
             ]
           }
         ]

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -2067,6 +2067,14 @@
             ]
           }
         ]
+      },
+      {
+        "product": "Version Dashboard",
+        "icon": "table",
+        "root": "shared/version-compatibility-dashboard",
+        "pages": [
+          "shared/version-compatibility-dashboard"
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

Adds a "Version Dashboard" entry at the bottom of the product dropdown (Overview, App Development, API Reference, Global Synchronizer, Integrations, SDKs and Tools, **Version Dashboard**).

Points at the existing `/shared/version-compatibility-dashboard` page. The dashboard is already linked from the docs landing page and the appdev "What's new" page but was missing from the top-level product dropdown.