### PR TITLE
Replace remaining reference docs.digitalasset.com links

### DIFF
--- a/docs-main/appdev/modules/m3-language-fundamentals.mdx
+++ b/docs-main/appdev/modules/m3-language-fundamentals.mdx
@@ -138,7 +138,7 @@ If we want to partially apply an infix operation we can also do that as follows:
 
 #### Associativity and Precedence
 
-When dealing with multiple infix operators, precedence determines how the Daml compiler should parse an expression. For example, for the expression `x + y * z`, because `\*` has a higher precedence than `+`, the expression is parsed as `x + (y * z)` instead of `(x + y) * z`. When dealing with infix operators with the same precedence, associativity determines how the Daml compiler should parse an expression. For example, because `+` and `-` are left-associative, the expression `x + y - z` is parsed as `(x + y) - z` instead of `x + (y - z)`. For built-in operators this has been predefined, for user-defined operators, it must be user-defined. See the [Daml reference on Fixity, Associativity and Precedence](https://docs.digitalasset.com/daml/reference/base.html) for details.
+When dealing with multiple infix operators, precedence determines how the Daml compiler should parse an expression. For example, for the expression `x + y * z`, because `\*` has a higher precedence than `+`, the expression is parsed as `x + (y * z)` instead of `(x + y) * z`. When dealing with infix operators with the same precedence, associativity determines how the Daml compiler should parse an expression. For example, because `+` and `-` are left-associative, the expression `x + y - z` is parsed as `(x + y) - z` instead of `x + (y - z)`. For built-in operators this has been predefined, for user-defined operators, it must be user-defined. See the [Daml reference on Fixity, Associativity and Precedence](/appdev/reference/daml-language-reference#fixity-associativity-and-precedence) for details.
 
 ### Type constraints
 

--- a/docs-main/appdev/modules/m3-standard-library.mdx
+++ b/docs-main/appdev/modules/m3-standard-library.mdx
@@ -226,3 +226,5 @@ Let's try another search. Suppose you didn't want the first element, but the one
 In the following section, you'll find options for testing and interacting with Daml code. We also talk about the operational semantics of some keywords and their commonly associated failures, and a little bit about how coverage reports work in Daml testing.
 
 {/* COPIED_END */}
+
+{/* Mintlify preview rebuild marker. */}

--- a/docs-main/appdev/modules/m3-standard-library.mdx
+++ b/docs-main/appdev/modules/m3-standard-library.mdx
@@ -176,7 +176,7 @@ Other than the typeclasses defined in Prelude, there are two modules generalizin
 
 Being able to browse the standard library starting from `stdlib-reference-base` is a start, and the module naming helps, but it's not an efficient process for finding out what a function you've encountered does, even less so for finding a function that does a thing you need to do.
 
-Daml has its own version of the [Hoogle](https://hoogle.haskell.org/) search engine, which offers search both by name and by signature. This function is fully integrated into the search bar on [https://docs.digitalasset.com/](https://docs.digitalasset.com/), but for those wanting a pure standard library search, it's also available on [https://hoogle.daml.com](https://hoogle.daml.com).
+Daml has its own version of the [Hoogle](https://hoogle.haskell.org/) search engine, which offers search both by name and by signature. This function is fully integrated into the search bar on [/](/), but for those wanting a pure standard library search, it's also available on [https://hoogle.daml.com](https://hoogle.daml.com).
 
 ### Search for functions by name
 

--- a/docs-main/appdev/modules/m3-standard-library.mdx
+++ b/docs-main/appdev/modules/m3-standard-library.mdx
@@ -176,7 +176,7 @@ Other than the typeclasses defined in Prelude, there are two modules generalizin
 
 Being able to browse the standard library starting from `stdlib-reference-base` is a start, and the module naming helps, but it's not an efficient process for finding out what a function you've encountered does, even less so for finding a function that does a thing you need to do.
 
-Daml has its own version of the [Hoogle](https://hoogle.haskell.org/) search engine, which offers search both by name and by signature. This function is fully integrated into the search bar on [/](/), but for those wanting a pure standard library search, it's also available on [https://hoogle.daml.com](https://hoogle.daml.com).
+Daml has its own version of the [Hoogle](https://hoogle.haskell.org/) search engine: [Daml Hoogle](https://hoogle.daml.com). It offers standard library search both by name and by signature.
 
 ### Search for functions by name
 

--- a/docs-main/appdev/modules/m3-testing.mdx
+++ b/docs-main/appdev/modules/m3-testing.mdx
@@ -118,7 +118,7 @@ The first part of the summary is a list of each executed script. For each script
 
 The second part of the summary is the coverage report. It shows you how many templates and choices are tested by the complete set of scripts in the package, in proportion of the total number of templates and choices.
 
-To learn more about Daml test coverage, read the [Daml test coverage guide](https://docs.digitalasset.com/build/3.4/sdk/howtos/testing/test-coverage).
+To learn more about Daml test coverage, read the [Daml test coverage guide](/appdev/modules/m3-testing).
 
 ## Debug, trace, and stacktraces
 

--- a/docs-main/appdev/modules/m7-security.mdx
+++ b/docs-main/appdev/modules/m7-security.mdx
@@ -62,7 +62,7 @@ Canton uses cryptographic keys for party identity, node identity, and transactio
 
 On LocalNet, keys are generated and stored locally — this is fine for development. In production:
 
-- Use [Hardware Security Modules (HSM) or cloud Key Management Services (KMS)](https://docs.digitalasset.com/canton/usermanual/kms) for private keys
+- Use [Hardware Security Modules (HSM) or cloud Key Management Services (KMS)](/global-synchronizer/production-operations/kms-operations) for private keys
 - Never store production keys on developer machines or in CI systems
 - Rotate keys according to your organization's security policy
 - Back up key material securely — losing keys means losing access to your party identity

--- a/docs-main/appdev/reference/pqs-sql-reference.mdx
+++ b/docs-main/appdev/reference/pqs-sql-reference.mdx
@@ -342,7 +342,7 @@ Join through the `*_at_ix` column to enrich contract or exercise data with trans
 
 ## Summary functions
 
-This section will be expanded in a future update. For PQS query patterns and usage, see the [PQS documentation](https://docs.digitalasset.com/canton/3.5/participant/how-to/pqs/pqs-user-guide).
+This section will be expanded in a future update. For PQS query patterns and usage, see the [PQS documentation](/appdev/deep-dives/query-with-pqs).
 
 ## Contract columns
 

--- a/docs-main/global-synchronizer/deployment/configuration.mdx
+++ b/docs-main/global-synchronizer/deployment/configuration.mdx
@@ -30,7 +30,7 @@ The full configuration for each app can be observed in the scala code, with the 
 - [SvAppConfig.scala](https://github.com/canton-network/splice/blob/main/apps/sv/src/main/scala/org/lfdecentralizedtrust/splice/sv/config/SvAppConfig.scala#L199)
 - [ScanAppConfig.scala](https://github.com/canton-network/splice/blob/main/apps/scan/src/main/scala/org/lfdecentralizedtrust/splice/scan/config/ScanAppConfig.scala#L28)
 
-Furthermore, the participant and other synchronizer components can be configured independently as well. Further information on such configurations can be found in the [Canton docs](https://docs.digitalasset.com/operate/3.4/howtos/configure/general/conf_file.html).
+Furthermore, the participant and other synchronizer components can be configured independently as well. Further information on such configurations can be found in the [Canton docs](/global-synchronizer/reference/canton-configuration-guide).
 
 <Note>
 Examples in the Canton docs might have different root configuration keys for the configured nodes; Splice participants/mediators/sequencers are always configured under `canton.participants.participant {`/`canton.mediators.mediator {`/`canton.sequencers.sequencer {`, respectively.

--- a/docs-main/global-synchronizer/production-operations/scalability.mdx
+++ b/docs-main/global-synchronizer/production-operations/scalability.mdx
@@ -29,7 +29,7 @@ It does not apply to:
 
 ### Bypassing the Limit
 
-The preferred option of bypassing the limit is to set up an external party either directly through the [Canton APIs for external signing](https://docs.digitalasset.com/build/3.4/explanations/external-signing/external_signing_overview.html) or `/v0/admin/external-party/topology/{generate,submit}` on the validator API but *not* use the endpoints under `/v0/admin/external-party/setup-proposal`.
+The preferred option of bypassing the limit is to set up an external party either directly through the [Canton APIs for external signing](/appdev/deep-dives/external-signing) or `/v0/admin/external-party/topology/{generate,submit}` on the validator API but *not* use the endpoints under `/v0/admin/external-party/setup-proposal`.
 
 If you do not need preapprovals, this is sufficient.
 

--- a/docs-main/global-synchronizer/reference/configuration-reference.mdx
+++ b/docs-main/global-synchronizer/reference/configuration-reference.mdx
@@ -210,7 +210,7 @@ Add this to `validator-values.yaml`:
 If your node is offline longer than the pruning retention window, it may become corrupted as apps race to catch up with pruned data. Set the retention to a value that reflects your uptime guarantee -- 30 days is a reasonable starting point, since sequencers are also pruned after 30 days.
 </Warning>
 
-See the Canton documentation on [pruning operations](https://docs.digitalasset.com/operate/3.5/usermanual/pruning.html) for more details.
+See the Canton documentation on [pruning operations](/global-synchronizer/production-operations/pruning#participant-node-pruning) for more details.
 
 ## Monitoring and observability
 

--- a/docs-main/sdks-tools/api-reference/admin-api.mdx
+++ b/docs-main/sdks-tools/api-reference/admin-api.mdx
@@ -18,7 +18,7 @@ The Admin API is split across two layers: the **Ledger API admin services** (def
 
 ### Ledger API Admin Services
 
-These services run on participant nodes alongside the Ledger API. They are defined in the [gRPC Ledger API proto specifications](https://docs.digitalasset.com/build/3.5/reference/lapi-proto-docs.html).
+These services run on participant nodes alongside the Ledger API. They are defined in the [gRPC Ledger API proto specifications](/reference/grpc-ledger-api-reference).
 
 ### Canton-Specific Admin Services
 

--- a/docs-main/shared/version-compatibility-dashboard.mdx
+++ b/docs-main/shared/version-compatibility-dashboard.mdx
@@ -9,7 +9,7 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 export const componentDescriptions = {
   splice: { text: 'Canton Network infrastructure including validator apps, wallet, and governance tools.', link: 'https://github.com/canton-network/splice/releases', linkText: 'View releases' },
   damlSdk: { text: 'Smart contract language SDK for building and compiling Daml applications.', link: 'https://github.com/digital-asset/daml/releases', linkText: 'View releases' },
-  pqs: { text: 'Participant Query Store - SQL database for querying ledger data.', link: '/', linkText: 'Documentation' },
+  pqs: { text: 'Participant Query Store - SQL database for querying ledger data.', link: '/sdks-tools/development-tools/pqs', linkText: 'Documentation' },
   tokenStandard: { text: 'Canton Network Token Standard API for fungible token operations (CIP-0056).' },
   walletSdk: { text: 'TypeScript SDK for wallet providers and exchanges.', link: 'https://www.npmjs.com/package/@canton-network/wallet-sdk', linkText: 'npm package' },
   dappSdk: { text: 'Browser-optimized SDK for building decentralized applications.', link: 'https://www.npmjs.com/package/@canton-network/dapp-sdk', linkText: 'npm package' },

--- a/docs-main/shared/version-compatibility-dashboard.mdx
+++ b/docs-main/shared/version-compatibility-dashboard.mdx
@@ -9,7 +9,7 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 export const componentDescriptions = {
   splice: { text: 'Canton Network infrastructure including validator apps, wallet, and governance tools.', link: 'https://github.com/canton-network/splice/releases', linkText: 'View releases' },
   damlSdk: { text: 'Smart contract language SDK for building and compiling Daml applications.', link: 'https://github.com/digital-asset/daml/releases', linkText: 'View releases' },
-  pqs: { text: 'Participant Query Store - SQL database for querying ledger data.', link: 'https://docs.digitalasset.com/', linkText: 'Documentation' },
+  pqs: { text: 'Participant Query Store - SQL database for querying ledger data.', link: '/', linkText: 'Documentation' },
   tokenStandard: { text: 'Canton Network Token Standard API for fungible token operations (CIP-0056).' },
   walletSdk: { text: 'TypeScript SDK for wallet providers and exchanges.', link: 'https://www.npmjs.com/package/@canton-network/wallet-sdk', linkText: 'npm package' },
   dappSdk: { text: 'Browser-optimized SDK for building decentralized applications.', link: 'https://www.npmjs.com/package/@canton-network/dapp-sdk', linkText: 'npm package' },


### PR DESCRIPTION
## Summary

- Replaces a focused batch of `docs.digitalasset.com` links with portable local docs-site URLs.
- Branch is based directly on `origin/main` and owns whole files to avoid cross-PR file conflicts.

## Mapping

| Current URL | Docs page(s) changed | Local target URL | Basis | Verification |
| --- | --- | --- | --- | --- |
| [`https://docs.digitalasset.com/`](<https://docs.digitalasset.com/>) | [/appdev/modules/m3-standard-library](https://docs.canton.network/appdev/modules/m3-standard-library) | [Daml Hoogle](https://hoogle.daml.com) | Rewrote the sentence to point standard-library search directly to Daml Hoogle instead of the old docs-site search. | daniel verified |
| [`https://docs.digitalasset.com/`](<https://docs.digitalasset.com/>) | [/shared/version-compatibility-dashboard](https://docs.canton.network/shared/version-compatibility-dashboard) | `/sdks-tools/development-tools/pqs` | PQS dashboard documentation link now points to the current PQS docs instead of the old docs root. | daniel verified |
| [`https://docs.digitalasset.com/build/3.4/explanations/external-signing/external_signing_overview.html`](<https://docs.digitalasset.com/build/3.4/explanations/external-signing/external_signing_overview.html>) | [/global-synchronizer/production-operations/scalability](https://docs.canton.network/global-synchronizer/production-operations/scalability) | `/appdev/deep-dives/external-signing` | Exact copied source: `external_signing_overview.rst`. | daniel verified |
| [`https://docs.digitalasset.com/build/3.4/sdk/howtos/testing/test-coverage`](<https://docs.digitalasset.com/build/3.4/sdk/howtos/testing/test-coverage>) | [/appdev/modules/m3-testing](https://docs.canton.network/appdev/modules/m3-testing) | `/appdev/modules/m3-testing` | New testing module covers Daml Script coverage output. | daniel verified |
| [`https://docs.digitalasset.com/build/3.5/reference/lapi-proto-docs.html`](<https://docs.digitalasset.com/build/3.5/reference/lapi-proto-docs.html>) | [/sdks-tools/api-reference/admin-api](https://docs.canton.network/sdks-tools/api-reference/admin-api) | `/reference/grpc-ledger-api-reference` | Generated gRPC Ledger API reference. | daniel verified |
| [`https://docs.digitalasset.com/canton/3.5/participant/how-to/pqs/pqs-user-guide`](<https://docs.digitalasset.com/canton/3.5/participant/how-to/pqs/pqs-user-guide>) | [/appdev/reference/pqs-sql-reference](https://docs.canton.network/appdev/reference/pqs-sql-reference) | `/appdev/deep-dives/query-with-pqs` | Closest migrated PQS query/usage guide. | daniel verified |
| [`https://docs.digitalasset.com/canton/usermanual/kms`](<https://docs.digitalasset.com/canton/usermanual/kms>) | [/appdev/modules/m7-security](https://docs.canton.network/appdev/modules/m7-security) | `/global-synchronizer/production-operations/kms-operations` | New KMS operations page covers KMS setup and migration. | daniel verified |
| [`https://docs.digitalasset.com/daml/reference/base.html`](<https://docs.digitalasset.com/daml/reference/base.html>) | [/appdev/modules/m3-language-fundamentals](https://docs.canton.network/appdev/modules/m3-language-fundamentals) | `/appdev/reference/daml-language-reference#fixity-associativity-and-precedence` | Daml language reference contains copied fixity section. | daniel verified |
| [`https://docs.digitalasset.com/operate/3.4/howtos/configure/general/conf_file.html`](<https://docs.digitalasset.com/operate/3.4/howtos/configure/general/conf_file.html>) | [/global-synchronizer/deployment/configuration](https://docs.canton.network/global-synchronizer/deployment/configuration) | `/global-synchronizer/reference/canton-configuration-guide` | Exact copied source: `conf_file.rst`. | daniel verified |
| [`https://docs.digitalasset.com/operate/3.5/usermanual/pruning.html`](<https://docs.digitalasset.com/operate/3.5/usermanual/pruning.html>) | [/global-synchronizer/reference/configuration-reference](https://docs.canton.network/global-synchronizer/reference/configuration-reference) | `/global-synchronizer/production-operations/pruning#participant-node-pruning` | New pruning operations page contains participant pruning guidance. | daniel verified |

## Verification

- `git diff --check`
