### PR TITLE
Rename landing card to Global Synchronizer

### DIFF
--- a/docs-main/index.mdx
+++ b/docs-main/index.mdx
@@ -13,7 +13,7 @@ mode: "center"
     Easy-to-follow modules that explain how to develop on the Canton Network. Review development tools, app reward structures, and more.
   </Card>
 
-  <Card title="Network Operations" icon="server" href="/global-synchronizer/understand/introduction">
+  <Card title="Global Synchronizer" icon="server" href="/global-synchronizer/understand/introduction">
     Understand node operations, Splice fundamentals, validator deployment, setup for the Super Validator and network, and general structure around the Global Synchronizer.
   </Card>
 </Columns>


### PR DESCRIPTION
## Summary
- Fixes #399.
- Renames the main landing page card from `Network Operations` to `Global Synchronizer`.

## Validation
- `git diff --check`

## Screenshots

![PR #428 screenshot](https://raw.githubusercontent.com/canton-network/cf-docs/refs/heads/pr-assets/cf-docs-curtis-batch-screenshots/pr-assets/cf-docs-curtis-batch-screenshots/pr-428-global-synchronizer-card.png)

Shows the landing page card renamed to `Global Synchronizer`.

Source: Hosted Mintlify preview.
