### PR TITLE
Remove internal note from Topology page

### DIFF
--- a/docs-main/overview/reference/topology.mdx
+++ b/docs-main/overview/reference/topology.mdx
@@ -13,12 +13,6 @@ Reviewers: Skip this section. Remove markers after final approval.
 
 # Topology management
 
-<Note>
-- Replace with [https://docs.google.com/document/d/1z2yNEUdVQ7bt8wDjPWrXaEh6XnkNvta7uumrQdnq33Q/edit?tab=t.0#heading=h.j1o9vy5fqmrz](https://docs.google.com/document/d/1z2yNEUdVQ7bt8wDjPWrXaEh6XnkNvta7uumrQdnq33Q/edit?tab=t.0#heading=h.j1o9vy5fqmrz)
-- Merge in some ideas from [https://www.canton.network/hubfs/Canton%20Network%20Files/whitepapers/Polyglot_Canton_Whitepaper_11_02_25.pdf](https://www.canton.network/hubfs/Canton%20Network%20Files/whitepapers/Polyglot_Canton_Whitepaper_11_02_25.pdf) (topology ledger)
-- Decentralization is out of scope here and will be dealt with in a separate section
-</Note>
-
 All Participant Nodes and Synchronizer components must know the topology state of a Synchronizer, which includes all identities on the Synchronizer and their associated keys. The two-phase commit protocol on a Synchronizer can therefore assume that identities and keys are common knowledge and thus omit to include such information in the protocol messages. Updates to the topology state are distributed via the Synchronizer so that nodes maintain the synchronized topology state via state machine replication.
 
 The mechanism that establishes this shared understanding in a Synchronizer is referred to as *topology management*. Each Canton node (Participant Nodes and Synchronizer components) locally replicates a deterministic state machine to validate changes to the topology state. This means that each Canton node independently determines which topology changes are properly authorized according to the authorization rules. The deterministic nature of the state machine causes all Canton nodes connected to a Synchronizer to compute the same conclusion about the topology state of that Synchronizer at any given time.


### PR DESCRIPTION
## Summary
- Fixes #404.
- Removes the rendered internal planning note from the Topology page, including the Google Doc link and whitepaper TODO text shown in the issue screenshot.

## Validation
- `git diff --check`
- Confirmed `docs.google.com` and `Polyglot_Canton_Whitepaper` no longer appear in `docs-main/overview/reference/topology.mdx`

## Screenshots

![PR #433 screenshot](https://raw.githubusercontent.com/canton-network/cf-docs/refs/heads/pr-assets/cf-docs-curtis-batch-screenshots/pr-assets/cf-docs-curtis-batch-screenshots/pr-433-topology-internal-note-removed.png)

Shows the Topology page opening without the DA-internal note at the top.

Source: Validated local fallback preview.
