### PR TITLE
Replace app/API docs.digitalasset.com links

### DIFF
--- a/docs-main/appdev/deep-dives/token-standard.mdx
+++ b/docs-main/appdev/deep-dives/token-standard.mdx
@@ -62,7 +62,7 @@ We recommend to use the `MergeDelegation` contracts in a batched fashion as foll
 
 3.  Run a background process that regularly performs the following steps:
 
-    > 1.  Determines all users that have more than 10 `Holding` UTXOs. For example, using the DB provided by the [Participant Query Store](https://docs.digitalasset.com/build/3.4/sdlc-howtos/applications/develop/pqs/index.html); or by reading the Holding contracts directly from the Ledger API of your validator node. The former being the more scalable option.
+    > 1.  Determines all users that have more than 10 `Holding` UTXOs. For example, using the DB provided by the [Participant Query Store](/appdev/deep-dives/query-with-pqs); or by reading the Holding contracts directly from the Ledger API of your validator node. The former being the more scalable option.
     >
     > 2.  Constructs the transfer choices to merge the extra `Holding` contracts by querying the registry API as explained in `token_standard_usage_executing_factory_choice`.
     >
@@ -99,13 +99,13 @@ This section provides wallet developers with guidance on how to integrate with t
 > - `token_standard_usage_executing_nonfactory_choice`
 > - `token_standard_usage_custom_daml_code`
 
-These integrations patterns have recently been nicely packaged in the wallet SDK maintained as part of [canton-network/splice-wallet-kernel](https://github.com/canton-network/splice-wallet-kernel/tree/main/sdk/wallet-sdk) and [documented here](https://docs.digitalasset.com/integrate/devnet/index.html).
+These integrations patterns have recently been nicely packaged in the wallet SDK maintained as part of [canton-network/splice-wallet-kernel](https://github.com/canton-network/splice-wallet-kernel/tree/main/sdk/wallet-sdk) and [documented here](/integrations/wallet/guidance).
 
 All of these integration patterns are also demonstrated in the form of executable code as part of the [experimental command-line interface](https://github.com/canton-network/splice/tree/main/token-standard#cli) for token standard assets. The sections below explaining the patterns below thus all start with a link to the code. They then provide additional context for an implementor.
 
 All interaction works via the JSON Ledger API (see its [OpenAPI definition here](https://github.com/digital-asset/canton/blob/f608ec2cbb7b3e9331b7cc564eb260916606d815/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi.yaml#L1#L1)). This OpenAPI definition is also accessible at `http(s)://${YOUR_PARTICIPANT}/docs/openapi`. We encourage developers to use OpenAPI code generation tools as opposed to manually writing HTTP requests.
 
-Check out the [Authentication docs](https://docs.digitalasset.com/operate/3.4/howtos/secure/apis/jwt.html) for more information on how to authenticate the requests.
+Check out the [Authentication docs](/global-synchronizer/reference/security-configuration#configure-api-authentication-and-authorization-with-jwt) for more information on how to authenticate the requests.
 
 ### Reading contracts implementing a Token Standard interface for a party
 

--- a/docs-main/appdev/deep-dives/token-standard.mdx
+++ b/docs-main/appdev/deep-dives/token-standard.mdx
@@ -368,3 +368,5 @@ This allows implementation of [Delivery versus Payment (DVP) Transfer Workflows]
 
 
 {/* COPIED_END */}
+
+{/* Mintlify preview rebuild marker. */}

--- a/docs-main/appdev/faq.mdx
+++ b/docs-main/appdev/faq.mdx
@@ -672,7 +672,7 @@ If a course doesn't mention Canton Network or Daml 3.x, or covers only Daml 2.x 
 **Recommended resources:**
 
 1. **Official Documentation:**
-   - [Build Documentation](https://docs.digitalasset.com/build/3.4)
+   - [Build Documentation](/appdev/get-started/choose-your-path)
    - [Operator Documentation](https://docs.sync.global)
 
 2. **Hands-on:**

--- a/docs-main/global-synchronizer/canton-console/console-overview.mdx
+++ b/docs-main/global-synchronizer/canton-console/console-overview.mdx
@@ -40,7 +40,7 @@ Welcome to Canton!
 
 ## Participant console
 
-1.  Obtain an authentication token as specified in [the Canton authentication docs](https://docs.digitalasset.com/operate/3.4/howtos/secure/apis/jwt.html)
+1.  Obtain an authentication token as specified in [the Canton authentication docs](/global-synchronizer/reference/security-configuration#configure-api-authentication-and-authorization-with-jwt)
 
 2.  Ensure you can access the participant's ports 5001 and 5002
 

--- a/docs-main/global-synchronizer/faq.mdx
+++ b/docs-main/global-synchronizer/faq.mdx
@@ -139,9 +139,9 @@ How can I fetch more than 200 entries for ACS through the JSON API?
 >
 > Then you can add an extra limit on query `(?limit=xyz)` to the request but the result will never exceed server limit.
 >
-> One alternative is the use the [websockets APIs](https://docs.digitalasset.com/build/3.4/reference/json-api/asyncapi.html) which don't have a hard limit.
+> One alternative is the use the [websockets APIs](/reference/json-api-asyncapi-reference) which don't have a hard limit.
 >
-> Another alternative is to use the [PQS](https://docs.digitalasset.com/build/3.4/sdlc-howtos/applications/develop/pqs/index.html) which can simplify debugging via [Daml Shell](https://docs.digitalasset.com/build/3.4/sdlc-howtos/applications/develop/debug/daml-shell/index.html#contract-summaries).
+> Another alternative is to use the [PQS](/appdev/deep-dives/query-with-pqs) which can simplify debugging via [Daml Shell](/sdks-tools/cli-tools/daml-shell#contract-summaries).
 
 How can I create a transaction with more than one root node?
 
@@ -167,7 +167,7 @@ How do I find the specifications for the latest API version for a Dev/Test/MainN
 > >   - Go to the open source [Canton Git repo](https://github.com/digital-asset/canton).
 > >   - Pick the appropriate release line by selecting the drop down that says `main` to expose the different branches that are available. Then select the release line that has the same version found above. In this example, the release line to select is `release-line-3.3`.
 > >   - This is the most up to date code for that release line. So follow the path `/canton/tree/main/community/ledger/ledger-json-api/src/test/resources/json-api-docs` to the `openapi.yaml` and `asyncapi.yaml` files.
-> > - Another source for the JSON API's specifications is to retrieve them from a running Canton participant node. A description of this is in the [Verification - download OpenAPI](https://docs.digitalasset.com/build/3.4/tutorials/json-api/canton_and_the_json_ledger_api.html#verification-download-openapi) section. The specifications are available as:
+> > - Another source for the JSON API's specifications is to retrieve them from a running Canton participant node. A description of this is in the [Verification - download OpenAPI](/sdks-tools/api-reference/json-api#configuration) section. The specifications are available as:
 > >   - For OpenAPI: `http://<host>:<port>/docs/openapi`
 > >   - For AsyncAPI: `http://<host>:<port>/docs/asyncapi`
 > > - For the GRPC protobuf definitions, follow the same steps as above but change the last step to be:
@@ -195,7 +195,7 @@ What would be the best practice to including the `DAR` file of token standard in
 
 Is there any open-source wallet implementation for canton coins?
 
-> There's a wallet SDK [here](https://docs.digitalasset.com/integrate/devnet/index.html) which is under rapid development. No OSS UI yet though.
+> There's a wallet SDK [here](/integrations/wallet/guidance) which is under rapid development. No OSS UI yet though.
 
 </div>
 

--- a/docs-main/global-synchronizer/reference/canton-console-reference.mdx
+++ b/docs-main/global-synchronizer/reference/canton-console-reference.mdx
@@ -40,7 +40,7 @@ Welcome to Canton!
 
 ## Participant console
 
-1.  Obtain an authentication token as specified in [the Canton authentication docs](https://docs.digitalasset.com/operate/3.4/howtos/secure/apis/jwt.html)
+1.  Obtain an authentication token as specified in [the Canton authentication docs](/global-synchronizer/reference/security-configuration#configure-api-authentication-and-authorization-with-jwt)
 
 2.  Ensure you can access the participant's ports 5001 and 5002
 

--- a/docs-main/global-synchronizer/splice-fundamentals/rewards-minting.mdx
+++ b/docs-main/global-synchronizer/splice-fundamentals/rewards-minting.mdx
@@ -131,7 +131,7 @@ Before creating a proposal, the beneficiary must have:
 
 The `MintingDelegationProposal` contract contains a `delegation` field with the same properties as described in the Overview section above (beneficiary, delegate, expiration, and amulet merge limit), plus the DSO party ID.
 
-All interaction works via the JSON Ledger API (see its [OpenAPI definition](https://github.com/digital-asset/canton/blob/main/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi.yaml)). Check out the [Authentication docs](https://docs.digitalasset.com/operate/3.4/howtos/secure/apis/jwt.html) for more information on how to authenticate the requests.
+All interaction works via the JSON Ledger API (see its [OpenAPI definition](https://github.com/digital-asset/canton/blob/main/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi.yaml)). Check out the [Authentication docs](/global-synchronizer/reference/security-configuration#configure-api-authentication-and-authorization-with-jwt) for more information on how to authenticate the requests.
 
 To create the proposal, submit a `create` command via the Ledger API [command submission endpoint](https://github.com/digital-asset/canton/blob/main/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi.yaml#L173).
 

--- a/docs-main/sdks-tools/sdks/wallet-sdk.mdx
+++ b/docs-main/sdks-tools/sdks/wallet-sdk.mdx
@@ -83,7 +83,7 @@ Before performing any operations, you need to create a key pair and allocate an 
 
 <DamlDocsSdksToolsSdksWalletSdkL93 />
 
-The SDK generates Ed25519 key pairs by default. BIP-0039 mnemonic-based key generation is also supported for deterministic key recovery. For details on the key pair and party creation process, including topology transactions and multi-hosting, see the full [Wallet Integration Guide](https://docs.digitalasset.com/integrate/devnet/index.html).
+The SDK generates Ed25519 key pairs by default. BIP-0039 mnemonic-based key generation is also supported for deterministic key recovery. For details on the key pair and party creation process, including topology transactions and multi-hosting, see the full [Wallet Integration Guide](/integrations/wallet/guidance).
 
 ## Token operations
 
@@ -183,5 +183,5 @@ The SDK can decode prepared transactions into human-readable JSON for display to
 - [Splice Wallet Kernel GitHub repository](https://github.com/canton-network/wallet-gateway) -- source code, API specs, and example scripts
 - [Token standard documentation](https://docs.sync.global/app_dev/token_standard/index.html) -- full token standard reference
 - [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) -- Canton Network token standard specification
-- [External party signing tutorial](https://docs.digitalasset.com/build/3.5/tutorials/app-dev/external_signing_onboarding) -- step-by-step external signing walkthrough
+- [External party signing tutorial](/appdev/deep-dives/external-signing-onboarding) -- step-by-step external signing walkthrough
 - [CN Quickstart](https://github.com/digital-asset/cn-quickstart) -- reference application for getting started with Canton Network development


### PR DESCRIPTION
## Summary

- Replaces a focused batch of `docs.digitalasset.com` links with portable local docs-site URLs.
- Branch is based directly on `origin/main` and owns whole files to avoid cross-PR file conflicts.

## Mapping

| Current URL | Docs page(s) changed | Local target URL | Basis |
| --- | --- | --- | --- |
| [`https://docs.digitalasset.com/build/3.4`](<https://docs.digitalasset.com/build/3.4>) | [/appdev/faq](https://docs.canton.network/appdev/faq) | `/appdev/get-started/choose-your-path` | New App Development entry point. |
| [`https://docs.digitalasset.com/build/3.4/reference/json-api/asyncapi.html`](<https://docs.digitalasset.com/build/3.4/reference/json-api/asyncapi.html>) | [/global-synchronizer/faq](https://docs.canton.network/global-synchronizer/faq) | `/reference/json-api-asyncapi-reference` | Generated JSON API AsyncAPI reference. |
| [`https://docs.digitalasset.com/build/3.4/sdlc-howtos/applications/develop/debug/daml-shell/index.html#contract-summaries`](<https://docs.digitalasset.com/build/3.4/sdlc-howtos/applications/develop/debug/daml-shell/index.html#contract-summaries>) | [/global-synchronizer/faq](https://docs.canton.network/global-synchronizer/faq) | `/sdks-tools/cli-tools/daml-shell#contract-summaries` | Daml Shell page contains the `Contract summaries` section. |
| [`https://docs.digitalasset.com/build/3.4/sdlc-howtos/applications/develop/pqs/index.html`](<https://docs.digitalasset.com/build/3.4/sdlc-howtos/applications/develop/pqs/index.html>) | [/appdev/deep-dives/token-standard](https://docs.canton.network/appdev/deep-dives/token-standard)<br>[/global-synchronizer/faq](https://docs.canton.network/global-synchronizer/faq) | `/appdev/deep-dives/query-with-pqs` | Exact copied source: `pqs/index.rst`. |
| [`https://docs.digitalasset.com/build/3.4/tutorials/json-api/canton_and_the_json_ledger_api.html#verification-download-openapi`](<https://docs.digitalasset.com/build/3.4/tutorials/json-api/canton_and_the_json_ledger_api.html#verification-download-openapi>) | [/global-synchronizer/faq](https://docs.canton.network/global-synchronizer/faq) | `/sdks-tools/api-reference/json-api#configuration` | New JSON API page documents runtime OpenAPI/AsyncAPI specs. |
| [`https://docs.digitalasset.com/build/3.5/tutorials/app-dev/external_signing_onboarding`](<https://docs.digitalasset.com/build/3.5/tutorials/app-dev/external_signing_onboarding>) | [/sdks-tools/sdks/wallet-sdk](https://docs.canton.network/sdks-tools/sdks/wallet-sdk) | `/appdev/deep-dives/external-signing-onboarding` | Exact copied source family for external signing onboarding. |
| [`https://docs.digitalasset.com/integrate/devnet/index.html`](<https://docs.digitalasset.com/integrate/devnet/index.html>) | [/appdev/deep-dives/token-standard](https://docs.canton.network/appdev/deep-dives/token-standard)<br>[/global-synchronizer/faq](https://docs.canton.network/global-synchronizer/faq)<br>[/sdks-tools/sdks/wallet-sdk](https://docs.canton.network/sdks-tools/sdks/wallet-sdk) | `/integrations/wallet/guidance` | Wallet Integration Guide migrated into Integrations. |
| [`https://docs.digitalasset.com/operate/3.4/howtos/secure/apis/jwt.html`](<https://docs.digitalasset.com/operate/3.4/howtos/secure/apis/jwt.html>) | [/appdev/deep-dives/token-standard](https://docs.canton.network/appdev/deep-dives/token-standard)<br>[/global-synchronizer/canton-console/console-overview](https://docs.canton.network/global-synchronizer/canton-console/console-overview)<br>[/global-synchronizer/reference/canton-console-reference](https://docs.canton.network/global-synchronizer/reference/canton-console-reference)<br>[/global-synchronizer/splice-fundamentals/rewards-minting](https://docs.canton.network/global-synchronizer/splice-fundamentals/rewards-minting) | `/global-synchronizer/reference/security-configuration#configure-api-authentication-and-authorization-with-jwt` | Exact copied source: `secure/apis/jwt.rst`. |

## Verification

- `git diff --check`
