### PR TITLE
add token doc link to reference

### DIFF
--- a/docs-main/sdks-tools/api-reference/splice-daml-apis.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml-apis.mdx
@@ -20,7 +20,7 @@ These APIs are not mandatory to use. Feel free to build your own Daml APIs, pote
 
 ## Canton Network Token Standard APIs (CIP-0056)
 
-Refer to the Token Standard documentation section.
+Refer to the [Token Standard documentation](/appdev/deep-dives/token-standard) section.
 
 ## Featured App Activity Markers API (CIP-0047)
 


### PR DESCRIPTION
Add a link to token documentation where its refered to in `splice-daml-apis-mdx`.