### PR TITLE
Remove visible pre-reviewed-content reviewer warnings

### DIFF
--- a/docs-main/appdev/app-rewards.mdx
+++ b/docs-main/appdev/app-rewards.mdx
@@ -9,12 +9,6 @@ The Canton Network incentivizes application providers through a reward system ti
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/overview_tokenomics.rst" hash="2b34b077" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/overview_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 
 
 {/* COPIED_END */}

--- a/docs-main/appdev/deep-dives/app-architecture-design.mdx
+++ b/docs-main/appdev/deep-dives/app-architecture-design.mdx
@@ -5,12 +5,6 @@ description: "Design considerations for Canton Network application components an
 
 {/* COPIED_START source="docs-website:docs/manual/build/3.4/sdlc-howtos/system-design/daml-app-arch-design.rst" hash="1493fac1" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/manual/build/3.4/sdlc-howtos/system-design/daml-app-arch-design.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Canton Network application architecture design considerations
 
 Building and operating a production-level Canton Network application requires careful design considerations for each component. This document introduces the fundamental components of a Canton Network application, focusing on the core responsibilities of the backend, and discusses the costs and benefits of viable tech stacks and architectural options from both the app provider's and app user's perspectives. It also serves as a cross-reference to the *Daml Application Architecture* and *Daml Application Backend* lessons in the Technical Solution Architect certification path.

--- a/docs-main/appdev/deep-dives/authorization.mdx
+++ b/docs-main/appdev/deep-dives/authorization.mdx
@@ -5,12 +5,6 @@ description: "Access tokens, identity providers, scopes, and rights for the Cant
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/secure/authorization.rst" hash="04aa3ece" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/secure/authorization.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 When developing Daml applications using SDK tools, your local setup will most likely not perform any Ledger API request authorization --by default, any valid Ledger API request will be accepted by the sandbox.
 
 This is not the case for participant nodes of deployed ledgers. For every Ledger API request, the participant node checks whether the request contains an access token that is valid and sufficient to authorize that request. You thus need to add support for authorization using access tokens to your application to run it against a deployed ledger.

--- a/docs-main/appdev/deep-dives/command-deduplication.mdx
+++ b/docs-main/appdev/deep-dives/command-deduplication.mdx
@@ -5,12 +5,6 @@ description: "How Daml command deduplication works and how applications can use 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/develop/command-deduplication.rst" hash="1579db0f" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/develop/command-deduplication.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The interaction of a Daml application with the ledger is inherently asynchronous: applications send commands to the ledger, and some time later they see the effect of that command on the ledger. Many things can fail during this time window:
 
 - The application can crash.

--- a/docs-main/appdev/deep-dives/contracts-and-transactions-in-java.mdx
+++ b/docs-main/appdev/deep-dives/contracts-and-transactions-in-java.mdx
@@ -8,12 +8,6 @@ import DevelopPomSnippetDependencyBindingsJava from '/snippets/daml-docs/develop
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/develop/contracts-and-transactions-in-java.rst" hash="b2acac32" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/develop/contracts-and-transactions-in-java.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # How to work with contracts and transactions in Java
 
 When writing Canton Network applications in Java, it is convenient to work with a representation of Daml templates and data types in Java that closely resemble the original Daml code while still being as close to the native types of Java as possible. To achieve this, use the Daml Codegen for Java to generate Java types based on a Daml model. You can then use these types in your Java code when reading information from and sending data to the ledger.

--- a/docs-main/appdev/deep-dives/explicit-contract-disclosure.mdx
+++ b/docs-main/appdev/deep-dives/explicit-contract-disclosure.mdx
@@ -5,12 +5,6 @@ description: "Disclose contracts to non-stakeholders so they can use them as inp
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/develop/explicit-contract-disclosure.rst" hash="fbd2f79a" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/develop/explicit-contract-disclosure.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 In Daml, you must specify who can view data using stakeholder annotations in your template definitions. To change who can see the data, you would typically need to recreate a contract with a template that computes different stakeholder parties.
 
 Explicit contract disclosure allows you to delegate contract read rights to non-stakeholders using off-ledger data distribution. This supports efficient, scalable data sharing on the ledger.

--- a/docs-main/appdev/deep-dives/external-signing-hashing-algorithm.mdx
+++ b/docs-main/appdev/deep-dives/external-signing-hashing-algorithm.mdx
@@ -5,12 +5,6 @@ description: "Deterministic hashing specification for prepared transactions used
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/explanations/external-signing/external_signing_hashing_algorithm.rst" hash="bd159eb2" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/explanations/external-signing/external_signing_hashing_algorithm.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # External Signing Hashing Algorithm
 
 ## Introduction

--- a/docs-main/appdev/deep-dives/external-signing-onboarding.mdx
+++ b/docs-main/appdev/deep-dives/external-signing-onboarding.mdx
@@ -5,12 +5,6 @@ description: "Onboard external parties for external signing using the Admin API 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_onboarding.rst" hash="eb174c28" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_onboarding.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Onboard External Party Using the Admin API
 
 This tutorial demonstrates how to onboard an **external party** using the Admin API. External parties can authorize Daml transactions without the need to trust any node of the network by signing transactions using a key they control. Before proceeding, it is recommended to review the external signing overview to understand the concept of external signing. Additionally, the topology tutorial provides a detailed explanation of the topology concepts used in this tutorial.
@@ -1830,12 +1824,6 @@ if __name__ == "__main__":
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_onboarding_lapi.rst" hash="51422925" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_onboarding_lapi.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Onboard External Party
 
 This tutorial demonstrates how to onboard an **external party** using the Ledger API.
@@ -1965,12 +1953,6 @@ The transactions can be signed one by one, or together as one hash, as done in t
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_onboarding_multihosted.rst" hash="83333f88" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_onboarding_multihosted.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Onboard Multi-Hosted External Party
 

--- a/docs-main/appdev/deep-dives/external-signing-topology.mdx
+++ b/docs-main/appdev/deep-dives/external-signing-topology.mdx
@@ -5,12 +5,6 @@ description: "Build, sign, and submit topology transactions with external keys"
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_topology_transaction.rst" hash="da5014ba" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_topology_transaction.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Externally Signed Topology Transactions
 
 Canton's [Topology](/overview/reference/topology) formalizes a shared state on a synchronizer and provides a secure, distributed mechanism for modifying this state.

--- a/docs-main/appdev/deep-dives/external-signing-transactions.mdx
+++ b/docs-main/appdev/deep-dives/external-signing-transactions.mdx
@@ -5,12 +5,6 @@ description: "Submit externally signed transactions to the Canton ledger"
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_submission.rst" hash="8784b709" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_submission.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Submit Externally Signed Transactions - Part 1
 
 This tutorial demonstrates how to submit Daml commands to a Canton ledger using an external private key for transaction authorization. Before proceeding, it is recommended to review the external signing overview to understand the concept of external signing.
@@ -1693,12 +1687,6 @@ This concludes Part 1 of the tutorial. In Part 2, `Bob` exercises the `Respond` 
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_submission_part_2.rst" hash="cdbe11dc" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_submission_part_2.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Submit Externally Signed Transactions - Part 2
 

--- a/docs-main/appdev/deep-dives/external-signing.mdx
+++ b/docs-main/appdev/deep-dives/external-signing.mdx
@@ -5,12 +5,6 @@ description: "Use external cryptographic keys to sign Canton transactions - over
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_overview.rst" hash="150c3919" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/tutorials/app-dev/external_signing_overview.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # External Signing
 
 ## What you'll learn

--- a/docs-main/appdev/deep-dives/manage-daml-parties.mdx
+++ b/docs-main/appdev/deep-dives/manage-daml-parties.mdx
@@ -5,12 +5,6 @@ description: "Allocate new parties on a participant and query party metadata."
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/sdlc-howtos/applications/develop/manage-daml-parties.rst" hash="350b9af7" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/sdlc-howtos/applications/develop/manage-daml-parties.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # How to allocate and query Daml parties
 
 Canton Participant Node exposes a party management service that allows creation and discovery of the Daml parties. This guide explains how to programmatically manipulate the parties using the JSON Ledger API, which is described using OpenAPI specifications.

--- a/docs-main/appdev/deep-dives/multi-hosting.mdx
+++ b/docs-main/appdev/deep-dives/multi-hosting.mdx
@@ -62,12 +62,6 @@ When onboarding an external party, include additional validators in the topology
 
 {/* COPIED_START source="docs-website:canton/3.5/sdk/tutorials/app-dev/external_signing_onboarding_multihosted.rst" hash="multi-hosting-lapi" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `canton/3.5/sdk/tutorials/app-dev/external_signing_onboarding_multihosted.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The generated topology transactions need to be uploaded to each hosting validator's Ledger API. When a party-to-participant mapping is uploaded through the allocate endpoint which mentions the local validator, it is automatically signed by the local validator and forwarded to the network. If the topology transaction is not fully authorized (some signatures are still missing), it is treated as a proposal.
 
 If the proposal already exists on the network, the new signatures are merged into the proposal. Once enough signatures are present, the topology transaction is accepted and added to the state.

--- a/docs-main/appdev/deep-dives/open-tracing.mdx
+++ b/docs-main/appdev/deep-dives/open-tracing.mdx
@@ -5,12 +5,6 @@ description: "Adding OpenTelemetry-based distributed tracing to Daml application
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/observe/open-tracing.rst" hash="03a5f726" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/observe/open-tracing.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Introduction
 
 Distributed tracing is a technique used for troubleshooting performance issues in a microservices environment like Daml Enterprise. Tracing in Canton has been described in a page dedicated to monitoring (Canton Monitoring / Tracing). This guide describes how to write **Ledger API** client applications so that distributed traces and spans can seamlessly continue between the client and Canton software components.

--- a/docs-main/appdev/deep-dives/performance-optimization.mdx
+++ b/docs-main/appdev/deep-dives/performance-optimization.mdx
@@ -12,12 +12,6 @@ import DamlAppdevModulesM7PerformanceL45 from "/snippets/daml-docs/appdev_module
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/optimize/performance.rst" hash="398aa5ae" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/optimize/performance.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <Note>
 Ensure that the following performance tuning parameters (in ParticipantNodeParameterConfig or CantonParameters) are covered somewhere in the optimize group of docs - startup parallelism - timeouts - startup memory checks - batching config - caching config - warn if overloaded - journal GC delay - package metadata view
 </Note>
@@ -421,12 +415,6 @@ Generally, using `lookupKey` is also discouraged. If you use `lookupByKey` for o
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/optimise/latency-and-throughput.rst" hash="bcca0bd1" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/optimise/latency-and-throughput.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Managing Latency and Throughput
 
 ## Problem Definition
@@ -746,12 +734,6 @@ Profile the JVM and monitor your databases to see where the bottlenecks occur.
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/optimise/active-contract-set.rst" hash="d8f44824" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/optimise/active-contract-set.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Managing Active Contract Set (ACS) Size
 
 ## Problem Definition
@@ -793,12 +775,6 @@ Large ACS can have a negative impact on many aspects of system performance in re
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/optimise/contention-avoiding.rst" hash="9368bace" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/optimise/contention-avoiding.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Avoid Contention Issues
 
@@ -843,12 +819,6 @@ Contention slows performance significantly. While you cannot avoid contention co
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/optimise/contention-reducing.rst" hash="bfd45687" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/optimise/contention-reducing.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Reduce Contention
 
 Contention is natural and expected when programming within a distributed system like Daml in which every action is asynchronous. It is important to understand the different causes of contention, be able to diagnose the root cause if errors of this type occur, and be able to avoid contention by designing contracts appropriately.
@@ -880,12 +850,6 @@ You can use different techniques to manage contention and to improve performance
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/optimise/contention-techniques.rst" hash="c49bf0bb" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/optimise/contention-techniques.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Example Application with Techniques for Reducing Contention
 
@@ -1243,12 +1207,6 @@ Performance optimization for Canton applications means understanding the boundar
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst" hash="on-off-ledger" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Canton Network application design should account for performance characteristics, carefully considering on-ledger versus off-ledger implementation. When deciding whether information should be stored on-ledger:
 
 - **State** — Essential facts in the workflow. When these facts require agreement across organizations, store them on-ledger.
@@ -1284,12 +1242,6 @@ Contract keys enable efficient lookups but introduce contention. If multiple tra
 ## PQS Query Optimization
 
 {/* COPIED_START source="docs-website:replicated/pqs/3.5/component-howtos/pqs/optimize/index.rst" hash="pqs-optimize" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `replicated/pqs/3.5/component-howtos/pqs/optimize/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 PQS stores contract data in JSONB columns in PostgreSQL. For read-heavy workloads, proper indexing is critical.
 

--- a/docs-main/appdev/deep-dives/smart-contract-upgrade.mdx
+++ b/docs-main/appdev/deep-dives/smart-contract-upgrade.mdx
@@ -5,12 +5,6 @@ description: "Develop, deploy, and validate smart contract upgrades across Daml 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/smart-contracts/upgrade/smart-contract-upgrades.rst" hash="ffdaf7cc" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/sdlc-howtos/smart-contracts/upgrade/smart-contract-upgrades.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Smart Contract Upgrade
 
 ## Overview

--- a/docs-main/appdev/deep-dives/smart-contract-upgrading-reference.mdx
+++ b/docs-main/appdev/deep-dives/smart-contract-upgrading-reference.mdx
@@ -5,12 +5,6 @@ description: "Detailed rules for package validation on upload, and runtime upgra
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/smart-contract-upgrades.rst" hash="9f2fcd76" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/smart-contract-upgrades.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 This document describes in detail what rules govern package validation upon upload and how contracts, choice arguments and choice results are upgraded or downgraded at runtime. These topics are for a large part covered in Smart Contract Upgrade. This document acts as a thorough reference.
 
 ## Static Checks

--- a/docs-main/appdev/deep-dives/token-standard.mdx
+++ b/docs-main/appdev/deep-dives/token-standard.mdx
@@ -8,12 +8,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/app_dev/token_standard/index.rst" hash="f20ad600" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/token_standard/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Overview
 
 - See the [text of the CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) for an overview of the APIs that are part of the Canton Network Token Standard.

--- a/docs-main/appdev/deep-dives/tokenomics.mdx
+++ b/docs-main/appdev/deep-dives/tokenomics.mdx
@@ -7,12 +7,6 @@ Following is an overview of the Canton Network tokenomics for application develo
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/overview_tokenomics.rst" hash="4b0e1a6e" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/overview_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Canton Network tokenomics is based on an *Activity Record* which identifies a party that performed an action which provides value to the network. An activity record has a *weight* which is the relative share of CC minting associated with this activity record.
 
 Creating an activity record and minting the associated Canton Coin (CC) are two distinct steps. The creation and minting steps are performed in a cycle that is called a *round* which has five phases. In the first phase, any fee values for that round are written to the ledger (the fees can be obtained from the Scan State API). The second phase is called the *activity recording* and it is when activity records are created; records created in this phase belong to that round. The next phase calculates a [CC-issuance-per-activity-weight](https://github.com/canton-network/splice/blob/332e06a7ae9e13fde5bba0bf7dcb059aa36f979e/daml/splice-amulet/daml/Splice/Issuance.daml#L67) for each kind of activity record which is the share of total CC that can be minted for this type of activity record. This is followed by a *minting phase* where the owners of an activity record can mint CC proportional to its minting weight.
@@ -73,12 +67,6 @@ The holding fees is a fixed fee, per separate coin contract (UTXO) per unit of t
 
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst" hash="f4ed8911" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ## Featured Application Activity Marker
 
@@ -158,12 +146,6 @@ It is possible to share the attribution of activity for the `FeaturedAppActivity
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/cc_transfer_splice_wallet_tokenomics.rst" hash="d0136d43" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/cc_transfer_splice_wallet_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## A CC Transfer using the Splice Wallet UI
 
 A manual CC transfer using the UI of the Splice wallet (the wallet UI built into every validator) is an example of an AmuletRules_Transfer. There are three types of manual transfers possible with the Splice Wallet UI:
@@ -193,12 +175,6 @@ When comparing the `Amulet` legacy and token standard two-step transfers, a diff
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/traffic_tokenomics.rst" hash="f063357a" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/traffic_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Traffic credits are used for all submissions to the Global Synchronizer. Traffic costs are charged for sending all data based on the size of the messages and its delivery cost. However only the sending validator node is charged. Please refer to `traffic` for more details.
 
 A validator increases its traffic credit balance by burning CC at the current USD-to-Canton-Coin conversion rate (a USD/MB price). When needed, the operator of a validator (or a third-party service provider) burns CC in exchange for traffic credits. The CC burned creates a ValidatorRewardCoupon with the amount of CC burnt and where the `user` is the validator operator of the validator hosting the purchasing party. There is no application involved so no AppRewardCoupon is created.
@@ -213,12 +189,6 @@ Note that traffic credits are used whenever a confirmation request for a Daml tr
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/val_live_tokenomics.rst" hash="48ad8bfc" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/val_live_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 In each round, each live validator records its liveness activity with a ValidatorLivenessActivityRecord. This rewards a validator for being available to validate and confirm transactions. It also provides them with initial funds to purchase extra traffic for higher throughput, after onboarding.
 
 
@@ -226,12 +196,6 @@ In each round, each live validator records its liveness activity with a Validato
 
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/sv_live_tokenomics.rst" hash="a7bf1890" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/sv_live_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Each Super Validator, in each round, creates an SvRewardCoupon.
 

--- a/docs-main/appdev/deep-dives/upgrading-architecture.mdx
+++ b/docs-main/appdev/deep-dives/upgrading-architecture.mdx
@@ -5,12 +5,6 @@ description: "Architectural considerations when upgrading a Canton Network appli
 
 {/* COPIED_START source="docs-website:docs/manual/build/3.4/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="0acbea7d" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/manual/build/3.4/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Architectural considerations for upgrading a Canton Network application
 
 Upgrading a Canton Network application involves deploying new versions of its components with the aim to modify existing workflows or to introduce new ones. The upgrade process must ensure data continuity: it must allow the application state and in-flight workflows to remain accessible and to advance without interruption post-upgrade. Note, in this context, “in-flight” refers to incomplete multi-step workflows that are stable on-ledger, rather than individual transactions.

--- a/docs-main/appdev/deep-dives/values-in-the-ledger-api.mdx
+++ b/docs-main/appdev/deep-dives/values-in-the-ledger-api.mdx
@@ -5,12 +5,6 @@ description: "Validation, normalization, and dynamic package resolution rules fo
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/smart-contract-upgrades.rst#values-in-the-ledger-api" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/smart-contract-upgrades.rst` (section: Values in the Ledger API)
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Commands and queries have relaxed validation rules for ingested values. Returned values are subject to normalization.
 
 ### Value Validation in Commands

--- a/docs-main/appdev/modules/m3-building-packaging.mdx
+++ b/docs-main/appdev/modules/m3-building-packaging.mdx
@@ -123,12 +123,6 @@ When working on Canton Network projects, use the [`dpm`](/sdks-tools/cli-tools/d
 The `dpm` tool wraps the Daml compiler and build system with Canton Network defaults, handling SDK versioning and dependency resolution automatically.
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/smart-contracts/build/how-to-build-dar-files.rst" hash="497ab124" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/smart-contracts/build/how-to-build-dar-files.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # How to build Daml Archive (.dar) files
 
 This guide shows you how to organize the source code defining your Daml workflows and how to build and package that code as Daml Archive (.dar) files, which you can deploy to the ledger or use to develop applications against. The guide is organized into the following smaller how-tos:

--- a/docs-main/appdev/modules/m3-design-patterns.mdx
+++ b/docs-main/appdev/modules/m3-design-patterns.mdx
@@ -385,12 +385,6 @@ One party kicks off the workflow by creating a `Pending` contract listing only t
 {/* COPIED_END */}
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/compose.rst" hash="f782af8e" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/compose.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Compose choices
 
 It's time to put everything you've learned so far together into a complete and secure Daml model for asset issuance, management, transfer, and trading. This application will have capabilities similar to the one in `/app-dev/bindings-java/quickstart`. In the process you will learn about a few more concepts:

