### PR TITLE
Add Common Issues FAQ card to troubleshooting

### DIFF
--- a/docs-main/appdev/troubleshooting.mdx
+++ b/docs-main/appdev/troubleshooting.mdx
@@ -19,6 +19,10 @@ For detailed troubleshooting steps, see the topic guides below. For diagnostic a
   Traffic exhaustion, upgrade problems, PQS failures on DevNet, TestNet, and MainNet.
 </Card>
 
+<Card title="Common Issues FAQ" icon="circle-question" href="/appdev/faq">
+  Frequently encountered app development and validator operation issues with short answers and next steps.
+</Card>
+
 <Card title="Common Questions" icon="circle-question" href="/appdev/troubleshooting-guide/common-questions">
   Frequently asked questions about Canton Network application development.
 </Card>


### PR DESCRIPTION
## Summary
- Fixes #411.
- Adds a `Common Issues FAQ` card to the Troubleshooting Cheat Sheet card grid, linking to `/appdev/faq`.

## Validation
- `git diff --check`
- Confirmed the troubleshooting page now contains a `Common Issues FAQ` card with `href="/appdev/faq"`

## Screenshots

![PR #434 screenshot](https://raw.githubusercontent.com/canton-network/cf-docs/refs/heads/pr-assets/cf-docs-curtis-batch-screenshots/pr-assets/cf-docs-curtis-batch-screenshots/pr-434-common-issues-card.png)

Shows the `Common Issues FAQ` card in the Troubleshooting Cheat Sheet grid.

Source: Validated local fallback preview.
