### PR TITLE
Move Validator Upgrades under validator deployment

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -357,6 +357,7 @@
               "global-synchronizer/deployment/required-network-parameters",
               "global-synchronizer/production-operations/validator-backups",
               "global-synchronizer/production-operations/validator-disaster-recovery",
+              "global-synchronizer/production-operations/validator-upgrades",
               "global-synchronizer/production-operations/validator-security",
               "global-synchronizer/deployment/validator-networking"
             ]
@@ -400,7 +401,6 @@
               "global-synchronizer/production-operations/monitoring-setup",
               "global-synchronizer/production-operations/key-metrics",
               "global-synchronizer/production-operations/splice-metrics-overview",
-              "global-synchronizer/production-operations/validator-upgrades",
               "global-synchronizer/production-operations/validator-major-upgrade",
               "global-synchronizer/production-operations/sv-major-upgrade",
               "global-synchronizer/production-operations/performance-optimization",


### PR DESCRIPTION
## Summary
- Fixes #422.
- Moves `Validator Upgrades` from `Global Synchronizer > Production Operations` into `Global Synchronizer > Validator Deployment`, below the validator deployment pages.

## Validation
- `python3 -m json.tool docs-main/docs.json`
- Python nav assertion confirmed the page is present under `Validator Deployment` and no longer under `Production Operations`
- `git diff --check`

## Screenshots

![PR #431 screenshot](https://raw.githubusercontent.com/canton-network/cf-docs/refs/heads/pr-assets/cf-docs-curtis-batch-screenshots/pr-assets/cf-docs-curtis-batch-screenshots/pr-431-validator-upgrades-sidebar.png)

Shows `Validator Upgrades` positioned under the Validator Deployment sidebar group.

Source: Hosted Mintlify preview.
