### PR TITLE
Fix splice-validator-api page render

### DIFF
--- a/docs-main/sdks-tools/api-reference/splice-validator-api.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-validator-api.mdx
@@ -59,7 +59,7 @@ Use the endpoints below to create and manage Splice Wallet transfer offers. Use 
 | Endpoint                                                 | Description                          |
 |----------------------------------------------------------|--------------------------------------|
 | **POST** /v0/wallet/transfer-offers                      | Create a transfer offer              |
-| **POST** /v0/wallet/transfer-offers/{tracking_id}/status | Check the status of a transfer offer |
+| **POST** /v0/wallet/transfer-offers/`{tracking_id}`/status | Check the status of a transfer offer |
 | **GET** /v0/wallet/transfer-offers                       | List transfer offers                 |
 
 ### Buying Traffic
@@ -74,7 +74,7 @@ Any user can buy traffic for any validator. Buying traffic is a multi-step proce
 | Endpoint                                                      | Description                               |
 |---------------------------------------------------------------|-------------------------------------------|
 | **POST** /v0/wallet/buy-traffic-requests                      | Create a request to buy traffic           |
-| **POST** /v0/wallet/buy-traffic-requests/{tracking_id}/status | Check the status of a buy traffic request |
+| **POST** /v0/wallet/buy-traffic-requests/`{tracking_id}`/status | Check the status of a buy traffic request |
 
 ## Internal user wallet API
 
@@ -92,18 +92,18 @@ These endpoints are not intended to be used by other applications. If you want t
 
 | Endpoint                                                       |
 |----------------------------------------------------------------|
-| **POST** /v0/wallet/transfer-offers/{contract_id}/accept       |
-| **POST** /v0/wallet/transfer-offers/{contract_id}/reject       |
-| **POST** /v0/wallet/transfer-offers/{contract_id}/withdraw     |
+| **POST** /v0/wallet/transfer-offers/`{contract_id}`/accept       |
+| **POST** /v0/wallet/transfer-offers/`{contract_id}`/reject       |
+| **POST** /v0/wallet/transfer-offers/`{contract_id}`/withdraw     |
 | **GET** /v0/wallet/app-payment-requests                        |
-| **POST** /v0/wallet/app-payment-requests/{contract_id}/reject  |
-| **POST** /v0/wallet/app-payment-requests/{contract_id}/accept  |
-| **GET** /v0/wallet/app-payment-requests/{contract_id}          |
+| **POST** /v0/wallet/app-payment-requests/`{contract_id}`/reject  |
+| **POST** /v0/wallet/app-payment-requests/`{contract_id}`/accept  |
+| **GET** /v0/wallet/app-payment-requests/`{contract_id}`          |
 | **GET** /v0/wallet/subscription-requests                       |
-| **POST** /v0/wallet/subscription-requests/{contract_id}/reject |
-| **POST** /v0/wallet/subscription-requests/{contract_id}/accept |
-| **DELETE** /v0/wallet/subscription-requests/{contract_id}      |
-| **GET** /v0/wallet/subscription-requests/{contract_id}         |
+| **POST** /v0/wallet/subscription-requests/`{contract_id}`/reject |
+| **POST** /v0/wallet/subscription-requests/`{contract_id}`/accept |
+| **DELETE** /v0/wallet/subscription-requests/`{contract_id}`      |
+| **GET** /v0/wallet/subscription-requests/`{contract_id}`         |
 | **DELETE** /v0/wallet/cancel-featured-app-rights               |
 | **POST** /v0/wallet/transfer-preapproval                       |
 | **POST** /v0/wallet/transfer-preapproval/send                  |
@@ -152,8 +152,8 @@ For the common case of wanting to set up an external party in a topology where t
 | **POST** /v0/admin/external-party/setup-proposal/prepare-accept      |
 | **POST** /v0/admin/external-party/setup-proposal/submit-accept       |
 | **GET** /v0/admin/transfer-preapprovals                              |
-| **GET** /v0/admin/transfer-preapprovals/by-party/{receiver-party}    |
-| **DELETE** /v0/admin/transfer-preapprovals/by-party/{receiver-party} |
+| **GET** /v0/admin/transfer-preapprovals/by-party/`{receiver-party}`    |
+| **DELETE** /v0/admin/transfer-preapprovals/by-party/`{receiver-party}` |
 | **POST** /v0/admin/external-party/transfer-preapproval/prepare-send  |
 | **POST** /v0/admin/external-party/transfer-preapproval/submit-send   |
 | **GET** /v0/admin/external-party/balance                             |
@@ -229,12 +229,12 @@ If the validator app is part of a `CN Supervalidator` node, then each call to on
 | **GET** /v0/scan-proxy/dso-party-id                          |
 | **GET** /v0/scan-proxy/open-and-issuing-mining-rounds        |
 | **GET** /v0/scan-proxy/ans-entries                           |
-| **GET** /v0/scan-proxy/ans-entries/by-name/{name}            |
-| **GET** /v0/scan-proxy/ans-entries/by-party/{party}          |
-| **GET** /v0/scan-proxy/featured-apps/{provider_party_id}     |
-| **GET** /v0/scan-proxy/transfer-command-counter/{party}      |
+| **GET** /v0/scan-proxy/ans-entries/by-name/`{name}`            |
+| **GET** /v0/scan-proxy/ans-entries/by-party/`{party}`          |
+| **GET** /v0/scan-proxy/featured-apps/`{provider_party_id}`     |
+| **GET** /v0/scan-proxy/transfer-command-counter/`{party}`      |
 | **GET** /v0/scan-proxy/transfer-command/status               |
-| **GET** /v0/scan-proxy/transfer-preapprovals/by-party/{party} |
+| **GET** /v0/scan-proxy/transfer-preapprovals/by-party/`{party}` |
 
 
 {/* COPIED_END */}


### PR DESCRIPTION
## Symptom

19 bare `{var}` placeholders in markdown table cells in `docs-main/sdks-tools/api-reference/splice-validator-api.mdx` (e.g., `{tracking_id}`, `{contract_id}`, `{receiver-party}`, `{party}`, `{name}`, `{provider_party_id}`) are parsed by MDX as JSX expressions referencing undefined identifiers. `{receiver-party}` is doubly broken — the hyphen makes MDX parse it as subtraction.

Closes https://github.com/canton-network/cf-docs/issues/447