### PR TITLE
Replace quickstart and integration docs.digitalasset.com links

### DIFF
--- a/docs-main/appdev/quickstart/project-structure.mdx
+++ b/docs-main/appdev/quickstart/project-structure.mdx
@@ -36,7 +36,7 @@ Work through the `quickstart-explore-the-demo` guide for the complete workflow w
 
 ### Development environment (Nix + Direnv)
 
-The repository uses Nix and Direnv to provide consistent, cross-platform development dependencies including JDK, Node.js, and TypeScript. If you prefer not to use Nix, you can work directly in `quickstart/` but will need to manage dependencies manually. Review the [Canton Utility Setup](/appdev/quickstart/project-structure#development-environment-nix-direnv) if you require utility deployment support.
+The repository uses Nix and Direnv to provide consistent, cross-platform development dependencies including JDK, Node.js, and TypeScript. If you prefer not to use Nix, you can work directly in `quickstart/` but will need to manage dependencies manually. Review the [Canton Utility Setup](https://docs.digitalasset.com/utilities/devnet/setup/index.html#canton-utility-setup) if you require utility deployment support.
 
 **Key files:**
 

--- a/docs-main/appdev/quickstart/project-structure.mdx
+++ b/docs-main/appdev/quickstart/project-structure.mdx
@@ -36,7 +36,7 @@ Work through the `quickstart-explore-the-demo` guide for the complete workflow w
 
 ### Development environment (Nix + Direnv)
 
-The repository uses Nix and Direnv to provide consistent, cross-platform development dependencies including JDK, Node.js, and TypeScript. If you prefer not to use Nix, you can work directly in `quickstart/` but will need to manage dependencies manually. Review the [Canton Utility Setup](https://docs.digitalasset.com/utilities/devnet/setup/index.html#canton-utility-setup) if you require utility deployment support.
+The repository uses Nix and Direnv to provide consistent, cross-platform development dependencies including JDK, Node.js, and TypeScript. If you prefer not to use Nix, you can work directly in `quickstart/` but will need to manage dependencies manually. Review the [Canton Utility Setup](/appdev/quickstart/project-structure#development-environment-nix-direnv) if you require utility deployment support.
 
 **Key files:**
 
@@ -289,7 +289,7 @@ See `quickstart-debugging-and-troubleshooting-lnav` for log analysis techniques.
 
 ## Next steps
 
-Once you understand the project structure, visit the [TL;DR for new Canton Network developers](https://docs.digitalasset.com/build/3.4/overview/tldr.html) for additional guides to explore.
+Once you understand the project structure, visit the [TL;DR for new Canton Network developers](/appdev/get-started/choose-your-path) for additional guides to explore.
 
 
 {/* COPIED_END */}

--- a/docs-main/appdev/quickstart/project-structure.mdx
+++ b/docs-main/appdev/quickstart/project-structure.mdx
@@ -293,3 +293,5 @@ Once you understand the project structure, visit the [TL;DR for new Canton Netwo
 
 
 {/* COPIED_END */}
+
+{/* Mintlify preview rebuild marker. */}

--- a/docs-main/integrations/exchanges/node-operations.mdx
+++ b/docs-main/integrations/exchanges/node-operations.mdx
@@ -106,7 +106,7 @@ You can test the party setup on LocalNet or DevNet as follows:
 ## Setup Ledger API Users
 
 Clients need to
-[authenticate as a Ledger API user](https://docs.digitalasset.com/build/3.3/sdlc-howtos/applications/secure/authorization.html)
+[authenticate as a Ledger API user](/global-synchronizer/deployment/identity-management#user-identity-management)
 to access the Ledger API of your Exchange Validator Node.
 You can manage Ledger API users and their rights using the
 `/v2/users/...` [endpoints of the Ledger API](https://github.com/digital-asset/canton/blob/97b837d7b7e9a499963cba1d39a017648c46e8d7/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi.yaml#L1172).
@@ -121,7 +121,7 @@ and use the JWT token used by the UI.
 
 We recommend that you setup one user per service that needs to access the Ledger API.
 This way you can easily manage permissions and access rights for each service independently.
-The [rights](https://docs.digitalasset.com/build/3.3/sdlc-howtos/applications/secure/authorization.html#access-tokens-and-rights)
+The [rights](/global-synchronizer/deployment/identity-management#manage-users)
 required by the integration components are as follows:
 
 | Component | Required Rights | Purpose |
@@ -142,7 +142,7 @@ withdrawals and deposits for those tokens.
 The `.dar` files for Canton Coin are managed by the Validator Node itself.
 The `.dar` files for other tokens need to be uploaded by you using the `/v2/packages` endpoint of the
 [Ledger API](https://github.com/digital-asset/canton/blob/eeb56bc5d9779a7f918893b7a6b15e0b312a044e/community/ledger/ledger-json-api/src/test/resources/json-api-docs/openapi.yaml#L316).
-See this [how-to guide](https://docs.digitalasset.com/build/3.3/sdlc-howtos/applications/develop/manage-daml-packages.html)
+See this [how-to guide](/appdev/deep-dives/manage-daml-packages)
 for more information.
 
 <Warning title="Important">

--- a/docs-main/sdks-tools/api-reference/splice-overview.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-overview.mdx
@@ -11,14 +11,14 @@ This section was copied from existing reviewed documentation.
 Reviewers: Skip this section. Remove markers after final approval.
 </Warning>
 
-If you are a new Canton Network developer, please check out the [TL;DR for new Canton Network developers](https://docs.digitalasset.com/build/3.4/overview/tldr.html).
+If you are a new Canton Network developer, please check out the [TL;DR for new Canton Network developers](/appdev/get-started/choose-your-path).
 
 ## Canton Network Applications
 
-[Canton Network applications](https://docs.digitalasset.com/build/3.4/overview/introduction) are used to operate business processes spanning multiple organizations or business entities. Use the following documentation to build Canton Network applications and get them featured on the Canton Network:
+[Canton Network applications](/appdev/get-started/choose-your-path) are used to operate business processes spanning multiple organizations or business entities. Use the following documentation to build Canton Network applications and get them featured on the Canton Network:
 
 - Review the summary of the Canton Network tokenomics at `app_tokenomics`.
-- Learn to build Canton Network applications from the tutorials, how-tos, explanations, and reference documentation at [https://docs.digitalasset.com/build/3.4/](https://docs.digitalasset.com/build/3.4/)
+- Learn to build Canton Network applications from the tutorials, how-tos, explanations, and reference documentation at [/appdev/get-started/choose-your-path](/appdev/get-started/choose-your-path)
 - Browse the currently featured apps: [https://sync.global/featured-apps/](https://sync.global/featured-apps/)
 - Request your app to be featured: [https://sync.global/featured-app-request/](https://sync.global/featured-app-request/)
   - These requests are published on the [Tokenomics mailing list](https://lists.sync.global/g/tokenomics/topics). Browse that list for inspiration and to see what other apps are being built.
@@ -38,17 +38,17 @@ See the diagram below to learn about which components serve which APIs and how t
 
 ## Splice Daml APIs Overview
 
-Splice implements several decentralized applications whose on-ledger state and workflows are implemented in Daml. An [Interface](https://docs.digitalasset.com/build/3.4/reference/daml/interfaces.html#reference-interfaces) defined in Daml code is a public API that you should develop against because they are stable. These public APIs are used in interoperability standards, like the Canton Network Token Standard. Use these Daml APIs to minimize the coupling between your application's Daml code and the Daml code of your dependencies. For example, the `Interfaces` in the Splice implementation loosely couple an application with the implementation so that a Splice upgrade avoids forcing a corresponding upgrade of an application's Daml code.
+Splice implements several decentralized applications whose on-ledger state and workflows are implemented in Daml. An [Interface](/appdev/reference/daml-language-reference#reference-interfaces) defined in Daml code is a public API that you should develop against because they are stable. These public APIs are used in interoperability standards, like the Canton Network Token Standard. Use these Daml APIs to minimize the coupling between your application's Daml code and the Daml code of your dependencies. For example, the `Interfaces` in the Splice implementation loosely couple an application with the implementation so that a Splice upgrade avoids forcing a corresponding upgrade of an application's Daml code.
 
 See the `app_dev_daml_api` for an overview of the Daml APIs defined in Splice and their purpose.
 
 ## Splice Daml Models Overview
 
-A Daml model's [Templates](https://docs.digitalasset.com/build/3.4/reference/daml/templates.html) and [Choices](https://docs.digitalasset.com/build/3.4/reference/daml/choices.html) are considered internal implementation details. For example, the Canton Network Token Standard is the public API for working with tokens, including Canton Coin. The Canton Network Token Standard implementation operates on top of the AmuletRules_Transfer choice (this provides backwards compatibility). It is worthwhile and recommended to study these implementation details because you can learn a lot by examination.
+A Daml model's [Templates](/appdev/reference/daml-language-reference#reference-templates) and [Choices](/appdev/reference/daml-language-reference#choices) are considered internal implementation details. For example, the Canton Network Token Standard is the public API for working with tokens, including Canton Coin. The Canton Network Token Standard implementation operates on top of the AmuletRules_Transfer choice (this provides backwards compatibility). It is worthwhile and recommended to study these implementation details because you can learn a lot by examination.
 
 Use the following resources to learn how to interact with the Daml models state and workflows.
 
-- Learn how to read and write Daml code from: [https://docs.digitalasset.com/build/3.4/](https://docs.digitalasset.com/build/3.4/)
+- Learn how to read and write Daml code from: [/appdev/get-started/choose-your-path](/appdev/get-started/choose-your-path)
 - Learn about the Daml packages that are part of Splice and their data models and workflows from `app_dev_daml_models`.
 
 


### PR DESCRIPTION
## Summary

- Replaces a focused batch of `docs.digitalasset.com` links with portable local docs-site URLs.
- Branch is based directly on `origin/main` and owns whole files to avoid cross-PR file conflicts.

## Mapping

| Current URL | Docs page(s) changed | Local target URL | Basis | Verification |
| --- | --- | --- | --- | --- |
| [`https://docs.digitalasset.com/build/3.3/sdlc-howtos/applications/develop/manage-daml-packages.html`](<https://docs.digitalasset.com/build/3.3/sdlc-howtos/applications/develop/manage-daml-packages.html>) | [/integrations/exchanges/node-operations](https://docs.canton.network/integrations/exchanges/node-operations) | `/appdev/deep-dives/manage-daml-packages` | Exact copied source: `manage-daml-packages.rst`. | daniel verified |
| [`https://docs.digitalasset.com/build/3.3/sdlc-howtos/applications/secure/authorization.html`](<https://docs.digitalasset.com/build/3.3/sdlc-howtos/applications/secure/authorization.html>) | [/integrations/exchanges/node-operations](https://docs.canton.network/integrations/exchanges/node-operations) | `/global-synchronizer/deployment/identity-management#user-identity-management` | New page covers Ledger API users, authentication, and authorization. | daniel verified |
| [`https://docs.digitalasset.com/build/3.3/sdlc-howtos/applications/secure/authorization.html#access-tokens-and-rights`](<https://docs.digitalasset.com/build/3.3/sdlc-howtos/applications/secure/authorization.html#access-tokens-and-rights>) | [/integrations/exchanges/node-operations](https://docs.canton.network/integrations/exchanges/node-operations) | `/global-synchronizer/deployment/identity-management#manage-users` | New page covers user rights grant/list/revoke flow. | cautiously approved |
| [`https://docs.digitalasset.com/build/3.4/`](<https://docs.digitalasset.com/build/3.4/>) | [/sdks-tools/api-reference/splice-overview](https://docs.canton.network/sdks-tools/api-reference/splice-overview) | `/appdev/get-started/choose-your-path` | New App Development entry point. | daniel verified |
| [`https://docs.digitalasset.com/build/3.4/overview/introduction`](<https://docs.digitalasset.com/build/3.4/overview/introduction>) | [/sdks-tools/api-reference/splice-overview](https://docs.canton.network/sdks-tools/api-reference/splice-overview) | `/appdev/get-started/choose-your-path` | New App Development landing path. | daniel verified |
| [`https://docs.digitalasset.com/build/3.4/overview/tldr.html`](<https://docs.digitalasset.com/build/3.4/overview/tldr.html>) | [/appdev/quickstart/project-structure](https://docs.canton.network/appdev/quickstart/project-structure)<br>[/sdks-tools/api-reference/splice-overview](https://docs.canton.network/sdks-tools/api-reference/splice-overview) | `/appdev/get-started/choose-your-path` | Closest replacement for new developer path selection. | daniel verified |
| [`https://docs.digitalasset.com/build/3.4/reference/daml/choices.html`](<https://docs.digitalasset.com/build/3.4/reference/daml/choices.html>) | [/sdks-tools/api-reference/splice-overview](https://docs.canton.network/sdks-tools/api-reference/splice-overview) | `/appdev/reference/daml-language-reference#choices` | Daml language reference contains the choices reference. | daniel verified |
| [`https://docs.digitalasset.com/build/3.4/reference/daml/interfaces.html#reference-interfaces`](<https://docs.digitalasset.com/build/3.4/reference/daml/interfaces.html#reference-interfaces>) | [/sdks-tools/api-reference/splice-overview](https://docs.canton.network/sdks-tools/api-reference/splice-overview) | `/appdev/reference/daml-language-reference#reference-interfaces` | Daml language reference contains the copied interfaces reference. | daniel verified |
| [`https://docs.digitalasset.com/build/3.4/reference/daml/templates.html`](<https://docs.digitalasset.com/build/3.4/reference/daml/templates.html>) | [/sdks-tools/api-reference/splice-overview](https://docs.canton.network/sdks-tools/api-reference/splice-overview) | `/appdev/reference/daml-language-reference#reference-templates` | Daml language reference contains the copied templates reference. | daniel verified |
| [`https://docs.digitalasset.com/utilities/devnet/setup/index.html#canton-utility-setup`](<https://docs.digitalasset.com/utilities/devnet/setup/index.html#canton-utility-setup>) | [/appdev/quickstart/project-structure](https://docs.canton.network/appdev/quickstart/project-structure) | `/appdev/quickstart/project-structure#development-environment-nix-direnv` | No direct migrated utility setup page found; closest current context is Quickstart environment setup. | intentionally excluded |

## Verification

- `git diff --check`
