### PR TITLE
Replace Daml reference docs.digitalasset.com links

### DIFF
--- a/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
@@ -177,3 +177,5 @@ Fail with a failure status in a pure context
 - `instance ActionFail Update`
 
 - `instance CanAbort Update`
+
+{/* Mintlify preview rebuild marker. */}

--- a/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
@@ -33,7 +33,7 @@ Deprecated since: `-`
 
 The category of the failure, which determines the status code and log
 level of the failure. Maps 1-1 to the Canton error categories documented
-here: https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory
+here: /global-synchronizer/reference/error-codes#error-categories-inventory
 
 If you are more familiar with gRPC error codes, you can use the synonyms referenced in the
 comments.
@@ -47,7 +47,7 @@ and should thus not be retried.
 
 Corresponds to the gRPC status code `INVALID_ARGUMENT`.
 
-See https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#invalidindependentofsystemstate
+See /global-synchronizer/reference/error-codes#error-categories-inventory
 for more information.
 <span id="constr-da-internal-fail-types-invalidgivencurrentsystemstateother-6547"></span>
 - `InvalidGivenCurrentSystemStateOther`
@@ -57,7 +57,7 @@ requests after reading updated state from the ledger.
 
 Corresponds to the gRPC status code `FAILED_PRECONDITION`.
 
-See https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory
+See /global-synchronizer/reference/error-codes#error-categories-inventory
 for more information.
 
 Instances:

--- a/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
@@ -33,7 +33,7 @@ Deprecated since: `-`
 
 The category of the failure, which determines the status code and log
 level of the failure. Maps 1-1 to the Canton error categories documented
-here: /global-synchronizer/reference/error-codes#error-categories-inventory
+here: https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
 
 If you are more familiar with gRPC error codes, you can use the synonyms referenced in the
 comments.
@@ -47,7 +47,7 @@ and should thus not be retried.
 
 Corresponds to the gRPC status code `INVALID_ARGUMENT`.
 
-See /global-synchronizer/reference/error-codes#error-categories-inventory
+See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
 for more information.
 <span id="constr-da-internal-fail-types-invalidgivencurrentsystemstateother-6547"></span>
 - `InvalidGivenCurrentSystemStateOther`
@@ -57,7 +57,7 @@ requests after reading updated state from the ledger.
 
 Corresponds to the gRPC status code `FAILED_PRECONDITION`.
 
-See /global-synchronizer/reference/error-codes#error-categories-inventory
+See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
 for more information.
 
 Instances:

--- a/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-fail.mdx
@@ -33,7 +33,7 @@ Deprecated since: `-`
 
 The category of the failure, which determines the status code and log
 level of the failure. Maps 1-1 to the Canton error categories documented
-here: https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
+here: [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)
 
 If you are more familiar with gRPC error codes, you can use the synonyms referenced in the
 comments.
@@ -47,7 +47,7 @@ and should thus not be retried.
 
 Corresponds to the gRPC status code `INVALID_ARGUMENT`.
 
-See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
+See [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)
 for more information.
 <span id="constr-da-internal-fail-types-invalidgivencurrentsystemstateother-6547"></span>
 - `InvalidGivenCurrentSystemStateOther`
@@ -57,7 +57,7 @@ requests after reading updated state from the ledger.
 
 Corresponds to the gRPC status code `FAILED_PRECONDITION`.
 
-See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
+See [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)
 for more information.
 
 Instances:

--- a/docs-main/appdev/reference/daml-standard-library/da-record.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-record.mdx
@@ -53,7 +53,7 @@ MyRecord {foo = 3, bar = "hello"}
 daml>
 ```
 
-For more on Record syntax, see /appdev/reference/daml-standard-library/da-record.
+For more on Record syntax, see https://docs.canton.network/appdev/reference/daml-standard-library/da-record.
 
 `GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first
 parameter `x` is the field name, the second parameter `r` is the record type,

--- a/docs-main/appdev/reference/daml-standard-library/da-record.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-record.mdx
@@ -53,7 +53,7 @@ MyRecord {foo = 3, bar = "hello"}
 daml>
 ```
 
-For more on Record syntax, see https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Record.html.
+For more on Record syntax, see /appdev/reference/daml-standard-library/da-record.
 
 `GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first
 parameter `x` is the field name, the second parameter `r` is the record type,

