### PR TITLE
fix: add pureconfig url to link

### DIFF
--- a/docs-main/global-synchronizer/reference/kms-driver-guide.mdx
+++ b/docs-main/global-synchronizer/reference/kms-driver-guide.mdx
@@ -125,7 +125,7 @@ trait KmsDriverFactory extends DriverFactory {
 
 #### Driver Configuration Reading & Parsing
 
-Canton uses [pureconfig]() configuration library to read its configuration. Given that the configuration of the driver can be embedded inside a Canton configuration file, the factory of the driver needs to specify the type of configuration, as well as configuration readers and writers. A `ConfigType` can be a case class or as basic as a `Map[String, String]`. In the latter case, the config reader and writer can be defined as:
+Canton uses [pureconfig](https://github.com/pureconfig/pureconfig) configuration library to read its configuration. Given that the configuration of the driver can be embedded inside a Canton configuration file, the factory of the driver needs to specify the type of configuration, as well as configuration readers and writers. A `ConfigType` can be a case class or as basic as a `Map[String, String]`. In the latter case, the config reader and writer can be defined as:
 
 - `val configReader = pureconfig.ConfigReader.mapReader[String]`
 - `val configWriter = pureconfig.ConfigWriter.mapWriter[String]`


### PR DESCRIPTION
Adds the pureconfig repository link to what was empty URL markdown.