### PR TITLE
Replace console and tool docs.digitalasset.com links

### DIFF
--- a/docs-main/appdev/modules/m3-building-packaging.mdx
+++ b/docs-main/appdev/modules/m3-building-packaging.mdx
@@ -12,7 +12,7 @@ The application from `compose` is a complete and secure model for atomic swaps o
 1.  Upgrades, which change existing logic. For example, one might want the `Asset` template to have multiple signatories.
 2.  Extensions, which merely add new functionality through additional templates.
 
-Upgrades are covered in their own section outside this introduction to Daml: [smart contract upgrades](https://docs.digitalasset.com/build/3.4/sdk/explanations/smart-contract-upgrades),
+Upgrades are covered in their own section outside this introduction to Daml: [smart contract upgrades](/appdev/deep-dives/smart-contract-upgrade),
 so in this section we will extend the `compose` model with a simple second workflow: a multi-leg trade. In doing so, you'll learn about:
 
 - The software architecture of the Daml stack
@@ -111,7 +111,7 @@ The `MultiTrade` model has more complex control flow and data handling than prev
 
 ## Building with dpm
 
-When working on Canton Network projects, use the [`dpm`](https://docs.digitalasset.com/build/3.4/dpm/dpm.html) tool for all build operations:
+When working on Canton Network projects, use the [`dpm`](/sdks-tools/cli-tools/dpm) tool for all build operations:
 
 - `dpm build` — Compile your Daml project and produce a DAR file
 - `dpm build --all` — Build all packages in a multi-package project

--- a/docs-main/appdev/modules/m3-dev-environment.mdx
+++ b/docs-main/appdev/modules/m3-dev-environment.mdx
@@ -13,7 +13,7 @@ In this module, you will learn about the structure of a Daml ledger and how to w
 
 ## Prerequisites
 
-- You have installed [dpm](https://docs.digitalasset.com/build/3.4/dpm/dpm.html)
+- You have installed [dpm](/sdks-tools/cli-tools/dpm)
 
 ## Loading Example Code
 

--- a/docs-main/appdev/quickstart/index.mdx
+++ b/docs-main/appdev/quickstart/index.mdx
@@ -17,7 +17,7 @@ The QuickStart sets up a local environment (called LocalNet) with:
 - **A React frontend** for both provider and user roles
 - **A Java backend** service handling Ledger API interactions
 - **Canton Coin wallets** for traffic purchase and payment flows
-- **Log analysis** with [lnav](https://docs.digitalasset.com/build/3.4/quickstart/operate/lnav-in-cn.html) for debugging and troubleshooting
+- **Log analysis** with [lnav](/appdev/quickstart/lnav) for debugging and troubleshooting
 
 ## Pages in this section
 

--- a/docs-main/appdev/quickstart/prerequisites.mdx
+++ b/docs-main/appdev/quickstart/prerequisites.mdx
@@ -19,7 +19,7 @@ This guide walks through the installation and `LocalNet` deployment of the CN Qu
 
 - After installation, [explore the demo](/appdev/quickstart/running-the-demo) to complete a business operation in the example application.
 - For an overview of how the Quickstart project is structured, read the [project structure guide](/appdev/quickstart/project-structure).
-- Learn about debugging using lnav in the [Debugging and troubleshooting with lnav](https://docs.digitalasset.com/build/3.4/quickstart/operate/lnav-in-cn.html).
+- Learn about debugging using lnav in the [Debugging and troubleshooting with lnav](/appdev/quickstart/lnav).
 -  Additional debugging information is in the section in the observability and troubleshooting section of the [cn-quickstart repository](https://github.com/digital-asset/cn-quickstart).
 
 ## Prerequisites

--- a/docs-main/appdev/tooling/ide-setup.mdx
+++ b/docs-main/appdev/tooling/ide-setup.mdx
@@ -16,7 +16,7 @@ Daml Studio is the primary IDE for writing Daml smart contracts. It is a VS Code
 ### Installation
 
 1. Install [VS Code](https://code.visualstudio.com/) version 1.87 or later
-2. Install [DPM](https://docs.digitalasset.com/build/3.4/dpm/dpm.html) if you have not already
+2. Install [DPM](/sdks-tools/cli-tools/dpm) if you have not already
 3. From your project directory, run:
 
 <DamlDocsAppdevToolingIdeSetupL18 />

--- a/docs-main/global-synchronizer/reference/canton-console-commands.mdx
+++ b/docs-main/global-synchronizer/reference/canton-console-commands.mdx
@@ -1893,7 +1893,7 @@ synchronizers.modify
 
 - **Arguments**:
   - `synchronizerAlias`: com.digitalasset.canton.SynchronizerAlias
-  - `modifier`: [com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig =\> com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/participant/synchronizer/SynchronizerConnectionConfig.html)
+  - `modifier`: [com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig =\> com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig](/reference/scala/com-digitalasset-canton-participant-synchronizer#type-com-digitalasset-canton-participant-synchronizer-synchronizerconnectionconfig)
   - `validation`: com.digitalasset.canton.sequencing.SequencerConnectionValidation
   - `physicalSynchronizerId`: Option\[com.digitalasset.canton.topology.PhysicalSynchronizerId\]
 
@@ -3895,7 +3895,7 @@ ledger_api.users.update
 
 - **Arguments**:
   - `id`: String
-  - `modifier`: [com.digitalasset.canton.admin.api.client.data.User =\> com.digitalasset.canton.admin.api.client.data.User](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/User.html)
+  - `modifier`: [com.digitalasset.canton.admin.api.client.data.User =\> com.digitalasset.canton.admin.api.client.data.User](/reference/scala/com-digitalasset-canton-admin-api-client-data#type-com-digitalasset-canton-admin-api-client-data-user)
   - `identityProviderId`: String
 
 - **Return type**:
@@ -4253,7 +4253,7 @@ ledger_api.parties.update
 
 - **Arguments**:
   - `party`: com.digitalasset.canton.topology.Party
-  - `modifier`: [com.digitalasset.canton.admin.api.client.data.parties.PartyDetails =\> com.digitalasset.canton.admin.api.client.data.parties.PartyDetails](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/parties/PartyDetails.html)
+  - `modifier`: [com.digitalasset.canton.admin.api.client.data.parties.PartyDetails =\> com.digitalasset.canton.admin.api.client.data.parties.PartyDetails](/reference/scala/com-digitalasset-canton-admin-api-client-data-parties#type-com-digitalasset-canton-admin-api-client-data-parties-partydetails)
   - `identityProviderId`: String
 
 - **Return type**:
@@ -7737,7 +7737,7 @@ topology.synchronizer_parameters.propose_update
 
 - **Arguments**:
   - `synchronizerId`: com.digitalasset.canton.topology.SynchronizerId
-  - `update`: [com.digitalasset.canton.admin.api.client.data.DynamicSynchronizerParameters =\> com.digitalasset.canton.admin.api.client.data.DynamicSynchronizerParameters](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/DynamicSynchronizerParameters.html)
+  - `update`: [com.digitalasset.canton.admin.api.client.data.DynamicSynchronizerParameters =\> com.digitalasset.canton.admin.api.client.data.DynamicSynchronizerParameters](/reference/scala/com-digitalasset-canton-admin-api-client-data#type-com-digitalasset-canton-admin-api-client-data-dynamicsynchronizerparameters)
   - `mustFullyAuthorize`: Boolean
   - `signedBy`: Option\[com.digitalasset.canton.crypto.Fingerprint\]
   - `synchronize`: Option\[com.digitalasset.canton.config.NonNegativeDuration\]
@@ -11669,7 +11669,7 @@ sequencer_connection.modify
 - **Summary**: Modify Default Sequencer Connection
 
 - **Arguments**:
-  - `modifier`: [com.digitalasset.canton.sequencing.SequencerConnection =\> com.digitalasset.canton.sequencing.SequencerConnection](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/sequencing/SequencerConnection.html)
+  - `modifier`: [com.digitalasset.canton.sequencing.SequencerConnection =\> com.digitalasset.canton.sequencing.SequencerConnection](/reference/scala/com-digitalasset-canton-sequencing#type-com-digitalasset-canton-sequencing-sequencerconnection)
 
 - **Description**:
 
@@ -11685,7 +11685,7 @@ sequencer_connection.modify_connections
 - **Summary**: Modify Sequencer Connections
 
 - **Arguments**:
-  - `modifier`: [com.digitalasset.canton.sequencing.SequencerConnections =\> com.digitalasset.canton.sequencing.SequencerConnections](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/sequencing/SequencerConnections.html)
+  - `modifier`: [com.digitalasset.canton.sequencing.SequencerConnections =\> com.digitalasset.canton.sequencing.SequencerConnections](/reference/scala/com-digitalasset-canton-sequencing#type-com-digitalasset-canton-sequencing-sequencerconnections)
   - `validation`: com.digitalasset.canton.sequencing.SequencerConnectionValidation
 
 - **Description**:

--- a/docs-main/global-synchronizer/reference/canton-console-commands.mdx
+++ b/docs-main/global-synchronizer/reference/canton-console-commands.mdx
@@ -1893,7 +1893,7 @@ synchronizers.modify
 
 - **Arguments**:
   - `synchronizerAlias`: com.digitalasset.canton.SynchronizerAlias
-  - `modifier`: [com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig =\> com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig](/reference/scala/com-digitalasset-canton-participant-synchronizer#type-com-digitalasset-canton-participant-synchronizer-synchronizerconnectionconfig)
+  - `modifier`: [com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig =\> com.digitalasset.canton.participant.synchronizer.SynchronizerConnectionConfig](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/participant/synchronizer/SynchronizerConnectionConfig.html)
   - `validation`: com.digitalasset.canton.sequencing.SequencerConnectionValidation
   - `physicalSynchronizerId`: Option\[com.digitalasset.canton.topology.PhysicalSynchronizerId\]
 
@@ -3895,7 +3895,7 @@ ledger_api.users.update
 
 - **Arguments**:
   - `id`: String
-  - `modifier`: [com.digitalasset.canton.admin.api.client.data.User =\> com.digitalasset.canton.admin.api.client.data.User](/reference/scala/com-digitalasset-canton-admin-api-client-data#type-com-digitalasset-canton-admin-api-client-data-user)
+  - `modifier`: [com.digitalasset.canton.admin.api.client.data.User =\> com.digitalasset.canton.admin.api.client.data.User](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/User.html)
   - `identityProviderId`: String
 
 - **Return type**:
@@ -4253,7 +4253,7 @@ ledger_api.parties.update
 
 - **Arguments**:
   - `party`: com.digitalasset.canton.topology.Party
-  - `modifier`: [com.digitalasset.canton.admin.api.client.data.parties.PartyDetails =\> com.digitalasset.canton.admin.api.client.data.parties.PartyDetails](/reference/scala/com-digitalasset-canton-admin-api-client-data-parties#type-com-digitalasset-canton-admin-api-client-data-parties-partydetails)
+  - `modifier`: [com.digitalasset.canton.admin.api.client.data.parties.PartyDetails =\> com.digitalasset.canton.admin.api.client.data.parties.PartyDetails](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/parties/PartyDetails.html)
   - `identityProviderId`: String
 
 - **Return type**:
@@ -7737,7 +7737,7 @@ topology.synchronizer_parameters.propose_update
 
 - **Arguments**:
   - `synchronizerId`: com.digitalasset.canton.topology.SynchronizerId
-  - `update`: [com.digitalasset.canton.admin.api.client.data.DynamicSynchronizerParameters =\> com.digitalasset.canton.admin.api.client.data.DynamicSynchronizerParameters](/reference/scala/com-digitalasset-canton-admin-api-client-data#type-com-digitalasset-canton-admin-api-client-data-dynamicsynchronizerparameters)
+  - `update`: [com.digitalasset.canton.admin.api.client.data.DynamicSynchronizerParameters =\> com.digitalasset.canton.admin.api.client.data.DynamicSynchronizerParameters](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/DynamicSynchronizerParameters.html)
   - `mustFullyAuthorize`: Boolean
   - `signedBy`: Option\[com.digitalasset.canton.crypto.Fingerprint\]
   - `synchronize`: Option\[com.digitalasset.canton.config.NonNegativeDuration\]
@@ -11669,7 +11669,7 @@ sequencer_connection.modify
 - **Summary**: Modify Default Sequencer Connection
 
 - **Arguments**:
-  - `modifier`: [com.digitalasset.canton.sequencing.SequencerConnection =\> com.digitalasset.canton.sequencing.SequencerConnection](/reference/scala/com-digitalasset-canton-sequencing#type-com-digitalasset-canton-sequencing-sequencerconnection)
+  - `modifier`: [com.digitalasset.canton.sequencing.SequencerConnection =\> com.digitalasset.canton.sequencing.SequencerConnection](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/sequencing/SequencerConnection.html)
 
 - **Description**:
 
@@ -11685,7 +11685,7 @@ sequencer_connection.modify_connections
 - **Summary**: Modify Sequencer Connections
 
 - **Arguments**:
-  - `modifier`: [com.digitalasset.canton.sequencing.SequencerConnections =\> com.digitalasset.canton.sequencing.SequencerConnections](/reference/scala/com-digitalasset-canton-sequencing#type-com-digitalasset-canton-sequencing-sequencerconnections)
+  - `modifier`: [com.digitalasset.canton.sequencing.SequencerConnections =\> com.digitalasset.canton.sequencing.SequencerConnections](https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/sequencing/SequencerConnections.html)
   - `validation`: com.digitalasset.canton.sequencing.SequencerConnectionValidation
 
 - **Description**:

--- a/docs-main/global-synchronizer/understand/installing-daml-sdk.mdx
+++ b/docs-main/global-synchronizer/understand/installing-daml-sdk.mdx
@@ -27,7 +27,7 @@ Follow these steps to install a recent, compatible OSS Daml SDK version:
     curl -sSL https://get.digitalasset.com/ | sh
     ```
 
-For more information about installing the Daml SDK, see the [DPM installation guide](https://docs.digitalasset.com/build/3.4/dpm/dpm.html?).
+For more information about installing the Daml SDK, see the [DPM installation guide](/sdks-tools/cli-tools/dpm).
 
 
 {/* COPIED_END */}

--- a/docs-main/snippets/external/splice-wallet-kernel/main/docs/wallet-integration-guide/examples/bash/sign-transaction-hash.mdx
+++ b/docs-main/snippets/external/splice-wallet-kernel/main/docs/wallet-integration-guide/examples/bash/sign-transaction-hash.mdx
@@ -1,7 +1,7 @@
 ```bash
   # In this example the hash is signed using openssl and "PREPARE_TRANSACTION_RESPONSE.json" is the JSON output from the prepare 
   # transaction step is here. "PRIVATE_KEY_FILE" should be the private key of the namespace of the external party. For more information
-  # on the openssl commands to generate the key see here: https://docs.digitalasset.com/build/3.3/tutorials/app-dev/external_signing_topology_transaction.html#signing-keys
+  # on the openssl commands to generate the key see here: /appdev/deep-dives/external-signing-topology#1-signing-keys
 
   TRANSACTION_HASH=$(cat create_ping_prepare_response.json | jq -r .prepared_transaction_hash)
   PREPARED_TRANSACTION=$(cat create_ping_prepare_response.json | jq -r .prepared_transaction)


### PR DESCRIPTION
## Summary

- Replaces a focused batch of `docs.digitalasset.com` links with portable local docs-site URLs.
- Branch is based directly on `origin/main` and owns whole files to avoid cross-PR file conflicts.

## Mapping

| Current URL | Docs page(s) changed | Local target URL | Basis | Verification |
| --- | --- | --- | --- | --- |
| [`https://docs.digitalasset.com/build/3.3/tutorials/app-dev/external_signing_topology_transaction.html#signing-keys`](<https://docs.digitalasset.com/build/3.3/tutorials/app-dev/external_signing_topology_transaction.html#signing-keys>) | [/integrations/wallet/guidance](https://docs.canton.network/integrations/wallet/guidance) | `/appdev/deep-dives/external-signing-topology#1-signing-keys` | Exact copied source: `external_signing_topology_transaction.rst`. | daniel verified |
| [`https://docs.digitalasset.com/build/3.4/dpm/dpm.html`](<https://docs.digitalasset.com/build/3.4/dpm/dpm.html>) | [/appdev/modules/m3-building-packaging](https://docs.canton.network/appdev/modules/m3-building-packaging)<br>[/appdev/modules/m3-dev-environment](https://docs.canton.network/appdev/modules/m3-dev-environment)<br>[/appdev/tooling/ide-setup](https://docs.canton.network/appdev/tooling/ide-setup) | `/sdks-tools/cli-tools/dpm` | DPM command reference and install notes. | daniel verified |
| [`https://docs.digitalasset.com/build/3.4/dpm/dpm.html?`](<https://docs.digitalasset.com/build/3.4/dpm/dpm.html?>) | [/global-synchronizer/understand/installing-daml-sdk](https://docs.canton.network/global-synchronizer/understand/installing-daml-sdk) | `/sdks-tools/cli-tools/dpm` | Same target; source URL includes a stray `?`. | daniel verified |
| [`https://docs.digitalasset.com/build/3.4/quickstart/operate/lnav-in-cn.html`](<https://docs.digitalasset.com/build/3.4/quickstart/operate/lnav-in-cn.html>) | [/appdev/quickstart](https://docs.canton.network/appdev/quickstart)<br>[/appdev/quickstart/prerequisites](https://docs.canton.network/appdev/quickstart/prerequisites) | `/appdev/quickstart/lnav` | Exact copied source: `lnav-in-cn.rst`. | daniel verified |
| [`https://docs.digitalasset.com/build/3.4/sdk/explanations/smart-contract-upgrades`](<https://docs.digitalasset.com/build/3.4/sdk/explanations/smart-contract-upgrades>) | [/appdev/modules/m3-building-packaging](https://docs.canton.network/appdev/modules/m3-building-packaging) | `/appdev/deep-dives/smart-contract-upgrade` | Exact copied source: `smart-contract-upgrades.rst`. | daniel verified |
| [`https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/DynamicSynchronizerParameters.html`](<https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/DynamicSynchronizerParameters.html>) | [/global-synchronizer/reference/canton-console-commands](https://docs.canton.network/global-synchronizer/reference/canton-console-commands) | _Not replaced_ | Excluded: current docs site has no equivalent Scala reference page; proposed Scala target returned 404. | intentionally excluded - @hrischuk-da attention needed |
| [`https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/User.html`](<https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/User.html>) | [/global-synchronizer/reference/canton-console-commands](https://docs.canton.network/global-synchronizer/reference/canton-console-commands) | _Not replaced_ | Excluded: current docs site has no equivalent Scala reference page; proposed Scala target returned 404. | intentionally excluded - @hrischuk-da attention needed |
| [`https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/parties/PartyDetails.html`](<https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/admin/api/client/data/parties/PartyDetails.html>) | [/global-synchronizer/reference/canton-console-commands](https://docs.canton.network/global-synchronizer/reference/canton-console-commands) | _Not replaced_ | Excluded: current docs site has no equivalent Scala reference page; proposed Scala target returned 404. | intentionally excluded - @hrischuk-da attention needed |
| [`https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/participant/synchronizer/SynchronizerConnectionConfig.html`](<https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/participant/synchronizer/SynchronizerConnectionConfig.html>) | [/global-synchronizer/reference/canton-console-commands](https://docs.canton.network/global-synchronizer/reference/canton-console-commands) | _Not replaced_ | Excluded: current docs site has no equivalent Scala reference page; proposed Scala target returned 404. | intentionally excluded - @hrischuk-da attention needed |
| [`https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/sequencing/SequencerConnection.html`](<https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/sequencing/SequencerConnection.html>) | [/global-synchronizer/reference/canton-console-commands](https://docs.canton.network/global-synchronizer/reference/canton-console-commands) | _Not replaced_ | Excluded: current docs site has no equivalent Scala reference page; proposed Scala target returned 404. | intentionally excluded - @hrischuk-da attention needed |
| [`https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/sequencing/SequencerConnections.html`](<https://docs.digitalasset.com/operate/3.4/scaladoc/com/digitalasset/canton/sequencing/SequencerConnections.html>) | [/global-synchronizer/reference/canton-console-commands](https://docs.canton.network/global-synchronizer/reference/canton-console-commands) | _Not replaced_ | Excluded: current docs site has no equivalent Scala reference page; proposed Scala target returned 404. | intentionally excluded - @hrischuk-da attention needed |

## Verification

- `git diff --check`
