### PR TITLE
Fix malformed Super Validator Helm code examples

### DIFF
--- a/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
+++ b/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
@@ -62,26 +62,30 @@ export SERIAL_ID=0
 
 SV operators are identified by a human-readable name and an EC public key. This identification is stable across deployments of the Global Synchronizer. You are, for example, expected to reuse your SV name and public key between (test-)network resets.
 
-Use the following shell commands to generate a keypair in the format expected by the SV node software: :
+Use the following shell commands to generate a keypair in the format expected by the SV node software:
 
-    # Generate the keypair
-    openssl ecparam -name prime256v1 -genkey -noout -out sv-keys.pem
+```bash
+# Generate the keypair
+openssl ecparam -name prime256v1 -genkey -noout -out sv-keys.pem
 
-    # Encode the keys
-    public_key_base64=$(openssl ec -in sv-keys.pem -pubout -outform DER 2>/dev/null | base64 | tr -d "\n")
-    private_key_base64=$(openssl pkcs8 -topk8 -nocrypt -in sv-keys.pem -outform DER 2>/dev/null | base64 | tr -d "\n")
+# Encode the keys
+public_key_base64=$(openssl ec -in sv-keys.pem -pubout -outform DER 2>/dev/null | base64 | tr -d "\n")
+private_key_base64=$(openssl pkcs8 -topk8 -nocrypt -in sv-keys.pem -outform DER 2>/dev/null | base64 | tr -d "\n")
 
-    # Output the keys
-    echo "public-key = \"$public_key_base64\""
-    echo "private-key = \"$private_key_base64\""
+# Output the keys
+echo "public-key = \"$public_key_base64\""
+echo "private-key = \"$private_key_base64\""
 
-    # Clean up
-    rm sv-keys.pem
+# Clean up
+rm sv-keys.pem
+```
 
-These commands should result in an output similar to :
+These commands should result in an output similar to:
 
-    public-key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1eb+JkH2QFRCZedO/P5cq5d2+yfdwP+jE+9w3cT6BqfHxCd/PyA0mmWMePovShmf97HlUajFuN05kZgxvjcPQw=="
-    private-key = "MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCBsFuFa7Eumkdg4dcf/vxIXgAje2ULVz+qTKP3s/tHqKw=="
+```text
+public-key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1eb+JkH2QFRCZedO/P5cq5d2+yfdwP+jE+9w3cT6BqfHxCd/PyA0mmWMePovShmf97HlUajFuN05kZgxvjcPQw=="
+private-key = "MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCBsFuFa7Eumkdg4dcf/vxIXgAje2ULVz+qTKP3s/tHqKw=="
+```
 
 Store both keys in a safe location. You will be using them every time you want to deploy a new SV node, i.e., also when deploying an SV node to a different deployment of the Global Synchronizer and for redeploying an SV node after a (test-)network reset.
 
@@ -261,10 +265,12 @@ docker run --rm -v "$(pwd):/init" /cometbft:0.6.3 show-node-id --home /init
 
 Please keep a note of the node ID printed out above.
 
-In addition, please retain some of the configuration files generated, as follows (you might need to change the permissions/ownership for them as they are accessible only by the root user): :
+In addition, please retain some of the configuration files generated, as follows (you might need to change the permissions/ownership for them as they are accessible only by the root user):
 
-    cometbft/config/node_key.json
-    cometbft/config/priv_validator_key.json
+```text
+cometbft/config/node_key.json
+cometbft/config/priv_validator_key.json
+```
 
 Any other files can be ignored.
 


### PR DESCRIPTION
## Summary
- Fixes #416.
- Converts the malformed indented SV identity examples into fenced `bash` / `text` code blocks.
- Converts the CometBFT generated-file list into a fenced `text` block.
- Removes the stray RST `: :` artifacts from the affected file.

## Validation
- `git diff --check`
- `rg ': :' docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx` returns no matches

## Screenshots

![PR #435 screenshot](https://raw.githubusercontent.com/canton-network/cf-docs/refs/heads/pr-assets/cf-docs-curtis-batch-screenshots/pr-assets/cf-docs-curtis-batch-screenshots/pr-435-sv-helm-code-blocks.png)

Shows the Super Validator Helm key-generation commands rendered as a proper fenced code block.

Source: Validated local fallback preview.
