### PR TITLE
Remove leaked reconciliation note from party replication

### DIFF
--- a/docs-main/global-synchronizer/production-operations/party-management.mdx
+++ b/docs-main/global-synchronizer/production-operations/party-management.mdx
@@ -238,8 +238,6 @@ The simple party replication consists of these steps, follow them **in the order
 
 The following demonstrates these steps using two participants:
 
-[\#27707: Remove reconciliationInterval when ACS commitments consider the onboarding flag](https://github.com/DACH-NY/canton/issues/27707)
-
 ``` none
 @ val source = participant1
     source : com.digitalasset.canton.console.LocalParticipantReference = Participant 'participant1'
@@ -366,8 +364,6 @@ This documentation provides a guide. Your environment may require adjustments. T
 ### Scenario description
 
 The following steps show how to replicate party `alice` from the `source` participant to a new `target` participant on the synchronizer `mysynchronizer`. The `source` can be any participant already hosting the party.
-
-[\#27707: Remove reconciliationInterval when ACS commitments consider the onboarding flag](https://github.com/DACH-NY/canton/issues/27707)
 
 <ExternalCantonMainDocsOpenTargetSnippetJsonDataParticipantHowtosOperatePartiesPartyReplication5 />
 


### PR DESCRIPTION
## Summary
- Fixes #424.
- Removes the leaked internal `#27707: Remove reconciliationInterval...` links from both party replication sections requested in the issue.

## Validation
- `git diff --check`
- `rg '27707|Remove reconciliationInterval' docs-main/global-synchronizer/production-operations/party-management.mdx` returns no matches

## Screenshots

![PR #430 screenshot](https://raw.githubusercontent.com/canton-network/cf-docs/refs/heads/pr-assets/cf-docs-curtis-batch-screenshots/pr-assets/cf-docs-curtis-batch-screenshots/pr-430-party-replication-note-removed.png)

Shows the Simple party replication section without the leaked reconciliation-interval issue links.

Source: Validated local fallback preview.