--- a/docs-main/appdev/modules/m3-functional-programming.mdx
+++ b/docs-main/appdev/modules/m3-functional-programming.mdx
@@ -45,12 +45,6 @@ import DamlTutorialsSmartContractsIntroAssetMultiTradeExample from "/snippets/ex
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/functional-101.rst" hash="57479f7e" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/functional-101.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Functional programming 101
 
 In this chapter, you will learn more about expressing complex logic in a functional language like Daml. Specifically, you'll learn about

--- a/docs-main/appdev/modules/m3-language-fundamentals.mdx
+++ b/docs-main/appdev/modules/m3-language-fundamentals.mdx
@@ -426,12 +426,6 @@ You now know the basics of functions and control flow, both in pure and Action c
 {/* COPIED_END */}
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/data.rst" hash="22bd66ce" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/data.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Data types
 
 In `contracts`, you learnt about contract templates, which specify the types of contracts that can be created on the ledger, and what data those contracts hold in their arguments.

--- a/docs-main/appdev/modules/m3-standard-library.mdx
+++ b/docs-main/appdev/modules/m3-standard-library.mdx
@@ -5,12 +5,6 @@ description: "Tour of the Daml standard library: the Prelude, important types an
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/stdlib.rst" hash="0782e6fd" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/stdlib.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 In `data` and `functional-101` you learned how to define your own data types and functions. However, you don't have to implement everything from scratch. Daml comes with the Daml standard library, which contains types, functions, and typeclasses that cover a large range of use cases.
 
 In this chapter, you'll get an overview of the essentials and learn how to browse and search the library to find functions. Being proficient with the standard library will make you considerably more efficient writing Daml code. Specifically, this chapter covers:

--- a/docs-main/appdev/modules/m3-working-with-time.mdx
+++ b/docs-main/appdev/modules/m3-working-with-time.mdx
@@ -215,12 +215,6 @@ In the Coin contract, the Transfer choice has an additional deadline argument, s
 {/* COPIED_END */}
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/constraints.rst" hash="dc7e974c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/constraints.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Add constraints to a contract
 
 You will often want to constrain the data stored or the allowed data transformations in your contract models. In this section, you will learn about the two main mechanisms provided in Daml:

--- a/docs-main/appdev/modules/m4-featured-app-activity-marker.mdx
+++ b/docs-main/appdev/modules/m4-featured-app-activity-marker.mdx
@@ -9,12 +9,6 @@ When your application runs on Canton Network, economically meaningful events can
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst" hash="95e394aa" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 
 
 {/* COPIED_END */}
