### PR TITLE
Replace legacy sync docs links

### DIFF
--- a/docs-main/appdev/faq.mdx
+++ b/docs-main/appdev/faq.mdx
@@ -673,7 +673,7 @@ If a course doesn't mention Canton Network or Daml 3.x, or covers only Daml 2.x 
 
 1. **Official Documentation:**
    - [Build Documentation](/appdev/get-started/choose-your-path)
-   - [Operator Documentation](https://docs.sync.global)
+   - [Operator Documentation](/global-synchronizer/understand/introduction)
 
 2. **Hands-on:**
    - [Canton Quickstart](https://github.com/digital-asset/cn-quickstart)
@@ -767,7 +767,7 @@ Redact sensitive information (private keys, passwords, JWTs) before sharing logs
 **TestNet → MainNet:**
 1. Complete MainNet validator onboarding
 2. Request MainNet IP whitelisting
-3. Follow [MainNet onboarding documentation](https://docs.sync.global/validator_operator/validator_onboarding.html)
+3. Follow [MainNet onboarding documentation](/global-synchronizer/deployment/onboarding-process)
 4. Deploy with production configuration
 
 <Warning>

--- a/docs-main/appdev/quickstart/prerequisites.mdx
+++ b/docs-main/appdev/quickstart/prerequisites.mdx
@@ -214,7 +214,7 @@ The `LocalNet` deployment connects to a local validator which is in turn connect
 
 The Canton Network provides three synchronizer pools. The production network is `MainNet`; the production staging network is `TestNet`. As a developer you will mostly be connecting to the development staging network `DevNet`.
 
-Access to [a SV Node](https://docs.dev.sync.global/validator_operator/validator_onboarding.html) that is whitelisted on the CN is required to connect to DevNet. The GSF publishes a [list of SV nodes](https://sync.global/sv-network/) who have the ability to sponsor a Validator node. To access `DevNet`, contact your sponsoring SV agent for VPN connection information.
+Access to [a SV Node](/global-synchronizer/deployment/onboarding-process) that is whitelisted on the CN is required to connect to DevNet. The GSF publishes a [list of SV nodes](https://sync.global/sv-network/) who have the ability to sponsor a Validator node. To access `DevNet`, contact your sponsoring SV agent for VPN connection information.
 
 ## Resources
 
@@ -226,7 +226,7 @@ Access to [a SV Node](https://docs.dev.sync.global/validator_operator/validator_
 - [Digital Asset Docker](https://console.cloud.google.com/artifacts/docker/da-images/europe/public)
 - [Nix](https://nixos.org/download/)
 - [Quickstart GitHub repository](https://github.com/digital-asset/cn-quickstart)
-- [Validator onboarding documentation](https://docs.dev.sync.global/validator_operator/validator_onboarding.html)
+- [Validator onboarding documentation](/global-synchronizer/deployment/onboarding-process)
 - [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install)
 
 

--- a/docs-main/global-synchronizer/deployment/validator-docker-compose.mdx
+++ b/docs-main/global-synchronizer/deployment/validator-docker-compose.mdx
@@ -254,7 +254,7 @@ To do so, fill the following section and add the following additional config to 
 ```yaml
 # sweep by transferring directly through the transfer preapproval of the receiver,
 # if set to false sweeping creates transfer offers that need to be accepted on the receiver side.
-# Note that this refers to the preapprovals described in https://docs.dev.sync.global/background/preapprovals.html
+# Note that this refers to the preapprovals described in /appdev/modules/m7-canton-coin-preapprovals
 # and not to auto accepting transfers. Auto accept transfers does not setup preapproval contracts that allow
 # for a direct transfer but just automates the acceptance of the transfer offer so in that case
 # useTransferPreapproval should be set to false.

--- a/docs-main/global-synchronizer/deployment/validator-kubernetes.mdx
+++ b/docs-main/global-synchronizer/deployment/validator-kubernetes.mdx
@@ -522,7 +522,7 @@ To do so, uncomment and fill in the following section in the `validator-values.y
 #    receiver: "<receiverPartyId>"
 #    useTransferPreapproval: false # sweep by transferring directly through the transfer preapproval of the receiver,
 #                                    if set to false sweeping creates transfer offers that need to be accepted on the receiver side.
-#                                    Note that this refers to the preapprovals described in https://docs.dev.sync.global/background/preapprovals.html
+#                                    Note that this refers to the preapprovals described in /appdev/modules/m7-canton-coin-preapprovals
 #                                    and not to auto accepting transfers. Auto accept transfers does not setup preapproval contracts that allow
 #                                    for a direct transfer but just automates the acceptance of the transfer offer so in that case
 #                                    useTransferPreapproval should be set to false.

--- a/docs-main/global-synchronizer/faq.mdx
+++ b/docs-main/global-synchronizer/faq.mdx
@@ -162,7 +162,7 @@ How do I find the specifications for the latest API version for a Dev/Test/MainN
 > The Canton Network capabilities are always being enhanced so you need to use the latest API version specification. The steps for the JSON API or gRPC API are similar.
 >
 > > - For the JSON API's OpenAPI or AsyncAPI specifications, follow these steps:
-> >   - Find the network's SDK version from the Splice docs. For example, DevNet's version information [is here](https://docs.dev.sync.global/app_dev/overview/version_information.html). For TestNet, substitute `test` in the URL.
+> >   - Find the network's SDK version in the [Version Compatibility Dashboard](/shared/version-compatibility-dashboard).
 > >   - Record the major and minor semver digits for the Canton version. For example, if the snapshot is `3.3.0-snapshot.20250827.16063.0.vdc9a8874` then the important version information is `3.3`.
 > >   - Go to the open source [Canton Git repo](https://github.com/digital-asset/canton).
 > >   - Pick the appropriate release line by selecting the drop down that says `main` to expose the different branches that are available. Then select the release line that has the same version found above. In this example, the release line to select is `release-line-3.3`.

--- a/docs-main/global-synchronizer/release-notes/weekly-patch-releases.mdx
+++ b/docs-main/global-synchronizer/release-notes/weekly-patch-releases.mdx
@@ -20,7 +20,7 @@ Release notifications are communicated through:
 
 - The `#validator-operations` Slack channel for operational updates
 - The `#validator-operations-onboarding` Slack channel for new validators
-- Release notes published on the [Splice documentation site](https://docs.dev.sync.global/)
+- Release notes published on the [Splice release notes page](/global-synchronizer/release-notes/splice)
 
 ## Applying patch releases
 

--- a/docs-main/global-synchronizer/understand/validator-roles.mdx
+++ b/docs-main/global-synchronizer/understand/validator-roles.mdx
@@ -194,7 +194,7 @@ Operating a validator involves several cost categories:
 |----------|-------------|
 | **Slack** | #validator-operations for peer support |
 | **Forum** | forum.canton.network for technical questions |
-| **Documentation** | This site and docs.sync.global |
+| **Documentation** | This site |
 
 ### Commercial Support
 

--- a/docs-main/integrations/exchanges/node-operations.mdx
+++ b/docs-main/integrations/exchanges/node-operations.mdx
@@ -18,10 +18,10 @@ the transactions to execute withdrawals or accept multi-step deposits.
 As also explained in that section, the network provides rewards that can be used to fund traffic.
 
 Note also that every validator node has an associated **validator operator party** that represents
-that validator node's administrator ([docs](https://docs.dev.sync.global/validator_operator/validator_compose.html#deployment)).
+that validator node's administrator ([docs](/global-synchronizer/deployment/validator-docker-compose#deployment)).
 The validator node automatically mints rewards for that party.
 It can further be configured to
-[automatically purchase traffic](https://docs.dev.sync.global/validator_operator/validator_helm.html#configuring-automatic-traffic-purchases)
+[automatically purchase traffic](/global-synchronizer/deployment/validator-kubernetes#configuring-automatic-traffic-purchases)
 using that party's CC balance, which includes the minted rewards.
 
 We thus recommend the following setup as a starting point to mint
@@ -30,13 +30,13 @@ rewards and automatically fund traffic:
 1. Use the validator operator party as your featured `exchangeParty`.
    Follow [exchange-party-setup](#setup-the-featured-exchange-party) to get it featured.
 2. [treasury-party-setup](#setup-the-treasury-party) to create a `treasuryParty` with a transfer preapproval managed by your `exchangeParty`.
-3. Setup [automatic traffic purchases in the validator app](https://docs.dev.sync.global/validator_operator/validator_helm.html#configuring-automatic-traffic-purchases).
-4. Optional: setup [auto-sweep](https://docs.dev.sync.global/validator_operator/validator_helm.html#configuring-sweeps-and-auto-accepts-of-transfer-offers) from the `exchangParty` to your `treasuryParty` to limit the funds managed directly by the validator node.
+3. Setup [automatic traffic purchases in the validator app](/global-synchronizer/deployment/validator-kubernetes#configuring-automatic-traffic-purchases).
+4. Optional: setup [auto-sweep](/global-synchronizer/deployment/validator-kubernetes#configuring-sweeps-and-auto-accepts-of-transfer-offers) from the `exchangParty` to your `treasuryParty` to limit the funds managed directly by the validator node.
 
 As a starting point for the automatic traffic purchase configuration, set `targetThroughput` to 2kB/s
 and `minTopupInterval` to 1 minute, which should be sufficient to execute about one withdrawal or deposit acceptance every 10 seconds.
 Please test this with your expected traffic pattern and adjust as needed.
-See this [FAQ to measure the traffic spent on an individual transaction](https://docs.dev.sync.global/faq.html#term-How-do-I-determine-the-traffic-used-for-a-specific-transaction).
+See this [FAQ to measure the traffic spent on an individual transaction](/global-synchronizer/faq#how-do-i-determine-the-traffic-used-for-a-specific-transaction).
 
 ## Setup Exchange Parties
 
@@ -44,12 +44,12 @@ See this [FAQ to measure the traffic spent on an individual transaction](https:/
 
 As explained above in [reward-minting-and-traffic-funding](#reward-minting-and-traffic-funding), we recommend to use the validator operator party
 as your featured `exchangeParty`. This party is automatically created when you
-[deploy your validator node](https://docs.dev.sync.global/validator_operator/validator_compose.html#deployment).
+[deploy your validator node](/global-synchronizer/deployment/validator-docker-compose#deployment).
 Thus the only setup step is to get it featured by the SVs:
 
 **On DevNet**, you can self-feature your validator operator party as follows:
 
-1. [Log into the wallet UI for the validator user](https://docs.dev.sync.global/validator_operator/validator_helm.html#logging-into-the-wallet-ui), which presents itself as in this screenshot:
+1. [Log into the wallet UI for the validator user](/global-synchronizer/deployment/validator-kubernetes#logging-into-the-wallet-ui), which presents itself as in this screenshot:
 
    ![image](/images/exchange-integration/wallet_ui.png)
 
@@ -63,7 +63,7 @@ That's all. Continue with [setting up your treasury party](#setup-the-treasury-p
 
 **On MainNet**, apply for featured status for your validator operator party as follows:
 
-1. [Log into the wallet UI for the validator user](https://docs.dev.sync.global/validator_operator/validator_helm.html#logging-into-the-wallet-ui) on your MainNet validator node.
+1. [Log into the wallet UI for the validator user](/global-synchronizer/deployment/validator-kubernetes#logging-into-the-wallet-ui) on your MainNet validator node.
 2. Copy the party-id of your validator operator party using the copy button right of the abbreviated `"google-oaut.."` party name in the screenshot above.
 3. Apply for featured application status using this link: [https://sync.global/featured-app-request/](https://sync.global/featured-app-request/)
 
@@ -114,9 +114,9 @@ You can manage Ledger API users and their rights using the
 You will need to authenticate as an existing user that has `participant_admin` rights
 to create additional users and grant rights.
 One option is to authenticate as the `ledger-api-user` that you
-[configured when setting up authentication for your validator node](https://docs.dev.sync.global/validator_operator/validator_helm.html#oidc-provider-requirements).
+[configured when setting up authentication for your validator node](/global-synchronizer/deployment/validator-kubernetes#oidc-provider-requirements).
 Another option is to
-[log-in to your Splice Wallet UI for the validator operatory party](https://docs.dev.sync.global/validator_operator/validator_helm.html#logging-into-the-wallet-ui)
+[log-in to your Splice Wallet UI for the validator operatory party](/global-synchronizer/deployment/validator-kubernetes#logging-into-the-wallet-ui)
 and use the JWT token used by the UI.
 
 We recommend that you setup one user per service that needs to access the Ledger API.
@@ -152,16 +152,16 @@ Only upload `.dar` files from token admins that you trust. The uploaded `.dar` f
 ## Monitoring
 
 See the Splice documentation for guidance on
-[how to monitor your validator node](https://docs.dev.sync.global/deployment/observability/index.html).
+[how to monitor your validator node](/global-synchronizer/production-operations/splice-metrics-overview).
 Note in particular that it includes
-[Grafana dashboards](https://docs.dev.sync.global/deployment/observability/metrics.html#grafana-dashboards)
+[Grafana dashboards](/global-synchronizer/production-operations/splice-metrics-overview#grafana-dashboards)
 for monitoring the traffic usage, balances of local parties (e.g., the `exchangeParty`),
-and [many other metrics](https://docs.dev.sync.global/deployment/observability/metrics_reference.html).
+and [many other metrics](/global-synchronizer/reference/splice-metrics).
 
 ## Rolling out Major Splice Upgrades
 
 For major protocol changes, the global sychronizer undergoes a [Major
-Upgrade Procedure](https://docs.dev.sync.global/validator_operator/validator_major_upgrades.html).
+Upgrade Procedure](/global-synchronizer/production-operations/validator-major-upgrade).
 The schedule for these upgrades is published by the [Super Validators](https://docs.google.com/document/d/1QhLL5bL0u8temBL86y957VbWDtZJhH9udH-_C7nBlvc/edit?tab=t.0#heading=h.ripdn5ydglli)
 and also announced in the `#validator-operations` slack channel.
 
@@ -169,7 +169,7 @@ As part of this procedure, the old synchronizer is paused, all
 validator operators create an export of the state of their validator,
 and deploy a new validator connected to the new synchronizer and
 import their state again. For a more detailed overview, refer to the
-[Splice docs](https://docs.dev.sync.global/validator_operator/validator_major_upgrades.html).
+[Splice docs](/global-synchronizer/production-operations/validator-major-upgrade).
 
 The procedure requires some experience to get it right, so it is highly
 recommended to run nodes on DevNet and TestNet so you can practice the
@@ -193,7 +193,7 @@ We recommend to roll-out the upgrade as follows:
 
 1. Wait for the synchronizer to be paused and your node to have
    written the migration dump as described in the [Splice
-   docs](https://docs.dev.sync.global/validator_operator/validator_major_upgrades.html#catching-up-before-the-migration).
+   docs](/global-synchronizer/production-operations/validator-major-upgrade#catching-up-before-the-migration).
 2. Open the migration dump and extract the `acs_timestamp` from it, e.g., using `jq .acs_timestamp < /domain-upgrade-dump/domain_migration_dump.json`.
    This is the timestamp at which the synchronizer was paused.
 3. Wait for your Tx History Ingestion to have caught up to record time
@@ -201,13 +201,13 @@ We recommend to roll-out the upgrade as follows:
    to guarantee that your Tx History Ingestion advances past `acs_timestamp`.
 4. Stop your Tx History Ingestion component.
 5. Upgrade your validator and connect it to the new synchronizer following the
-   [Splice docs](https://docs.dev.sync.global/validator_operator/validator_major_upgrades.html#deploying-the-validator-app-and-participant-docker-compose).
+   [Splice docs](/global-synchronizer/production-operations/validator-major-upgrade#deploying-the-validator-app-and-participant-docker-compose).
 6. Follow the shortened version below of the
    [procedure for restoring a validator node from a backup](/global-synchronizer/production-operations/validator-disaster-recovery)
    to determine the offset from which to restart your Tx History Ingestion:
 
     1. Retrieve the `synchronizerId` of the last ingested transaction from the Canton Integration DB.
-    2. Log into the [Canton Console of your validator node](https://docs.dev.sync.global/deployment/console_access.html) and query the offset `offRecovery` assigned to the ACS import transactions at time `0001-01-01T00:00:00.000000Z` using
+    2. Log into the [Canton Console of your validator node](/global-synchronizer/canton-console/console-overview) and query the offset `offRecovery` assigned to the ACS import transactions at time `0001-01-01T00:00:00.000000Z` using
 
        ```scala
        def parseTimestamp(t: String) = {

--- a/docs-main/sdks-tools/sdks/wallet-sdk.mdx
+++ b/docs-main/sdks-tools/sdks/wallet-sdk.mdx
@@ -181,7 +181,7 @@ The SDK can decode prepared transactions into human-readable JSON for display to
 ## Further resources
 
 - [Splice Wallet Kernel GitHub repository](https://github.com/canton-network/wallet-gateway) -- source code, API specs, and example scripts
-- [Token standard documentation](https://docs.sync.global/app_dev/token_standard/index.html) -- full token standard reference
+- [Token standard documentation](/appdev/deep-dives/token-standard) -- full token standard reference
 - [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) -- Canton Network token standard specification
 - [External party signing tutorial](/appdev/deep-dives/external-signing-onboarding) -- step-by-step external signing walkthrough
 - [CN Quickstart](https://github.com/digital-asset/cn-quickstart) -- reference application for getting started with Canton Network development

--- a/docs-main/snippets/external/splice/main/splice-literal-marker-apps-app-src-pack-examples-sv-helm-validator-values-sweep-start.mdx
+++ b/docs-main/snippets/external/splice/main/splice-literal-marker-apps-app-src-pack-examples-sv-helm-validator-values-sweep-start.mdx
@@ -7,7 +7,7 @@
   #    receiver: "<receiverPartyId>"
   #    useTransferPreapproval: false # sweep by transferring directly through the transfer preapproval of the receiver,
   #                                    if set to false sweeping creates transfer offers that need to be accepted on the receiver side.
-  #                                    Note that this refers to the preapprovals described in https://docs.dev.sync.global/background/preapprovals.html
+  #                                    Note that this refers to the preapprovals described in /appdev/modules/m7-canton-coin-preapprovals
   #                                    and not to auto accepting transfers. Auto accept transfers does not setup preapproval contracts that allow
   #                                    for a direct transfer but just automates the acceptance of the transfer offer so in that case
   #                                    useTransferPreapproval should be set to false.


### PR DESCRIPTION
## Summary

Replaces legacy `docs.dev.sync.global` and `docs.sync.global` links with local links to the migrated docs pages. No `docs.test.sync.global` URLs were present on `origin/main`.

## Mapping

| Old URL | Local replacement | Changed page(s) | Basis |
| --- | --- | --- | --- |
| [`https://docs.dev.sync.global/app_dev/overview/version_information.html`](https://docs.dev.sync.global/app_dev/overview/version_information.html) | `/shared/version-compatibility-dashboard` | `/global-synchronizer/faq` | Version information migrated into the version compatibility dashboard used across the site. |
| [`https://docs.dev.sync.global/background/preapprovals.html`](https://docs.dev.sync.global/background/preapprovals.html) | `/appdev/modules/m7-canton-coin-preapprovals` | `/global-synchronizer/deployment/validator-docker-compose`, `/global-synchronizer/deployment/validator-kubernetes`, generated sweep snippet | Target page has `COPIED_START source="splice:docs/src/background/preapprovals.rst"`. |
| [`https://docs.dev.sync.global/`](https://docs.dev.sync.global/) | `/global-synchronizer/release-notes/splice` | `/global-synchronizer/release-notes/weekly-patch-releases` | Link text refers to Splice release notes; target is copied from `docs/src/release_notes.rst`. |
| `docs.sync.global` bare host mention | `This site` | `/global-synchronizer/understand/validator-roles` | The old separate docs host is now the current site. |
| [`https://docs.dev.sync.global/validator_operator/validator_compose.html#deployment`](https://docs.dev.sync.global/validator_operator/validator_compose.html#deployment) | `/global-synchronizer/deployment/validator-docker-compose#deployment` | `/integrations/exchanges/node-operations` | Target page has `COPIED_START source="splice:docs/src/validator_operator/validator_compose.rst"`. |
| [`https://docs.dev.sync.global/validator_operator/validator_helm.html#configuring-automatic-traffic-purchases`](https://docs.dev.sync.global/validator_operator/validator_helm.html#configuring-automatic-traffic-purchases) | `/global-synchronizer/deployment/validator-kubernetes#configuring-automatic-traffic-purchases` | `/integrations/exchanges/node-operations` | Target page has `COPIED_START source="splice:docs/src/validator_operator/validator_helm.rst"` and matching heading. |
| [`https://docs.dev.sync.global/validator_operator/validator_helm.html#configuring-sweeps-and-auto-accepts-of-transfer-offers`](https://docs.dev.sync.global/validator_operator/validator_helm.html#configuring-sweeps-and-auto-accepts-of-transfer-offers) | `/global-synchronizer/deployment/validator-kubernetes#configuring-sweeps-and-auto-accepts-of-transfer-offers` | `/integrations/exchanges/node-operations` | Target page has matching validator Helm copied section and heading. |
| [`https://docs.dev.sync.global/faq.html#term-How-do-I-determine-the-traffic-used-for-a-specific-transaction`](https://docs.dev.sync.global/faq.html#term-How-do-I-determine-the-traffic-used-for-a-specific-transaction) | `/global-synchronizer/faq#how-do-i-determine-the-traffic-used-for-a-specific-transaction` | `/integrations/exchanges/node-operations` | Target FAQ is copied from `docs/src/faq.rst` and contains the exact question. |
| [`https://docs.dev.sync.global/validator_operator/validator_helm.html#logging-into-the-wallet-ui`](https://docs.dev.sync.global/validator_operator/validator_helm.html#logging-into-the-wallet-ui) | `/global-synchronizer/deployment/validator-kubernetes#logging-into-the-wallet-ui` | `/integrations/exchanges/node-operations` | Target page has matching validator Helm heading. |
| [`https://docs.dev.sync.global/validator_operator/validator_helm.html#oidc-provider-requirements`](https://docs.dev.sync.global/validator_operator/validator_helm.html#oidc-provider-requirements) | `/global-synchronizer/deployment/validator-kubernetes#oidc-provider-requirements` | `/integrations/exchanges/node-operations` | Target page has matching validator Helm heading. |
| [`https://docs.dev.sync.global/deployment/observability/index.html`](https://docs.dev.sync.global/deployment/observability/index.html) | `/global-synchronizer/production-operations/splice-metrics-overview` | `/integrations/exchanges/node-operations` | Target page is the migrated Splice metrics/observability overview. |
| [`https://docs.dev.sync.global/deployment/observability/metrics.html#grafana-dashboards`](https://docs.dev.sync.global/deployment/observability/metrics.html#grafana-dashboards) | `/global-synchronizer/production-operations/splice-metrics-overview#grafana-dashboards` | `/integrations/exchanges/node-operations` | Target page has `COPIED_START source="splice:docs/src/deployment/observability/metrics.rst"` and matching heading. |
| [`https://docs.dev.sync.global/deployment/observability/metrics_reference.html`](https://docs.dev.sync.global/deployment/observability/metrics_reference.html) | `/global-synchronizer/reference/splice-metrics` | `/integrations/exchanges/node-operations` | Target page has `COPIED_START source="splice:docs/src/deployment/observability/metrics_reference.rst"`. |
| [`https://docs.dev.sync.global/validator_operator/validator_major_upgrades.html`](https://docs.dev.sync.global/validator_operator/validator_major_upgrades.html) | `/global-synchronizer/production-operations/validator-major-upgrade` | `/integrations/exchanges/node-operations` | Target page has `COPIED_START source="splice:docs/src/validator_operator/validator_major_upgrades.rst"`. |
| [`https://docs.dev.sync.global/validator_operator/validator_major_upgrades.html#catching-up-before-the-migration`](https://docs.dev.sync.global/validator_operator/validator_major_upgrades.html#catching-up-before-the-migration) | `/global-synchronizer/production-operations/validator-major-upgrade#catching-up-before-the-migration` | `/integrations/exchanges/node-operations` | Target page has matching major-upgrade heading. |
| [`https://docs.dev.sync.global/validator_operator/validator_major_upgrades.html#deploying-the-validator-app-and-participant-docker-compose`](https://docs.dev.sync.global/validator_operator/validator_major_upgrades.html#deploying-the-validator-app-and-participant-docker-compose) | `/global-synchronizer/production-operations/validator-major-upgrade#deploying-the-validator-app-and-participant-docker-compose` | `/integrations/exchanges/node-operations` | Target page has matching Docker Compose deployment subsection. |
| [`https://docs.dev.sync.global/deployment/console_access.html`](https://docs.dev.sync.global/deployment/console_access.html) | `/global-synchronizer/canton-console/console-overview` | `/integrations/exchanges/node-operations` | Target page has `COPIED_START source="splice:docs/src/deployment/console_access.rst"`. |
| [`https://docs.sync.global`](https://docs.sync.global) | `/global-synchronizer/understand/introduction` | `/appdev/faq` | Replaces the old operator-doc landing page link with the Global Synchronizer introduction. |
| [`https://docs.sync.global/validator_operator/validator_onboarding.html`](https://docs.sync.global/validator_operator/validator_onboarding.html) | `/global-synchronizer/deployment/onboarding-process` | `/appdev/faq` | Target page has `COPIED_START source="splice:docs/src/validator_operator/validator_onboarding.rst"`. |
| [`https://docs.dev.sync.global/validator_operator/validator_onboarding.html`](https://docs.dev.sync.global/validator_operator/validator_onboarding.html) | `/global-synchronizer/deployment/onboarding-process` | `/appdev/quickstart/prerequisites` | Same validator onboarding source match as above. |
| [`https://docs.sync.global/app_dev/token_standard/index.html`](https://docs.sync.global/app_dev/token_standard/index.html) | `/appdev/deep-dives/token-standard` | `/sdks-tools/sdks/wallet-sdk` | Target page is the migrated token standard deep dive. |

## Validation

- `rg -n "docs\\.(dev\\.|test\\.)?sync\\.global|docs\\.sync\\.global" docs-main -g '*.mdx'` returned no matches.
- Verified every replacement target has a corresponding `docs-main/*.mdx` file.
- `git diff --check`
