### PR TITLE
remove jfrog, link footer questions

### DIFF
--- a/docs-main/appdev/faq.mdx
+++ b/docs-main/appdev/faq.mdx
@@ -43,25 +43,6 @@ The prerequisites documentation may not list specific version requirements for a
 </Warning>
 </Accordion>
 
-<Accordion title="How do I get access to JFrog Artifactory for Canton Network artifacts?">
-To request JFrog access:
-
-1. Submit a request via [support.digitalasset.com](https://support.digitalasset.com) or email [da-support@digitalasset.com](mailto:da-support@digitalasset.com)
-
-2. Include:
-   - Organization name
-   - Email addresses for users requiring access
-   - Specific artifacts needed (Canton Quickstart, Canton Enterprise, Canton Utility)
-
-3. Wait for onboarding email with login instructions (typically 1-3 business days)
-
-4. Log in at [digitalasset.jfrog.io](https://digitalasset.jfrog.io)
-
-<Info>
-Community quickstart artifacts are available on GitHub without JFrog access. Enterprise features and certain production artifacts require JFrog credentials.
-</Info>
-</Accordion>
-
 <Accordion title="What's the difference between LocalNet, DevNet, TestNet, and MainNet?">
 | Environment | Purpose | Access | Real Value |
 |-------------|---------|--------|------------|
@@ -802,13 +783,13 @@ docker inspect validator-app --format='{{.Config.Image}}'
 
 If your question isn't answered here:
 
-1. **Search the documentation** on this site
+1. **[Search the documentation](https://docs.canton.network)** on this site
 
-2. **Check the Troubleshooting Cheat Sheet** for specific error solutions
+2. **Check the [Troubleshooting Cheat Sheet](/appdev/troubleshooting)** for specific error solutions
 
-3. **Ask in community Slack** channels for guidance from other developers
+3. **Ask in [community Slack](https://docs.canton.network/shared/support-channels)** channels for guidance from other developers
 
-4. **Contact support** with detailed information about your issue
+4. **[Contact support](mailto:da-support@digitalasset.com)** with detailed information about your issue
 
 <Card title="Contribute to this FAQ" icon="message-question" href="mailto:da-support@digitalasset.com">
   Have a common question that should be added? Let us know via support.


### PR DESCRIPTION
Remove stale reference to using JFrog

Adds links to "Still have questions" section at the bottom of the FAQ.