--- a/docs-main/appdev/reference/daml-standard-library/da-record.mdx
+++ b/docs-main/appdev/reference/daml-standard-library/da-record.mdx
@@ -53,7 +53,7 @@ MyRecord {foo = 3, bar = "hello"}
 daml>
 ```
 
-For more on Record syntax, see https://docs.canton.network/appdev/reference/daml-standard-library/da-record.
+For more on Record syntax, see [DA.Record](/appdev/reference/daml-standard-library/da-record).
 
 `GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first
 parameter `x` is the field name, the second parameter `r` is the record type,

--- a/tests/fixtures/characterization/daml_json/expected/da-fail.mdx
+++ b/tests/fixtures/characterization/daml_json/expected/da-fail.mdx
@@ -33,7 +33,7 @@ Deprecated since: `-`
 
 The category of the failure, which determines the status code and log
 level of the failure. Maps 1-1 to the Canton error categories documented
-here: /global-synchronizer/reference/error-codes#error-categories-inventory
+here: https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
 
 If you are more familiar with gRPC error codes, you can use the synonyms referenced in the
 comments.
@@ -47,7 +47,7 @@ and should thus not be retried.
 
 Corresponds to the gRPC status code `INVALID_ARGUMENT`.
 
-See /global-synchronizer/reference/error-codes#error-categories-inventory
+See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
 for more information.
 <a id="constr-da-internal-fail-types-invalidgivencurrentsystemstateother-6547"></a>
 - `InvalidGivenCurrentSystemStateOther`
@@ -57,7 +57,7 @@ requests after reading updated state from the ledger.
 
 Corresponds to the gRPC status code `FAILED_PRECONDITION`.
 
-See /global-synchronizer/reference/error-codes#error-categories-inventory
+See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
 for more information.
 
 Instances:

--- a/tests/fixtures/characterization/daml_json/expected/da-fail.mdx
+++ b/tests/fixtures/characterization/daml_json/expected/da-fail.mdx
@@ -33,7 +33,7 @@ Deprecated since: `-`
 
 The category of the failure, which determines the status code and log
 level of the failure. Maps 1-1 to the Canton error categories documented
-here: https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
+here: [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)
 
 If you are more familiar with gRPC error codes, you can use the synonyms referenced in the
 comments.
@@ -47,7 +47,7 @@ and should thus not be retried.
 
 Corresponds to the gRPC status code `INVALID_ARGUMENT`.
 
-See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
+See [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)
 for more information.
 <a id="constr-da-internal-fail-types-invalidgivencurrentsystemstateother-6547"></a>
 - `InvalidGivenCurrentSystemStateOther`
@@ -57,7 +57,7 @@ requests after reading updated state from the ledger.
 
 Corresponds to the gRPC status code `FAILED_PRECONDITION`.
 
-See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory
+See [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)
 for more information.
 
 Instances:

--- a/tests/fixtures/characterization/daml_json/expected/da-fail.mdx
+++ b/tests/fixtures/characterization/daml_json/expected/da-fail.mdx
@@ -33,7 +33,7 @@ Deprecated since: `-`
 
 The category of the failure, which determines the status code and log
 level of the failure. Maps 1-1 to the Canton error categories documented
-here: https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory
+here: /global-synchronizer/reference/error-codes#error-categories-inventory
 
 If you are more familiar with gRPC error codes, you can use the synonyms referenced in the
 comments.
@@ -47,7 +47,7 @@ and should thus not be retried.
 
 Corresponds to the gRPC status code `INVALID_ARGUMENT`.
 
-See https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#invalidindependentofsystemstate
+See /global-synchronizer/reference/error-codes#error-categories-inventory
 for more information.
 <a id="constr-da-internal-fail-types-invalidgivencurrentsystemstateother-6547"></a>
 - `InvalidGivenCurrentSystemStateOther`
@@ -57,7 +57,7 @@ requests after reading updated state from the ledger.
 
 Corresponds to the gRPC status code `FAILED_PRECONDITION`.
 
-See https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory
+See /global-synchronizer/reference/error-codes#error-categories-inventory
 for more information.
 
 Instances:

--- a/tests/fixtures/characterization/daml_json/expected/da-record.mdx
+++ b/tests/fixtures/characterization/daml_json/expected/da-record.mdx
@@ -53,7 +53,7 @@ MyRecord {foo = 3, bar = "hello"}
 daml>
 ```
 
-For more on Record syntax, see /appdev/reference/daml-standard-library/da-record.
+For more on Record syntax, see https://docs.canton.network/appdev/reference/daml-standard-library/da-record.
 
 `GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first
 parameter `x` is the field name, the second parameter `r` is the record type,

--- a/tests/fixtures/characterization/daml_json/expected/da-record.mdx
+++ b/tests/fixtures/characterization/daml_json/expected/da-record.mdx
@@ -53,7 +53,7 @@ MyRecord {foo = 3, bar = "hello"}
 daml>
 ```
 
-For more on Record syntax, see https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Record.html.
+For more on Record syntax, see /appdev/reference/daml-standard-library/da-record.
 
 `GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first
 parameter `x` is the field name, the second parameter `r` is the record type,

--- a/tests/fixtures/characterization/daml_json/expected/da-record.mdx
+++ b/tests/fixtures/characterization/daml_json/expected/da-record.mdx
@@ -53,7 +53,7 @@ MyRecord {foo = 3, bar = "hello"}
 daml>
 ```
 
-For more on Record syntax, see https://docs.canton.network/appdev/reference/daml-standard-library/da-record.
+For more on Record syntax, see [DA.Record](/appdev/reference/daml-standard-library/da-record).
 
 `GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first
 parameter `x` is the field name, the second parameter `r` is the record type,

--- a/tests/fixtures/characterization/daml_json/input/cache/json/3.4.10/modules.json
+++ b/tests/fixtures/characterization/daml_json/input/cache/json/3.4.10/modules.json
@@ -25862,7 +25862,7 @@
                     "",
                     "Corresponds to the gRPC status code `INVALID_ARGUMENT`.",
                     "",
-                    "See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
+                    "See [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)",
                     "for more information."
                   ]
                 ],
@@ -25881,7 +25881,7 @@
                     "",
                     "Corresponds to the gRPC status code `FAILED_PRECONDITION`.",
                     "",
-                    "See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
+                    "See [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)",
                     "for more information."
                   ]
                 ],
@@ -25893,7 +25893,7 @@
             [
               "The category of the failure, which determines the status code and log",
               "level of the failure. Maps 1-1 to the Canton error categories documented",
-              "here: https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
+              "here: [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)",
               "",
               "If you are more familiar with gRPC error codes, you can use the synonyms referenced in the",
               "comments."
@@ -47183,7 +47183,7 @@
               "daml>",
               "```",
               "",
-              "For more on Record syntax, see https://docs.canton.network/appdev/reference/daml-standard-library/da-record.",
+              "For more on Record syntax, see [DA.Record](/appdev/reference/daml-standard-library/da-record).",
               "",
               "`GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first",
               "parameter `x` is the field name, the second parameter `r` is the record type,",

--- a/tests/fixtures/characterization/daml_json/input/cache/json/3.4.10/modules.json
+++ b/tests/fixtures/characterization/daml_json/input/cache/json/3.4.10/modules.json
@@ -25862,7 +25862,7 @@
                     "",
                     "Corresponds to the gRPC status code `INVALID_ARGUMENT`.",
                     "",
-                    "See https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#invalidindependentofsystemstate",
+                    "See /global-synchronizer/reference/error-codes#error-categories-inventory",
                     "for more information."
                   ]
                 ],
@@ -25881,7 +25881,7 @@
                     "",
                     "Corresponds to the gRPC status code `FAILED_PRECONDITION`.",
                     "",
-                    "See https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory",
+                    "See /global-synchronizer/reference/error-codes#error-categories-inventory",
                     "for more information."
                   ]
                 ],
