### PR TITLE
Fix broken cross-page links to API reference, crypto schemes, perf optimization

### DIFF
--- a/docs-main/appdev/modules/m4-query-with-pqs.mdx
+++ b/docs-main/appdev/modules/m4-query-with-pqs.mdx
@@ -61,7 +61,7 @@ See also `pqs-how-to-add-an-index-on-expression-over-jsonb-payload`.
 </Note>
 
 <Warning>
-Querying by payload contents may require additional development and administrative work in order to achieve desired performance outcomes. Please, refer to `pqs-optimize-payload-queries` for ideas on how to get started.
+Querying by payload contents may require additional development and administrative work in order to achieve desired performance outcomes. Please refer to [Performance Optimization](/appdev/deep-dives/performance-optimization) for ideas on how to get started.
 </Warning>
 
 ### How to join contracts that are in ACS
@@ -128,7 +128,7 @@ PQS is backed by PostgreSQL database. Any query optimization is essentially a da
 - Avoid paginating with the help of `OFFSET` SQL clause
 - Avoid using queries similar to `SELECT COUNT(*)` if possible
 
-For additional information concerning performance optimization, refer to `pqs-optimize`.
+For additional information concerning performance optimization, refer to [Performance Optimization](/appdev/deep-dives/performance-optimization).
 
 ### How to add an index on expression over JSONB payload
 

--- a/docs-main/global-synchronizer/production-operations/kms-operations.mdx
+++ b/docs-main/global-synchronizer/production-operations/kms-operations.mdx
@@ -674,7 +674,7 @@ You need to follow the same steps if you want to migrate a Participant back to u
 
 By default, Canton nodes use the `jce` crypto provider, which is compatible with other nodes that use external KMS providers to store Canton private keys. If you change the default `jce` provider and use different cryptographic schemes, you must ensure that it supports the same algorithms and key schemes as the KMS providers, in order to interoperate with other KMS-enabled Canton nodes.
 
-See this table and this table for a description of the cryptographic schemes supported by a KMS provider and the ones used by default.
+See the [Supported Cryptographic Schemes](/global-synchronizer/reference/crypto-schemes) reference for a description of the cryptographic schemes supported by a KMS provider and the ones used by default.
 
 
 {/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-scan-openapi.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-scan-openapi.mdx
@@ -1,21 +1,10 @@
 ---
 title: "Scan Open API Reference"
-description: "The OpenAPI specification for the Scan API"
+description: "Full OpenAPI specification for the Scan API"
 ---
 
-{/* COPIED_START source="splice:docs/src/app_dev/scan_api/scan_openapi.rst" hash="24a3c0d1" */}
+The complete OpenAPI specification for the Scan API is published as a generated reference under [Scan API](/reference/splice-scan-api/common/readyz). It is organized by tag and includes the request and response schemas for every endpoint.
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/scan_api/scan_openapi.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
+For an overview of the individual Scan API surfaces (current state, bulk data, aggregates, connectivity, operations, and CC reference data), see [Scan APIs](/sdks-tools/api-reference/splice-scan-api).
 
-<div className="openapi" format="markdown" examples="" group="">
-
-../../../../apps/scan/src/main/openapi/scan.yaml
-
-</div>
-
-
-{/* COPIED_END */}
+The raw OpenAPI source is maintained in the [splice repository](https://github.com/canton-network/splice/blob/main/apps/scan/src/main/openapi/scan.yaml).


### PR DESCRIPTION
## Summary

Three places had unconverted RST references that rendered as plain text instead of working links.

