### PR TITLE
add release notes to top nav

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -509,8 +509,7 @@
             "pages": [
               "integrations/wallet/sdk-download",
               "integrations/wallet/configuration",
-              "integrations/wallet/guidance",
-              "integrations/wallet/release-notes"
+              "integrations/wallet/guidance"
             ]
           },
           {

--- a/docs-main/release-notes.mdx
+++ b/docs-main/release-notes.mdx
@@ -7,7 +7,8 @@ title: "Release Notes"
 <Columns cols={2}>
   <Column>
     <Card title="Splice" icon="notes" href="/global-synchronizer/release-notes/splice">
-      Review the release details for the latest updates, enhancements, and bug fixes.\
+      Review the release details for the latest updates, enhancements, and bug fixes.
+      
     </Card>
   </Column>
   <Column>

--- a/docs-main/styles.css
+++ b/docs-main/styles.css
@@ -22,6 +22,7 @@
   --canton-inline-highlight-border: rgba(115, 75, 226, 0.26);
   --canton-product-selector-line: rgba(115, 75, 226, 0.70);
   --canton-product-selector-line-active: #734BE2;
+  --canton-product-selector-divider: rgba(75, 85, 99, 0.16);
 
   /* Typography */
   --canton-font-family: 'Inter', system-ui, -apple-system, sans-serif;
@@ -38,6 +39,7 @@
   --canton-inline-highlight-border: rgba(169, 133, 255, 0.34);
   --canton-product-selector-line: rgba(169, 133, 255, 0.70);
   --canton-product-selector-line-active: #A985FF;
+  --canton-product-selector-divider: rgba(255, 255, 255, 0.10);
 }
 
 /* ============================================
@@ -111,6 +113,17 @@ nav a:hover {
 .nav-dropdown-products-selector-trigger[aria-expanded="true"] {
   background-color: var(--canton-hover-bg) !important;
   box-shadow: inset 0 0 0 2px var(--canton-product-selector-line-active) !important;
+}
+
+/* Product selector dropdown: visually group reference utilities below
+   the primary docs sections. Mintlify renders each product as a direct link. */
+.nav-dropdown-products-selector-content > a[href="/api-reference"] {
+  border-top: 1px solid var(--canton-product-selector-divider);
+  box-sizing: border-box;
+  display: block;
+  margin-top: 0.35rem;
+  padding-top: 0.35rem;
+  width: 100%;
 }
 
 /* ============================================

--- a/tests/test_api_reference_navigation.py
+++ b/tests/test_api_reference_navigation.py
@@ -31,6 +31,26 @@ def test_product_selector_has_visible_accent_line() -> None:
     assert "box-shadow: inset 0 0 0 2px var(--canton-product-selector-line-active)" in styles
 
 
+def test_product_selector_groups_reference_utility_links() -> None:
+    docs = json.loads((REPO_ROOT / "docs-main" / "docs.json").read_text(encoding="utf-8"))
+    products = docs["navigation"]["products"]
+
+    assert [item["product"] for item in products[-3:]] == [
+        "API Reference",
+        "Release Notes",
+        "Version Dashboard",
+    ]
+
+    integrations = next(item for item in products if item["product"] == "Integrations")
+    wallet = next(group for group in integrations["groups"] if group["group"] == "Wallet")
+    assert "integrations/wallet/release-notes" not in wallet["pages"]
+
+    styles = (REPO_ROOT / "docs-main" / "styles.css").read_text(encoding="utf-8")
+    assert "--canton-product-selector-divider" in styles
+    assert '.nav-dropdown-products-selector-content > a[href="/api-reference"]' in styles
+    assert "border-top: 1px solid var(--canton-product-selector-divider)" in styles
+
+
 def test_site_uses_brand_kit_logo_assets() -> None:
     docs = json.loads((REPO_ROOT / "docs-main" / "docs.json").read_text(encoding="utf-8"))
 


### PR DESCRIPTION
1. add release notes landing to top nav
2. remove release notes landing from overview
3. add a divider in top nav dropdown above API reference so that we can seperate API Ref, Release notes, and vers. board.

## Follow-up
- Added a CSS-only divider above `API Reference` in the product selector dropdown.
- The divider uses Mintlify's generated `.nav-dropdown-products-selector-content > a[href="/api-reference"]` structure so the reference utilities are visually grouped without unsupported `docs.json` separator fields.
- Added focused coverage for the top-level `API Reference`, `Release Notes`, and `Version Dashboard` grouping and the removed wallet release-notes sidebar entry.

## Screenshots
| Light mode | Dark mode |
| --- | --- |
| ![Product dropdown divider in light mode](https://raw.githubusercontent.com/canton-network/cf-docs/9c8cd391546fc24f9677d76068ee3298a06b8682/.github/pr-screenshots/pr-421-release-note-dropdown/product-dropdown-divider-light.png) | ![Product dropdown divider in dark mode](https://raw.githubusercontent.com/canton-network/cf-docs/9c8cd391546fc24f9677d76068ee3298a06b8682/.github/pr-screenshots/pr-421-release-note-dropdown/product-dropdown-divider-dark.png) |

## Validation
- `python3 - <<'PY' ...` direct invocation of `tests/test_api_reference_navigation.py` assertions
- `git diff --check`
- Hosted preview DOM check confirmed `/api-reference` receives a `1px solid` divider and spacing from the new CSS selector.

Note: local `direnv exec` could not activate fully because `nix-shell` is not available on this machine, and ambient Python does not have `pytest` installed. Local Mintlify preview is also blocked by the current branch's existing MDX parse error.
