### PR TITLE
Rename Metrics Reference to Splice Metrics Reference

### DIFF
--- a/docs-main/global-synchronizer/reference/metrics-reference.mdx
+++ b/docs-main/global-synchronizer/reference/metrics-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Metrics Reference"
+title: "Splice Metrics Reference"
 description: "Reference for monitoring metrics exposed by Canton Network validator and super validator nodes"
 ---
 


### PR DESCRIPTION
## Summary
- Fixes #426.
- Renames `docs-main/global-synchronizer/reference/metrics-reference.mdx` from `Metrics Reference` to `Splice Metrics Reference`, which controls the rendered/sidebar page title.

## Validation
- `git diff --check`
- Confirmed the frontmatter title is `Splice Metrics Reference`

## Screenshots

![PR #432 screenshot](https://raw.githubusercontent.com/canton-network/cf-docs/refs/heads/pr-assets/cf-docs-curtis-batch-screenshots/pr-assets/cf-docs-curtis-batch-screenshots/pr-432-splice-metrics-reference-title.png)

Shows the page title changed to `Splice Metrics Reference`.

Source: Hosted Mintlify preview.
