### PR TITLE
Point Global Synchronizer card to overview page

### DIFF
--- a/docs-main/index.mdx
+++ b/docs-main/index.mdx
@@ -13,7 +13,7 @@ mode: "center"
     Easy-to-follow modules that explain how to develop on the Canton Network. Review development tools, app reward structures, and more.
   </Card>
 
-  <Card title="Global Synchronizer" icon="server" href="/global-synchronizer/understand/introduction">
+  <Card title="Global Synchronizer" icon="server" href="/global-synchronizer/understand/overview">
     Understand node operations, Splice fundamentals, validator deployment, setup for the Super Validator and network, and general structure around the Global Synchronizer.
   </Card>
 </Columns>


### PR DESCRIPTION
## Summary
- Fixes #400.
- Points the main landing page Network Operations card at `/global-synchronizer/understand/overview`, whose page title is `Global Synchronizer for the Canton Network`.

## Validation
- `git diff --check`

## Screenshots

![PR #429 screenshot](https://raw.githubusercontent.com/canton-network/cf-docs/refs/heads/pr-assets/cf-docs-curtis-batch-screenshots/pr-assets/cf-docs-curtis-batch-screenshots/pr-429-global-synchronizer-overview-target.png)

Shows the Global Synchronizer overview page that the landing card now opens.

Source: Hosted Mintlify preview.
