### PR TITLE
Restore broken Daml standard library refs on m3-standard-library

### DIFF
--- a/docs-main/appdev/modules/m3-standard-library.mdx
+++ b/docs-main/appdev/modules/m3-standard-library.mdx
@@ -157,24 +157,24 @@ Additive and Multiplicative abstract out arithmetic operations, so that `(+)`, `
 
 For almost all the types and typeclasses presented above, the standard library contains a module:
 
-- `module-da-list-85985` for Lists
-- `module-da-optional-38505` for `Optional`
-- `module-da-tuple-81988` for Tuples
-- `module-da-either-91022` for `Either`
-- `module-da-functor-63823` for Functors
-- `module-da-action-7169` for Actions
-- `module-da-functor-63823` and `module-da-semigroup-27147` for Monoids and Semigroups
-- `module-da-text-83238` for working with `Text`
-- `module-da-time-32716` for working with `Time`
-- `module-da-date-80009` for working with `Date`
+- [DA.List](/appdev/reference/daml-standard-library/da-list) for Lists
+- [DA.Optional](/appdev/reference/daml-standard-library/da-optional) for `Optional`
+- [DA.Tuple](/appdev/reference/daml-standard-library/da-tuple) for Tuples
+- [DA.Either](/appdev/reference/daml-standard-library/da-either) for `Either`
+- [DA.Functor](/appdev/reference/daml-standard-library/da-functor) for Functors
+- [DA.Action](/appdev/reference/daml-standard-library/da-action) for Actions
+- [DA.Functor](/appdev/reference/daml-standard-library/da-functor) and [DA.Semigroup](/appdev/reference/daml-standard-library/da-semigroup) for Monoids and Semigroups
+- [DA.Text](/appdev/reference/daml-standard-library/da-text) for working with `Text`
+- [DA.Time](/appdev/reference/daml-standard-library/da-time) for working with `Time`
+- [DA.Date](/appdev/reference/daml-standard-library/da-date) for working with `Date`
 
 You get the idea, the names are fairly descriptive.
 
-Other than the typeclasses defined in Prelude, there are two modules generalizing concepts you've already learned, which are worth knowing about: `Foldable` and `Traversable`. In `loops` you learned all about folds and their Action equivalents. All the examples there were based on lists, but there are many other possible iterators. This is expressed in two additional typeclasses: `module-da-traversable-75075`, and `module-da-foldable-94882`. For more detail on these concepts, please refer to the literature in `haskell-connection`, or `https://wiki.haskell.org/Foldable_and_Traversable`.
+Other than the typeclasses defined in Prelude, there are two modules generalizing concepts you've already learned, which are worth knowing about: `Foldable` and `Traversable`. The examples earlier in this module were based on lists, but there are many other possible iterators. This is expressed in two additional typeclasses: [DA.Traversable](/appdev/reference/daml-standard-library/da-traversable) and [DA.Foldable](/appdev/reference/daml-standard-library/da-foldable). For more detail on these concepts, see [Foldable and Traversable on the Haskell wiki](https://wiki.haskell.org/Foldable_and_Traversable).
 
 ## Search the standard library
 
-Being able to browse the standard library starting from `stdlib-reference-base` is a start, and the module naming helps, but it's not an efficient process for finding out what a function you've encountered does, even less so for finding a function that does a thing you need to do.
+Being able to browse the standard library starting from the [Daml Standard Library reference](/appdev/reference/daml-standard-library/index) is a start, and the module naming helps, but it's not an efficient process for finding out what a function you've encountered does, even less so for finding a function that does a thing you need to do.
 
 Daml has its own version of the [Hoogle](https://hoogle.haskell.org/) search engine, which offers search both by name and by signature. This function is fully integrated into the search bar on [https://docs.digitalasset.com/](https://docs.digitalasset.com/), but for those wanting a pure standard library search, it's also available on [https://hoogle.daml.com](https://hoogle.daml.com).
 

--- a/docs-main/overview/reference/cross-sync-dvp-example.mdx
+++ b/docs-main/overview/reference/cross-sync-dvp-example.mdx
@@ -72,19 +72,14 @@ sequenceDiagram
     participant PS as Payments Sync
     participant SS as Settlement Sync
     participant XS as Securities Sync
-
     Note over PS: Cash assigned here
     Note over XS: Securities assigned here
-
-    PS->>SS: Unassign Cash → Assign Cash
-    XS->>SS: Unassign Securities → Assign Securities
-
+    PS->>SS: Unassign Cash, then Assign Cash
+    XS->>SS: Unassign Securities, then Assign Securities
     Note over SS: Both contracts now on Settlement Sync
-
-    SS->>SS: Atomic DvP transaction:<br/>Cash → Bob, Securities → Alice
-
-    SS->>PS: Unassign Bob's Cash → Assign to Payments Sync
-    SS->>XS: Unassign Alice's Securities → Assign to Securities Sync
+    SS->>SS: Atomic DvP — Cash to Bob, Securities to Alice
+    SS->>PS: Unassign Bob Cash, then Assign to Payments Sync
+    SS->>XS: Unassign Alice Securities, then Assign to Securities Sync
 ```
 
 ## Contract Location at Each State

--- a/docs-main/overview/reference/cross-sync-dvp-example.mdx
+++ b/docs-main/overview/reference/cross-sync-dvp-example.mdx
@@ -72,14 +72,19 @@ sequenceDiagram
     participant PS as Payments Sync
     participant SS as Settlement Sync
     participant XS as Securities Sync
+
     Note over PS: Cash assigned here
     Note over XS: Securities assigned here
-    PS->>SS: Unassign Cash, then Assign Cash
-    XS->>SS: Unassign Securities, then Assign Securities
+
+    PS->>SS: Unassign Cash → Assign Cash
+    XS->>SS: Unassign Securities → Assign Securities
+
     Note over SS: Both contracts now on Settlement Sync
-    SS->>SS: Atomic DvP — Cash to Bob, Securities to Alice
-    SS->>PS: Unassign Bob Cash, then Assign to Payments Sync
-    SS->>XS: Unassign Alice Securities, then Assign to Securities Sync
+
+    SS->>SS: Atomic DvP transaction:<br/>Cash → Bob, Securities → Alice
+
+    SS->>PS: Unassign Bob's Cash → Assign to Payments Sync
+    SS->>XS: Unassign Alice's Securities → Assign to Securities Sync
 ```
 
 ## Contract Location at Each State


### PR DESCRIPTION
## Summary

Replaces 10+ unconverted `:ref:` placeholders on the m3 standard library module page with real Markdown links to the corresponding stdlib reference pages.

Closes #407.

## Detail

### #407 — broken stdlib refs
Page: `/appdev/modules/m3-standard-library`

The "Important modules in the standard library" section had 10 unconverted `:ref:` placeholders (`module-da-list-85985`, `module-da-optional-38505`, etc.) that rendered as bare backtick code-spans instead of links to the relevant Daml stdlib reference pages.

Replaced each with a real Markdown link to the corresponding `/appdev/reference/daml-standard-library/da-*` page. Also fixed:

- The "Search the standard library" section's reference to `stdlib-reference-base` (now links to the stdlib index)
- The `haskell-connection` reference (no Canton equivalent — replaced with a public Haskell wiki link)