### PR TITLE
refactor: updates links from 2.x daml docs to 3.x canton net docs

### DIFF
--- a/docs-main/appdev/deep-dives/token-standard.mdx
+++ b/docs-main/appdev/deep-dives/token-standard.mdx
@@ -141,7 +141,7 @@ For example:
 Additionally, there's three flags that can be set:
 
 - `includeInterfaceView`: to include the interface view of the contract in the response.
-- `includeCreatedEventBlob`: to include a binary blob that is required for [explicit disclosure](https://docs.daml.com/app-dev/explicit-contract-disclosure.html).
+- `includeCreatedEventBlob`: to include a binary blob that is required for [explicit disclosure](/appdev/deep-dives/explicit-contract-disclosure).
 - `verbose`: to include additional information in the response.
 
 The response for such a query will contain the `createdEvent` of the contract, including the interface views requested (if any). The `viewValue` within it will be the JSON-serialized Daml interface view. If more than one interface is requested, you can distinguish them by checking the `interfaceId` field. You can find an [example response for Holdings here](https://github.com/canton-network/splice/blob/main/token-standard/cli/__tests__/mocks/data/holdings.json).

--- a/docs-main/global-synchronizer/deployment/sv-operations.mdx
+++ b/docs-main/global-synchronizer/deployment/sv-operations.mdx
@@ -48,7 +48,7 @@ Each identity is relevant on different layers, or within different subsystems, o
 
 ### Participant identities
 
-- Used for securing Daml workflows and for determining an SV's `svPartyId`, which is used for various DSO governance flows as well as for receiving SV rewards. For general information on Canton and Daml identities see the [Canton documentation on Identity Management](https://docs.daml.com/canton/usermanual/identity_management.html).
+- Used for securing Daml workflows and for determining an SV's `svPartyId`, which is used for various DSO governance flows as well as for receiving SV rewards. For general information on Canton and Daml identities see the [Canton documentation on Identity Management](/sdks-tools/api-reference/ledger-api-services#user-management-service).
 - Participant identities are important for multiple types of quorums
   - Quorums for confirming Daml transactions as the DSO party (\>⅓ of onboarded SVs)
   - Quorums for administering the domain topology on behalf of the DSO party (\>⅔ of onboarded SVs once activated)

--- a/docs-main/openapi/splice/validator/wallet-external.yaml
+++ b/docs-main/openapi/splice/validator/wallet-external.yaml
@@ -234,7 +234,7 @@ components:
             Expiry time of the transfer offer as unix timestamp in microseconds. After this time, the offer can no longer be accepted
             and automation in the wallet will eventually expire the transfer offer.
             Note that this time is compared against the ledger effective time of the Daml transaction accepting or expiring an offer, and can skew from the wall clock
-            time measured on the caller's machine. See https://docs.daml.com/concepts/time.html
+            time measured on the caller's machine. See [Working with time](/appdev/modules/m3-working-with-time)
             for how ledger effective time is bound to the record time of a transaction on a domain.
           type: integer
           format: int64
@@ -407,7 +407,7 @@ components:
             Expiry time of the request to buy traffic as unix timestamp in microseconds. If the request does not
             succeed before this time, the wallet automation will reject and expire it.
             Note that this time is compared against the ledger effective time of the Daml transaction accepting or expiring an offer, and can skew from the wall clock
-            time measured on the caller's machine. See https://docs.daml.com/concepts/time.html
+            time measured on the caller's machine. See [Working with time](/appdev/modules/m3-working-with-time)
             for how ledger effective time is bound to the record time of a transaction on a domain.
           type: integer
           format: int64

--- a/docs-main/openapi/splice/validator/wallet-internal.yaml
+++ b/docs-main/openapi/splice/validator/wallet-internal.yaml
@@ -1626,7 +1626,7 @@ components:
             Expiry time of the transfer offer as unix timestamp in microseconds. After this time, the offer can no longer be accepted
             and automation in the wallet will eventually expire the transfer offer.
             Note that this time is compared against the ledger effective time of the Daml transaction accepting or expiring an offer, and can skew from the wall clock
-            time measured on the caller's machine. See https://docs.daml.com/concepts/time.html
+            time measured on the caller's machine. See [Working with time](/appdev/modules/m3-working-with-time)
             for how ledger effective time is bound to the record time of a transaction on a domain.
           type: integer
           format: int64

--- a/docs-main/sdks-tools/api-reference/splice-architecture.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-architecture.mdx
@@ -56,7 +56,7 @@ The implementation uses three key techniques to achieves this Byzantine fault to
 
 Thus CC and CNS users that are willing to assume that no more than `f` SV nodes are dishonest can rely on the following guarantees:
 
-- **valid transactions**: every transaction that requires confirmation from the DSO party is [valid](https://docs.daml.com/concepts/ledger-model/ledger-integrity.html#valid-ledgers).
+- **valid transactions**: every transaction that requires confirmation from the DSO party is [valid](/overview/reference/ledger-model-detailed#valid-ledgers).
 - **timely automation**: actions required to be taken by the DSO party are taken in a timely fashion.
 - **predictable fees and configuration values**: fees and configuration values are reasonably predictable as they represent the *aggregate preferences* of ~2/3 of SV operators, which can be assumed to be acting in their own best interest.
 

--- a/docs-main/sdks-tools/api-reference/splice-http-apis.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-http-apis.mdx
@@ -45,7 +45,7 @@ Endpoints in the files named `APP-internal` do not have any backwards compatibil
 
 ### Contract Payload Encoding
 
-The `Contract` schema defined in `common.yaml` includes the `payload` of the given contract. This payload is encoded using the same [schema used by the HTTP JSON API](https://docs.daml.com/json-api/lf-value-specification.html).
+The `Contract` schema defined in `common.yaml` includes the `payload` of the given contract. This payload is encoded using the same [schema used by the HTTP JSON API](/appdev/modules/m4-sdks-apis#json-api).
 
 ## Authentication
 

--- a/docs-main/sdks-tools/api-reference/splice-scan-gs-connectivity-api.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-scan-gs-connectivity-api.mdx
@@ -137,7 +137,7 @@ Passing this `next_page_token` as the `after` query parameter, you might see ano
 
 ## Parties' Hosting Participants
 
-In any Canton deployment, [each party is hosted on a participant](https://docs.daml.com/canton/architecture/overview.html#synchronization-domain-entities). This can be accessed through Scan with /v0/domains/{domain_id}/parties/{party_id}/participant-id.
+In any Canton deployment, [each party is hosted on a participant](/overview/learn/global-synchronizer-architecture#global-synchronizer-architecture). This can be accessed through Scan with /v0/domains/{domain_id}/parties/{party_id}/participant-id.
 
 For example, looking up `/v0/domains/global-domain::122084177677350389dd0710d6516f700a33fe348c5f2702dffef6d36e1dedcbfc17/parties/digitalasset-testValidator-1::1220e92bbc9d80cb6e283184017b307b9f44f23d32d7d195cdbcac033ae91eac2f28/participant-id` on a test network yields
 

--- a/docs-main/snippets/external/splice/main/splice-literal-full-apps-app-src-pack-examples-sv-helm-kms-participant-aws-values.mdx
+++ b/docs-main/snippets/external/splice/main/splice-literal-full-apps-app-src-pack-examples-sv-helm-kms-participant-aws-values.mdx
@@ -1,6 +1,6 @@
 ```yaml
 # Participant using AWS KMS (mock values; please modify to match your setup)
-# See https://docs.daml.com/canton/usermanual/kms/kms_aws_setup.html
+# See [Canton KMS operations](/global-synchronizer/production-operations/kms-operations#configure-a-amazon-web-services-aws-kms)
 kms:
   type: aws
   # Replace REGION based on your AWS KMS setup

--- a/docs-main/snippets/external/splice/main/splice-literal-full-apps-app-src-pack-examples-sv-helm-kms-participant-gcp-values.mdx
+++ b/docs-main/snippets/external/splice/main/splice-literal-full-apps-app-src-pack-examples-sv-helm-kms-participant-gcp-values.mdx
@@ -1,6 +1,6 @@
 ```yaml
 # Participant using GCP KMS (mock values; please modify to match your setup)
-# See https://docs.daml.com/canton/usermanual/kms/kms_gcp_setup.html
+# See [Canton KMS operations](/global-synchronizer/production-operations/kms-operations#configure-a-google-cloud-provider-gcp-kms)
 
 kms:
   type: gcp


### PR DESCRIPTION
Updates the remaining `docs.daml.com` documentation links to the new `docs.canton.network` 3.x documentation. 