@@ -25893,7 +25893,7 @@
             [
               "The category of the failure, which determines the status code and log",
               "level of the failure. Maps 1-1 to the Canton error categories documented",
-              "here: https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory",
+              "here: /global-synchronizer/reference/error-codes#error-categories-inventory",
               "",
               "If you are more familiar with gRPC error codes, you can use the synonyms referenced in the",
               "comments."
@@ -47183,7 +47183,7 @@
               "daml>",
               "```",
               "",
-              "For more on Record syntax, see https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Record.html.",
+              "For more on Record syntax, see /appdev/reference/daml-standard-library/da-record.",
               "",
               "`GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first",
               "parameter `x` is the field name, the second parameter `r` is the record type,",

--- a/tests/fixtures/characterization/daml_json/input/cache/json/3.4.10/modules.json
+++ b/tests/fixtures/characterization/daml_json/input/cache/json/3.4.10/modules.json
@@ -25862,7 +25862,7 @@
                     "",
                     "Corresponds to the gRPC status code `INVALID_ARGUMENT`.",
                     "",
-                    "See /global-synchronizer/reference/error-codes#error-categories-inventory",
+                    "See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
                     "for more information."
                   ]
                 ],
@@ -25881,7 +25881,7 @@
                     "",
                     "Corresponds to the gRPC status code `FAILED_PRECONDITION`.",
                     "",
-                    "See /global-synchronizer/reference/error-codes#error-categories-inventory",
+                    "See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
                     "for more information."
                   ]
                 ],
@@ -25893,7 +25893,7 @@
             [
               "The category of the failure, which determines the status code and log",
               "level of the failure. Maps 1-1 to the Canton error categories documented",
-              "here: /global-synchronizer/reference/error-codes#error-categories-inventory",
+              "here: https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
               "",
               "If you are more familiar with gRPC error codes, you can use the synonyms referenced in the",
               "comments."
@@ -47183,7 +47183,7 @@
               "daml>",
               "```",
               "",
-              "For more on Record syntax, see /appdev/reference/daml-standard-library/da-record.",
+              "For more on Record syntax, see https://docs.canton.network/appdev/reference/daml-standard-library/da-record.",
               "",
               "`GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first",
               "parameter `x` is the field name, the second parameter `r` is the record type,",

--- a/tests/fixtures/characterization/daml_json/input/cache/json/3.4.11/modules.json
+++ b/tests/fixtures/characterization/daml_json/input/cache/json/3.4.11/modules.json
@@ -25862,7 +25862,7 @@
                     "",
                     "Corresponds to the gRPC status code `INVALID_ARGUMENT`.",
                     "",
-                    "See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
+                    "See [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)",
                     "for more information."
                   ]
                 ],
@@ -25881,7 +25881,7 @@
                     "",
                     "Corresponds to the gRPC status code `FAILED_PRECONDITION`.",
                     "",
-                    "See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
+                    "See [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)",
                     "for more information."
                   ]
                 ],
@@ -25893,7 +25893,7 @@
             [
               "The category of the failure, which determines the status code and log",
               "level of the failure. Maps 1-1 to the Canton error categories documented",
-              "here: https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
+              "here: [Error categories inventory](/global-synchronizer/reference/error-codes#error-categories-inventory)",
               "",
               "If you are more familiar with gRPC error codes, you can use the synonyms referenced in the",
               "comments."
@@ -47183,7 +47183,7 @@
               "daml>",
               "```",
               "",
-              "For more on Record syntax, see https://docs.canton.network/appdev/reference/daml-standard-library/da-record.",
+              "For more on Record syntax, see [DA.Record](/appdev/reference/daml-standard-library/da-record).",
               "",
               "`GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first",
               "parameter `x` is the field name, the second parameter `r` is the record type,",

--- a/tests/fixtures/characterization/daml_json/input/cache/json/3.4.11/modules.json
+++ b/tests/fixtures/characterization/daml_json/input/cache/json/3.4.11/modules.json
@@ -25862,7 +25862,7 @@
                     "",
                     "Corresponds to the gRPC status code `INVALID_ARGUMENT`.",
                     "",
-                    "See https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#invalidindependentofsystemstate",
+                    "See /global-synchronizer/reference/error-codes#error-categories-inventory",
                     "for more information."
                   ]
                 ],
@@ -25881,7 +25881,7 @@
                     "",
                     "Corresponds to the gRPC status code `FAILED_PRECONDITION`.",
                     "",