@@ -26,12 +20,6 @@ After [CIP-0078](https://github.com/global-synchronizer-foundation/cips/blob/mai
 ## When to Create Markers
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst" hash="95e394aa" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 
 
@@ -45,12 +33,6 @@ The `FeaturedAppActivityMarker` contract is specified in [CIP-0047](https://gith
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst" hash="95e394aa" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 
 
 {/* COPIED_END */}
@@ -58,12 +40,6 @@ Reviewers: Skip this section. Remove markers after final approval.
 The marker contract includes fields that identify your application, the type of activity, and metadata about the event. Refer to [CIP-0047](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0047/cip-0047.md) for the exact contract interface and required fields.
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst" hash="95e394aa" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/feat_app_act_marker_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 It is possible to share the attribution of activity for the `FeaturedAppActivityMarker`. The `FeaturedAppRight_CreateActivityMarker` choice accepts a list of `AppRewardBeneficiary` contracts. Then a `FeaturedAppActivityMarker` is created for each `beneficiary` with the `weight` field set appropriately.
 

--- a/docs-main/appdev/modules/m4-json-api-tutorial.mdx
+++ b/docs-main/appdev/modules/m4-json-api-tutorial.mdx
@@ -8,12 +8,6 @@ import ExternalDpmMainDpmRstCodeDocsSrcPublicDpmShell86 from "/snippets/external
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/tutorials/json-api/canton_and_the_json_ledger_api.rst" hash="37587c42" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/tutorials/json-api/canton_and_the_json_ledger_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Get started with Canton and the JSON Ledger API
 This tutorial demonstrates how to interact with the Canton Ledger using the JSON Ledger API from the command line. It uses `curl` and optionally `websocat` to communicate with the Ledger.
 
@@ -281,12 +275,6 @@ For more information about error codes returned by the JSON Ledger API, see `jso
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/tutorials/json-api/canton_and_the_json_ledger_api_ts.rst" hash="a2d8fcf5" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/tutorials/json-api/canton_and_the_json_ledger_api_ts.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ## Get Started with Canton, the JSON Ledger API, and TypeScript
 This tutorial shows you how to interact with a Canton Ledger using the JSON Ledger API and TypeScript.

--- a/docs-main/appdev/modules/m4-query-with-pqs.mdx
+++ b/docs-main/appdev/modules/m4-query-with-pqs.mdx
@@ -24,12 +24,6 @@ import ExternalScribeMainScribeRstCodeDocsUserSdlcHowtosApplicationsDevelopPqsIn
 
 {/* COPIED_START source="docs-website:docs/replicated/pqs/3.4/sdlc-howtos/applications/develop/pqs/index.rst" hash="a0009fae" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/pqs/3.4/sdlc-howtos/applications/develop/pqs/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # How to query contracts and transactions using SQL
 
 ## Query

--- a/docs-main/appdev/modules/m5-ci-cd-integration.mdx
+++ b/docs-main/appdev/modules/m5-ci-cd-integration.mdx
@@ -106,12 +106,6 @@ Each promotion runs the same deployment steps with different environment configu
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst" hash="ci-monitoring" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Regularly review logs during development and testing, such as by capturing logs in CI runs and using them for debugging CI failures. Set up alerts on metrics to monitor the application's health during testing and development. This ensures operational reuse and integration into the long-running test instance. Well-tuned alerts established during development can be reused in operations to detect system health issues.
 
 {/* COPIED_END */}

--- a/docs-main/appdev/modules/m5-deployment-progression.mdx
+++ b/docs-main/appdev/modules/m5-deployment-progression.mdx
@@ -31,12 +31,6 @@ For detailed upgrade procedures, see the [Validator Upgrades](/global-synchroniz
 
 {/* COPIED_START source="docs-website:replicated/quickstart/3.5/sdk/quickstart/upgrade/upgrades-on-global-sync.rst" hash="upgrade-types" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `replicated/quickstart/3.5/sdk/quickstart/upgrade/upgrades-on-global-sync.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The super validators (SVs) periodically implement upgrades to the Global Synchronizer to improve functionality, resolve issues, and introduce new features. As a node operator or application provider you should be aware of the three types of upgrades that may occur.
 
 ### Type 1: Backward-compatible changes
@@ -88,12 +82,6 @@ Before promoting your application to the next environment, verify:
 - Your organization has reviewed the DAR deployment coordination process with counterparties
 
 {/* COPIED_START source="docs-website:replicated/quickstart/3.5/sdk/quickstart/upgrade/upgrades-on-global-sync.rst" hash="preparing-upgrades" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `replicated/quickstart/3.5/sdk/quickstart/upgrade/upgrades-on-global-sync.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Application providers should maintain nodes on DevNet, TestNet, and MainNet to guarantee smooth operations during upgrades. By maintaining nodes across all three environments you substantially increase the likelihood that MainNet upgrades proceed without disrupting your services or customers.
 

--- a/docs-main/appdev/modules/m5-environment-configuration.mdx
+++ b/docs-main/appdev/modules/m5-environment-configuration.mdx
@@ -18,12 +18,6 @@ DPM is Daml's package manager.
 
 {/* COPIED_START source="docs-website:replicated/dpm/3.5/configuration.rst" hash="dpm-config" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `replicated/dpm/3.5/configuration.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 `dpm` can be configured through a config file and environment variables simultaneously. Environment variables take precedence over the config file.
 
 ### Config file
@@ -50,12 +44,6 @@ These override the corresponding config file settings:
 ## Project Configuration
 
 {/* COPIED_START source="docs-website:replicated/dpm/3.5/configuration.rst" hash="project-config" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `replicated/dpm/3.5/configuration.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ### daml.yaml
 
@@ -131,12 +119,6 @@ This is an advanced topic. Override SDK components only with guidance from suppo
 </Warning>
 
 {/* COPIED_START source="docs-website:replicated/dpm/3.5/configuration.rst" hash="override-components" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `replicated/dpm/3.5/configuration.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 `dpm` supports overriding individual SDK components for a single package or an entire multi-package project. In `daml.yaml`:
 

--- a/docs-main/appdev/modules/m5-localnet-development.mdx
+++ b/docs-main/appdev/modules/m5-localnet-development.mdx
@@ -15,12 +15,6 @@ LocalNet is a Docker Compose-based local network that mirrors the Canton Network
 
 {/* COPIED_START source="splice:docs/src/app_dev/testing/localnet.rst" hash="localnet-overview" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `splice/docs/src/app_dev/testing/localnet.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 LocalNet provides a topology comprising three participants, three validators, a PostgreSQL database, and several web applications (wallet, SV, scan) behind an NGINX gateway. Each validator plays a distinct role within the Splice ecosystem:
 
 - **app-provider** — For the user operating their application
@@ -34,12 +28,6 @@ LocalNet is designed for development and testing. It is not intended for product
 ## The Development Lifecycle
 
 {/* COPIED_START source="docs-website:replicated/quickstart/3.5/sdk/quickstart/configure/development-lifecycle.rst" hash="dev-lifecycle" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `replicated/quickstart/3.5/sdk/quickstart/configure/development-lifecycle.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Most development teams go through five distinct phases with the cn-quickstart:
 
@@ -108,12 +96,6 @@ If you're using cn-quickstart, the Makefile wraps the Docker Compose commands:
 
 {/* COPIED_START source="splice:docs/src/app_dev/testing/localnet.rst" hash="localnet-start-stop" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `splice/docs/src/app_dev/testing/localnet.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 For direct Docker Compose control, set the environment variables `LOCALNET_DIR` (path to the LocalNet directory) and `IMAGE_TAG` (Splice version), then use:
 
 ```bash
@@ -143,12 +125,6 @@ You can use Docker Compose profiles (`--profile app-provider`, etc.) alongside e
 ## Ports and Services
 
 {/* COPIED_START source="splice:docs/src/app_dev/testing/localnet.rst" hash="localnet-ports" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `splice/docs/src/app_dev/testing/localnet.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Ports follow a pattern based on the validator role:
 

--- a/docs-main/appdev/modules/m5-manage-daml-packages.mdx
+++ b/docs-main/appdev/modules/m5-manage-daml-packages.mdx
@@ -5,12 +5,6 @@ description: "Upload DAR files to a participant and query available Daml package
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/sdlc-howtos/applications/develop/manage-daml-packages.rst" hash="79eb54da" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/sdlc-howtos/applications/develop/manage-daml-packages.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # How to upload and query Daml packages
 
 Canton Participant Node exposes a package management service that allows uploading and discovery of the Daml packages. This guide explains how to programmatically manipulate the packages using the JSON Ledger API, which is described using OpenAPI specifications.

--- a/docs-main/appdev/modules/m5-networks-and-use-cases.mdx
+++ b/docs-main/appdev/modules/m5-networks-and-use-cases.mdx
@@ -5,12 +5,6 @@ description: "DevNet, TestNet, and MainNet purpose and testing guidelines for ap
 
 {/* COPIED_START source="splice:docs/src/app_dev/testing/networks_and_usecases.rst" hash="91779539" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/testing/networks_and_usecases.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The Super Validators operate three(3) different networks:
 
 1.  DevNet

--- a/docs-main/appdev/modules/m5-testing-strategies.mdx
+++ b/docs-main/appdev/modules/m5-testing-strategies.mdx
@@ -13,12 +13,6 @@ Testing Canton applications follows the same principle as any distributed system
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst" hash="test-section" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Canton applications use a three-layer testing approach, where each layer catches different classes of issues:
 
 - **Unit tests** — Daml Script tests that verify smart contract logic in isolation. These run against an in-memory ledger (the Sandbox) without any network overhead.
@@ -55,12 +49,6 @@ Focus on the behaviors that are unique to your Daml model:
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst" hash="test-separation" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Unit tests for Daml workflows are compiled into DAR files. These DAR files are for testing only and should not be deployed to validators. Keep test code in separate DAR files from production code by placing tests in a dedicated package:
 
 ```text
@@ -90,12 +78,6 @@ For backend services that talk to the Ledger API, write tests that:
 4. Assert on the resulting ledger state or API responses
 
 {/* COPIED_START source="docs-website:daml/3.5/sdk/tutorials/quickstart/template-root/src/main/java/com/daml/quickstart/iou/IouMain.java" hash="integration-pattern" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `daml/3.5/sdk/tutorials/quickstart/template-root/src/main/java/com/daml/quickstart/iou/IouMain.java`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 A Java integration test connects to the Ledger API over gRPC and submits commands:
 
@@ -139,12 +121,6 @@ Iterator<GetActiveContractsResponse> activeContracts =
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst" hash="test-isolation" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 A testing optimization is to have a  long-running Canton instances to avoid repeatedly initializing and starting Canton. Isolate tests using unique participant users and parties for each test run.
 One approach is appending a test run ID as a suffix to party and user names in your test harness.
 
@@ -163,12 +139,6 @@ For frontend-involved tests, use tools like [Selenium](https://www.selenium.dev/
 ### Time-dependent workflows
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst" hash="time-deps" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 For time-sensitive workflows, use the `passTime` function in Daml and configure reduced wait times for faster CI execution. Workflows that incorporate calendar or time functions — such as bond lifecycling with coupon payments — can be tested by advancing time with `passTime`. For end-to-end tests, configure workflows to advance in milliseconds to reduce CI execution time. Pause and resume automation from the test harness to prevent race conditions.
 
@@ -189,12 +159,6 @@ Investing time to eliminate flaky tests pays off quickly. A reliable test suite 
 ## Performance Testing
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst" hash="perf-testing" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Start performance testing early and continuously. Create separate performance tests for each relevant workflow. Test at scale with synthetic data resembling production characteristics. Measure performance characteristics and reset them between test runs to detect regressions. Perform soak testing with long-running deployments to detect bottlenecks. Set up alerting to monitor system failures, tuning it over time for optimal observability.
 

--- a/docs-main/appdev/modules/m6-deployment.mdx
+++ b/docs-main/appdev/modules/m6-deployment.mdx
@@ -29,12 +29,6 @@ The deployment follows the asynchronous rollout model described in the [Overview
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="uncoordinated-risks" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Uncoordinated transitions to v2 workflows can cause command submission failures, resulting in workflows getting stuck. Common scenarios include:
 
 - **Daml model version mismatch** — A command referencing v2 workflows fails if a stakeholder's participant node lacks the required v2 package or the v2 package is not vetted.  In this situation, the v1 version will be used if it remains vetted.
@@ -53,12 +47,6 @@ To avoid these issues, communicate the upgrade timeline clearly:
 ## Contract Migration Strategies
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="migration-strategies" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Not all contracts need explicit migration. Contract archival in Daml can happen through several paths:
 
@@ -80,12 +68,6 @@ For backward-incompatible changes that require old v1 contracts to upgrade to v2
 ## Rollback Strategies
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="rollback" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ### Rollback by unvetting
 

--- a/docs-main/appdev/modules/m6-limitations.mdx
+++ b/docs-main/appdev/modules/m6-limitations.mdx
@@ -26,12 +26,6 @@ You cannot remove a template from a package in a later version. If version 1 def
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="0acbea7d" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ### Adding and Deprecating Templates
 
 New templates can be added. Existing templates cannot be removed but can be deprecated by:
@@ -78,12 +72,6 @@ For contrast, these modifications are allowed across package versions:
 ## Planning Around Limitations
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="0acbea7d" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ### Manage Backward-Incompatible Changes
 

--- a/docs-main/appdev/modules/m6-overview.mdx
+++ b/docs-main/appdev/modules/m6-overview.mdx
@@ -15,12 +15,6 @@ This creates a challenge: you can't force all organizations to upgrade simultane
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="recommended-approach" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The recommended approach combines an asynchronous rollout with a synchronous switch-over:
 
 **Asynchronous rollout:**
@@ -63,12 +57,6 @@ Not every change requires the upgrade mechanism. Consider the trade-offs:
 ## Key Challenges
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="challenges" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 - **Asynchronous rollouts** — App providers and app users often cannot upgrade simultaneously. Upgrades must allow independent deployment schedules.
 - **Mixed-version deployments** — Due to asynchronous rollouts, the application must temporarily support mixed-version deployments across organizations. Backends and frontends must remain compatible with both v1 and v2 DAR workflows.

--- a/docs-main/appdev/modules/m6-package-naming.mdx
+++ b/docs-main/appdev/modules/m6-package-naming.mdx
@@ -9,12 +9,6 @@ Good package naming prevents confusion as your application evolves through multi
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="0acbea7d" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Avoid package name conflicts, particularly between packages published by different app providers. Follow the Java ecosystem’s convention of prefixing package names with the reverse Domain Name System (DNS) name of the app provider. For example, for the issuance workflows of the money market fund app provided by Acme Inc., the recommended <span class="title-ref">daml.yaml</span> configuration would be: <span class="title-ref">name: com-acme-money-market-fund-issuance</span>.
 
 Daml package names use hyphens as separators (not dots). The reverse DNS prefix establishes organizational ownership, and the remaining segments describe the package's purpose.

--- a/docs-main/appdev/modules/m6-package-selection.mdx
+++ b/docs-main/appdev/modules/m6-package-selection.mdx
@@ -41,12 +41,6 @@ The ledger doesn't automatically migrate v1 contracts to v2. A v1 contract stays
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="package-vetting" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Vetting a package allows other participant nodes to determine which workflows the parties on the participant can engage in. A package cannot be used until it is vetted, providing an additional verification step in the deployment process. By default, when a Daml package is uploaded, the participant node automatically marks it as vetted and publishes its vetting status on the synchronizer.
 
 Packages can also be unvetted. For example, after uploading and vetting v2, unvetting v1 signals that the participant node can no longer participate in v1 workflows, finalizing the upgrade process.

--- a/docs-main/appdev/modules/m6-testing-upgrades.mdx
+++ b/docs-main/appdev/modules/m6-testing-upgrades.mdx
@@ -13,12 +13,6 @@ Upgrading Daml packages across a distributed network leaves no room for guesswor
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="type-level-testing" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 A type-level compatibility test checks whether the old and new versions of a package with the same name can coexist without breaking. The easiest way to test this during development is to use the `dpm upgrade-check` command.
 
 It is also recommended to do this as part of CI by uploading both old and new versions to a fresh
@@ -37,12 +31,6 @@ In practice, this means your CI pipeline should:
 ## Workflow-Level Compatibility Tests
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="workflow-testing" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 A workflow-level compatibility test verifies that core business processes continue to function correctly after an upgrade. A basic integration test should follow these steps:
 

--- a/docs-main/appdev/modules/m6-upgrade-compatibility.mdx
+++ b/docs-main/appdev/modules/m6-upgrade-compatibility.mdx
@@ -9,12 +9,6 @@ SCU defines strict rules about which changes to Daml models are backward-compati
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="backward-compat" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ### Adding Optional fields
 
 `Optional` fields can be added to contracts, choice arguments, and choice return types.
@@ -82,12 +76,6 @@ If you need to make a breaking change, create new templates with the desired str
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="backend-compat" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 You must use symbolic package references and not package IDs. These references take the form of `#package-name:module-name:template-id` for ledger reads to retrieve data from all contracts that are instances of the template with `module-name` and `template-id` of any version of the `package-name`.
 
 Since newer versions of a template may introduce `Optional` fields that did not exist in earlier versions, the backend must handle cases where these fields are missing. The Daml SDK's codegens automatically set missing `Optional` fields to `None`.
@@ -97,12 +85,6 @@ Since newer versions of a template may introduce `Optional` fields that did not 
 ## Package Naming
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst" hash="package-naming" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/applications/upgrade/arch-considerations-upgrading.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Avoid package name conflicts, particularly between packages published by different app providers. Follow the Java ecosystem's convention of prefixing package names with the reverse DNS name of the app provider. For example, for the issuance workflows of the money market fund app provided by Acme Inc., the recommended `daml.yaml` configuration would be: `name: com-acme-money-market-fund-issuance`.
 

--- a/docs-main/appdev/modules/m7-canton-coin-preapprovals.mdx
+++ b/docs-main/appdev/modules/m7-canton-coin-preapprovals.mdx
@@ -5,12 +5,6 @@ description: "How TransferPreapproval contracts enable preapproved Canton Coin t
 
 {/* COPIED_START source="splice:docs/src/background/preapprovals.rst" hash="b2b9b8f3" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/preapprovals.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Contrary to other assets like Eth or Bitcoin, Canton Coin requires a party to explicitly agree to hold Canton Coin. This includes explicitly agreeing to any incoming transfers.
 
 Parties that are ok with accepting incoming Canton Coin transfers from any sender, can setup a `TransferPreapproval`. This allows any party to send Canton Coin to the party that setup the `TransferPreapproval`. Note that this only applies to transfers of Canton Coin but not to other assets. Other assets may provide their own variant of a preapproval which needs to be setup separately or they may require approval of each incoming transfer individually.

--- a/docs-main/appdev/modules/m7-package-management.mdx
+++ b/docs-main/appdev/modules/m7-package-management.mdx
@@ -64,12 +64,6 @@ DARs are small, so checking them into version control is also a viable approach 
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst" hash="dar-distribution" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The same DAR files must be deployed on all validators hosting parties involved in the workflow. Daml code defines the API for state and workflows synchronized across validators, similar to `.proto` files for a gRPC server shared with gRPC client developers.
 
 It is recommended to store Daml code in a separate repo from backend and frontend code and provide app user organizations with a tarball or read-only access to this repo. This allows organizations to review and build the code to ensure confidence in the behavior of the DAR file installed on their validators.
@@ -86,12 +80,6 @@ Practical steps for distribution:
 ## Package Modularization
 
 {/* COPIED_START source="docs-website:manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst" hash="dar-modularization" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `manual/build/3.5/sdlc-howtos/sdlc-best-practices.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 - **Stakeholder-oriented modules** — Modularize workflows based on stakeholder interaction to simplify upgrades and maintain privacy. DAR files only need to be distributed to validators hosting the parties involved in the workflow.
 - **Public and private APIs** — Minimize public workflows and store internal workflows in separate DAR files to allow more flexibility in adapting to evolving business needs.  Separate interface definitions in their own package for better workflow management.  Use interface definitions to specify public APIs which will make application upgrades easier.

--- a/docs-main/appdev/quickstart/deploy-to-devnet.mdx
+++ b/docs-main/appdev/quickstart/deploy-to-devnet.mdx
@@ -69,12 +69,6 @@ import ExternalCnQuickstartMainCnQuickstartRstCodeSdkDocsSharableSdkQuickstartOp
 
 {/* COPIED_START source="docs-website:docs/replicated/quickstart/3.5/sdk/quickstart/operate/deploy-quickstart-to-devnet.rst" hash="d9f5e11c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/quickstart/3.5/sdk/quickstart/operate/deploy-quickstart-to-devnet.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Overview
 
 In this guide, you'll deploy the Quickstart app from LocalNet to DevNet.

--- a/docs-main/appdev/quickstart/external-parties.mdx
+++ b/docs-main/appdev/quickstart/external-parties.mdx
@@ -32,12 +32,6 @@ import ExternalCnQuickstartMainCnQuickstartRstCodeSdkDocsSharableSdkQuickstartOp
 
 {/* COPIED_START source="docs-website:docs/replicated/quickstart/3.5/sdk/quickstart/operate/how-to-onboard-external-parties-in-quickstart.rst" hash="98e63e58" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/quickstart/3.5/sdk/quickstart/operate/how-to-onboard-external-parties-in-quickstart.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Introduction
 
 External parties control their cryptographic signing keys, which removes

--- a/docs-main/appdev/quickstart/json-api.mdx
+++ b/docs-main/appdev/quickstart/json-api.mdx
@@ -73,12 +73,6 @@ import ExternalCnQuickstartMainCnQuickstartRstCodeSdkDocsSharableSdkQuickstartOp
 
 {/* COPIED_START source="docs-website:docs/replicated/quickstart/3.4/sdk/quickstart/operate/json-api.rst" hash="db5d73c4" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/quickstart/3.4/sdk/quickstart/operate/json-api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Using the JSON Ledger API
 
 ## Overview

--- a/docs-main/appdev/quickstart/lnav.mdx
+++ b/docs-main/appdev/quickstart/lnav.mdx
@@ -5,12 +5,6 @@ description: "Use lnav to inspect Canton quickstart logs interactively."
 
 {/* COPIED_START source="docs-website:docs/replicated/quickstart/3.4/sdk/quickstart/operate/lnav-in-cn.rst" hash="ec23657b" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/quickstart/3.4/sdk/quickstart/operate/lnav-in-cn.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Debugging and troubleshooting with lnav
 
 <div className="contents" depth="2" local="" backlinks="top">

--- a/docs-main/appdev/quickstart/observability-and-tracing.mdx
+++ b/docs-main/appdev/quickstart/observability-and-tracing.mdx
@@ -12,12 +12,6 @@ import ExternalCnQuickstartMainCnQuickstartRstCodeSdkDocsSharableSdkQuickstartOb
 
 {/* COPIED_START source="docs-website:docs/replicated/quickstart/3.4/sdk/quickstart/observe/observability-troubleshooting-overview.rst" hash="57ec2d59" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/quickstart/3.4/sdk/quickstart/observe/observability-troubleshooting-overview.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Canton Network Quickstart observability & troubleshooting overview
 
 <Note>

--- a/docs-main/appdev/reference/daml-language-reference.mdx
+++ b/docs-main/appdev/reference/daml-language-reference.mdx
@@ -58,12 +58,6 @@ import DamlAppdevModulesM3ContractKeysL107 from "/snippets/daml-docs/appdev_modu
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/structure.rst" hash="018c350f" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/structure.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Overview: Template Structure
 This page covers what a template looks like: what parts of a template there are, and where they go.
 
@@ -223,12 +217,6 @@ For example: `contractFetched <- fetch someContractId`
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/templates.rst" hash="964a20f1" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/templates.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ## Reference: Templates
 This page gives reference information on templates:
@@ -441,12 +429,6 @@ Users should remove any agreement declarations from their code, as this feature 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/choices.rst" hash="a391ce22" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/choices.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Reference: Choices
 This page gives reference information on choices. For information on the high-level structure of a choice, see `structure`.
 
@@ -530,12 +512,6 @@ If no qualifier is present, choices are *consuming*: the contract is archived be
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/updates.rst" hash="f8b9a0ff" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/updates.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ## Reference: Updates
 This page gives reference information on Updates. For the structure around them, see `structure`.
@@ -737,12 +713,6 @@ It's useful, for example, if you want to pass the current contract to a helper f
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/data-types.rst" hash="e8514698" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/data-types.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ## Reference: Data Types
 This page gives reference information on Daml's data types.
@@ -970,12 +940,6 @@ An underscore was used in place of a variable name. The reason for this is that 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/expressions.rst" hash="ed2e9625" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/expressions.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Reference: Expressions
 This page gives reference information for Daml expressions that are not updates.
 
@@ -1063,12 +1027,6 @@ You can also use `let` inside `do` blocks:
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/functions.rst" hash="2a0983ac" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/functions.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Reference: Functions
 This page gives reference information on functions in Daml.
 
@@ -1138,12 +1096,6 @@ Daml currently does not support generic functions for a specific set of types, s
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/file-structure.rst" hash="4bb0b27c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/file-structure.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Reference: Daml File Structure
 This page gives reference information on the structure of Daml files outside of templates.
 
@@ -1182,12 +1134,6 @@ You can use `==` and `/=` on contract identifiers of the same type.
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/packages.rst" hash="4011d059" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/packages.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ## Reference: Daml Packages
 This page gives reference information on Daml package dependencies.
@@ -1376,12 +1322,6 @@ You can also use more complex module prefixes, e.g., `foo-1.0.0: Foo1.Bar` which
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/contract-keys.rst" hash="85971992" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/contract-keys.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Reference: Contract Keys
 <Warning>
 Contract keys coming in the Canton 3.5 release. This documentation will be updated at that time.
@@ -1479,12 +1419,6 @@ A complete example of possible success and failure scenarios of `fetchByKey` and
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/interfaces.rst" hash="fdeb13bb" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/interfaces.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ## Reference: Interfaces
 In Daml, an interface defines an abstract type together with a behavior specified by its view type, method signatures, and choices. For a template to conform to this interface, there must be a corresponding `interface instance` definition where all the methods of the interface (including the special `view` method) are implemented. This allows decoupling such behavior from its implementation, so other developers can write applications in terms of the interface instead of the concrete template.
@@ -1748,12 +1682,6 @@ For context, a simple template definition:
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/exceptions.rst" hash="0c6fee4c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/exceptions.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Reference: Exceptions (Deprecated)
 <Warning>
 User-defined Daml Exceptions, catching, and throwing have been deprecated and are being phased out in favour of the Canton error framework, which represents Daml errors as `InvalidGivenCurrentSystemStateOther`.
@@ -1804,12 +1732,6 @@ In the example below the `create` of `T` will be rolled back and the first `catc
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/daml/working-with.rst" hash="56b3d265" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/daml/working-with.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ## Reference: Built-in Functions
 This page gives reference information on built-in functions for working with a variety of common concepts.
@@ -1936,12 +1858,6 @@ As an example, to sum up a list of integers in Daml:
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/fixity.rst" hash="a12a5d86" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/fixity.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ## Fixity, Associativity and Precedence
 With normal, *prefix* operators (e.g. functions), the semantics of `f g h` is clear: `f` is a function that takes `g` and `h` as parameters. If we want `f` to take the result of applying `g` to `h` we write `f (g h)`.

--- a/docs-main/appdev/reference/daml-lf-reference.mdx
+++ b/docs-main/appdev/reference/daml-lf-reference.mdx
@@ -25,12 +25,6 @@ import GrpcExerciseByKeyMySimpleTemplateFull from '/snippets/daml-docs/grpc_Exer
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/explanations/ledger-api.rst" hash="096c6edb" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/explanations/ledger-api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Ledger API overview
 
 ## What is the Ledger API
@@ -76,12 +70,6 @@ For the most part the translation of types from Daml to Daml-LF should not be su
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/sdk/reference/json-api/lf-value-specification.rst" hash="a3820c5d" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/sdk/reference/json-api/lf-value-specification.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 > \<br /\>
 
@@ -236,12 +224,6 @@ Daml LF JSON encoding
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/reference/damllf/daml-lf-translation.rst" hash="2de9f83c" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/reference/damllf/daml-lf-translation.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # How Daml Types are translated to Daml-LF
 
@@ -506,12 +488,6 @@ All names in Daml—of types, templates, choices, fields, and variant data const
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/integrate/grpc/daml-to-ledger-api.rst" hash="b7b29e30" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/sdlc-howtos/applications/integrate/grpc/daml-to-ledger-api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # How Daml Types are Translated to Protobuf
 
 This page gives an overview and reference on how Daml types and contracts are represented by the gRPC Ledger API as protobuf messages, most notably:
@@ -599,12 +575,6 @@ If the template specifies a key, the `com.daml.ledger.api.v1.exercisebykeycomman
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/explanations/daml-packages-and-archive-files.rst" hash="b5af20b7" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/explanations/daml-packages-and-archive-files.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Daml packages and archive (.dar) files
 
@@ -710,12 +680,6 @@ For more information on how to open up and inspect the DAR files and DALF files,
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst" hash="1a25e77f" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/component-howtos/development-tooling-authors/how-to-parse-daml-archive-files.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # How to parse Daml archive files
 

--- a/docs-main/appdev/reference/pqs-sql-reference.mdx
+++ b/docs-main/appdev/reference/pqs-sql-reference.mdx
@@ -25,12 +25,6 @@ PQS data can be joined across contract tables to build projections (for example,
 
 {/* COPIED_START source="docs-website:replicated/pqs/3.5/component-howtos/pqs/references/sql-api.rst" hash="addc8b94" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `replicated/pqs/3.5/component-howtos/pqs/references/sql-api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # SQL API
 
 While data consumers do not communicate with the PQS process directly, they do use an API that PQS has provisioned in the database itself. This SQL API is designed to provide a consistent and stable interface for users to access the ledger. It consists of a set of functions that should be the only database artifacts readers interact with.

--- a/docs-main/appdev/troubleshooting-guide/common-questions.mdx
+++ b/docs-main/appdev/troubleshooting-guide/common-questions.mdx
@@ -130,12 +130,6 @@ The process involves submitting a proposal that describes your application, its 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/smart-contracts/debug/troubleshooting.rst" hash="f7ed3422" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/sdlc-howtos/smart-contracts/debug/troubleshooting.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Modeling Questions
 
 ### Model an Agreement With Another Party

--- a/docs-main/appdev/troubleshooting-guide/development-issues.mdx
+++ b/docs-main/appdev/troubleshooting-guide/development-issues.mdx
@@ -169,12 +169,6 @@ For cn-quickstart, run `make setup` then `make build` before `make start`. The b
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/sdlc-howtos/smart-contracts/debug/troubleshooting.rst" hash="f7ed3422" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/sdlc-howtos/smart-contracts/debug/troubleshooting.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Additional Daml Error Messages
 
 ### Error: "\<X\> is not authorized to commit an update"

--- a/docs-main/global-synchronizer/canton-console/console-overview.mdx
+++ b/docs-main/global-synchronizer/canton-console/console-overview.mdx
@@ -12,12 +12,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/deployment/console_access.rst" hash="bccf3653" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/deployment/console_access.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 For more involved debugging and disaster recovery, direct access to the console of a Canton node (participant, sequencer, mediator) might be required. Steps to obtain such access:
 
 Requirements:

--- a/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
+++ b/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
@@ -50,12 +50,6 @@ import ExternalCantonMainCommunitySrcExampleSimpleTopology from "/snippets/exter
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/tutorials/getting_started.rst" hash="1e3b752b" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/tutorials/getting_started.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <div className="todo">
 change the section where we provision smart contract code: - create a new empty project - use the "Understanding IOUs" section to explain the structure of a daml contract (see [Java language bindings](/sdks-tools/language-bindings/java)) - transact on the IOU contract using curl and JSON Ledger API, not via console commands
 </div>
@@ -535,12 +529,6 @@ Note how we again use `retry_until_true` to add a manual synchronization point, 
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/tutorials/install.rst" hash="5b3da911" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/tutorials/install.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Tutorial to download, install, run canton with a simple configuration. Link to other howtos for follow-up topics.
 

--- a/docs-main/global-synchronizer/deployment/community-docker-compose-helm.mdx
+++ b/docs-main/global-synchronizer/deployment/community-docker-compose-helm.mdx
@@ -5,12 +5,6 @@ description: "Community-contributed Docker Compose deployment based on the Helm 
 
 {/* COPIED_START source="splice:docs/src/community/docker-compose-helm-chart.rst" hash="901429e4" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/community/docker-compose-helm-chart.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <Warning>
 This section features solutions shared by community members. While they haven’t been formally tested by the Splice maintainers, users are encouraged to verify the information independently. Contributions to enhance accuracy and completeness are always welcome.
 </Warning>

--- a/docs-main/global-synchronizer/deployment/community-helm-templating.mdx
+++ b/docs-main/global-synchronizer/deployment/community-helm-templating.mdx
@@ -5,12 +5,6 @@ description: "Community-contributed tool for templating Helm and Kubernetes depl
 
 {/* COPIED_START source="splice:docs/src/community/helm-kubernetes-templating-tool.rst" hash="b83e0f4d" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/community/helm-kubernetes-templating-tool.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <Warning>
 This section features solutions shared by community members. While they haven’t been formally tested by the Splice maintainers, users are encouraged to verify the information independently. Contributions to enhance accuracy and completeness are always welcome.
 </Warning>

--- a/docs-main/global-synchronizer/deployment/community-keycloak-config.mdx
+++ b/docs-main/global-synchronizer/deployment/community-keycloak-config.mdx
@@ -5,12 +5,6 @@ description: "Community-contributed end-to-end Keycloak configuration guide for 
 
 {/* COPIED_START source="splice:docs/src/community/keycloak-docker-canton-validator-config.rst" hash="b03f12f0" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/community/keycloak-docker-canton-validator-config.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <Warning>
 This section features solutions shared by community members. While they haven't been formally tested by the Splice maintainers, users are encouraged to verify the information independently. Contributions to enhance accuracy and completeness are always welcome.
 </Warning>

--- a/docs-main/global-synchronizer/deployment/configuration.mdx
+++ b/docs-main/global-synchronizer/deployment/configuration.mdx
@@ -8,12 +8,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcDeploymentConfigurationYaml68 from 
 
 {/* COPIED_START source="splice:docs/src/deployment/configuration.rst" hash="22d3b95a" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/deployment/configuration.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 All the apps have an extended set of configuration options which might need tuning based on different scenarios. These configurations are accepted in the [HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) format.
 
 ## Adding ad-hoc configuration

--- a/docs-main/global-synchronizer/deployment/docker.mdx
+++ b/docs-main/global-synchronizer/deployment/docker.mdx
@@ -5,12 +5,6 @@ description: "Obtain and run Canton Docker images"
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/download/docker.rst" hash="6b639a8b" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/download/docker.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Obtaining the Docker Images
 
 (See Install With Docker for instructions on running the Canton Docker images.)
@@ -37,12 +31,6 @@ Snapshot releases are available at `/da-images/public-unstable/docker/` instead 
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/install/docker.rst" hash="10693c6e" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/install/docker.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Link to howto for downloading docker images. Link to hardware and software requirements. Explain how to run canton from docker.
 

--- a/docs-main/global-synchronizer/deployment/identity-management.mdx
+++ b/docs-main/global-synchronizer/deployment/identity-management.mdx
@@ -21,12 +21,6 @@ import ExternalCantonMainCommunityAppSrcTestResourcesRandomNodeIdentifier from "
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/operate/identity_management.rst" hash="f3949198" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/operate/identity_management.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Split this entire page into its pieces for specific howtos. High-level explanation covered by overview site.
 
 # Identity Management
@@ -555,18 +549,6 @@ See [Initializing node identity manually](#initializing-node-identity-manually) 
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/operate/identity/manual_identity_init.rst" hash="69f33a74" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/operate/identity/manual_identity_init.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/operate/identity/manual_identity_init.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Initializing node identity manually
 

--- a/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
+++ b/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
@@ -29,12 +29,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_helm.rst" hash="37dc325e" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/sv_operator/sv_helm.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 This section describes deploying a Super Validator (SV) node in kubernetes using Helm charts. The Helm charts deploy a complete node and connect it to a target cluster.
 
 ## Requirements

--- a/docs-main/global-synchronizer/deployment/oidc-providers.mdx
+++ b/docs-main/global-synchronizer/deployment/oidc-providers.mdx
@@ -5,12 +5,6 @@ description: "Step-by-step OIDC provider setup walkthroughs for Okta and Keycloa
 
 {/* COPIED_START source="splice:docs/src/community/oidc-config-okta-keycloak.rst" hash="bb49ca0b" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/community/oidc-config-okta-keycloak.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <Warning>
 This section features solutions shared by community members.
 While they haven't been formally tested by the Splice maintainers,

--- a/docs-main/global-synchronizer/deployment/onboarding-process.mdx
+++ b/docs-main/global-synchronizer/deployment/onboarding-process.mdx
@@ -11,12 +11,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_onboarding.rst" hash="a1a3ab0c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_onboarding.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Networks
 
 There are three different networks: DevNet, TestNet and MainNet. If you are only interested in setting up a validator node, you can set up a node on DevNet for practice, then jump to MainNet. If you’d like to build, test, or deploy an app, we recommend that you run a node on DevNet, TestNet, and MainNet.

--- a/docs-main/global-synchronizer/deployment/prerequisites.mdx
+++ b/docs-main/global-synchronizer/deployment/prerequisites.mdx
@@ -5,12 +5,6 @@ description: "System requirements for running a validator on the Canton Network"
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_hardware_requirements.rst" hash="22640d55" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_hardware_requirements.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 This section describes hardware requirements for running a validator. Note that these are reference values. Actual requirements can vary based on usage of your validator. We recommend monitoring your production validator nodes with respect to CPU and memory usage of all components and disk usage of the database, and adjust the resourcing as needed.
 
 The requirements include both the validator and participant container.

--- a/docs-main/global-synchronizer/deployment/required-network-parameters.mdx
+++ b/docs-main/global-synchronizer/deployment/required-network-parameters.mdx
@@ -8,12 +8,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/validator_operator/required_network_parameters.rst" hash="236187bd" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/required_network_parameters.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <NetworkVariables networkData={networkData}>
 
 To initialize your validator node, you need the following parameters that define the network you're onboarding to and the secret required for doing so.

--- a/docs-main/global-synchronizer/deployment/sv-network-resets.mdx
+++ b/docs-main/global-synchronizer/deployment/sv-network-resets.mdx
@@ -12,12 +12,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_network_resets.rst" hash="1e423aba" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/sv_operator/sv_network_resets.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <NetworkVariables networkData={networkData}>
 
 DevNet and TestNet get reset roughly every 3 months with the resets spread out such that they never happen at the same time on DevNet and TestNet. The exact time is announced in the `#supervalidator-operations` channel run by the [Global Synchronizer Foundation](https://sync.global/).

--- a/docs-main/global-synchronizer/deployment/sv-operations.mdx
+++ b/docs-main/global-synchronizer/deployment/sv-operations.mdx
@@ -15,12 +15,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcSvOperatorSvOperationsBash683 from 
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_operations.rst" hash="cbceece9" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/sv_operator/sv_operations.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 These sections give an overview of some of the functionalities enabled through your SV node as well as general information useful to SV node operators.
 
 ## Security Notice

--- a/docs-main/global-synchronizer/deployment/sv-scratchnet.mdx
+++ b/docs-main/global-synchronizer/deployment/sv-scratchnet.mdx
@@ -5,12 +5,6 @@ description: "Bootstrapping a new Canton Network from scratch as a Super Validat
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_scratchnet.rst" hash="21f98ad1" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/sv_operator/sv_scratchnet.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <div className="todo">
 
 adjust style of write-up below to the rest of docs

--- a/docs-main/global-synchronizer/deployment/synchronizer-traffic.mdx
+++ b/docs-main/global-synchronizer/deployment/synchronizer-traffic.mdx
@@ -10,12 +10,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/deployment/traffic.rst" hash="0e110a7b" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/deployment/traffic.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Synchronizer usage incurs operational costs for SVs. For amortizing these costs, improving the incentives for operating an SV, and making Denial Of Service attacks on the network unattractive, synchronizer usage beyond a certain free `base rate` level is charged with so-called `synchronizer fees` paid in `Canton Coin`. For supporting this functionality, sequencers keep track of available and consumed traffic for each synchronizer member (most relevantly: for all validator participants). Whenever both the free (base rate) and paid-for (extra) traffic are exhausted for a participant, attempted writes are denied by the sequencer.
 
 SVs, or more specifically SV participants and mediators, have unlimited traffic and are therefore not subject to synchronizer fees themselves. However, it is part of the responsibilities of SV operators to jointly ensure that the fee configuration of the Global Synchronizer is sound and in line with the operational objectives of the network.

--- a/docs-main/global-synchronizer/deployment/validator-docker-compose.mdx
+++ b/docs-main/global-synchronizer/deployment/validator-docker-compose.mdx
@@ -14,12 +14,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_compose.rst" hash="074ae45b" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_compose.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 This section describes how to deploy a standalone validator node on a VM or a local machine using [Docker Compose](https://docs.docker.com/compose/). The deployment consists of the validator node along with associated wallet and CNS UIs, and onboards the validator node to the target network.
 
 This deployment is useful for:

--- a/docs-main/global-synchronizer/deployment/validator-kubernetes.mdx
+++ b/docs-main/global-synchronizer/deployment/validator-kubernetes.mdx
@@ -25,12 +25,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_helm.rst" hash="b0bc851d" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_helm.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 This section describes how to deploy a standalone validator node in Kubernetes using Helm charts. The Helm charts deploy a validator node along with associated wallet and CNS UIs, and connect it to a global synchronizer.
 
 ## Requirements

--- a/docs-main/global-synchronizer/deployment/validator-network-resets.mdx
+++ b/docs-main/global-synchronizer/deployment/validator-network-resets.mdx
@@ -5,12 +5,6 @@ description: "Handling DevNet and TestNet resets on validator nodes"
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_network_resets.rst" hash="dbd50be9" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_network_resets.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 DevNet and TestNet get reset roughly every 3 months with the resets spread out such that they never happen at the same time on DevNet and TestNet. The exact time is announced in the `#validator-operations` channel run by the [Global Synchronizer Foundation](https://sync.global/).
 
 A reset requires a full redeployment of your node and loses any data you had on the node. Your node will not be functional until you complete the reset.

--- a/docs-main/global-synchronizer/deployment/validator-networking.mdx
+++ b/docs-main/global-synchronizer/deployment/validator-networking.mdx
@@ -5,12 +5,6 @@ description: "Network ingress and egress requirements for validator nodes"
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_networking.rst" hash="59d9c925" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_networking.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Ingress
 
 The validators have no external ingress requirements and don't need to whitelist any other SVs or validators.

--- a/docs-main/global-synchronizer/deployment/validator-users.mdx
+++ b/docs-main/global-synchronizer/deployment/validator-users.mdx
@@ -8,12 +8,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcValidatorOperatorValidatorUsersBash
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_users.rst" hash="b6c1f50f" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_users.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Canton distinguishes between parties and users, as documented in detail in [Manage Daml parties](/appdev/deep-dives/manage-daml-parties). In essence, a party is an identity on-ledger, while a user represents an off-ledger entity that can be associated with one or more parties.
 
 By default, when a user logs in for the first time in the wallet, and presses the "Onboard yourself" button, the Validator allocates a fresh party, with a fresh Party ID, and associates that user with the newly allocated party. As part of validator initialization, a party is automatically created for the Validator Operator. The user provided during installation as the `validatorWalletUser` will be associated with this party as its primary party.

--- a/docs-main/global-synchronizer/extension-synchronizers/bft-orderer.mdx
+++ b/docs-main/global-synchronizer/extension-synchronizers/bft-orderer.mdx
@@ -5,12 +5,6 @@ description: "Byzantine fault-tolerant orderer architecture for Canton synchroni
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/explanations/bft_orderer_arch.rst" hash="ef905796" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/explanations/bft_orderer_arch.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # BFT Orderer
 
 The BFT Orderer provides a Byzantine-fault tolerant (BFT) total-order broadcast service. It ensures **safety** (consistency) and **liveness** (eventual progress) in the presence of Byzantine failures. It also guarantees that all clients read an identical stream of messages.

--- a/docs-main/global-synchronizer/extension-synchronizers/linking-validator-multi-sync.mdx
+++ b/docs-main/global-synchronizer/extension-synchronizers/linking-validator-multi-sync.mdx
@@ -151,12 +151,6 @@ Consider these factors when deciding where to assign a contract:
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/operate/synchronizers/connectivity.rst" hash="2bbbe3df" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/howtos/operate/synchronizers/connectivity.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Synchronizer connections
 
 A Participant Node connects to the Synchronizer by connecting to one or many Sequencers of this Synchronizer.

--- a/docs-main/global-synchronizer/extension-synchronizers/synchronizer-monitoring.mdx
+++ b/docs-main/global-synchronizer/extension-synchronizers/synchronizer-monitoring.mdx
@@ -16,12 +16,6 @@ import ExternalCantonMainDocsOpenTargetSnippetJsonDataSynchronizerHowtosObserveM
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/observe/sequencer_health.rst" hash="449981b9" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/observe/sequencer_health.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Check and monitor Sequencer Node health
 
 This page describes how to inspect and understand the current status of a Sequencer Node, and how to continuously monitor it using health checks.
@@ -80,12 +74,6 @@ Place the above under `canton.sequencers.sequencer.parameters` in the configurat
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/observe/mediator_health.rst" hash="572f2273" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/observe/mediator_health.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Check and monitor Mediator Node health
 
 This page describes how to inspect and understand the current status of a Mediator Node, and how to continuously monitor it using health checks.
@@ -138,12 +126,6 @@ Place the above under `canton.mediators.mediator.parameters` in the configuratio
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/observe/mediator_inspection.rst" hash="addb7204" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/observe/mediator_inspection.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Mediator inspection
 
 The Mediator inspection provides access to metadata associated with finalized transactions, also known as verdicts, to give insights on the transactions completed on a Synchronizer. This page describes how to obtain the verdicts from the admin console.
@@ -168,12 +150,6 @@ To learn more about related concepts, see the Mediator overview.
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/troubleshoot/index.rst" hash="44a81d5c" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/troubleshoot/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Link to participant docs for general troubleshooting guidelines.
 

--- a/docs-main/global-synchronizer/extension-synchronizers/synchronizer-operations.mdx
+++ b/docs-main/global-synchronizer/extension-synchronizers/synchronizer-operations.mdx
@@ -83,12 +83,6 @@ import ExternalCantonMainDocsOpenTargetSnippetJsonDataSynchronizerHowtosOperateB
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/operate/bootstrap.rst" hash="4309c2e2" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/operate/bootstrap.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Bootstrap a Synchronizer
 
 This howto assumes familiarity with general Synchronizer concepts. Refer to the Canton overview for more information.
@@ -384,12 +378,6 @@ Finally, check that the Participant Node is healthy and can use the Synchronizer
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/operate/new_nodes.rst" hash="9f3029cf" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/operate/new_nodes.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Add New Nodes
 
 ## Add a new Sequencer to a distributed Synchronizer
@@ -577,12 +565,6 @@ For details on the necessary admin commands, check the reference documentation.
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/operate/dynamic_params.rst" hash="e8c87fd8" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/operate/dynamic_params.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Manage dynamic Synchronizer parameters
 
 <div id="dynamic_synchronizer_parameters">
@@ -716,12 +698,6 @@ Once Canton has recovered, use the admin command to set the `maxRequestSize` val
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/operate/traffic.rst" hash="0308899a" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/operate/traffic.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Sequencer Traffic Management
 
 <Note>
@@ -811,12 +787,6 @@ For more information on traffic control and its configuration parameters, read t
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/operate/pruning.rst" hash="bb82d965" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/operate/pruning.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Synchronizer Pruning
 
@@ -927,12 +897,6 @@ val schedule = sequencer1.bft.pruning.get_bft_schedule()
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/operate/ha.rst" hash="711b141d" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/operate/ha.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # High Availability in Synchronizer
 
@@ -1060,12 +1024,6 @@ See the sequencer connectivity documentation for more details on how to add many
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/configure/apis.rst" hash="a0993dd6" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/configure/apis.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Configure Synchronizer APIs
 
 A Synchronizer exposes two main APIs, the Admin API and the Public API, while the Participant Node exposes the Ledger API and the Admin API. In this section, we explain what the APIs do and how they can be configured.
@@ -1119,12 +1077,6 @@ mediators {
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/configure/sequencer_backend.rst" hash="f62eca63" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/configure/sequencer_backend.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Configure Sequencer Backend
 
@@ -1260,12 +1212,6 @@ Every external Sequencer requires a corresponding Sequencer Driver on the classp
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/secure/apis.rst" hash="8b67f3f9" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/secure/apis.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Secure Synchronizer APIs
 
 ## Sequencer Public API
@@ -1360,12 +1306,6 @@ mediator1.sequencer_connections.logout()
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/secure/limits.rst" hash="3828c946" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/secure/limits.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Set sequencer resource limits
 
 ## Protect against large requests
@@ -1417,12 +1357,6 @@ You can protect a Synchronizer from excessive traffic from its members by enabli
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/decommission/index.rst" hash="13c55e5a" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/decommission/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Decommissioning Canton nodes and Synchronizer entities
 
@@ -1506,12 +1440,6 @@ Mediators are also part of a synchronizer’s messaging infrastructure and do no
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/howtos/recover/index.rst" hash="4187dc6f" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/howtos/recover/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Backup and Restore
 

--- a/docs-main/global-synchronizer/faq.mdx
+++ b/docs-main/global-synchronizer/faq.mdx
@@ -5,12 +5,6 @@ description: "Frequently asked questions for Canton Network validators and Super
 
 {/* COPIED_START source="splice:docs/src/faq.rst" hash="10d62bbe" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/faq.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Super Validators
 
 <div className="glossary">

--- a/docs-main/global-synchronizer/production-operations/canton-console.mdx
+++ b/docs-main/global-synchronizer/production-operations/canton-console.mdx
@@ -7,12 +7,6 @@ import ExternalCantonMainCommunityAppSrcTestResourcesDocumentationSnippetsMigrat
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/operate/console/console.rst" hash="b26d8816" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/operate/console/console.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Canton Console
 
 Canton offers a console (REPL) where entities can be dynamically started and stopped, and a variety of administrative or debugging commands can be run.

--- a/docs-main/global-synchronizer/production-operations/decommission-nodes.mdx
+++ b/docs-main/global-synchronizer/production-operations/decommission-nodes.mdx
@@ -5,12 +5,6 @@ description: "Procedures for decommissioning Canton nodes and synchronizer entit
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/decommission/index.rst" hash="65754be5" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/decommission/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Decommissioning Canton Nodes and Synchronizer Entities
 
 This guide assumes general familiarity with Canton, in particular Canton identity management concepts and operations from the Canton console.

--- a/docs-main/global-synchronizer/production-operations/disaster-recovery.mdx
+++ b/docs-main/global-synchronizer/production-operations/disaster-recovery.mdx
@@ -7,12 +7,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcSvOperatorSvRestoreBash104 from "/s
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_restore.rst" hash="9e120ae8" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/sv_operator/sv_restore.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 There are three ways to recover from disasters:
 
 1.  In simple cases where only a single node is affected but the overall network is still healthy, a Restore from backup is usually sufficient.

--- a/docs-main/global-synchronizer/production-operations/key-management.mdx
+++ b/docs-main/global-synchronizer/production-operations/key-management.mdx
@@ -26,12 +26,6 @@ import ExternalCantonMainDocsOpenTargetSnippetJsonParticipantHowtosSecureKeysNam
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/keys/key_management.rst" hash="8d5b7232" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/keys/key_management.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Crypto key management
 This page explains how to list, rotate, generate, deactivate, and delete keys of a Canton node. It also explains how to configure the cryptographic schemes supported by a node.
 
@@ -132,18 +126,6 @@ Please note that **session signing keys** are only used with an external KMS (Ke
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/keys/key_restrictions.rst" hash="52807875" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/keys/key_restrictions.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/keys/key_restrictions.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Restrict key usage
 This page explains how to limit the usage of cryptographic keys of a Canton node to specific purposes, as best practice to contain damage of potentially compromised keys.
 
@@ -243,18 +225,6 @@ If you omit the `filterTargetKey` parameter, all the existing namespace delegati
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/keys/namespace_key.rst" hash="d886452e" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/keys/namespace_key.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/keys/namespace_key.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 This document is a work in progress. The feature will be developed and released in the future, following the procedures described in the document.
 
@@ -625,18 +595,6 @@ You cannot rotate the root namespace key. If you need to discontinue the usage o
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/optimize/session_keys.rst" hash="8063c0c2" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/optimize/session_keys.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/optimize/session_keys.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ## Configure session keys
 Canton uses session keys to reduce expensive cryptographic operations during protocol execution, improving performance. There are two types: session encryption keys, which reduce the number of asymmetric encryptions, and session signing keys, which help avoid frequent calls to external signers such as a KMS.

--- a/docs-main/global-synchronizer/production-operations/key-metrics.mdx
+++ b/docs-main/global-synchronizer/production-operations/key-metrics.mdx
@@ -5,12 +5,6 @@ description: "Critical metrics to monitor for Canton Network validators and SV n
 
 {/* COPIED_START source="splice:docs/src/deployment/observability/validator_health.rst" hash="eed61697" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/deployment/observability/validator_health.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 You can check your validator's health using the readiness endpoints. All CN applications provide the `/readyz` and `/livez` endpoints, which are used for readiness and liveness probes.
 
 - **Checking readiness**

--- a/docs-main/global-synchronizer/production-operations/kms-operations.mdx
+++ b/docs-main/global-synchronizer/production-operations/kms-operations.mdx
@@ -5,12 +5,6 @@ description: "Configure and operate a KMS for Canton: AWS, GCP, driver-based; mo
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/kms.rst" hash="d3cc26ab" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/kms.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Key management service (KMS) configuration
 
 By default Canton keys are generated in the node and stored in the node's primary storage. We currently support a version of Canton that can use a KMS to either: (a) protect Canton's private keys at rest or (b) protect the private keys both at rest and at use by storing the keys in the KMS.
@@ -52,12 +46,6 @@ The following sections focus on how to set up a Participant Node to run with a K
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/configuration/kms_configuration.rst" hash="3c286d0d" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/configuration/kms_configuration.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Configure a KMS
 
 This section explains how to configure a Key Management System (KMS) in Canton.
@@ -75,12 +63,6 @@ Currently, three KMS alternatives are available:
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/mode/kms_mode.rst" hash="82b212ee" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/mode/kms_mode.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Select a KMS mode of operation
 
@@ -103,12 +85,6 @@ Throughout this documentation, these modes might be referred to as **envelope en
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/mode/encrypted_key_storage.rst" hash="9b3e7c0c" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/mode/encrypted_key_storage.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Enable encrypted private key storage with a KMS
 
@@ -228,12 +204,6 @@ After subsequent restarts the operator does not need to specify the identifier f
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/mode/external_key_storage.rst" hash="32773506" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/mode/external_key_storage.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Enable external key storage with a KMS
 
 This section shows how to enable external key storage for a Canton Participant, so that private keys are stored and managed by a KMS, and all cryptographic operations using those keys must go through the KMS.
@@ -320,12 +290,6 @@ When using AWS cross account keys the key ID can't be used, use the key `ARN` in
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/configuration/kms_aws_config.rst" hash="a785a56a" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/configuration/kms_aws_config.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Configure a Amazon Web Services (AWS) KMS
 
@@ -420,12 +384,6 @@ Note that sensitive data is removed before logging. The general log format is as
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/configuration/kms_gcp_config.rst" hash="b03c88a5" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/configuration/kms_gcp_config.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Configure a Google Cloud Provider (GCP) KMS
 
@@ -522,12 +480,6 @@ Note that sensitive data is removed before logging. The general log format is as
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/configuration/kms_driver_config.rst" hash="2ea5fd56" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/configuration/kms_driver_config.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Configure a Driver-based KMS
 
 Canton allows integration with a variety of KMS and HSM solutions through a KMS Driver. This approach enables you to connect Canton to an external key manager by building your own integration layer.
@@ -572,12 +524,6 @@ For guidance on developing and deploying your own KMS Driver in Canton, refer to
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/migration/kms_migration.rst" hash="024d318f" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/migration/kms_migration.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Migrate to a KMS
 
 This section outlines the steps required to migrate from a running non-KMS participant to one that is KMS-enabled, as well as the interoperability between nodes that use KMS and those that do not. The migration procedure depends on the selected mode of operation:
@@ -597,12 +543,6 @@ This section outlines the steps required to migrate from a running non-KMS parti
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/migration/encrypted_key_storage_migration.rst" hash="81793b9d" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/migration/encrypted_key_storage_migration.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Migrate to encrypted private key storage with KMS
 
@@ -627,12 +567,6 @@ Encrypted private key storage can be enabled again by deleting the `reverted` fi
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/migration/external_key_storage_migration.rst" hash="00f0a330" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/migration/external_key_storage_migration.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Migrate to external key storage with a KMS
 
@@ -682,12 +616,6 @@ See the [Supported Cryptographic Schemes](/global-synchronizer/reference/crypto-
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/key_rotation/kms_key_rotation.rst" hash="8b47170c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/key_rotation/kms_key_rotation.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Rotate keys with KMS
 
 Canton supports both rotating the wrapper key when using envelope encryption, and rotating Canton keys stored externally in a KMS.
@@ -699,12 +627,6 @@ For smooth disaster recovery, key rotation must be interleaved with backups as d
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/key_rotation/rotate_wrapper_key.rst" hash="dcb0594c" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/key_rotation/rotate_wrapper_key.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Rotate the envelope wrapper key
 
@@ -741,12 +663,6 @@ participant1.keys.secret.rotate_wrapper_key(newWrapperKeyId)
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/kms/key_rotation/rotate_external_keys.rst" hash="f1a0d457" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/secure/kms/key_rotation/rotate_external_keys.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Rotate external KMS keys
 

--- a/docs-main/global-synchronizer/production-operations/logical-synchronizer-upgrade.mdx
+++ b/docs-main/global-synchronizer/production-operations/logical-synchronizer-upgrade.mdx
@@ -8,12 +8,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_logical_synchronizer_upgrade.rst" hash="0cf8ccb8" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/sv_operator/sv_logical_synchronizer_upgrade.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <Warning>
 Logical Synchronizer Upgrades (LSU) are still in development and the instructions here are intended as a preview primarily targeted at Super Validators but will likely change in minor ways before the full release.
 </Warning>

--- a/docs-main/global-synchronizer/production-operations/manage-packages.mdx
+++ b/docs-main/global-synchronizer/production-operations/manage-packages.mdx
@@ -15,12 +15,6 @@ import ExternalCantonMainDocsOpenTargetSnippetJsonDataParticipantHowtosOperatePa
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/operate/packages/packages.rst" hash="7a88253c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/operate/packages/packages.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Manage Daml packages and archives
 
 ## About

--- a/docs-main/global-synchronizer/production-operations/monitoring-setup.mdx
+++ b/docs-main/global-synchronizer/production-operations/monitoring-setup.mdx
@@ -13,12 +13,6 @@ For Splice / Canton Network metrics specifically — what each component exposes
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/tutorials/monitoring/example_monitoring_setup.rst" hash="c78cf431" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/tutorials/monitoring/example_monitoring_setup.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 This guide and the scripts/configs are not tested, do they still work? Try to split this up into specific howtos and ensure the configs/scripts move to examples that are tested.
 
 how should this relate to the other observability docs that we have? we have the observability gh stuff plus the observability stuff in the quickstart
@@ -795,12 +789,6 @@ This version of the example only has the logging structure provided via GELF. It
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/observe/health.rst" hash="64490235" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/howtos/observe/health.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Participant Node Health
 
 The participant exposes health status information in several ways, which may be inspected manually when troubleshooting or integrated into larger monitoring and orchestration systems.
@@ -1035,12 +1023,6 @@ which will cause the Node to stay alive and report unhealthy in such cases.
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/observe/commitments.rst" hash="448aca51" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/howtos/observe/commitments.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Monitor ACS Commitments
 

--- a/docs-main/global-synchronizer/production-operations/multi-sig.mdx
+++ b/docs-main/global-synchronizer/production-operations/multi-sig.mdx
@@ -5,12 +5,6 @@ description: "Decentralized namespaces, decentralized party hosting, and decentr
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.5/participant/howtos/operate/parties/multi-sig-in-canton.rst" hash="a3505340" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.5/participant/howtos/operate/parties/multi-sig-in-canton.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Introduction
 
 In the Canton protocol, at a high level, there are two categories of

--- a/docs-main/global-synchronizer/production-operations/node-backup-restore.mdx
+++ b/docs-main/global-synchronizer/production-operations/node-backup-restore.mdx
@@ -5,12 +5,6 @@ description: "Back up and restore Canton participant and synchronizer nodes, inc
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/recover/backup-restore.rst" hash="95a0937c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/recover/backup-restore.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Backup and Restore
 
 It is recommended that your database is frequently backed up so that the data can be restored in case of a disaster.

--- a/docs-main/global-synchronizer/production-operations/party-management.mdx
+++ b/docs-main/global-synchronizer/production-operations/party-management.mdx
@@ -38,12 +38,6 @@ import ExternalCantonMainDocsOpenTargetSnippetJsonDataParticipantHowtosOperatePa
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/operate/parties/parties.rst" hash="98576236" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/operate/parties/parties.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Party Management
 
 Parties are the entities that interact with the Daml ledger, representing users or organizations. They can be onboarded to a Participant Node, which allows them to submit transactions and access the ledger.
@@ -157,18 +151,6 @@ The simplest and safest way to multi-host a party is only available to you while
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/operate/parties/party_replication.rst" hash="3d2e1e44" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/operate/parties/party_replication.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/operate/parties/party_replication.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Party replication
 
@@ -549,18 +531,6 @@ You have successfully multi-hosted Alice on `source` and `target` participants.
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/operate/parties/decentralized_parties.rst" hash="3e9efbd6" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/operate/parties/decentralized_parties.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/operate/parties/decentralized_parties.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Decentralized party overview
 

--- a/docs-main/global-synchronizer/production-operations/performance-optimization.mdx
+++ b/docs-main/global-synchronizer/production-operations/performance-optimization.mdx
@@ -145,12 +145,6 @@ Track these metrics to identify bottlenecks: `canton_participant_command_complet
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/operate/ha/ha.rst" hash="81b9b3df" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/howtos/operate/ha/ha.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Document howto enable replication (on by default) on enterprise nodes with supported storage. Document health check configuration and fail-over times. Document admin commands to work with multiple replicas (find active replica), document commands to inspect activeness. For participant: load balancer configuration in front of gRPC Ledger API to route to active instance. Link to explanation on HA architecture.
 
 # High Availability Usage
@@ -253,12 +247,6 @@ To use a load balancer it must support http/1 health checks for routing requests
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/optimize/storage.rst" hash="b2f96e3b" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/howtos/optimize/storage.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Add query cost logging.
 

--- a/docs-main/global-synchronizer/production-operations/pruning.mdx
+++ b/docs-main/global-synchronizer/production-operations/pruning.mdx
@@ -9,12 +9,6 @@ For Super Validator pruning of the sequencer and CometBFT layers, see [SV Prunin
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/operate/pruning/pruning.rst" hash="4a51fcd8" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/operate/pruning/pruning.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Participant node pruning
 
 Pruning helps bound the size of the database storage. Participant Node pruning refers to the selective removal of archived contracts and old transactions. Select one of two options, choosing between ease-of-use and control:
@@ -93,12 +87,6 @@ Monitor the `daml_pruning_max_event_age` metric describing the age of the "oldes
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/reference/automatic_pruning.rst" hash="6e2b1915" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/reference/automatic_pruning.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ### Automatic pruning reference
 

--- a/docs-main/global-synchronizer/production-operations/scalability.mdx
+++ b/docs-main/global-synchronizer/production-operations/scalability.mdx
@@ -7,12 +7,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcScalabilityScalabilityNone117 from 
 
 {/* COPIED_START source="splice:docs/src/scalability/scalability.rst" hash="f6c365e2" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/scalability/scalability.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Number of Parties per Validator
 
 While the underlying Canton participant supports up to 1 million parties per node, limitations in the validator app currently mean that only up to 200 parties are supported when the validator app is involved. The limit of 200 parties is expected to be lifted in the future which should make those workarounds no longer required.

--- a/docs-main/global-synchronizer/production-operations/splice-metrics-overview.mdx
+++ b/docs-main/global-synchronizer/production-operations/splice-metrics-overview.mdx
@@ -8,12 +8,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/deployment/observability/metrics.rst" hash="88d7cba8" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/deployment/observability/metrics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Every node exposes a set of metrics on the port 10013 under the path `/metrics`. These metrics can be used to monitor the health of the node, and to diagnose issues.
 
 <Note>

--- a/docs-main/global-synchronizer/production-operations/sv-backup.mdx
+++ b/docs-main/global-synchronizer/production-operations/sv-backup.mdx
@@ -7,12 +7,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcSvOperatorSvBackupBash23 from "/sni
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_backup.rst" hash="5601f74c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/sv_operator/sv_backup.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Backup of Node Identities
 
 Once your SV node is up and onboarded, please make sure to backup the node identities of your SV node. **Note that this information is highly sensitive, and contains the private keys of your participant, sequencer and mediator,** so make sure to store it in a secure location, such as a Secret Manager. On the other hand, it is crucial for maintaining your identity (and thus, e.g. access to your Canton Coin holdings), so must be backed up outside of the cluster.

--- a/docs-main/global-synchronizer/production-operations/sv-major-upgrade.mdx
+++ b/docs-main/global-synchronizer/production-operations/sv-major-upgrade.mdx
@@ -8,12 +8,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcSvOperatorSvMajorUpgradeSql255 from
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_major_upgrade.rst" hash="1ca238da" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/sv_operator/sv_major_upgrade.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 For supporting non-backwards-compatible major version upgrades of the
 Canton software the Global Synchronizer uses, the SV operatores follow
 the procedure for synchronizer (i.e., domain) upgrades with downtime

--- a/docs-main/global-synchronizer/production-operations/sv-pruning.mdx
+++ b/docs-main/global-synchronizer/production-operations/sv-pruning.mdx
@@ -5,12 +5,6 @@ description: "Sequencer and CometBFT pruning on Super Validator nodes"
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_pruning.rst" hash="07e081c3" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/sv_operator/sv_pruning.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The sequencer, participant and CometBFT have pruning options that can be used to ensure storage use is kept within reasonable bounds.
 
 ## Sequencer pruning

--- a/docs-main/global-synchronizer/production-operations/sv-security.mdx
+++ b/docs-main/global-synchronizer/production-operations/sv-security.mdx
@@ -5,12 +5,6 @@ description: "Security hardening, KMS configuration, and extra DAR notice for Su
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_security.rst" hash="ae70b7be" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/sv_operator/sv_security.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Third-party Daml apps
 
 ## Using an external KMS for managing participant keys

--- a/docs-main/global-synchronizer/production-operations/sv-upgrades.mdx
+++ b/docs-main/global-synchronizer/production-operations/sv-upgrades.mdx
@@ -5,12 +5,6 @@ description: "Minor upgrade procedures for Super Validator nodes"
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_upgrades.rst" hash="5405319d" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/sv_operator/sv_upgrades.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 There are two types of upgrades:
 
 Version upgrades (this corresponds to an upgrade from `0.A.X` to `0.B.Y`) and protocol upgrades (the actual version can remain the same, only the protocol is upgraded).

--- a/docs-main/global-synchronizer/production-operations/upgrade-canton-nodes.mdx
+++ b/docs-main/global-synchronizer/production-operations/upgrade-canton-nodes.mdx
@@ -19,12 +19,6 @@ import ExternalCantonMainDocsOpenTargetSnippetJsonDataParticipantHowtosUpgradeIn
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/upgrade/index.rst" hash="1d3d613c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/upgrade/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Upgrade To a New Release
 
 This section covers the processes to upgrade Canton participant nodes and synchronizers. Upgrading Daml applications is covered elsewhere.

--- a/docs-main/global-synchronizer/production-operations/validator-backups.mdx
+++ b/docs-main/global-synchronizer/production-operations/validator-backups.mdx
@@ -8,12 +8,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcValidatorOperatorValidatorBackupsBa
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_backups.rst" hash="51cdf21c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_backups.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 While all components in the system are designed to be crash-fault-tolerant, there is always a chance of failures from which the system cannot immediately recover, e.g. due to misconfiguration or bugs. In such cases, you will need to restore a component or a full validator node from backups or from dumps of the components that are still operational.
 
 Node operators should take **both** Node Identity backups and Postgres Instance Backups to protect their node from the widest range of disaster scenarios.

--- a/docs-main/global-synchronizer/production-operations/validator-disaster-recovery.mdx
+++ b/docs-main/global-synchronizer/production-operations/validator-disaster-recovery.mdx
@@ -17,12 +17,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_disaster_recovery.rst" hash="48572fc5" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_disaster_recovery.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 There are three ways to recover from disasters:
 
 1.  In simple cases where only a single node is affected but the overall network is still healthy, a Restore from backup is usually sufficient.

--- a/docs-main/global-synchronizer/production-operations/validator-major-upgrade.mdx
+++ b/docs-main/global-synchronizer/production-operations/validator-major-upgrade.mdx
@@ -8,12 +8,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcValidatorOperatorValidatorMajorUpgr
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_major_upgrades.rst" hash="794a1313" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_major_upgrades.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 To consume non-backwards-compatible major version upgrades of the Canton
 software the Global Synchronizer uses, you need to follow the procedure
 for synchronizer (i.e., domain) upgrades with downtime described below.

--- a/docs-main/global-synchronizer/production-operations/validator-security.mdx
+++ b/docs-main/global-synchronizer/production-operations/validator-security.mdx
@@ -5,12 +5,6 @@ description: "Security hardening and KMS configuration for validator nodes"
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_security.rst" hash="18c779fa" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_security.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Using an external KMS for managing participant keys
 
 In the following, we describe how to configure a validator so that its participant keys are managed by an external KMS. This guide assumes that you are using the Helm-based deployment of the validator. KMS usage is not currently supported for Docker Compose-based deployments.

--- a/docs-main/global-synchronizer/production-operations/validator-upgrades.mdx
+++ b/docs-main/global-synchronizer/production-operations/validator-upgrades.mdx
@@ -5,12 +5,6 @@ description: "Minor upgrade procedures for validator nodes"
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_upgrades.rst" hash="1951360a" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_upgrades.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 There are two types of upgrades:
 
 Version upgrades (this corresponds to an upgrade from `0.A.X` to `0.B.Y`) and protocol upgrades (the actual version can remain the same, only the protocol is upgraded and it requires no action).

--- a/docs-main/global-synchronizer/reference/api-configuration.mdx
+++ b/docs-main/global-synchronizer/reference/api-configuration.mdx
@@ -8,12 +8,6 @@ import ExternalCantonMainCommunityAppSrcTestResourcesDocumentationSnippetsLargeL
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/configure/apis/apis.rst" hash="e2cf7d55" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/configure/apis/apis.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # API Configuration
 
 Participant nodes expose the Admin API, the gRPC Ledger API, and optionally the JSON Ledger API.
@@ -124,12 +118,6 @@ Even when this is expected, falling back to NIO might lead to a warning being em
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/configure/apis/admin_api.rst" hash="eb18a523" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/configure/apis/admin_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Admin API Configuration
 
 ## Administration API
@@ -145,12 +133,6 @@ You should not expose the admin-api publicly in an unsecured way as it serves ad
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/configure/apis/ledger_api.rst" hash="1c225af4" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/configure/apis/ledger_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # gRPC Ledger API Configuration
 
@@ -216,12 +198,6 @@ canton.participants.participant.ledger-api.index-service {
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/configure/apis/json_api.rst" hash="a4b05afb" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/configure/apis/json_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # JSON Ledger API Configuration
 
 The configuration of the JSON Ledger API is similar to the gRPC Ledger API configuration. The corresponding parameter group starts with `http-ledger-api`.
@@ -279,12 +255,6 @@ You can enable the experimental `Daml Definitions Service` by setting the `daml-
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/optimize/caching.rst" hash="89c687c5" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/optimize/caching.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Configure Caching
 

--- a/docs-main/global-synchronizer/reference/canton-configuration-guide.mdx
+++ b/docs-main/global-synchronizer/reference/canton-configuration-guide.mdx
@@ -10,12 +10,6 @@ import ExternalCantonMainCommunityAppSrcPackExampleSimpleTopology from "//snippe
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/configure/general/conf_file.rst" hash="01a8d862" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/configure/general/conf_file.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Explain the difference between static and dynamic configuration. Move out specific configuration parts from here to their howto sections, such as multi-synchronizer below.
 
 # Set Configuration Options
@@ -177,12 +171,6 @@ The option `ledger-api.max-deduplication-duration` sets the maximum deduplicatio
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/configure/general/command_line.rst" hash="5d37a7f5" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/configure/general/command_line.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Use the Canton Command Line
 
 Canton supports a variety of command line arguments. Please run `bin/canton --help` to see all of them. Here, we explain the most relevant ones.
@@ -289,12 +277,6 @@ There are several log related options that can be specified. Refer to Logging fo
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/configure/general/declarative_conf.rst" hash="29ee858d" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/configure/general/declarative_conf.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Declarative Configuration
 
 <Note>
@@ -374,12 +356,6 @@ It is also possible to mix declarative and imperative configurations. Excess ite
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/configure/storage/storage.rst" hash="02111269" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/configure/storage/storage.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Configure storage
 
 Canton needs to persist data to operate. Participant Nodes, Mediator Nodes, and Synchronizer Nodes all require storage configuration.
@@ -452,12 +428,6 @@ This setting keeps the database open until the Canton process terminates.
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/configure/storage/postgres.rst" hash="e08b03d4" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/configure/storage/postgres.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Configure Canton with PostgreSQL<span id="postgres-config"></span>
 
@@ -686,12 +656,6 @@ Please refer to the documentation of the respective cloud provider for details o
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/configure/parameters/parameters.rst" hash="978f5ecd" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/configure/parameters/parameters.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Configure Canton parameters
 

--- a/docs-main/global-synchronizer/reference/canton-console-commands.mdx
+++ b/docs-main/global-synchronizer/reference/canton-console-commands.mdx
@@ -5,12 +5,6 @@ description: "Canton admin console command reference: participant, mediator, seq
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/reference/console.rst" hash="88ec36c6" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/reference/console.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <div id="canton_console_reference">
 
 <Note>

--- a/docs-main/global-synchronizer/reference/canton-console-reference.mdx
+++ b/docs-main/global-synchronizer/reference/canton-console-reference.mdx
@@ -12,12 +12,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/deployment/console_access.rst" hash="bccf3653" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/deployment/console_access.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 For more involved debugging and disaster recovery, direct access to the console of a Canton node (participant, sequencer, mediator) might be required. Steps to obtain such access:
 
 Requirements:

--- a/docs-main/global-synchronizer/reference/canton-metrics.mdx
+++ b/docs-main/global-synchronizer/reference/canton-metrics.mdx
@@ -5,12 +5,6 @@ description: "Canton node metrics exported for Prometheus scraping."
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/reference/metrics.rst" hash="9de8735e" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/reference/metrics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Metrics
 
 The following sections contain the common metrics exposed for Daml services supporting a Prometheus metrics reporter.

--- a/docs-main/global-synchronizer/reference/crypto-schemes.mdx
+++ b/docs-main/global-synchronizer/reference/crypto-schemes.mdx
@@ -5,12 +5,6 @@ description: "Reference of supported cryptographic schemes and key formats for C
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/reference/crypto_schemes.rst" hash="73450fd8" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/reference/crypto_schemes.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Supported Cryptographic Schemes And Formats
 
 Within Canton, we use the cryptographic primitives of signing, symmetric encryption, and asymmetric encryption, with the following supported cryptographic schemes and formats. For asymmetric signing and encryption, each scheme is divided into a key and an algorithm specification.

--- a/docs-main/global-synchronizer/reference/error-codes.mdx
+++ b/docs-main/global-synchronizer/reference/error-codes.mdx
@@ -25,12 +25,6 @@ As an operator, you should set up alerting on WARN and ERROR level messages. INF
 
 {/* COPIED_START source="docs-website:manual/build/3.5/reference/app-dev/error-codes.rst" hash="b2118eac" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `manual/build/3.5/reference/app-dev/error-codes.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Error Categories
 
 The error categories allow you to group errors such that application logic can be built to automatically deal with errors and decide whether to retry a request or escalate to the operator.

--- a/docs-main/global-synchronizer/reference/kms-driver-guide.mdx
+++ b/docs-main/global-synchronizer/reference/kms-driver-guide.mdx
@@ -5,12 +5,6 @@ description: "Develop a custom Canton KMS driver."
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/tutorials/kms_driver_guide.rst" hash="2256a3cc" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/tutorials/kms_driver_guide.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Canton KMS Driver developer guide
 
 ## Introduction

--- a/docs-main/global-synchronizer/reference/metrics-reference.mdx
+++ b/docs-main/global-synchronizer/reference/metrics-reference.mdx
@@ -5,12 +5,6 @@ description: "Reference for monitoring metrics exposed by Canton Network validat
 
 {/* COPIED_START source="splice:docs/src/deployment/observability/validator_health.rst" hash="eed61697" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/deployment/observability/validator_health.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 You can check your validator's health using the readiness endpoints. All CN applications provide the `/readyz` and `/livez` endpoints, which are used for readiness and liveness probes.
 
 - **Checking readiness**

--- a/docs-main/global-synchronizer/reference/observability-configuration.mdx
+++ b/docs-main/global-synchronizer/reference/observability-configuration.mdx
@@ -5,12 +5,6 @@ description: "Configure logging, tracing, metrics, and health monitoring on Cant
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/observe/monitoring.rst" hash="02880d45" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/observe/monitoring.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Monitoring Best Practices
 
 ## Introduction
@@ -449,12 +443,6 @@ When packaging large amounts of data, increase the default timeout of the dump c
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/observe/metrics.rst" hash="2d6be380" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/participant/howtos/observe/metrics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Configure Metrics
 

--- a/docs-main/global-synchronizer/reference/security-configuration.mdx
+++ b/docs-main/global-synchronizer/reference/security-configuration.mdx
@@ -9,12 +9,6 @@ import ExternalCantonMainCommunityAppSrcTestResourcesDocumentationSnippetsLedger
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/apis/tls.rst" hash="4223ca62" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/howtos/secure/apis/tls.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # TLS API Configuration
 
 Both the gRPC Ledger API and the Admin API support the same TLS capabilities and can be configured using identical directives. TLS provides end-to-end channel encryption between the server and the client, and—depending on the configuration—can enforce either server-only or mutual authentication.
@@ -133,12 +127,6 @@ canton.participants.participant4.ledger-api.tls.ciphers =
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/apis/jwt.rst" hash="6dd0171a" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/howtos/secure/apis/jwt.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Configure API Authentication and Authorization with JWT
 
@@ -335,12 +323,6 @@ canton {
 {/* COPIED_END */}
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/secure/apis/limits.rst" hash="c2b8d444" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/howtos/secure/apis/limits.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Cover gRPC max message size for both Admin API and Ledger API. Cover rate limiting on the Ledger API. Discuss load balancer in front of APIs as best practice for additional protection. Discuss the possible performance impact if rate limits are too strict. Link to howto for resource limits on the participant. Link to "build" site for daml related size limits.
 

--- a/docs-main/global-synchronizer/reference/splice-metrics.mdx
+++ b/docs-main/global-synchronizer/reference/splice-metrics.mdx
@@ -5,12 +5,6 @@ description: "Reference for Canton Network application metrics (Common, Validato
 
 {/* COPIED_START source="splice:docs/src/deployment/observability/metrics_reference.rst" hash="bde3c37a" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/deployment/observability/metrics_reference.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Common Metrics
 ### splice.domain_params_store.confirmation-requests-max-rate
 

--- a/docs-main/global-synchronizer/release-notes/splice.mdx
+++ b/docs-main/global-synchronizer/release-notes/splice.mdx
@@ -7,10 +7,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcReleaseNotesYaml192 from "/snippets
 
 {/* COPIED_START source="splice:docs/src/release_notes.rst" hash="b9660f66" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-  This section was copied from existing reviewed documentation. **Source:** `docs/src/release_notes.rst` Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## 0.6.3
 
 - Scan app

--- a/docs-main/global-synchronizer/splice-fundamentals/glossary.mdx
+++ b/docs-main/global-synchronizer/splice-fundamentals/glossary.mdx
@@ -5,12 +5,6 @@ description: "Glossary of Canton Network, Splice, and CNS terminology"
 
 {/* COPIED_START source="splice:docs/src/glossary.rst" hash="81da33d3" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/glossary.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <div className="glossary">
 
 ACS

--- a/docs-main/global-synchronizer/splice-fundamentals/rewards-minting.mdx
+++ b/docs-main/global-synchronizer/splice-fundamentals/rewards-minting.mdx
@@ -5,12 +5,6 @@ description: "How validator operators delegate minting authority for external pa
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_delegations.rst" hash="af0084d8" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_delegations.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Minting delegations allow a delegate to instruct their validator node to automate the minting of rewards on behalf of an external party (the beneficiary) hosted on the same validator node. The delegate can be any party onboarded to the validator node's wallet (e.g., the validator operator party, but other internal parties are also possible). This is useful to automate the reward collection for external parties.
 
 ## Overview

--- a/docs-main/global-synchronizer/splice-fundamentals/sv-live-tokenomics.mdx
+++ b/docs-main/global-synchronizer/splice-fundamentals/sv-live-tokenomics.mdx
@@ -5,12 +5,6 @@ description: "How Super Validator nodes earn and distribute Canton Coin rewards"
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/sv_live_tokenomics.rst" hash="a7bf1890" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/sv_live_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Each Super Validator, in each round, creates an SvRewardCoupon.
 
 These SV minting rights are granted by the tokenomics committee in exchange for operating an SV node or contributing key infrastructure or activity to the network. The tokenomics committee uses the CIP process to record the SV rights. The current list of SV rights is thus available from the [CIP repo](https://github.com/global-synchronizer-foundation/cips).

--- a/docs-main/global-synchronizer/splice-fundamentals/validator-development-fund.mdx
+++ b/docs-main/global-synchronizer/splice-fundamentals/validator-development-fund.mdx
@@ -5,12 +5,6 @@ description: "How validator operators access and use the Splice development fund
 
 {/* COPIED_START source="splice:docs/src/validator_operator/validator_development_fund.rst" hash="5cb253be" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/validator_operator/validator_development_fund.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Overview
 
 The Development Fund is a protocol-level mechanism introduced by [CIP-0082](https://github.com/canton-foundation/cips/blob/main/cip-0082/cip-0082.md). From its activation onward, a configurable percentage of all future mint emissions in each issuance round are allocated to the Development Fund, as defined by `IssuanceConfig.optDevelopmentFundPercentage` (default: 5%).

--- a/docs-main/global-synchronizer/splice-fundamentals/validator-liveness.mdx
+++ b/docs-main/global-synchronizer/splice-fundamentals/validator-liveness.mdx
@@ -5,12 +5,6 @@ description: "Validator liveness rewards and the tokenomics behind them"
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/val_live_tokenomics.rst" hash="48ad8bfc" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/val_live_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 In each round, each live validator records its liveness activity with a ValidatorLivenessActivityRecord. This rewards a validator for being available to validate and confirm transactions. It also provides them with initial funds to purchase extra traffic for higher throughput, after onboarding.
 
 

--- a/docs-main/global-synchronizer/troubleshooting-guide/security-issues.mdx
+++ b/docs-main/global-synchronizer/troubleshooting-guide/security-issues.mdx
@@ -138,12 +138,6 @@ Key rotation requires careful coordination. Always test in a non-production envi
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/troubleshoot/tls.rst" hash="633553d6" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/howtos/troubleshoot/tls.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Troubleshoot TLS
 
 TLS can be configured using the parameters described here.

--- a/docs-main/global-synchronizer/troubleshooting-guide/transaction-failures.mdx
+++ b/docs-main/global-synchronizer/troubleshooting-guide/transaction-failures.mdx
@@ -148,12 +148,6 @@ The timeout error includes a `context` field listing `unresponsiveParties`. If t
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/troubleshoot/commitments.rst" hash="e3be4cf9" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/participant/howtos/troubleshoot/commitments.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Troubleshoot ACS Commitments
 
 A participant node generates commitments to the active contract set (ACS) at regular intervals and exchanges them with its counter-participants. These commitments are used to establish non-repudiation on the common ACS state between participants, which is necessary for pruning the participant state. More information on commitments is available in the Pruning overview section.

--- a/docs-main/global-synchronizer/troubleshooting-guide/troubleshooting-methodology.mdx
+++ b/docs-main/global-synchronizer/troubleshooting-guide/troubleshooting-methodology.mdx
@@ -12,12 +12,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcDeploymentTroubleshootingText174 fr
 
 {/* COPIED_START source="splice:docs/src/deployment/troubleshooting.rst" hash="15096792" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/deployment/troubleshooting.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 This section provides an overview of which information can be collected to debug issues in a Canton Network node. For direct console access to a Canton node, see the [Canton Console Reference](/global-synchronizer/reference/canton-console-reference).
 
 ## Where to find logs

--- a/docs-main/global-synchronizer/understand/installing-daml-sdk.mdx
+++ b/docs-main/global-synchronizer/understand/installing-daml-sdk.mdx
@@ -5,12 +5,6 @@ description: "How to install a Daml SDK version compatible with the current Spli
 
 {/* COPIED_START source="splice:docs/src/app_dev/overview/version_information.rst#installing-a-compatible-daml-sdk" hash="2149e7a4" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was extracted from existing reviewed documentation.
-**Source:** `docs/src/app_dev/overview/version_information.rst`, section "Installing a Compatible Daml SDK"
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 You are not required to install the exact same Daml SDK versions used to build this Splice release. These versions are provided for reference only. `.dar` files built by older 3.x Daml SDKs are generally compatible with the Canton version used in this Splice release.
 
 For testing the interaction of your app with a Validator Node, we do recommend to use the Canton version used in this Splice release, which is the case if you deploy your Validator Node using the validator deployment instructions.

--- a/docs-main/global-synchronizer/understand/local-testing.mdx
+++ b/docs-main/global-synchronizer/understand/local-testing.mdx
@@ -8,12 +8,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/app_dev/testing/localnet.rst" hash="a3270359" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/testing/localnet.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 LocalNet provides a straightforward topology comprising three participants, three validators, a PostgreSQL database, and several web applications (wallet, sv, scan) behind an NGINX gateway. Each validator plays a distinct role within the Splice ecosystem:
 
 - **app-provider**: for the user operating their application

--- a/docs-main/global-synchronizer/understand/overview.mdx
+++ b/docs-main/global-synchronizer/understand/overview.mdx
@@ -5,12 +5,6 @@ description: "What the Global Synchronizer is and how it fits into the Canton Ne
 
 {/* COPIED_START source="splice:docs/src/overview/overview.rst" hash="546b3b07" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/overview/overview.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Canton Network
 
 The [Canton Network](https://www.canton.network) is the first privacy-enabled interoperable blockchain network, designed for regulated, real-world assets. Blockchain applications in the Canton Network can use the Global Synchronizer to enable atomic transactions across sovereign blockchains, without sacrificing privacy or control.

--- a/docs-main/integrations/exchanges/guidance.mdx
+++ b/docs-main/integrations/exchanges/guidance.mdx
@@ -9,12 +9,6 @@ import ExchangeIntegrationTransferInstructionAcceptFull from '/snippets/daml-doc
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/exchange-integration/index.rst" hash="07f260be" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/exchange-integration/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Exchange Integration Guide
 
 The pages below guide you how to integrate an exchange with Canton for the purpose of trading Canton Network Token Standard compliant tokens like Canton Coin.
@@ -32,12 +26,6 @@ overview architecture workflows txingestion non-functionals node-operations disa
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/exchange-integration/overview.rst" hash="d02c931e" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/exchange-integration/overview.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Overview
 
@@ -97,12 +85,6 @@ Use the following support code to simplify your integration development for:
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/exchange-integration/architecture.rst" hash="56b6899e" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/exchange-integration/architecture.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Integration Architecture
 
@@ -194,12 +176,6 @@ The other information flows interact with the main flows as part of a deposit or
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/exchange-integration/workflows.rst" hash="60badcf7" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/exchange-integration/workflows.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Integration Workflows
 
@@ -502,12 +478,6 @@ For example, Canton Coin also exist on TestNet and DevNet with different `dsoPar
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/exchange-integration/txingestion.rst" hash="72f69ac3" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/exchange-integration/txingestion.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Transaction History Ingestion Details
 
 ## Offset Checkpoints
@@ -686,12 +656,6 @@ For Canton Coin, both the creation of the `TransferInstruction` as well as the a
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/exchange-integration/non-functionals.rst" hash="d3042647" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/exchange-integration/non-functionals.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Fault Tolerance
 
 Recall the architecture diagram from the `integration-architecture` section:
@@ -770,12 +734,6 @@ If that is not possible, then you can read from a random Canton Coin Scan instan
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/exchange-integration/node-operations.rst" hash="7a5fbddf" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/exchange-integration/node-operations.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Validator Node Operations
 
@@ -945,12 +903,6 @@ Once you have completed these steps, the integration workflows will continue.
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/exchange-integration/disaster-recovery.rst" hash="30832232" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/exchange-integration/disaster-recovery.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Backup and Restore
 
 Recall that the `integration-architecture`, shown in the diagram below, relies on two stateful components: the Exchange Validator Node and the Canton Integration DB. We recommend backing them up regularly, so that you can restore them in case of a disaster.
@@ -1058,12 +1010,6 @@ We recommend doing so by having the Tx History Ingestion re-create the withdrawa
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/exchange-integration/testing.rst" hash="2afcf5f3" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/exchange-integration/testing.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Integration Testing
 
 ## Test Node Setup
@@ -1103,12 +1049,6 @@ Where possible, we recommend to automate these tests as part of your CI pipeline
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/exchange-integration/extensions.rst" hash="b9f41620" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/exchange-integration/extensions.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Integration Extensions
 

--- a/docs-main/integrations/exchanges/node-operations.mdx
+++ b/docs-main/integrations/exchanges/node-operations.mdx
@@ -5,12 +5,6 @@ description: "Operate an Exchange Validator Node: reward minting, traffic fundin
 
 {/* COPIED_START source="docs-website:docs/replicated/splice-wallet-kernel/devnet/src/exchange-integration/node-operations.rst" hash="7a5fbddf" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/splice-wallet-kernel/devnet/src/exchange-integration/node-operations.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ## Reward Minting and Traffic Funding
 
 As explained in *tokenomics-and-rewards*, your validator node will need traffic to submit

--- a/docs-main/integrations/exchanges/sdk-download.mdx
+++ b/docs-main/integrations/exchanges/sdk-download.mdx
@@ -13,12 +13,6 @@ Exchange integrations use the Wallet SDK, the Canton Network Token Standard, and
 
 {/* COPIED_START source="splice-wallet-kernel:exchange-integration/overview.rst" hash="exchange-sdk-support" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `splice-wallet-kernel:exchange-integration/overview.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Use the following support code to simplify your integration development:
 
 - **JavaScript/TypeScript** — Use the functions from the [Wallet SDK](https://github.com/canton-network/wallet-gateway) to simplify building your integration
@@ -51,12 +45,6 @@ The Java sample repository demonstrates how to interact with the JSON Ledger API
 ## Integration Milestones
 
 {/* COPIED_START source="splice-wallet-kernel:exchange-integration/overview.rst" hash="exchange-milestones" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `splice-wallet-kernel:exchange-integration/overview.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 The exchange integration guide is structured as incremental milestones:
 

--- a/docs-main/integrations/release-notes/wallet-sdk.mdx
+++ b/docs-main/integrations/release-notes/wallet-sdk.mdx
@@ -5,12 +5,6 @@ description: "Release notes for the Canton Wallet SDK."
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/release-notes/index.rst" hash="7fa6307c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/release-notes/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Wallet SDK Release Notes
 
 Below are the release notes for the Wallet SDK versions, detailing new features, improvements, and bug fixes in each version.

--- a/docs-main/integrations/wallet/configuration.mdx
+++ b/docs-main/integrations/wallet/configuration.mdx
@@ -12,12 +12,6 @@ The Wallet SDK includes default configuration that works with a standard LocalNe
 
 {/* COPIED_START source="splice-wallet-kernel:wallet-sdk-configuration/index.rst" hash="wallet-sdk-config-default" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `splice-wallet-kernel:wallet-sdk-configuration/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The default configuration connects to a LocalNet instance running on standard ports. Use it for local development and testing without modification.
 
 When migrating to a different environment, you must create custom factories for each controller with the correct URLs and ports for that environment.
@@ -45,12 +39,6 @@ For remote environments, configure the following connection parameters:
 ## Validating Your Configuration
 
 {/* COPIED_START source="splice-wallet-kernel:wallet-sdk-configuration/index.rst" hash="wallet-sdk-config-validation" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `splice-wallet-kernel:wallet-sdk-configuration/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 Verify your connection endpoints with these commands:
 

--- a/docs-main/integrations/wallet/guidance.mdx
+++ b/docs-main/integrations/wallet/guidance.mdx
@@ -60,12 +60,6 @@ import SpliceWalletKernelExecuteTransactionBash from '/snippets/external/splice-
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/canton-network-overview/index.rst" hash="cdfe654c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/canton-network-overview/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Canton Network Overview
 
 ## High-level Overview
@@ -169,12 +163,6 @@ The Canton Network is designed to be agile and undergoes frequent upgrades. Node
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/integrating-with-canton-network/index.rst" hash="241a9637" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/integrating-with-canton-network/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Integrating with the Canton Network
 
 When integrating with the Canton Network, we recommend that wallet providers support the necessary features outlined below to optimal user experience. Additionally, there are optional features that can further enhance the integration and provide additional value to users.
@@ -238,12 +226,6 @@ If you are interested in building your own application, a good first place would
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/party-management/index.rst" hash="6b3d9715" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/party-management/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Create an External Party (Wallet)
 
@@ -354,12 +336,6 @@ Using the `userLedgerControllers` party allocation we only need to specify other
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/finding-and-reading-data/index.rst" hash="22f63846" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/finding-and-reading-data/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Finding and Reading Data
 
@@ -723,12 +699,6 @@ Bob then also sees one new unlocked utxo for the 100.
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/preparing-and-signing-transactions/index.rst" hash="cf0da06a" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/preparing-and-signing-transactions/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Preparing and Signing Transactions Using External Party
 
 ## High-level Signing Process
@@ -872,12 +842,6 @@ The SDK exposes functionality that can be used in an offline environment to sign
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/signing-transactions-from-dapps/index.rst" hash="4b0292af" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/signing-transactions-from-dapps/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Signing Transactions from third party dApps
 
 A normal flow on blockchain applications is to have dApps that interact with the blockchain on the clients behalf, these flows usually require the user to sign transactions that the dApp prepares and submit it. To faciliate this in Canton it is required that the prepared transaction is sent to the wallet for signing. An easy way of supporting this is to expose a dApp API (OpenRPC spec can be found here: [https://github.com/canton-network/wallet-gateway/blob/main/api-specs/openrpc-dapp-api.json](https://github.com/canton-network/wallet-gateway/blob/main/api-specs/openrpc-dapp-api.json) ).
@@ -907,12 +871,6 @@ It is important when integrating with third party dApps to showcase the User exa
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/token-standard/index.rst" hash="c3641fc0" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/token-standard/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Token Standard
 
@@ -1044,12 +1002,6 @@ If you have accidentally created a transfer preapproval that you dont want to ke
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/wallet-sdk-configuration/index.rst" hash="c5b36cba" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/wallet-sdk-configuration/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Wallet SDK Configuration
 
@@ -1187,12 +1139,6 @@ export interface AuthController {
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/traffic/index.rst" hash="2ba91b35" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/traffic/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Traffic
 
 Below is a high-level summary of the Sycnrhonizer Traffic Fees page in the Splice Validator documentation. For more detail on point, it's advised to read the that documenation.
@@ -1234,12 +1180,6 @@ Follow this FAQ entry in the Splice [documentation]().
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/tokenomics-and-rewards/index.rst" hash="08ff71a4" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/tokenomics-and-rewards/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Tokenomics and Rewards
 
@@ -1323,12 +1263,6 @@ Featured Application rewards can be shared between multiple parties, this can be
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/user-management/index.rst" hash="ae1fa985" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/user-management/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # User Management
 
 The Wallet SDK has functionality for creating and managing user rights, by default when you are connecting it uses whichever user is defined in your auth-controller. If the user is an admin user on the ledger api they can be used to create other users and grant them rights.
@@ -1378,12 +1312,6 @@ The setup is similar to the \`CanReadAsAnyParty\`:
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/canton-coin-specific-considerations/index.rst" hash="45961707" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/canton-coin-specific-considerations/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Canton Coin Specific Considerations
 
@@ -1443,12 +1371,6 @@ Instead of signing the transfer transaction directly (which pins a short-lived M
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/deposits-into-exchanges/index.rst" hash="8d2784fe" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/deposits-into-exchanges/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Sending Deposits to Exchanges
 
 To enable deposits to be sent to specific user accounts at exchanges, an account identifier needs to be sent to the exchange along with the transfer information. In Canton, the “memo tag” [pattern]() is implemented as follows.
@@ -1478,12 +1400,6 @@ Token standard compliant registries must ensure that they pass the `Transfer` sp
 
 
 {/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/usdcx-support/index.rst" hash="852eb3cf" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/wallet-integration-guide/src/usdcx-support/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # USDCx Support for Wallets
 

--- a/docs-main/overview/learn/multi-synchronizer.mdx
+++ b/docs-main/overview/learn/multi-synchronizer.mdx
@@ -51,12 +51,6 @@ Most applications only need the Global Synchronizer. Multiple synchronizers beco
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/overview/explanations/canton/multi-synchronizer.rst" hash="71dbc111" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/overview/explanations/canton/multi-synchronizer.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Multiple Synchronizers
 
 ## Motivation
@@ -409,12 +403,6 @@ Contrast to command dedup time model
 
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/overview/explanations/canton/traffic-management.rst" hash="c8ff2996" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/overview/explanations/canton/traffic-management.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Traffic management
 

--- a/docs-main/overview/reference/canton-coin-tokenomics.mdx
+++ b/docs-main/overview/reference/canton-coin-tokenomics.mdx
@@ -23,12 +23,6 @@ Traffic credits are consumed even if a confirmation request fails due to content
 
 {/* COPIED_START source="splice:docs/src/background/tokenomics/overview_tokenomics.rst" hash="2b34b077" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/tokenomics/overview_tokenomics.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 holding fee remains but its behavior changed so that no holding fees are charged when using a coin as an input to a transfer.
 
 The holding fees is a fixed fee, per separate coin contract (UTXO) per unit of time, that is independent of the coin amount. It promotes merging of CC to reduce network storage use by incentivizing merging or removal of dust coins. Holding fees are not charged when transferring coins but only explicitly on expired coin contracts via the `Amulet_Expire` choice. A coin contract (UTXO) may be expired by the Super Validators once its accrued holding fees are greater than its coin value. This makes accounting for holding fees simple as the value of the coin contract is constant and independent of the holding fee.

--- a/docs-main/overview/reference/decentralization.mdx
+++ b/docs-main/overview/reference/decentralization.mdx
@@ -5,12 +5,6 @@ description: "Decentralized namespaces, decentralized parties, and decentralized
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/overview/explanations/canton/decentralization.rst" hash="8b3f3d2c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/overview/explanations/canton/decentralization.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Decentralization
 
 In the context of Canton, decentralization is primarily a distribution of power or ownership over a particular entity to various owners or trustees. This means that no trustee can unilaterally effect changes on behalf of that entity.

--- a/docs-main/overview/reference/external-party.mdx
+++ b/docs-main/overview/reference/external-party.mdx
@@ -5,12 +5,6 @@ description: "Local and external parties, hosting relationships, and the distinc
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/overview/explanations/canton/external-party.rst" hash="c50cd0e1" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/overview/explanations/canton/external-party.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Local and external parties
 
 In Canton, a **party** represents an entity capable of creating and interacting with contracts on the ledger. Each party is hosted on one or more **Participant Nodes**, which act as intermediaries between the party and the ledger. Different kinds of interactions require the appropriate authentication and authorization from the party. This page explains how a party integrates and interacts with the Canton Protocol, the trust relationships involved, and their implications.

--- a/docs-main/overview/reference/ledger-causality.mdx
+++ b/docs-main/overview/reference/ledger-causality.mdx
@@ -5,12 +5,6 @@ description: "Causality graphs, local ledgers, and time on Daml ledgers."
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/overview/explanations/ledger-model/local-ledger.rst" hash="2871e956" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/overview/explanations/ledger-model/local-ledger.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Causality
 
 Daml ledgers do not totally order all transactions. So different parties may observe two transactions on different Participant Nodes in different orders via the gRPC Ledger API. Moreover, different Participant Nodes may output two transactions for the same party in different orders. This document explains the ordering guarantees that Daml ledgers do provide, by example and formally via the concept of causality graphs and local ledgers.
@@ -286,12 +280,6 @@ The causality examples can be explained in terms of causality graphs and local l
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/overview/explanations/ledger-model/time.rst" hash="e88a1d96" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/overview/explanations/ledger-model/time.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 <Note>
 - Move LAPI parts to BUILD subsite

--- a/docs-main/overview/reference/ledger-model-detailed.mdx
+++ b/docs-main/overview/reference/ledger-model-detailed.mdx
@@ -12,12 +12,6 @@ import LedgerModelSimpleDvPREVERTPROPOSAL from '/snippets/daml-docs/ledger-model
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/overview/explanations/ledger-model/ledger-structure.rst" hash="52f080a2" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/overview/explanations/ledger-model/ledger-structure.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Structure
 
 This section looks at the structure of a ledger that records the interactions between the parties as ledger changes. The definitions presented here address the first question: "What do changes and ledgers look like?". The basic building blocks of the recorded interactions are actions, which get grouped into transactions, *updates*, *commits*, and the Ledger.
@@ -217,12 +211,6 @@ As the Ledger is a DAG, one can always extend the order into a linear sequence v
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/overview/explanations/ledger-model/ledger-validity.rst" hash="3710723f" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/overview/explanations/ledger-model/ledger-validity.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Valid Ledgers
 
 At the core is the concept of a *valid ledger*; changes are permissible if adding the corresponding commit to the ledger results in a valid ledger. **Valid ledgers** are those that fulfill three conditions:
@@ -243,12 +231,6 @@ Only the last of these conditions depends on the party (or parties) requesting t
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/overview/explanations/ledger-model/ledger-integrity.rst" hash="c93dba12" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/overview/explanations/ledger-model/ledger-integrity.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Integrity
 
@@ -582,12 +564,6 @@ Finally, validity conditions ensure three important properties of the Daml ledge
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/overview/explanations/ledger-model/ledger-privacy.rst" hash="b3c9457c" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/overview/explanations/ledger-model/ledger-privacy.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Privacy
 
 The ledger structure section answered the question "What does the Ledger looks like?" by introducing a hierarchical format to record the party interactions as changes. This section addresses the question "Who sees which changes and data?". That is, it explains the privacy model for Canton Ledgers.
@@ -758,12 +734,6 @@ Moveover, adding parties as observers scales poorly to large numbers, because ev
 
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/overview/explanations/ledger-model/interoperability.rst" hash="a2bb1cc4" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/overview/explanations/ledger-model/interoperability.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Synchronizer-aware projection
 

--- a/docs-main/overview/reference/pruning.mdx
+++ b/docs-main/overview/reference/pruning.mdx
@@ -5,12 +5,6 @@ description: "How Canton pruning works: retention, safe-to-prune markers, and co
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/overview/explanations/canton/pruning.rst" hash="3735823a" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/overview/explanations/canton/pruning.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Pruning
 
 As a synchronizer orchestrates the execution of commands, the sequencers, mediators and participant persist records of the data/changes that they process:

--- a/docs-main/overview/reference/splice-wallet-reference.mdx
+++ b/docs-main/overview/reference/splice-wallet-reference.mdx
@@ -32,12 +32,6 @@ The validator app runs several background automations on behalf of wallet users.
 
 {/* COPIED_START source="splice:docs/src/background/preapprovals.rst" hash="02f3cce9" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/preapprovals.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Contrary to other assets like Eth or Bitcoin, Canton Coin requires a party to explicitly agree to hold Canton Coin. This includes explicitly agreeing to any incoming transfers.
 
 Parties that are ok with accepting incoming Canton Coin transfers from any sender, can setup a `TransferPreapproval`. This allows any party to send Canton Coin to the party that setup the `TransferPreapproval`. Note that this only applies to transfers of Canton Coin but not to other assets. Other assets may provide their own variant of a preapproval which needs to be setup separately or they may require approval of each incoming transfer individually.

--- a/docs-main/overview/reference/sv-governance-reference.mdx
+++ b/docs-main/overview/reference/sv-governance-reference.mdx
@@ -9,12 +9,6 @@ The Global Synchronizer is governed by its Super Validators (SVs) acting collect
 
 {/* COPIED_START source="splice:docs/src/background/architecture.rst" hash="6eba999e" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/architecture.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 CC, CNS, and Global Synchronizer governance are implemented in a decentralized fashion to tolerate up to `f` faulty or dishonest SV nodes for `f = numSvNodes - t` and confirmation threshold `t = ceiling (numSvNodes * 2.0 / 3.0)`.
 
 The implementation uses three key techniques to achieves this Byzantine fault tolerance:

--- a/docs-main/overview/reference/synchronizer-overview.mdx
+++ b/docs-main/overview/reference/synchronizer-overview.mdx
@@ -5,12 +5,6 @@ description: "Overview of the Canton Synchronizer: role in architecture, technic
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/synchronizer/overview/index.rst" hash="36bcc724" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/synchronizer/overview/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Synchronizer
 
 A Synchronizer is a foundational part of the Canton architecture that provides two main functionalities:

--- a/docs-main/overview/reference/topology.mdx
+++ b/docs-main/overview/reference/topology.mdx
@@ -5,12 +5,6 @@ description: "Canton topology management: namespaces, cryptographic keys, party-
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/overview/explanations/canton/topology.rst" hash="efe99632" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/overview/explanations/canton/topology.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Topology management
 
 All Participant Nodes and Synchronizer components must know the topology state of a Synchronizer, which includes all identities on the Synchronizer and their associated keys. The two-phase commit protocol on a Synchronizer can therefore assume that identities and keys are common knowledge and thus omit to include such information in the protocol messages. Updates to the topology state are distributed via the Synchronizer so that nodes maintain the synchronized topology state via state machine replication.

--- a/docs-main/overview/reference/validator-node-components.mdx
+++ b/docs-main/overview/reference/validator-node-components.mdx
@@ -73,12 +73,6 @@ flowchart TB
 
 {/* COPIED_START source="docs-website:replicated/canton/3.5/overview/explanations/canton/participant.rst" hash="3ccc7b7d" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `replicated/canton/3.5/overview/explanations/canton/participant.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Participant nodes
 
 <div class="wip">

--- a/docs-main/overview/understand/global-synchronizer.mdx
+++ b/docs-main/overview/understand/global-synchronizer.mdx
@@ -286,12 +286,6 @@ The Global Synchronizer and validators currently have frequent upgrades with the
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/overview/explanations/canton/synchronizers.rst" hash="ff3b68a4" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/canton/3.4/overview/explanations/canton/synchronizers.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Synchronizers
 
 A deep look into the synchronizer architecture; functional requirements have already been established in protocols.rst

--- a/docs-main/sdks-tools/api-reference/json-api.mdx
+++ b/docs-main/sdks-tools/api-reference/json-api.mdx
@@ -44,12 +44,6 @@ Use gRPC directly when:
 
 {/* COPIED_START source="docs-website:canton/3.5/sdk/tutorials/json-api/canton_and_the_json_ledger_api.rst" hash="json-api-command-submit" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `canton/3.5/sdk/tutorials/json-api/canton_and_the_json_ledger_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 ```bash
 curl localhost:7575/v2/commands/submit-and-wait \
   -H "Content-Type: application/json" \
@@ -80,12 +74,6 @@ Other submission endpoints include `/v2/commands/submit-and-wait-for-transaction
 ### Active Contract Queries
 
 {/* COPIED_START source="docs-website:canton/3.5/sdk/tutorials/json-api/canton_and_the_json_ledger_api.rst" hash="json-api-acs-query" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `canton/3.5/sdk/tutorials/json-api/canton_and_the_json_ledger_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ```bash
 curl localhost:7575/v2/state/active-contracts \

--- a/docs-main/sdks-tools/api-reference/ledger-api-services.mdx
+++ b/docs-main/sdks-tools/api-reference/ledger-api-services.mdx
@@ -5,12 +5,6 @@ description: "Service-by-service explanation of the gRPC Ledger API: command sub
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/explanations/ledger-api-services.rst" hash="3d9b9067" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/explanations/ledger-api-services.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The Ledger API is structured as a set of services. This page gives more
 detail about each of the services in the API, and will be relevant
 whichever way you're accessing it.

--- a/docs-main/sdks-tools/api-reference/splice-architecture.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-architecture.mdx
@@ -5,12 +5,6 @@ description: "Daml package structure, decentralized validation and automation, a
 
 {/* COPIED_START source="splice:docs/src/background/architecture.rst" hash="6eba999e" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/background/architecture.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <div className="todo">
 
 add more architecture docs (possibly starting with the architecture currently in the scan bulk api docs)

--- a/docs-main/sdks-tools/api-reference/splice-daml-apis.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml-apis.mdx
@@ -8,12 +8,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/app_dev/daml_api/index.rst" hash="812c336f" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/daml_api/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The APIs below are published by Splice to aid decoupling different Canton Network applications. Consider using them to decouple your code from the upgrading cycles of your dependencies, when building Daml code that interacts with workflows of other apps in the Canton Network.
 
 These APIs are not mandatory to use. Feel free to build your own Daml APIs, potentially using the APIs below as inspiration.

--- a/docs-main/sdks-tools/api-reference/splice-daml-models.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml-models.mdx
@@ -5,12 +5,6 @@ description: "The Daml model packages shipped with Splice"
 
 {/* COPIED_START source="splice:docs/src/app_dev/daml_models/index.rst" hash="2f95ec18" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/daml_models/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Use the docs below when interacting with the on-ledger state of the decentralized applications that are part of Splice.
 
 <div className="toctree" maxdepth="1">

--- a/docs-main/sdks-tools/api-reference/splice-http-apis.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-http-apis.mdx
@@ -8,12 +8,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/app_dev/overview/splice_app_apis.rst" hash="10312958" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/overview/splice_app_apis.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <div id="app_dev_http_apis">
 
 There are two sets of HTTP APIs exposed by Splice applications, as can be seen in the diagram below:

--- a/docs-main/sdks-tools/api-reference/splice-overview.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-overview.mdx
@@ -5,12 +5,6 @@ description: "Overview of the REST and gRPC APIs exposed by Splice nodes on the 
 
 {/* COPIED_START source="splice:docs/src/app_dev/overview/index.rst" hash="241c45b9" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/overview/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 If you are a new Canton Network developer, please check out the [TL;DR for new Canton Network developers](/appdev/get-started/choose-your-path).
 
 ## Canton Network Applications

--- a/docs-main/sdks-tools/api-reference/splice-scan-aggregates-api.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-scan-aggregates-api.mdx
@@ -5,12 +5,6 @@ description: "Aggregated views over Canton Coin holdings and ANS entries"
 
 {/* COPIED_START source="splice:docs/src/app_dev/scan_api/scan_aggregates_api.rst" hash="00ee04b4" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/scan_api/scan_aggregates_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Scan provides a couple shortcuts for using the `scan_bulk_data_api` to look up Amulet and Amulet Name Service records.
 
 ## Amulet Summaries

--- a/docs-main/sdks-tools/api-reference/splice-scan-api.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-scan-api.mdx
@@ -5,12 +5,6 @@ description: "Public, read-only access to Global Synchronizer state, history, an
 
 {/* COPIED_START source="splice:docs/src/app_dev/scan_api/index.rst" hash="73c3f5b6" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/scan_api/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The Scan APIs consist of the following APIs:
 
 - `scan_bulk_data_api`: A comprehensive API that provides access to the exact and full history of updates and ACS snapshots as recorded on the SV participant node.

--- a/docs-main/sdks-tools/api-reference/splice-scan-bulk-data-api.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-scan-bulk-data-api.mdx
@@ -8,12 +8,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/app_dev/scan_api/scan_bulk_data_api.rst" hash="2753bd48" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/scan_api/scan_bulk_data_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 At a high level, participant nodes provide two separate endpoints through a Ledger API:
 
 - An endpoint to submit commands to the ledger that allow an application to submit transactions and change state, by creating, exercising or archiving contracts.

--- a/docs-main/sdks-tools/api-reference/splice-scan-cc-reference-data-api.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-scan-cc-reference-data-api.mdx
@@ -5,12 +5,6 @@ description: "Canton Coin reference data exposed by the Scan API"
 
 {/* COPIED_START source="splice:docs/src/app_dev/scan_api/scan_cc_reference_data_api.rst" hash="596f8c4f" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/scan_api/scan_cc_reference_data_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Alongside ephemeral status such as open rounds in the `scan_current_state_api`, there are more fixed data records for aspects of a Splice network.
 
 ## DSO party ID

--- a/docs-main/sdks-tools/api-reference/splice-scan-current-state-api.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-scan-current-state-api.mdx
@@ -5,12 +5,6 @@ description: "Open and issuing mining rounds, traffic status, and conversion rat
 
 {/* COPIED_START source="splice:docs/src/app_dev/scan_api/scan_current_state_api.rst" hash="c7a6ba6f" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/scan_api/scan_current_state_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Alongside information about the overall Splice network operations, Scan provides some more specific details about current Amulet-related network state.
 
 ## Validator Traffic Credits and Purchases

--- a/docs-main/sdks-tools/api-reference/splice-scan-gs-connectivity-api.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-scan-gs-connectivity-api.mdx
@@ -8,12 +8,6 @@ import { networkData } from '/snippets/generated/version-dashboard-data.mdx';
 
 {/* COPIED_START source="splice:docs/src/app_dev/scan_api/scan_global_synchronizer_connectivity_api.rst" hash="05c0a1f9" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/scan_api/scan_global_synchronizer_connectivity_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Splice network applications and validators need to be able to connect to multiple supervalidators' Scan apps and Canton sequencers. If you have the base URL for a single SV Scan app, you can query for all other connected Scans and the SV sequencers. This lets you dynamically update your app configuration based on changing network SV configurations, and easily check that your own deployments can successfully connect to all needed endpoints. Additionally, you can query for all network-approved validators and get their details.
 
 ## Listing all SV Scans

--- a/docs-main/sdks-tools/api-reference/splice-scan-gs-operations-api.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-scan-gs-operations-api.mdx
@@ -5,12 +5,6 @@ description: "Validator liveness, DSO info, and governance state"
 
 {/* COPIED_START source="splice:docs/src/app_dev/scan_api/scan_global_synchronizer_operations_api.rst" hash="00a941a7" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/scan_api/scan_global_synchronizer_operations_api.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 Scan provides endpoints to query about the ongoing operations of the Global Synchronizer, based on information recorded on-ledger.
 
 ## Validator Liveness

--- a/docs-main/sdks-tools/api-reference/splice-validator-api.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-validator-api.mdx
@@ -5,12 +5,6 @@ description: "Wallet, user management, external signing, and validator administr
 
 {/* COPIED_START source="splice:docs/src/app_dev/validator_api/index.rst" hash="3b98ada8" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/validator_api/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 The Validator App exposing the validator APIs is part of a `CN Validator` or `CN Supervalidator` node. It connects to a Canton participant and provides the following functionality:
 
 > - It manages the Canton participant. Examples are automatically setting up the participant's connection to `Canton Network` synchronizer, uploading DAR files, or managing daml parties.

--- a/docs-main/sdks-tools/cli-tools/daml-script.mdx
+++ b/docs-main/sdks-tools/cli-tools/daml-script.mdx
@@ -120,12 +120,6 @@ Aim for high coverage on all choices that will run in production. See the [testi
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/daml-scripts.rst" hash="aaa6a370" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/tutorials/smart-contracts/daml-scripts.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Test templates using Daml scripts
 
 In this section we test the `Token` model from `contracts` using the Daml Script integration in Daml Studio. This includes:

--- a/docs-main/sdks-tools/cli-tools/daml-shell.mdx
+++ b/docs-main/sdks-tools/cli-tools/daml-shell.mdx
@@ -26,12 +26,6 @@ import ExternalDamlShellMainDamlShellRstCodeDocsUserSdlcHowtosApplicationsDevelo
 
 {/* COPIED_START source="daml-shell:docs/user/component-howtos/daml-shell/index.rst" hash="f2fcc9ff" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `daml-shell:docs/user/component-howtos/daml-shell/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Daml Shell
 
 Daml Shell is a component that enables you to interactively query ledger data made available in the Participant Query Store (`PQS`) PostgreSQL database.
@@ -321,12 +315,6 @@ Type `help set` or help set to learn more about specific settings:
 {/* COPIED_END */}
 
 {/* COPIED_START source="daml-shell:docs/user/sdlc-howtos/applications/develop/debug/daml-shell/index.rst" hash="d6b9b545" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `daml-shell:docs/user/sdlc-howtos/applications/develop/debug/daml-shell/index.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # How to inspect the ledger using Daml Shell
 

--- a/docs-main/sdks-tools/cli-tools/dpm.mdx
+++ b/docs-main/sdks-tools/cli-tools/dpm.mdx
@@ -426,12 +426,6 @@ See `dpm sandbox` for details on running a local Canton installation.
 
 {/* COPIED_START source="docs-website:docs/replicated/dpm/3.4/dpm-components.rst" hash="a8899270" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/dpm/3.4/dpm-components.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 <Note>
 This functionality is available in DPM version 1.0.13 or later (or bundled with SDK 3.5 or later).
 </Note>
@@ -473,12 +467,6 @@ A common development cycle with `dpm`:
 - [Daml Script](/sdks-tools/cli-tools/daml-script) -- Writing and running tests with `dpm test`
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/component-howtos/application-development/dpm-sandbox.rst" hash="5f8df40b" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/component-howtos/application-development/dpm-sandbox.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 # Sandbox<span id="component-howtos-application-development-daml-sandbox"></span>
 

--- a/docs-main/sdks-tools/development-tools/daml-compiler.mdx
+++ b/docs-main/sdks-tools/development-tools/daml-compiler.mdx
@@ -5,12 +5,6 @@ description: "Daml compiler flags and invocation options."
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/component-howtos/smart-contracts/flags.rst" hash="24de3fac" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/component-howtos/smart-contracts/flags.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # The Daml Compiler
 
 At the core of the Daml toolchain lies the Daml Compiler, also known as `damlc`. Its primary usage is to compile Daml source code, which defines smart contracts and their behaviours, into a lower-level language called Daml-LF, which Canton participants can evaluate in order to run those smart contracts.

--- a/docs-main/sdks-tools/development-tools/daml-studio.mdx
+++ b/docs-main/sdks-tools/development-tools/daml-studio.mdx
@@ -103,12 +103,6 @@ For projects with many packages or large dependency trees, the background type c
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/component-howtos/smart-contracts/daml-studio.rst" hash="f04f848f" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/component-howtos/smart-contracts/daml-studio.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Daml Studio
 
 Daml Studio is an integrated development environment (IDE) for Daml. It is an extension on top of [Visual Studio Code](https://code.visualstudio.com) (VS Code), a cross-platform, open-source editor providing a [rich code editing experience](https://code.visualstudio.com/docs/editor/editingevolved).

--- a/docs-main/sdks-tools/development-tools/localnet.mdx
+++ b/docs-main/sdks-tools/development-tools/localnet.mdx
@@ -12,12 +12,6 @@ import ExternalSpliceMainSpliceRstCodeDocsSrcAppDevTestingLocalnetNone126 from "
 
 {/* COPIED_START source="splice:docs/src/app_dev/testing/localnet.rst" hash="7adf9498" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/testing/localnet.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 LocalNet provides a straightforward topology comprising three participants, three validators, a PostgreSQL database, and several web applications (wallet, sv, scan) behind an NGINX gateway. Each validator plays a distinct role within the Splice ecosystem:
 
 - **app-provider**: for the user operating their application
@@ -79,12 +73,6 @@ Each validator runs a participant, wallet services, and supporting infrastructur
 ## Port Conventions
 
 {/* COPIED_START source="splice:docs/src/app_dev/testing/localnet.rst" hash="7adf9498" */}
-
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/src/app_dev/testing/localnet.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
 
 ## Exposed Ports
 

--- a/docs-main/sdks-tools/development-tools/pqs.mdx
+++ b/docs-main/sdks-tools/development-tools/pqs.mdx
@@ -120,12 +120,6 @@ Design your backend to support PQS failover:
 
 {/* COPIED_START source="docs-website:pqs/3.5/component-howtos/pqs/references/sharing-database.rst" hash="pqs-sharing" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was adapted from existing reviewed documentation.
-**Source:** `replicated/pqs/3.5/component-howtos/pqs/references/sharing-database.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 An application making use of the PQS datastore may also manage its own database migrations via Flyway — either embedded, command-line, or other supported means. An example of such a scenario is the creation of application-specific indexes.
 
 With default settings, the application's Flyway produces an error because its view of available/valid migrations is different from PQS. However, it is trivial to instruct the application's Flyway to use a different, non-default table name to store its versioning information, which allows both Flyways to coexist in the same database:

--- a/docs-main/sdks-tools/development-tools/sandbox.mdx
+++ b/docs-main/sdks-tools/development-tools/sandbox.mdx
@@ -86,12 +86,6 @@ Press Ctrl+C in the terminal where the Sandbox is running. Since the Sandbox use
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/component-howtos/application-development/dpm-sandbox.rst" hash="5f8df40b" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/component-howtos/application-development/dpm-sandbox.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Sandbox<span id="component-howtos-application-development-daml-sandbox"></span>
 
 Sandbox is a program for running a Canton ledger with your Daml code. The ledger uses the simplest topology possible: a single Participant Node connected to a Synchronizer Node. Use the sandbox when you need access to a Canton ledger running your Daml code and matching the target Participant Node topology is not required.

--- a/docs-main/sdks-tools/language-bindings/java-client-libraries.mdx
+++ b/docs-main/sdks-tools/language-bindings/java-client-libraries.mdx
@@ -5,12 +5,6 @@ description: "Overview, installation, and reference for the Canton Java client l
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/component-howtos/application-development/client-libraries/java-client-libraries.rst" hash="6ccddace" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/component-howtos/application-development/client-libraries/java-client-libraries.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Java client libraries
 
 The Java client libraries simplify using the gRPC Ledger API. Read How to work with contracts and transactions in Java for guidance on how to use them. Read below to learn about their code architecture, installation, and reference materials.

--- a/docs-main/sdks-tools/language-bindings/java.mdx
+++ b/docs-main/sdks-tools/language-bindings/java.mdx
@@ -133,12 +133,6 @@ The full Javadoc for the Daml Java bindings library is published with each [Daml
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/component-howtos/application-development/daml-codegen-java.rst" hash="bbdcc685" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs-website:docs/replicated/daml/3.4/sdk/component-howtos/application-development/daml-codegen-java.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Daml Codegen for Java
 
 Use the Daml Codegen for Java (`dpm codegen-java`) to generate Java classes representing all Daml data types defined in a Daml Archive (.dar) file. These classes simplify constructing the types required by the Java gRPC bindings for the gRPC Ledger API; for example, `com.daml.ledger.api.v2.CreateCommand` and `com.daml.ledger.api.v2.ExerciseCommand`. They also provide JSON decoding utilities, making it easier to work with JSON when using the JSON Ledger API.

--- a/docs-main/sdks-tools/language-bindings/javascript.mdx
+++ b/docs-main/sdks-tools/language-bindings/javascript.mdx
@@ -5,12 +5,6 @@ description: "Generate JavaScript/TypeScript bindings from Daml interfaces and t
 
 {/* COPIED_START source="docs-website:docs/replicated/daml/3.4/sdk/component-howtos/application-development/daml-codegen-javascript.rst" hash="64480016" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/daml/3.4/sdk/component-howtos/application-development/daml-codegen-javascript.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Daml Codegen for JavaScript
 
 Use the Daml Codegen for JavaScript (`dpm codegen-js`) to generate JavaScript/TypeScript code representing all Daml data types defined in a Daml Archive (.dar) file.

--- a/docs-main/shared/support-checklist.mdx
+++ b/docs-main/shared/support-checklist.mdx
@@ -5,12 +5,6 @@ description: "Information to gather before contacting Canton support for trouble
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/overview/reference/support/support_checklist.rst" hash="14268f8f" */}
 
-<Warning title="Pre-reviewed Content - Do Not Modify">
-This section was copied from existing reviewed documentation.
-**Source:** `docs/replicated/canton/3.4/overview/reference/support/support_checklist.rst`
-Reviewers: Skip this section. Remove markers after final approval.
-</Warning>
-
 # Support Checklist
 
 So that we can successfully provide support, and to ensure that you can troubleshoot the system efficiently on your own, we recommend that you follow the checklist below to ensure that you have access to all the necessary information and tools to resolve an issue and that you have established the necessary administrative access to your production system.


### PR DESCRIPTION
## Summary

Strip `<Warning title="Pre-reviewed Content - Do Not Modify">` blocks from 180 `.mdx` files (1,960 lines deleted). These reviewer-facing notices were never meant to render on the public site.

- The MDX-comment `COPIED_START` / `COPIED_END` markers stay intact (still present in 192 files); they remain useful for tooling to detect drift from upstream sources.