### PR TITLE
Clean up RST conversion residue across Global Synchronizer pages

### DIFF
--- a/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
+++ b/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
@@ -532,21 +532,6 @@ participant2.health.ping(participant1)
 
 Note how we again use `retry_until_true` to add a manual synchronization point, making sure that participant2 is registered, before proceeding to ping participant1.
 
-## What Next?
-
-You are now ready to start using Canton for serious tasks. If you want to develop a Daml application and run it on Canton, we recommend the following resources:
-
-1.  Install the [Daml SDK](https://docs.daml.com/getting-started/installation.html) to get access to the Daml IDE and other tools.
-2.  Follow the [Daml documentation](https://docs.daml.com/) to learn how to program new contracts, or check out the [Daml Examples](https://daml.com/examples/) to find existing ones for your needs.
-3.  Use the [Navigator (Deprecated)](https://docs.daml.com/tools/navigator/index.html) for easy Web-based access and manipulation of your contracts.
-
-If you want to understand more about Canton:
-
-1.  Read the requirements that Canton was built for to find out more about the properties of Canton.
-2.  Read the architectural overview for more understanding of Canton concepts and internals.
-
-If you want to deploy your own Canton nodes, consult the installation guide.
-
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/tutorials/install.rst" hash="5b3da911" */}

--- a/docs-main/global-synchronizer/deployment/identity-management.mdx
+++ b/docs-main/global-synchronizer/deployment/identity-management.mdx
@@ -550,17 +550,7 @@ val encryptionKey =
 Be aware that in some particular use cases, you might want to register keys rather than generate new ones (for instance when you have pre-generated KMS keys that you want to use). Please refer to External Key Storage with a Key Management Service (KMS) for more details.
 </Note>
 
-#### Synchronizer Initialization
-
-The following steps describe how to manually initialize a synchronizer node:
-
-[\#22917: Fix broken literalinclude](https://github.com/DACH-NY/canton/issues/22917) literalinclude:: CANTON/community/app/src/test/scala/com/digitalasset/canton/integration/tests/topology/TopologyManagementHelper.scala language: scala start-after: architecture-handbook-entry-begin: ManualInitSynchronizer end-before: architecture-handbook-entry-end: ManualInitSynchronizer dedent:
-
-#### Participant Initialization
-
-The following steps describe how to manually initialize a participant node:
-
-[\#22917: Fix broken literalinclude](https://github.com/DACH-NY/canton/issues/22917) literalinclude:: CANTON/community/app/src/test/scala/com/digitalasset/canton/integration/tests/topology/TopologyManagementHelper.scala language: scala start-after: architecture-handbook-entry-begin: ManualInitParticipant end-before: architecture-handbook-entry-end: ManualInitParticipant dedent:
+See [Initializing node identity manually](#initializing-node-identity-manually) below for the full manual initialization procedure.
 
 {/* COPIED_END */}
 

--- a/docs-main/global-synchronizer/reference/canton-configuration-guide.mdx
+++ b/docs-main/global-synchronizer/reference/canton-configuration-guide.mdx
@@ -147,11 +147,7 @@ canton {
 
 A Canton configuration allows you to define multiple synchronizers. Also, a Canton participant can connect to multiple synchronizers. This is however only supported as a preview feature and not yet suitable for production use.
 
-In particular, contract key uniqueness cannot be enforced over multiple synchronizers. In this situation, we need to turn contract key uniqueness off by setting
-
-[\#22917: Fix broken literalinclude](https://github.com/DACH-NY/canton/issues/22917) literalinclude:: CANTON/community/app/src/test/resources/documentation-snippets/non-uck-mode.conf
-
-Please note that the setting is final and cannot be changed subsequently. We will provide a migration path once multi-synchronizer functionality is fully implemented.
+In particular, contract key uniqueness cannot be enforced over multiple synchronizers. In this situation, you must turn off contract key uniqueness in the Canton configuration. Please note that the setting is final and cannot be changed subsequently. We will provide a migration path once multi-synchronizer functionality is fully implemented.
 
 ## Fail Fast Mode
 

--- a/docs-main/global-synchronizer/troubleshooting-guide/troubleshooting-methodology.mdx
+++ b/docs-main/global-synchronizer/troubleshooting-guide/troubleshooting-methodology.mdx
@@ -18,13 +18,7 @@ This section was copied from existing reviewed documentation.
 Reviewers: Skip this section. Remove markers after final approval.
 </Warning>
 
-This section provides an overview of which information can be collected to debug issues in a Canton Network node.
-
-<div className="toctree">
-
-console_access.rst
-
-</div>
+This section provides an overview of which information can be collected to debug issues in a Canton Network node. For direct console access to a Canton node, see the [Canton Console Reference](/global-synchronizer/reference/canton-console-reference).
 
 ## Where to find logs
 


### PR DESCRIPTION
## Summary

Removes four visible rst-to-mdx conversion artifacts that were leaking onto rendered Global Synchronizer pages.

Closes #441, #427, #425, #419. Confirms #452 already resolved on main.

## Per-issue detail

### #441 — broken literalinclude in Canton Configuration Guide
Page: `/global-synchronizer/reference/canton-configuration-guide#multiple-synchronizers`

The literal text `[#22917: Fix broken literalinclude] literalinclude:: CANTON/community/app/src/test/resources/documentation-snippets/non-uck-mode.conf` was being rendered as visible page content because the upstream `.. todo::` block (Sphinx-only directive) wasn't stripped by the rst-to-mdx converter. The TODO was placed by the canton team to track that the literalinclude is broken upstream (DACH-NY/canton#22917).

Removed the visible TODO and rewrote the lead-in sentence so it no longer dangles into the next paragraph. The actual config-snippet content is still missing — tracked as a follow-up issue (filed alongside this PR).

### #427 — `console_access.rst` toctree residue in Troubleshooting Methodology
Page: `/global-synchronizer/troubleshooting-guide/troubleshooting-methodology`

Upstream uses a Sphinx `.. toctree:: console_access.rst` directive to generate a link to the Canton Console Reference. The converter emitted `<div className="toctree">console_access.rst</div>` — a bare filename inside a div. Replaced with a real markdown link to `/global-synchronizer/reference/canton-console-reference` (which is what `console_access.rst` becomes on our site).

### #425 — empty Synchronizer/Participant Initialization stubs in Identity Management
Page: `/global-synchronizer/deployment/identity-management`

Two `#### Synchronizer Initialization` / `#### Participant Initialization` headings whose body was nothing but broken-literalinclude TODOs (same root cause as #441, same upstream tracker DACH-NY/canton#22917). The intended snippets referenced markers `ManualInitSynchronizer` / `ManualInitParticipant` in a Scala helper file, but those markers were renamed upstream to `ManualInitKeys` / `ManualInitNode` and the upstream RST wasn't updated.

Removed both empty stub sections. The next section on the same page ("Initializing node identity manually") already contains the full manual initialization procedure, so no content was lost. The Scala snippets are still missing — tracked as a follow-up issue.

### #419 — out-of-place "What Next?" section in Canton Console getting-started tutorial
Page: `/global-synchronizer/canton-console/getting-started-tutorial`

A trailing "What Next?" section pointed to outdated `docs.daml.com` URLs and the deprecated Navigator tool. Removed.

### #452 — confirmed already resolved
Page: `/sdks-tools/api-reference/splice-scan-gs-connectivity-api#parties-hosting-participants`

The example URL on this page already shows the correct `/v0/domains/{domain_id}/parties/{party_id}/participant-id` form. A site-wide grep for empty path placeholders (`//` between path segments outside URLs) returned zero results. No code changes needed.

## Follow-up issues filed

Two follow-up issues will be opened alongside this PR to track the missing content that this PR doesn't restore (only the visible TODOs were removed):

- "Multiple Synchronizers section is missing HOCON config example"
- "Identity Management - Manual initialization sections need code examples"

Both reference DACH-NY/canton#22917 as the upstream root cause.