-                    "See https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory",
+                    "See /global-synchronizer/reference/error-codes#error-categories-inventory",
                     "for more information."
                   ]
                 ],
@@ -25893,7 +25893,7 @@
             [
               "The category of the failure, which determines the status code and log",
               "level of the failure. Maps 1-1 to the Canton error categories documented",
-              "here: https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory",
+              "here: /global-synchronizer/reference/error-codes#error-categories-inventory",
               "",
               "If you are more familiar with gRPC error codes, you can use the synonyms referenced in the",
               "comments."
@@ -47183,7 +47183,7 @@
               "daml>",
               "```",
               "",
-              "For more on Record syntax, see https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Record.html.",
+              "For more on Record syntax, see /appdev/reference/daml-standard-library/da-record.",
               "",
               "`GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first",
               "parameter `x` is the field name, the second parameter `r` is the record type,",

--- a/tests/fixtures/characterization/daml_json/input/cache/json/3.4.11/modules.json
+++ b/tests/fixtures/characterization/daml_json/input/cache/json/3.4.11/modules.json
@@ -25862,7 +25862,7 @@
                     "",
                     "Corresponds to the gRPC status code `INVALID_ARGUMENT`.",
                     "",
-                    "See /global-synchronizer/reference/error-codes#error-categories-inventory",
+                    "See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
                     "for more information."
                   ]
                 ],
@@ -25881,7 +25881,7 @@
                     "",
                     "Corresponds to the gRPC status code `FAILED_PRECONDITION`.",
                     "",
-                    "See /global-synchronizer/reference/error-codes#error-categories-inventory",
+                    "See https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
                     "for more information."
                   ]
                 ],
@@ -25893,7 +25893,7 @@
             [
               "The category of the failure, which determines the status code and log",
               "level of the failure. Maps 1-1 to the Canton error categories documented",
-              "here: /global-synchronizer/reference/error-codes#error-categories-inventory",
+              "here: https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory",
               "",
               "If you are more familiar with gRPC error codes, you can use the synonyms referenced in the",
               "comments."
@@ -47183,7 +47183,7 @@
               "daml>",
               "```",
               "",
-              "For more on Record syntax, see /appdev/reference/daml-standard-library/da-record.",
+              "For more on Record syntax, see https://docs.canton.network/appdev/reference/daml-standard-library/da-record.",
               "",
               "`GetField x r a` and `SetField x r a` are typeclasses taking three parameters. The first",
               "parameter `x` is the field name, the second parameter `r` is the record type,",


### PR DESCRIPTION
## Summary

- Replaces a focused batch of `docs.digitalasset.com` links with portable local docs-site URLs.
- Branch is based directly on `origin/main` and owns whole files to avoid cross-PR file conflicts.

## Mapping

| Current URL | Docs page(s) changed | Local target URL | Basis | Verification |
| --- | --- | --- | --- | --- |
| [`https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Record.html`](<https://docs.digitalasset.com/build/3.4/reference/daml/stdlib/DA-Record.html>) | [/appdev/reference/daml-standard-library/da-record](https://docs.canton.network/appdev/reference/daml-standard-library/da-record) | [`/appdev/reference/daml-standard-library/da-record`](https://docs.canton.network/appdev/reference/daml-standard-library/da-record) | Generated standard-library module page. | daniel verified |
| [`https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory`](<https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#error-categories-inventory>) | [/appdev/reference/daml-standard-library/da-fail](https://docs.canton.network/appdev/reference/daml-standard-library/da-fail) | [`/global-synchronizer/reference/error-codes#error-categories-inventory`](https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory) | Error codes page contains the error categories inventory. | daniel verified |
| [`https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#invalidindependentofsystemstate`](<https://docs.digitalasset.com/operate/3.4/reference/error_codes.html#invalidindependentofsystemstate>) | [/appdev/reference/daml-standard-library/da-fail](https://docs.canton.network/appdev/reference/daml-standard-library/da-fail) | [`/global-synchronizer/reference/error-codes#error-categories-inventory`](https://docs.canton.network/global-synchronizer/reference/error-codes#error-categories-inventory) | New page lists `InvalidIndependentOfSystemState` as a category but lacks a dedicated category anchor. | daniel verified |

## Verification

- `git diff --check`
