### PR TITLE
Fix render-broken pages and port archived Splice Daml packages

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -608,6 +608,74 @@
                   "sdks-tools/api-reference/splice-daml-models",
                   "sdks-tools/api-reference/splice-architecture",
                   {
+                    "group": "Splice Daml Packages",
+                    "pages": [
+                      {
+                        "group": "splice-api-featured-app-v1",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/index",
+                          "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-featured-app-v2",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/index",
+                          "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-allocation-v1",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/index",
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-allocation-instruction-v1",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/index",
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-allocation-request-v1",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/index",
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-burn-mint-v1",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/index",
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-holding-v1",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/index",
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-metadata-v1",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/index",
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-transfer-instruction-v1",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/index",
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1"
+                        ]
+                      }
+                    ]
+                  },
+                  {
                     "group": "Scan APIs",
                     "pages": [
                       "sdks-tools/api-reference/splice-scan-api",

--- a/docs-main/global-synchronizer/production-operations/monitoring-setup.mdx
+++ b/docs-main/global-synchronizer/production-operations/monitoring-setup.mdx
@@ -17,19 +17,19 @@ This guide and the scripts/configs are not tested, do they still work? Try to sp
 
 how should this relate to the other observability docs that we have? we have the observability gh stuff plus the observability stuff in the quickstart
 
-# Example Monitoring Setup
+## Example Monitoring Setup
 
 This section provides an example of how Canton can be run inside a connected network of Docker containers. The example also shows how you can monitor network activity. See the [glossary](/overview/understand/glossary) for monitoring term definitions and the [Monitoring Choices](#monitoring-choices) section for the reasoning behind the example monitoring setup.
 
-## Container Setup
+### Container Setup
 
 To configure [Docker Compose](https://docs.docker.com/compose/) to spin up the Docker container network shown in the diagram, use the information below. See the `compose` documentation for detailed information concerning the structure of the configuration files.
 
 `compose` allows you to provide the overall configuration across multiple files. Each configuration file is described below, followed by information on how to bring them together in a running network.
 
-<img src="./images/basic-canton-setup.svg" class="align-center" style="width:100.0%" alt="A diagram showing an example Docker network setup" />
+<img src="./images/basic-canton-setup.svg" className="align-center" style="width:100.0%" alt="A diagram showing an example Docker network setup" />
 
-### Intended Use
+#### Intended Use
 
 This example is intended to demonstrate how to expose, aggregate, and observe monitoring information from Canton. It is not suitable for production without alterations. Note the following warnings:
 
@@ -58,7 +58,7 @@ The versions of the Docker images used in the example may become outdated. In a 
 </Warning>
 
 
-### Network Configuration
+#### Network Configuration
 
 In this compose file, define the network that will be used to connect all the running containers:
 
@@ -74,7 +74,7 @@ networks:
     external: false
 ```
 
-### Postgres Setup
+#### Postgres Setup
 
 Using only a single Postgres container, create databases for the synchronizer, along with Canton and index databases for each participant. To do this, mount `postgres-init.sql` into the Postgres-initialized directory. Note that in a production environment, passwords must not be inlined inside config.
 
@@ -110,13 +110,13 @@ create database canton2db;
 create database index2db;
 ```
 
-### Synchronizer Setup
+#### Synchronizer Setup
 
 Run the synchronizer with the `--log-profile container` that writes plain text to standard out at debug level.
 
 #\. Add examples here \<[https://github.com/DACH-NY/canton/issues/23872](https://github.com/DACH-NY/canton/issues/23872)\>
 
-### Participant Setup
+#### Participant Setup
 
 The participant container has two files mapped into it on container creation. The `.conf` file provides details of the synchronizer and database locations. An HTTP metrics endpoint is exposed that returns metrics in the [Prometheus Text Based Format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-based-format). By default, participants do not connect to remote synchronizers, so a bootstrap script is provided to accomplish that.
 
@@ -242,7 +242,7 @@ canton {
 }
 ```
 
-### Logstash
+#### Logstash
 
 Docker containers can specify a log driver to automatically export log information from the container to an aggregating service. The example exports log information in GELF, using Logstash as the aggregation point for all GELF streams. You can use Logstash to feed many downstream logging data stores, including Elasticsearch, Loki, and Graylog.
 
@@ -303,7 +303,7 @@ The default Logstash settings are used, with the HTTP port bound to all host IP 
 http.host: "0.0.0.0"
 ```
 
-### Elasticsearch
+#### Elasticsearch
 
 Elasticsearch supports running in a clustered configuration with built-in resiliency. The example runs only a single Elasticsearch node.
 
@@ -334,7 +334,7 @@ services:
       retries: 10
 ```
 
-### Kibana
+#### Kibana
 
 Kibana provides a UI that allows the Elasticsearch log index to be searched.
 
@@ -359,7 +359,7 @@ services:
 
 You must manually configure a data view to view logs. See [Kibana Log Monitoring](#kibana-log-monitoring) for instructions.
 
-### cAdvisor
+#### cAdvisor
 
 cAdvisor exposes container system metrics (CPU, memory, disk, and network) to Prometheus. It also provides a UI to view these metrics.
 
@@ -392,11 +392,11 @@ To view container metrics:
 
 You should now see a UI similar to the one shown.
 
-<img src="./images/c-advisor.png" class="align-center" style="width:100.0%" alt="An example cAdvisor UI" />
+<img src="./images/c-advisor.png" className="align-center" style="width:100.0%" alt="An example cAdvisor UI" />
 
 Prometheus-formatted metrics are available by default at [http://localhost:8080/metrics](http://localhost:8080/metrics).
 
-### Prometheus
+#### Prometheus
 
 Configure Prometheus with `prometheus.yml` to provide the endpoints from which metric data should be scraped. By default, port `9090` can query the stored metric data.
 
@@ -438,7 +438,7 @@ scrape_configs:
         action: labeldrop
 ```
 
-### Grafana
+#### Grafana
 
 Grafana is provided with:
 
@@ -515,7 +515,7 @@ providers:
       foldersFromFilesStructure: true
 ```
 
-### Dependencies
+#### Dependencies
 
 There are startup dependencies between the Docker containers. For example, the synchronizer needs to be running before the participant, and the database needs to run before the synchronizer.
 
@@ -571,7 +571,7 @@ services:
         condition: service_started
 ```
 
-### Docker Images
+#### Docker Images
 
 The Docker images need to be pulled down before starting the network:
 
@@ -584,7 +584,7 @@ The Docker images need to be pulled down before starting the network:
 - postgres:17.5-bullseye
 - prom/prometheus:v2.40.6
 
-### Running Docker Compose
+#### Running Docker Compose
 
 Since running `docker compose` with all the compose files shown above creates a long command line, a helper script `dc.sh` is used.
 
@@ -632,7 +632,7 @@ docker compose \
 ./dc.sh down        # Stops and tears down the network, removing any created containers
 ```
 
-## Connecting to Nodes
+### Connecting to Nodes
 
 To interact with the running network, a Canton console can be used with a remote configuration. For example:
 
@@ -640,7 +640,7 @@ To interact with the running network, a Canton console can be used with a remote
 bin/canton -c etc/remote-participant1.conf
 ```
 
-### Remote Configurations
+#### Remote Configurations
 
 ``` none
 canton {
@@ -679,11 +679,11 @@ canton {
 }  
 ```
 
-### Getting Started
+#### Getting Started
 
 Using the previous scripts, you can follow the examples provided in the Getting Started guide.
 
-## Kibana log monitoring
+### Kibana log monitoring
 
 When Kibana is started for the first time, you must set up a data view to allow view the log data:
 
@@ -698,7 +698,7 @@ When Kibana is started for the first time, you must set up a data view to allow 
 
 You should now see a UI similar to the one shown here:
 
-<img src="./images/kibana.png" class="align-center" style="width:100.0%" alt="An example Kibana UI" />
+<img src="./images/kibana.png" className="align-center" style="width:100.0%" alt="An example Kibana UI" />
 
 In the Kibana interface, you can:
 
@@ -710,7 +710,7 @@ In the Kibana interface, you can:
 
 For more details, see the Kibana documentation. Note that querying based on plain text for a wide time window likely results in poor UI performance. See [Logging Improvements](#logging-improvements) for ideas to improve it.
 
-## Grafana Metric Monitoring
+### Grafana Metric Monitoring
 
 You can log into the Grafana UI and set up a dashboard. The example imports a [GrafanaLabs community dashboard](https://grafana.com/grafana/dashboards/) that has graphs for cAdvisor metrics. The [cAdvisor Export dashboard](https://grafana.com/grafana/dashboards/14282-cadvisor-exporter/) imported below has an ID of **14282**.
 
@@ -722,15 +722,15 @@ You can log into the Grafana UI and set up a dashboard. The example imports a [G
 
 You should see a container system metrics dashboard similar to the one shown here:
 
-<img src="./images/grafana-cadvisor.png" class="align-center" style="width:100.0%" alt="An example metrics dashboard" />
+<img src="./images/grafana-cadvisor.png" className="align-center" style="width:100.0%" alt="An example metrics dashboard" />
 
 See the [Grafana documentation](https://grafana.com/grafana/) for how to configure dashboards. For information about which metrics are available, see the Metrics documentation in the Monitoring section of this user manual.
 
-## Monitoring Choices
+### Monitoring Choices
 
 This section documents the reasoning behind the technology used in the example monitoring setup.
 
-### Use Docker Log Drivers
+#### Use Docker Log Drivers
 
 **Reasons:**
 
@@ -739,7 +739,7 @@ This section documents the reasoning behind the technology used in the example m
 - No additional dockerfile layers need to be added to install and start log scrapers.
 - There is no need to worry about local file naming, log rotation, and so on.
 
-### Use GELF Docker Log Driver
+#### Use GELF Docker Log Driver
 
 **Reasons:**
 
@@ -748,7 +748,7 @@ This section documents the reasoning behind the technology used in the example m
 - It does not have the size limitations of syslog.
 - A UDP listener can be used to debug problems.
 
-### Use Logstash
+#### Use Logstash
 
 **Reasons:**
 
@@ -760,7 +760,7 @@ This section documents the reasoning behind the technology used in the example m
 - It can be used to feed Elasticsearch, Loki, or Graylog.
 - It has support for the Elastic Common Schema (ECS) if needed.
 
-### Use Elasticsearch/Kibana
+#### Use Elasticsearch/Kibana
 
 **Reasons:**
 
@@ -768,7 +768,7 @@ This section documents the reasoning behind the technology used in the example m
 - Good defaults for these products allow a basic setup to be started with almost zero configuration.
 - The ELK setup acts as a good baseline as compared to other options such as Loki or Graylog.
 
-### Use Prometheus/Grafana
+#### Use Prometheus/Grafana
 
 **Reasons:**
 
@@ -777,7 +777,7 @@ This section documents the reasoning behind the technology used in the example m
 - The Prometheus approach of pulling metrics from the underlying system means that the running containers do not need infrastructure to store and push metric data.
 - Grafana works very well with Prometheus.
 
-## Logging Improvements
+### Logging Improvements
 
 This version of the example only has the logging structure provided via GELF. It is possible to improve this by:
 
@@ -789,11 +789,11 @@ This version of the example only has the logging structure provided via GELF. It
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/observe/health.rst" hash="64490235" */}
 
-# Participant Node Health
+## Participant Node Health
 
 The participant exposes health status information in several ways, which may be inspected manually when troubleshooting or integrated into larger monitoring and orchestration systems.
 
-## Using gRPC Health Service for Load Balancing and Orchestration
+### Using gRPC Health Service for Load Balancing and Orchestration
 
 The Participant Node provides a `grpc.health.v1.Health` service, implementing the [gRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) protocol.
 
@@ -825,7 +825,7 @@ When multiple Participant replicas are configured, passive nodes return `NOT_SER
 
 In practice, the health of the Participant is composed of the health of the components it depends on. You can query these individually by name, by making a request with the [service](https://github.com/grpc/grpc-proto/blob/6565a1ba38af695ace7c3ce6e6ff837ee87d4c10/grpc/health/v1/health.proto#L29) field set to the name of the component. An empty or unset `service` field returns the aggregate health of all components. An unknown name will result in a gRPC `NOT_FOUND` error.
 
-## Checking health via HTTP
+### Checking health via HTTP
 
 Health checking can also be done via HTTP, which is useful for frameworks that don't support gRPC Health Checking Protocol. Setting monitoring.http-health-server.port= in the configuration for your node will expose health information at the URL `http://<host>:<port>/health`.
 
@@ -843,7 +843,7 @@ readinessProbe:
     port: <port>
     path: /health
 ```
-## Inspection of General Health Status
+### Inspection of General Health Status
 
 General information about the Participant Node, including about unhealthy synchronizers and dependencies, and whether the node is currently Active, can be displayed in the canton console by invoking the `health.status` command on the node.
 
@@ -961,7 +961,7 @@ The canton console can also provide information about *all* connected nodes, inc
     Supported protocol version(s): 34
 ```
 
-## Generating a Node Health Dump for Troubleshooting
+### Generating a Node Health Dump for Troubleshooting
 
 When interacting with support or attempting to troubleshoot an issue, it is often necessary to capture a snapshot of relevant execution state. Canton implements a facility that gathers key system information and bundles it into a ZIP file.
 
@@ -990,7 +990,7 @@ When packaging large amounts of data, increase the default timeout of the dump c
 
 Health dumps can also be gathered via gRPC on the `Admin API` of the Participant Node via the [StatusService](https://github.com/DACH-NY/canton/blob/release-line-3.3/community/admin-api/src/main/protobuf/com/digitalasset/canton/admin/health/v30/status_service.proto#L10)'s `HealthDump`. This call streams back the bytes of the produced ZIP file.
 
-## Monitoring for Slow or Stuck Tasks
+### Monitoring for Slow or Stuck Tasks
 
 Some operations can report when they are slow, if you enable
 
@@ -1008,7 +1008,7 @@ canton.monitoring.deadlock-detection.enabled = yes
 
 If a problem is detected, a log line containing `Task runner <name> is stuck or overloaded for <duration>` will be emitted. This may indicate that resources such as CPU are overloaded, that the Execution Context is too small, or that too many tasks are otherwise stuck. If the issue resolves itself, a subsequent log message: `Task runner <name> is just overloaded, but operating correctly. Task got executed in the meantime` will be emitted.
 
-## Disabling Restart on Fatal Failures
+### Disabling Restart on Fatal Failures
 
 Processes should be run under a process supervisor, such as `systemd` or Kubernetes, which can monitor them and restart them as needed. By default, the Participant Node process will exit in the event of a fatal failure.
 
@@ -1024,7 +1024,7 @@ which will cause the Node to stay alive and report unhealthy in such cases.
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/howtos/observe/commitments.rst" hash="448aca51" */}
 
-# Monitor ACS Commitments
+## Monitor ACS Commitments
 
 A participant that fails to send commitments in a timely manner is problematic for its counter-participants: Counter-participants cannot prune their state, because they have no proof that their state is the same as the state of the participant. More information on commitments is available in the Pruning overview section.
 
@@ -1032,7 +1032,7 @@ This page describes the monitoring options for ACS commitments. Commitment monit
 
 Second, monitoring provides insights into the status of commitments from counter-participants. This is relevant for the participant node operator because a counter-participant that runs behind in commitment generation, either because it is faulty or because the network is slow, prevents pruning on the participant: The participant does not know whether its state and the counter-participant's state diverged, and cannot prune because it might need to investigate a potential fork. The operator can use the monitoring metrics to identify slow counter-participants and potentially blacklist them.
 
-## Monitoring own commitments
+### Monitoring own commitments
 
 We provide the following metrics for commitment generation, which are described in detail in the Metrics reference section:
 
@@ -1040,7 +1040,7 @@ We provide the following metrics for commitment generation, which are described 
 - `daml.participant.sync.commitments.sequencing-time`: Measures the time between the end of a commitment period, and the time when the sequencer observes the corresponding commitment.
 - `daml.participant.sync.commitments.catchup-mode-enabled`: Measures how many times the catch-up mode has been triggered.
 
-## Monitoring counter-participant commitments
+### Monitoring counter-participant commitments
 
 The operator can monitor the status of commitments from the counter-participants through latency metrics. These metrics can reveal slow counter-participants, which are behind in sending commitments, and enable operators to configure thresholds defining when a counter-participant is considered slow.
 

--- a/docs-main/global-synchronizer/production-operations/monitoring-setup.mdx
+++ b/docs-main/global-synchronizer/production-operations/monitoring-setup.mdx
@@ -27,7 +27,7 @@ To configure [Docker Compose](https://docs.docker.com/compose/) to spin up the D
 
 `compose` allows you to provide the overall configuration across multiple files. Each configuration file is described below, followed by information on how to bring them together in a running network.
 
-<img src="./images/basic-canton-setup.svg" className="align-center" style="width:100.0%" alt="A diagram showing an example Docker network setup" />
+<img src="./images/basic-canton-setup.svg" className="align-center" style={{width: "100%"}} alt="A diagram showing an example Docker network setup" />
 
 #### Intended Use
 
@@ -392,7 +392,7 @@ To view container metrics:
 
 You should now see a UI similar to the one shown.
 
-<img src="./images/c-advisor.png" className="align-center" style="width:100.0%" alt="An example cAdvisor UI" />
+<img src="./images/c-advisor.png" className="align-center" style={{width: "100%"}} alt="An example cAdvisor UI" />
 
 Prometheus-formatted metrics are available by default at [http://localhost:8080/metrics](http://localhost:8080/metrics).
 
@@ -698,7 +698,7 @@ When Kibana is started for the first time, you must set up a data view to allow 
 
 You should now see a UI similar to the one shown here:
 
-<img src="./images/kibana.png" className="align-center" style="width:100.0%" alt="An example Kibana UI" />
+<img src="./images/kibana.png" className="align-center" style={{width: "100%"}} alt="An example Kibana UI" />
 
 In the Kibana interface, you can:
 
@@ -722,7 +722,7 @@ You can log into the Grafana UI and set up a dashboard. The example imports a [G
 
 You should see a container system metrics dashboard similar to the one shown here:
 
-<img src="./images/grafana-cadvisor.png" className="align-center" style="width:100.0%" alt="An example metrics dashboard" />
+<img src="./images/grafana-cadvisor.png" className="align-center" style={{width: "100%"}} alt="An example metrics dashboard" />
 
 See the [Grafana documentation](https://grafana.com/grafana/) for how to configure dashboards. For information about which metrics are available, see the Metrics documentation in the Monitoring section of this user manual.
 

--- a/docs-main/global-synchronizer/production-operations/sv-security.mdx
+++ b/docs-main/global-synchronizer/production-operations/sv-security.mdx
@@ -5,7 +5,7 @@ description: "Security hardening, KMS configuration, and extra DAR notice for Su
 
 {/* COPIED_START source="splice:docs/src/sv_operator/sv_security.rst" hash="ae70b7be" */}
 
-## Third-party Daml apps
+{/* TODO: "Third-party Daml apps" section is empty in the upstream splice:docs/src/sv_operator/sv_security.rst source. Content gap — fill in or remove when upstream provides. */}
 
 ## Using an external KMS for managing participant keys
 
@@ -87,9 +87,7 @@ Beyond the changes to the SV app deployment described above, the setup of an SV 
 
 Also recall that you need to deploy a **fresh** participant in order for KMS to be used correctly, which implies that you will need to set up the remaining SV components afresh as well (see above).
 
-##### Google Cloud KMS
-
-##### Amazon Web Services KMS
+{/* TODO(#523): Google Cloud KMS and Amazon Web Services KMS subsections are empty in upstream splice:docs/src/sv_operator/sv_security.rst. Content gap tracked in #523. */}
 
 
 {/* COPIED_END */}

--- a/docs-main/global-synchronizer/reference/crypto-schemes.mdx
+++ b/docs-main/global-synchronizer/reference/crypto-schemes.mdx
@@ -5,7 +5,7 @@ description: "Reference of supported cryptographic schemes and key formats for C
 
 {/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/reference/crypto_schemes.rst" hash="73450fd8" */}
 
-# Supported Cryptographic Schemes And Formats
+## Supported Cryptographic Schemes And Formats
 
 Within Canton, we use the cryptographic primitives of signing, symmetric encryption, and asymmetric encryption, with the following supported cryptographic schemes and formats. For asymmetric signing and encryption, each scheme is divided into a key and an algorithm specification.
 
@@ -18,183 +18,30 @@ Within Canton, we use the cryptographic primitives of signing, symmetric encrypt
 - Values in brackets (**\[\<scheme\>\]**) indicate the configuration strings to use in Canton
 </Note>
 
-<table style="width:98%;">
-<caption>Supported Asymmetric Encryption and Signing Key Specifications</caption>
-<colgroup>
-<col style="width: 43%" />
-<col style="width: 12%" />
-<col style="width: 11%" />
-<col style="width: 30%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Key Spec</strong></th>
-<th><blockquote>
-<p>JCE</p>
-</blockquote></th>
-<th><blockquote>
-<p>KMS</p>
-</blockquote></th>
-<th><strong>Purpose</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>EC-Curve25519 `[ec-curve-25519]`</td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td><blockquote>
-<p>P¹</p>
-</blockquote></td>
-<td>Signing</td>
-</tr>
-<tr class="even">
-<td>EC-P256 `[ec-p-256]`</td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td>Signing, Encryption</td>
-</tr>
-<tr class="odd">
-<td>EC-P384 `[ec-p-384]`</td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td>Signing</td>
-</tr>
-<tr class="even">
-<td>EC-Secp256k1 `[ec-secp-256k-1]`</td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td>Signing</td>
-</tr>
-<tr class="odd">
-<td>RSA-2048 `[rsa-2048]`</td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td>Encryption</td>
-</tr>
-</tbody>
-</table>
+**Supported Asymmetric Encryption and Signing Key Specifications**
 
-Supported Asymmetric Encryption and Signing Key Specifications
+| Key Spec | JCE | KMS | Purpose |
+| --- | --- | --- | --- |
+| EC-Curve25519 `[ec-curve-25519]` | S | P¹ | Signing |
+| EC-P256 `[ec-p-256]` | S | S | Signing, Encryption |
+| EC-P384 `[ec-p-384]` | S | S | Signing |
+| EC-Secp256k1 `[ec-secp-256k-1]` | S | S | Signing |
+| RSA-2048 `[rsa-2048]` | S | S | Encryption |
 
-<table style="width:98%;">
-<caption>Supported Signing Algorithm Specifications</caption>
-<colgroup>
-<col style="width: 41%" />
-<col style="width: 11%" />
-<col style="width: 10%" />
-<col style="width: 34%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Algorithm</strong></th>
-<th><blockquote>
-<p>JCE</p>
-</blockquote></th>
-<th><blockquote>
-<p>KMS</p>
-</blockquote></th>
-<th><strong>Supported Key Specs</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>Ed25519 `[ed-25519]`</td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td><blockquote>
-<p>P¹</p>
-</blockquote></td>
-<td>EC-Curve25519</td>
-</tr>
-<tr class="even">
-<td>EC-DSA-SHA256 `[ec-dsa-sha-256]`</td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td>EC-P256, EC-Secp256k1</td>
-</tr>
-<tr class="odd">
-<td>EC-DSA-SHA384 `[ec-dsa-sha-384]`</td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td>EC-P384</td>
-</tr>
-</tbody>
-</table>
+**Supported Signing Algorithm Specifications**
 
-Supported Signing Algorithm Specifications
+| Algorithm | JCE | KMS | Supported Key Specs |
+| --- | --- | --- | --- |
+| Ed25519 `[ed-25519]` | S | P¹ | EC-Curve25519 |
+| EC-DSA-SHA256 `[ec-dsa-sha-256]` | S | S | EC-P256, EC-Secp256k1 |
+| EC-DSA-SHA384 `[ec-dsa-sha-384]` | S | S | EC-P384 |
 
-<table style="width:98%;">
-<caption>Supported Asymmetric Encryption Algorithm Specifications</caption>
-<colgroup>
-<col style="width: 57%" />
-<col style="width: 9%" />
-<col style="width: 9%" />
-<col style="width: 22%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Algorithm</strong></th>
-<th><blockquote>
-<p>JCE</p>
-</blockquote></th>
-<th><blockquote>
-<p>KMS</p>
-</blockquote></th>
-<th><strong>Supported Key Specs</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>ECIES-HMAC-SHA256-AES128-CBC `[ecies-hkdf-hmac-sha-256-aes-128-cbc]`</td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td><blockquote>
-<p>P²</p>
-</blockquote></td>
-<td>EC-P256</td>
-</tr>
-<tr class="even">
-<td>RSA-OAEP-SHA256 `[rsa-oaep-sha-256]`</td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td><blockquote>
-<p>S</p>
-</blockquote></td>
-<td>RSA-2048</td>
-</tr>
-</tbody>
-</table>
+**Supported Asymmetric Encryption Algorithm Specifications**
 
-Supported Asymmetric Encryption Algorithm Specifications
+| Algorithm | JCE | KMS | Supported Key Specs |
+| --- | --- | --- | --- |
+| ECIES-HMAC-SHA256-AES128-CBC `[ecies-hkdf-hmac-sha-256-aes-128-cbc]` | S | P² | EC-P256 |
+| RSA-OAEP-SHA256 `[rsa-oaep-sha-256]` | S | S | RSA-2048 |
 
 | **Crypto provider**                     | JCE Default Scheme                    | KMS Default Scheme        |
 |-----------------------------------------|---------------------------------------|---------------------------|
@@ -208,56 +55,13 @@ Supported Asymmetric Encryption Algorithm Specifications
 
 Default Cryptographic Schemes
 
-<table style="width:99%;">
-<caption>Key configuration for external keys with a Key Management Service (KMS)</caption>
-<colgroup>
-<col style="width: 13%" />
-<col style="width: 48%" />
-<col style="width: 36%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Provider</strong></th>
-<th><strong>SIGNING</strong></th>
-<th><strong>ENCRYPTION</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>AWS</td>
-<td><ul>
-<li><strong>Key Purpose:</strong> `SIGN_VERIFY`</li>
-<li><strong>Key Algorithms:</strong> `ECC_NIST_P256` or `ECC_NIST_P384`</li>
-</ul></td>
-<td><ul>
-<li><strong>Key Purpose:</strong> `ENCRYPT_DECRYPT`</li>
-<li><strong>Key Algorithm:</strong> `RSA_2048`</li>
-</ul></td>
-</tr>
-<tr class="even">
-<td>GCP</td>
-<td><ul>
-<li><strong>Key Purpose:</strong> `ASYMMETRIC_SIGN`</li>
-<li><strong>Key Algorithms:</strong> `EC_SIGN_P256_SHA256` or `EC_SIGN_P384_SHA384`</li>
-</ul></td>
-<td><ul>
-<li><strong>Key Purpose:</strong> `ASYMMETRIC_DECRYPT`</li>
-<li><strong>Key Algorithm:</strong> `RSA_DECRYPT_OAEP_2048_SHA256`</li>
-</ul></td>
-</tr>
-<tr class="odd">
-<td>Driver</td>
-<td><ul>
-<li>Must be compatible with `EC_P256_SHA256` or `EC_P384_SHA384`</li>
-</ul></td>
-<td><ul>
-<li>Must be compatible with `RSA_OAEP_2048_SHA256`</li>
-</ul></td>
-</tr>
-</tbody>
-</table>
+**Key configuration for external keys with a Key Management Service (KMS)**
 
-Key configuration for external keys with a Key Management Service (KMS)
+| Provider | SIGNING | ENCRYPTION |
+| --- | --- | --- |
+| AWS | **Key Purpose:** `SIGN_VERIFY`<br/>**Key Algorithms:** `ECC_NIST_P256` or `ECC_NIST_P384` | **Key Purpose:** `ENCRYPT_DECRYPT`<br/>**Key Algorithm:** `RSA_2048` |
+| GCP | **Key Purpose:** `ASYMMETRIC_SIGN`<br/>**Key Algorithms:** `EC_SIGN_P256_SHA256` or `EC_SIGN_P384_SHA384` | **Key Purpose:** `ASYMMETRIC_DECRYPT`<br/>**Key Algorithm:** `RSA_DECRYPT_OAEP_2048_SHA256` |
+| Driver | Must be compatible with `EC_P256_SHA256` or `EC_P384_SHA384` | Must be compatible with `RSA_OAEP_2048_SHA256` |
 
 | **Key Type**      | Format (Config)                               | Format (gRPC / Protobuf)                                                          |
 |-------------------|-----------------------------------------------|-----------------------------------------------------------------------------------|
@@ -267,63 +71,13 @@ Key configuration for external keys with a Key Management Service (KMS)
 
 Supported Cryptographic Key Formats by Key Type
 
-<table style="width:97%;">
-<caption>Commands and Flags to Export Keys in Supported Formats</caption>
-<colgroup>
-<col style="width: 6%" />
-<col style="width: 17%" />
-<col style="width: 7%" />
-<col style="width: 11%" />
-<col style="width: 11%" />
-<col style="width: 12%" />
-<col style="width: 10%" />
-<col style="width: 18%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th><strong>Key Type</strong></th>
-<th><strong>Supported Format</strong></th>
-<th><strong>OpenSSL</strong></th>
-<th><strong>GCP KMS</strong></th>
-<th><strong>AWS KMS</strong></th>
-<th><strong>Java.security</strong></th>
-<th colspan="2"><strong>Python (cryptography)</strong></th>
-</tr>
-</thead>
-<tbody>
-<tr class="odd">
-<td>Public Key</td>
-<td>DER SPKI (X.509 SubjectPublicKeyInfo)</td>
-<td>`-outform DER`</td>
-<td>keys default to DER SPKI</td>
-<td>keys default to DER SPKI</td>
-<td>keys default to DER SPKI</td>
-<td colspan="2">`public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)`</td>
-</tr>
-<tr class="even">
-<td>Private Key</td>
-<td>DER PKCS#8 PrivateKeyInfo</td>
-<td>`-outform DER`</td>
-<td>n/a</td>
-<td>n/a</td>
-<td>keys default to DER PKCS#8</td>
-<td colspan="2">`private_bytes(Encoding.DER, PrivateFormat.PKCS8)`</td>
-</tr>
-<tr class="odd">
-<td>Symmetric Key</td>
-<td>raw bytes</td>
-<td><blockquote>
-<p>n/a</p>
-</blockquote></td>
-<td>n/a</td>
-<td>n/a</td>
-<td>keys default to raw bytes</td>
-<td colspan="2">keys default to raw bytes</td>
-</tr>
-</tbody>
-</table>
+**Commands and Flags to Export Keys in Supported Formats**
 
-Commands and Flags to Export Keys in Supported Formats
+| Key Type | Supported Format | OpenSSL | GCP KMS | AWS KMS | Java.security | Python (cryptography) |
+| --- | --- | --- | --- | --- | --- | --- |
+| Public Key | DER SPKI (X.509 SubjectPublicKeyInfo) | `-outform DER` | keys default to DER SPKI | keys default to DER SPKI | keys default to DER SPKI | `public_bytes(Encoding.DER, PublicFormat.SubjectPublicKeyInfo)` |
+| Private Key | DER PKCS#8 PrivateKeyInfo | `-outform DER` | n/a | n/a | keys default to DER PKCS#8 | `private_bytes(Encoding.DER, PrivateFormat.PKCS8)` |
+| Symmetric Key | raw bytes | n/a | n/a | n/a | keys default to raw bytes | keys default to raw bytes |
 
 | **Signing Algorithm Specifications** | Signature Format (Config)             | Signature Format (gRPC / Protobuf)                     |
 |--------------------------------------|---------------------------------------|--------------------------------------------------------|

--- a/docs-main/sdks-tools/api-reference/splice-daml-apis.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml-apis.mdx
@@ -20,29 +20,14 @@ Refer to the [Token Standard documentation](/appdev/deep-dives/token-standard) s
 
 - See the [text of the CIP-0047](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0047/cip-0047.md) for its background on its design and its specification.
 
-- See the reference docs below for the Daml interfaces that are part of the Featured App Activity Markers API; or [read the source code](https://github.com/canton-network/splice/blob/main/daml/splice-api-featured-app-v2/daml/Splice/Api/FeaturedAppRightV2.daml).
+- The Daml interfaces that are part of the Featured App Activity Markers API are defined in:
 
-  > <div className="toctree" maxdepth="1">
-  >
-  > ../api/splice-api-featured-app-v2/index
-  >
-  > </div>
-  >
-  > or the old API:
-  >
-  > <div className="toctree" maxdepth="1">
-  >
-  > ../api/splice-api-featured-app-v1/index
-  >
-  > </div>
+  - [splice-api-featured-app-v2](/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2) — current API
+  - [splice-api-featured-app-v1](/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1) — previous API
 
-- The utility package below provides templates that allow to delegate the usage of featured app rights to other parties for the purpose of executing token standard actions. Use these templates to earn app rewards on token standard operations, and to potentially share some of them with your users.
+- The utility package `splice-util-featured-app-proxies` provides templates that allow to delegate the usage of featured app rights to other parties for the purpose of executing token standard actions. Use these templates to earn app rewards on token standard operations, and to potentially share some of them with your users.
 
-  > <div className="toctree" maxdepth="1">
-  >
-  > ../api/splice-util-featured-app-proxies/index
-  >
-  > </div>
+  {/* TODO(#539): Port per-package reference for splice-util-featured-app-proxies into this site. */}
 
 ### How to earn featured app rewards for wallet user activity
 
@@ -86,13 +71,7 @@ Assuming you are a wallet provider that runs a validator node for your users, yo
 
 ## Additional Splice Daml APIs
 
-The app provider of an asset registry is not necessarily the same as the party controlling the minting and burning of tokens. A typical example are tokens that are bridged from another network. The following API targets that use-case; and thus enables to decouple the upgrade cycles of an asset registry from the ones of the bridging app.
-
-> <div className="toctree" maxdepth="1">
->
-> ../api/splice-api-token-burn-mint-v1/index
->
-> </div>
+The app provider of an asset registry is not necessarily the same as the party controlling the minting and burning of tokens. A typical example are tokens that are bridged from another network. The [splice-api-token-burn-mint-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1) package targets that use-case; and thus enables to decouple the upgrade cycles of an asset registry from the ones of the bridging app.
 
 The API is built in a similar style as the token standard APIs, but is not part of the token standard. In particular, implementors of the token standard are not required to implement this API.
 

--- a/docs-main/sdks-tools/api-reference/splice-daml-models.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml-models.mdx
@@ -7,13 +7,9 @@ description: "The Daml model packages shipped with Splice"
 
 Use the docs below when interacting with the on-ledger state of the decentralized applications that are part of Splice.
 
-<div className="toctree" maxdepth="1">
+{/* TODO(#539): Port per-package Daml reference content into this site: splice-amulet, splice-amulet-name-service, splice-dso-governance, splice-util, splice-validator-lifecycle, splice-wallet, splice-wallet-payments, splice-token-test-trading-app, splice-token-standard-test, splice-util-batched-markers. */}
 
-../api/splice-amulet/index ../api/splice-amulet-name-service/index ../api/splice-dso-governance/index ../api/splice-util/index ../api/splice-validator-lifecycle/index ../api/splice-wallet/index ../api/splice-wallet-payments/index ../api/splice-token-test-trading-app/index ../api/splice-token-standard-test/index ../api/splice-util-batched-markers/index
-
-</div>
-
-See `daml_code_architecture` for an overview of the apps and their relation.
+For an overview of the apps and their relation, see [Splice Architecture](/sdks-tools/api-reference/splice-architecture).
 
 
 {/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "splice-api-featured-app-v1 docs"
+description: "Documentation for splice-api-featured-app-v1 docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-api-featured-app-v1/docs/index.rst" hash="2b64d7fd" */}
+
+## Modules
+
+- [Splice.Api.FeaturedAppRightV1](/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1.mdx
@@ -1,0 +1,222 @@
+---
+title: "Splice.Api.FeaturedAppRightV1"
+description: "Documentation for Splice.Api.FeaturedAppRightV1"
+---
+
+{/* COPIED_START source="splice:daml/splice-api-featured-app-v1/docs/Splice-Api-FeaturedAppRightV1.rst" hash="f7813223" */}
+
+The API for featured apps to record their activity.
+
+## Interfaces
+
+<div id="type-splice-api-featuredapprightv1-featuredappactivitymarker-46407">
+
+**interface** FeaturedAppActivityMarker
+
+</div>
+
+> A marker created by a featured application for activity generated from that app. This is used to record activity other than amulet transfers, which have built-in support for recording featured app activity.
+>
+> **viewtype** FeaturedAppActivityMarkerView
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-api-featuredapprightv1-featuredappright-34177">
+
+**interface** FeaturedAppRight
+
+</div>
+
+> An interface for contracts allowing application providers to record their featured activity. Note that most instances of amulet will likely define some fair usage constraints.
+>
+> **viewtype** FeaturedAppRightView
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-api-featuredapprightv1-featuredapprightcreateactivitymarker-36646">
+>
+>   **Choice** FeaturedAppRight_CreateActivityMarker
+>
+>   </div>
+>
+>   Record activity due to a featured app.
+>
+>   Controller: (DA.Internal.Record.getField @"provider" (view this))
+>
+>   Returns: FeaturedAppRight_CreateActivityMarkerResult
+>
+>   | Field         | Type                     | Description                                                                                                                                                                                                                                                                        |
+>   |---------------|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+>   | beneficiaries | \[AppRewardBeneficiary\] | The set of beneficiaries and weights that define how the rewards should be split up between the beneficiary parties. Implementations SHOULD check that the weights are positive and add up to 1.0. Implementations MAY also impose a limit on the maximum number of beneficiaries. |
+>
+> - **Method featuredAppRight_CreateActivityMarkerImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+
+## Data Types
+
+<div id="type-splice-api-featuredapprightv1-apprewardbeneficiary-32645">
+
+**data** AppRewardBeneficiary
+
+</div>
+
+> Specification of a beneficiary of featured app rewards.
+>
+> <div id="constr-splice-api-featuredapprightv1-apprewardbeneficiary-16584">
+>
+> AppRewardBeneficiary
+>
+> </div>
+>
+> > | Field       | Type                                                                                    | Description                                                                                  |
+> > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AppRewardBeneficiary
+>
+> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) AppRewardBeneficiary
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AppRewardBeneficiary
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+
+<div id="type-splice-api-featuredapprightv1-featuredappactivitymarkerview-84352">
+
+**data** FeaturedAppActivityMarkerView
+
+</div>
+
+> <div id="constr-splice-api-featuredapprightv1-featuredappactivitymarkerview-55819">
+>
+> FeaturedAppActivityMarkerView
+>
+> </div>
+>
+> > | Field       | Type                                                                                    | Description                                                                                  |
+> > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+> > | dso         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.                                                                               |
+> > | provider    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider.                                                                   |
+> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppActivityMarkerView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppActivityMarkerView
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+
+<div id="type-splice-api-featuredapprightv1-featuredapprightview-50078">
+
+**data** FeaturedAppRightView
+
+</div>
+
+> <div id="constr-splice-api-featuredapprightv1-featuredapprightview-35459">
+>
+> FeaturedAppRightView
+>
+> </div>
+>
+> > | Field    | Type                                                                                    | Description                |
+> > |----------|-----------------------------------------------------------------------------------------|----------------------------|
+> > | dso      | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.             |
+> > | provider | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppRightView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppRightView
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppRight FeaturedAppRightView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppRight FeaturedAppRightView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+<div id="type-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerresult-54383">
+
+**data** FeaturedAppRight_CreateActivityMarkerResult
+
+</div>
+
+> Result of calling the `FeaturedAppRight_CreateActivityMarker` choice.
+>
+> <div id="constr-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerresult-43104">
+>
+> FeaturedAppRight_CreateActivityMarkerResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                            | Description                                        |
+> > |--------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
+> > | activityMarkerCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
+>
+> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+
+## Functions
+
+<div id="function-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerimpl-71588">
+
+featuredAppRight_CreateActivityMarkerImpl
+: FeaturedAppRight -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "splice-api-featured-app-v2 docs"
+description: "Documentation for splice-api-featured-app-v2 docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-api-featured-app-v2/docs/index.rst" hash="ce05c0d9" */}
+
+## Modules
+
+- [Splice.Api.FeaturedAppRightV2](/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2.mdx
@@ -1,0 +1,223 @@
+---
+title: "Splice.Api.FeaturedAppRightV2"
+description: "Documentation for Splice.Api.FeaturedAppRightV2"
+---
+
+{/* COPIED_START source="splice:daml/splice-api-featured-app-v2/docs/Splice-Api-FeaturedAppRightV2.rst" hash="d25fee56" */}
+
+The API for featured apps to record their activity. This package extends FeaturedAppRightV1 with support for specifying a weight when creating a marker to improve efficiency.
+
+## Interfaces
+
+<div id="type-splice-api-featuredapprightv2-featuredappactivitymarker-59464">
+
+**interface** FeaturedAppActivityMarker
+
+</div>
+
+> A marker created by a featured application for activity generated from that app. This is used to record activity other than amulet transfers, which have built-in support for recording featured app activity.
+>
+> **viewtype** FeaturedAppActivityMarkerView
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-api-featuredapprightv2-featuredappright-28172">
+
+**interface** FeaturedAppRight
+
+</div>
+
+> An interface for contracts allowing application providers to record their featured activity. Note that most instances of amulet will likely define some fair usage constraints.
+>
+> **viewtype** FeaturedAppRightView
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-api-featuredapprightv2-featuredapprightcreateactivitymarker-77229">
+>
+>   **Choice** FeaturedAppRight_CreateActivityMarker
+>
+>   </div>
+>
+>   Record activity due to a featured app.
+>
+>   Controller: (DA.Internal.Record.getField @"provider" (view this))
+>
+>   Returns: FeaturedAppRight_CreateActivityMarkerResult
+>
+>   | Field         | Type                                                                                                                                                                                      | Description                                                                                                                                                                                                                                                                                       |
+>   |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+>   | beneficiaries | \[AppRewardBeneficiary\]                                                                                                                                                                  | The set of beneficiaries and weights that define how the rewards should be split up between the beneficiary parties. Implementations SHOULD check that the weights are positive and add up to 1.0. Implementations MAY also impose a limit on the maximum number of beneficiaries.                |
+>   | weight        | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135) | A weight for the resulting markers. None defaults to a weight of 1.0. Specifying a weight of 5 for example makes the resulting markers equivalent to 5 markers of weight 1 in terms of rewards they generate. The weight must be \>= 1.0 Implementations MAY impose an upper limit on the weight. |
+>
+> - **Method featuredAppRight_CreateActivityMarkerImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+
+## Data Types
+
+<div id="type-splice-api-featuredapprightv2-apprewardbeneficiary-35536">
+
+**data** AppRewardBeneficiary
+
+</div>
+
+> Specification of a beneficiary of featured app rewards.
+>
+> <div id="constr-splice-api-featuredapprightv2-apprewardbeneficiary-41661">
+>
+> AppRewardBeneficiary
+>
+> </div>
+>
+> > | Field       | Type                                                                                    | Description                                                                                  |
+> > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AppRewardBeneficiary
+>
+> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) AppRewardBeneficiary
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AppRewardBeneficiary
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+
+<div id="type-splice-api-featuredapprightv2-featuredappactivitymarkerview-70739">
+
+**data** FeaturedAppActivityMarkerView
+
+</div>
+
+> <div id="constr-splice-api-featuredapprightv2-featuredappactivitymarkerview-19000">
+>
+> FeaturedAppActivityMarkerView
+>
+> </div>
+>
+> > | Field       | Type                                                                                    | Description                                                                                  |
+> > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+> > | dso         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.                                                                               |
+> > | provider    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider.                                                                   |
+> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppActivityMarkerView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppActivityMarkerView
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+
+<div id="type-splice-api-featuredapprightv2-featuredapprightview-58075">
+
+**data** FeaturedAppRightView
+
+</div>
+
+> <div id="constr-splice-api-featuredapprightv2-featuredapprightview-48166">
+>
+> FeaturedAppRightView
+>
+> </div>
+>
+> > | Field    | Type                                                                                    | Description                |
+> > |----------|-----------------------------------------------------------------------------------------|----------------------------|
+> > | dso      | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.             |
+> > | provider | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppRightView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppRightView
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppRight FeaturedAppRightView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppRight FeaturedAppRightView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+<div id="type-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerresult-27928">
+
+**data** FeaturedAppRight_CreateActivityMarkerResult
+
+</div>
+
+> Result of calling the `FeaturedAppRight_CreateActivityMarker` choice.
+>
+> <div id="constr-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerresult-95607">
+>
+> FeaturedAppRight_CreateActivityMarkerResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                            | Description                                        |
+> > |--------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
+> > | activityMarkerCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
+>
+> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+
+## Functions
+
+<div id="function-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerimpl-7767">
+
+featuredAppRight_CreateActivityMarkerImpl
+: FeaturedAppRight -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "splice-api-token-allocation-instruction-v1 docs"
+description: "Documentation for splice-api-token-allocation-instruction-v1 docs"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-instruction-v1/docs/index.rst" hash="219b8bde" */}
+
+## Modules
+
+- [Splice.Api.Token.AllocationInstructionV1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1.mdx
@@ -1,0 +1,380 @@
+---
+title: "Splice.Api.Token.AllocationInstructionV1"
+description: "Documentation for Splice.Api.Token.AllocationInstructionV1"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-instruction-v1/docs/Splice-Api-Token-AllocationInstructionV1.rst" hash="abe8f5ac" */}
+
+Interfaces to enable wallets to instruct the registry to create allocations.
+
+## Interfaces
+
+<div id="type-splice-api-token-allocationinstructionv1-allocationfactory-42588">
+
+**interface** AllocationFactory
+
+</div>
+
+> Contracts implementing `AllocationFactory` are retrieved from the registry app and are used by the wallet to create allocation instructions (or allocations directly).
+>
+> **viewtype** AllocationFactoryView
+>
+> - <div id="type-splice-api-token-allocationinstructionv1-allocationfactoryallocate-8885">
+>
+>   **Choice** AllocationFactory_Allocate
+>
+>   </div>
+>
+>   Generic choice for the sender's wallet to request the allocation of assets to a specific leg of a settlement. It depends on the registry whether this results in the allocation being created directly or in an allocation instruction being created instead.
+>
+>   Controller: (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))
+>
+>   Returns: AllocationInstructionResult
+>
+>   | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+>   |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+>   | expectedAdmin    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party.                                       |
+>   | allocation       | AllocationSpecification                                                                                       | The allocation which should be created.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+>   | requestedAt      | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                         | The time at which the allocation was requested.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+>   | inputHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that SHOULD be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger; or for registries that support automatic selection of holdings for allocations. If specified, then the successful allocation MUST archive all of these holdings, so that the execution of the allocation conflicts with any other allocations using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate allocations. |
+>   | extraArgs        | ExtraArgs                                                                                                     | Additional choice arguments.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+>
+> - <div id="type-splice-api-token-allocationinstructionv1-allocationfactorypublicfetch-20324">
+>
+>   **Choice** AllocationFactory_PublicFetch
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: AllocationFactoryView
+>
+>   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+>   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+>   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | actor         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - **Method allocationFactory_allocateImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+>
+> - **Method allocationFactory_publicFetchImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationFactoryView
+
+<div id="type-splice-api-token-allocationinstructionv1-allocationinstruction-29622">
+
+**interface** AllocationInstruction
+
+</div>
+
+> An interface for tracking the status of an allocation instruction, i.e., a request to a registry app to create an allocation.
+>
+> Registries MAY evolve the allocation instruction in multiple steps. They SHOULD do so using only the choices on this interface, so that wallets can reliably parse the transaction history and determine whether the creation of the allocation ultimately succeeded or failed.
+>
+> **viewtype** AllocationInstructionView
+>
+> - <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionupdate-50223">
+>
+>   **Choice** AllocationInstruction_Update
+>
+>   </div>
+>
+>   Update the state of the allocation instruction. Used by the registry to execute registry internal workflow steps that advance the state of the allocation instruction. A reason may be communicated via the metadata.
+>
+>   Controller: (DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this))))), extraActors
+>
+>   Returns: AllocationInstructionResult
+>
+>   | Field       | Type                                                                                        | Description                                                                                                                           |
+>   |-------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+>   | extraActors | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
+>   | extraArgs   | ExtraArgs                                                                                   | Additional context required in order to exercise the choice.                                                                          |
+>
+> - <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionwithdraw-35988">
+>
+>   **Choice** AllocationInstruction_Withdraw
+>
+>   </div>
+>
+>   Withdraw the allocation instruction as the sender.
+>
+>   Controller: (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this))))
+>
+>   Returns: AllocationInstructionResult
+>
+>   | Field     | Type      | Description                                                  |
+>   |-----------|-----------|--------------------------------------------------------------|
+>   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - **Method allocationInstruction_updateImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+>
+> - **Method allocationInstruction_withdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+
+## Data Types
+
+<div id="type-splice-api-token-allocationinstructionv1-allocationfactoryview-21751">
+
+**data** AllocationFactoryView
+
+</div>
+
+> View for `AllocationFactory`.
+>
+> <div id="constr-splice-api-token-allocationinstructionv1-allocationfactoryview-66354">
+>
+> AllocationFactoryView
+>
+> </div>
+>
+> > | Field | Type                                                                                    | Description                                                                                                             |
+> > |-------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this allocation factory can be used. |
+> > | meta  | Metadata                                                                                | Additional metadata specific to the allocation factory, used for extensibility.                                         |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationFactoryView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationFactoryView
+>
+> **instance** HasMethod AllocationFactory "allocationFactory_publicFetchImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationFactoryView)
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationFactory AllocationFactoryView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AllocationFactory AllocationFactoryView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" AllocationFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationFactoryView Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" AllocationFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationFactoryView Metadata
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+
+<div id="type-splice-api-token-allocationinstructionv1-allocationinstructionresult-30943">
+
+**data** AllocationInstructionResult
+
+</div>
+
+> The result of instructing an allocation or advancing the state of an allocation instruction.
+>
+> <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresult-54130">
+>
+> AllocationInstructionResult
+>
+> </div>
+>
+> > | Field            | Type                                                                                                          | Description                                                                                                                                                                      |
+> > |------------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | output           | AllocationInstructionResult_Output                                                                            | The output of the step.                                                                                                                                                          |
+> > | senderChangeCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple allocation instructions in a single Daml transaction. |
+> > | meta             | Metadata                                                                                                      | Additional metadata specific to the allocation instruction, used for extensibility; e.g., fees charged.                                                                          |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationInstructionResult
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationInstructionResult
+>
+> **instance** HasMethod AllocationFactory "allocationFactory_allocateImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult)
+>
+> **instance** HasMethod AllocationInstruction "allocationInstruction_updateImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult)
+>
+> **instance** HasMethod AllocationInstruction "allocationInstruction_withdrawImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationInstructionResult Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" AllocationInstructionResult AllocationInstructionResult_Output
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderChangeCids" AllocationInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationInstructionResult Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" AllocationInstructionResult AllocationInstructionResult_Output
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderChangeCids" AllocationInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+
+<div id="type-splice-api-token-allocationinstructionv1-allocationinstructionresultoutput-46212">
+
+**data** AllocationInstructionResult_Output
+
+</div>
+
+> The output of instructing an allocation or advancing the state of an allocation instruction.
+>
+> <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultpending-58494">
+>
+> AllocationInstructionResult_Pending
+>
+> </div>
+>
+> > Use this result to communicate that the creation of the allocation is pending further steps.
+> >
+> > | Field                    | Type                                                                                                                    | Description                                                               |
+> > |--------------------------|-------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+> > | allocationInstructionCid | [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction | Contract id of the allocation instruction representing the pending state. |
+>
+> <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultcompleted-89210">
+>
+> AllocationInstructionResult_Completed
+>
+> </div>
+>
+> > Use this result to communicate that the allocation was created.
+> >
+> > | Field         | Type                                                                                                         | Description                   |
+> > |---------------|--------------------------------------------------------------------------------------------------------------|-------------------------------|
+> > | allocationCid | [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation | The newly created allocation. |
+>
+> <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultfailed-56799">
+>
+> AllocationInstructionResult_Failed
+>
+> </div>
+>
+> > Use this result to communicate that the creation of the allocation did not succeed and all holdings reserved for funding the allocation have been released.
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationInstructionResult_Output
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationInstructionResult_Output
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocationCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocationInstructionCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" AllocationInstructionResult AllocationInstructionResult_Output
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocationCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocationInstructionCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" AllocationInstructionResult AllocationInstructionResult_Output
+
+<div id="type-splice-api-token-allocationinstructionv1-allocationinstructionview-72001">
+
+**data** AllocationInstructionView
+
+</div>
+
+> View for `AllocationInstruction`.
+>
+> <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionview-32140">
+>
+> AllocationInstructionView
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                                                                                                                         | Description                                                                                                                                                                                                                                |
+> > |------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | originalInstructionCid | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction)                                 | The contract id of the original allocation instruction contract. Used by the wallet to track the lineage of allocation instructions through multiple steps. Only set if the registry evolves the allocation instruction in multiple steps. |
+> > | allocation             | AllocationSpecification                                                                                                                                                                                                                                      | The allocation that this instruction should create.                                                                                                                                                                                        |
+> > | pendingActions         | [Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | The pending actions to be taken by different actors to create the allocation. ^ This field can by used to report on the progress of registry specific workflows that are required to prepare the allocation.                               |
+> > | requestedAt            | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                                                                                                                                                                        | The time at which the allocation was requested.                                                                                                                                                                                            |
+> > | inputHoldingCids       | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]                                                                                                                                                | The holdings to be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger.                                                                                                                |
+> > | meta                   | Metadata                                                                                                                                                                                                                                                     | Additional metadata specific to the allocation instruction, used for extensibility; e.g., more detailed status information.                                                                                                                |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationInstructionView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationInstructionView
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationInstruction AllocationInstructionView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AllocationInstruction AllocationInstructionView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocation" AllocationInstructionView AllocationSpecification
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "inputHoldingCids" AllocationInstructionView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationInstructionView Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "originalInstructionCid" AllocationInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction))
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "pendingActions" AllocationInstructionView ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "requestedAt" AllocationInstructionView [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocation" AllocationInstructionView AllocationSpecification
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "inputHoldingCids" AllocationInstructionView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationInstructionView Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "originalInstructionCid" AllocationInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction))
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "pendingActions" AllocationInstructionView ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "requestedAt" AllocationInstructionView [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+
+## Functions
+
+<div id="function-splice-api-token-allocationinstructionv1-allocationinstructionwithdrawimpl-26170">
+
+allocationInstruction_withdrawImpl
+: AllocationInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+
+</div>
+
+<div id="function-splice-api-token-allocationinstructionv1-allocationinstructionupdateimpl-49061">
+
+allocationInstruction_updateImpl
+: AllocationInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+
+</div>
+
+<div id="function-splice-api-token-allocationinstructionv1-allocationfactoryallocateimpl-1231">
+
+allocationFactory_allocateImpl
+: AllocationFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+
+</div>
+
+<div id="function-splice-api-token-allocationinstructionv1-allocationfactorypublicfetchimpl-77778">
+
+allocationFactory_publicFetchImpl
+: AllocationFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationFactoryView
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "splice-api-token-allocation-request-v1 docs"
+description: "Documentation for splice-api-token-allocation-request-v1 docs"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-request-v1/docs/index.rst" hash="4b87f804" */}
+
+## Modules
+
+- [Splice.Api.Token.AllocationRequestV1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1.mdx
@@ -1,0 +1,133 @@
+---
+title: "Splice.Api.Token.AllocationRequestV1"
+description: "Documentation for Splice.Api.Token.AllocationRequestV1"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-request-v1/docs/Splice-Api-Token-AllocationRequestV1.rst" hash="164341d7" */}
+
+This module defines the interface for an `AllocationRequest`, which is an interface that can be implemented by an app to request specific allocations from their users for the purpose of settling a DvP or a payment as part of an app's workflow.
+
+## Interfaces
+
+<div id="type-splice-api-token-allocationrequestv1-allocationrequest-90278">
+
+**interface** AllocationRequest
+
+</div>
+
+> A request by an app for allocations to be created to enable the execution of a settlement.
+>
+> Apps are free to use a single request spanning all senders or one request per sender.
+>
+> **viewtype** AllocationRequestView
+>
+> - <div id="type-splice-api-token-allocationrequestv1-allocationrequestreject-89381">
+>
+>   **Choice** AllocationRequest_Reject
+>
+>   </div>
+>
+>   Reject an allocation request.
+>
+>   Implementations SHOULD allow any sender of a transfer leg to reject the allocation request, and thereby signal that they are definitely not going to create a matching allocation for the settlement.
+>
+>   Controller: actor
+>
+>   Returns: ChoiceExecutionMetadata
+>
+>   | Field     | Type                                                                                    | Description                                                  |
+>   |-----------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------|
+>   | actor     | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party rejecting the allocation request.                  |
+>   | extraArgs | ExtraArgs                                                                               | Additional context required in order to exercise the choice. |
+>
+> - <div id="type-splice-api-token-allocationrequestv1-allocationrequestwithdraw-15628">
+>
+>   **Choice** AllocationRequest_Withdraw
+>
+>   </div>
+>
+>   Withdraw an allocation request as the executor.
+>
+>   Used by executors to withdraw the allocation request if they are unable to execute it; e.g., because a trade has been cancelled.
+>
+>   Controller: (DA.Internal.Record.getField @"executor" (DA.Internal.Record.getField @"settlement" (view this)))
+>
+>   Returns: ChoiceExecutionMetadata
+>
+>   | Field     | Type      | Description                                                  |
+>   |-----------|-----------|--------------------------------------------------------------|
+>   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - **Method allocationRequest_RejectImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+>
+> - **Method allocationRequest_WithdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+
+## Data Types
+
+<div id="type-splice-api-token-allocationrequestv1-allocationrequestview-51417">
+
+**data** AllocationRequestView
+
+</div>
+
+> View of `AllocationRequest`.
+>
+> Implementations SHOULD make sure that at least all senders of the transfer legs are observers of the implementing contract, so that their wallet can show the request to them.
+>
+> <div id="constr-splice-api-token-allocationrequestv1-allocationrequestview-59188">
+>
+> AllocationRequestView
+>
+> </div>
+>
+> > | Field        | Type                                                                                                    | Description                                                                                                                                                                                                                                                        |
+> > |--------------|---------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | settlement   | SettlementInfo                                                                                          | Settlement for which the assets are requested to be allocated.                                                                                                                                                                                                     |
+> > | transferLegs | [TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) TransferLeg | Transfer legs that are requested to be allocated for the execution of the settlement keyed by their identifier. This may or may not be a complete list of transfer legs that are part of the settlement, depending on the confidentiality requirements of the app. |
+> > | meta         | Metadata                                                                                                | Additional metadata specific to the allocation request, used for extensibility.                                                                                                                                                                                    |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationRequestView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationRequestView
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationRequest AllocationRequestView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AllocationRequest AllocationRequestView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationRequestView Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlement" AllocationRequestView SettlementInfo
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLegs" AllocationRequestView ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) TransferLeg)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationRequestView Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlement" AllocationRequestView SettlementInfo
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLegs" AllocationRequestView ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) TransferLeg)
+
+## Functions
+
+<div id="function-splice-api-token-allocationrequestv1-allocationrequestrejectimpl-48931">
+
+allocationRequest_RejectImpl
+: AllocationRequest -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+
+</div>
+
+<div id="function-splice-api-token-allocationrequestv1-allocationrequestwithdrawimpl-31866">
+
+allocationRequest_WithdrawImpl
+: AllocationRequest -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "splice-api-token-allocation-v1 docs"
+description: "Documentation for splice-api-token-allocation-v1 docs"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-v1/docs/index.rst" hash="afce550d" */}
+
+## Modules
+
+- [Splice.Api.Token.AllocationV1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1.mdx
@@ -1,0 +1,474 @@
+---
+title: "Splice.Api.Token.AllocationV1"
+description: "Documentation for Splice.Api.Token.AllocationV1"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-allocation-v1/docs/Splice-Api-Token-AllocationV1.rst" hash="be705c8b" */}
+
+This module defines the `Allocation` interface and supporting types.
+
+Contracts implementing the `Allocation` interface represent a reservation of assets to transfer them as part of an atomic on-ledger settlement requested by an app.
+
+## Interfaces
+
+<div id="type-splice-api-token-allocationv1-allocation-9928">
+
+**interface** Allocation
+
+</div>
+
+> A contract representing an allocation of some amount of aasset holdings to a specific leg of a settlement.
+>
+> **viewtype** AllocationView
+>
+> - <div id="type-splice-api-token-allocationv1-allocationcancel-25504">
+>
+>   **Choice** Allocation_Cancel
+>
+>   </div>
+>
+>   Cancel the allocation. Requires authorization from sender, receiver, and executor.
+>
+>   Typically this authorization is granted by sender and receiver to the executor as part of the contract coordinating the settlement, so that that the executor can release the allocated assets early in case the settlement is aborted or it has definitely failed.
+>
+>   Controller: allocationControllers (view this)
+>
+>   Returns: Allocation_CancelResult
+>
+>   | Field     | Type      | Description                                                  |
+>   |-----------|-----------|--------------------------------------------------------------|
+>   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+>
+> - <div id="type-splice-api-token-allocationv1-allocationexecutetransfer-74529">
+>
+>   **Choice** Allocation_ExecuteTransfer
+>
+>   </div>
+>
+>   Execute the transfer of the allocated assets. Intended to be used to execute the settlement. This choice SHOULD succeed provided the `settlement.settleBefore` deadline has not yet passed.
+>
+>   Controller: allocationControllers (view this)
+>
+>   Returns: Allocation_ExecuteTransferResult
+>
+>   | Field     | Type      | Description                                                  |
+>   |-----------|-----------|--------------------------------------------------------------|
+>   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+>
+> - <div id="type-splice-api-token-allocationv1-allocationwithdraw-60458">
+>
+>   **Choice** Allocation_Withdraw
+>
+>   </div>
+>
+>   Withdraw the allocated assets. Used by the sender to withdraw the assets before settlement was completed. This SHOULD not fail settlement if the sender has still time to allocate the assets again; i.e., the `settlement.allocateBefore` deadline has not yet passed.
+>
+>   Controller: (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" (DA.Internal.Record.getField @"allocation" (view this))))
+>
+>   Returns: Allocation_WithdrawResult
+>
+>   | Field     | Type      | Description                                                  |
+>   |-----------|-----------|--------------------------------------------------------------|
+>   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - **Method allocation_cancelImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_CancelResult
+>
+> - **Method allocation_executeTransferImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult
+>
+> - **Method allocation_withdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_WithdrawResult
+
+## Data Types
+
+<div id="type-splice-api-token-allocationv1-allocationspecification-94148">
+
+**data** AllocationSpecification
+
+</div>
+
+> The specification of an allocation of assets to a specific leg of a settlement.
+>
+> In contrast to an `AllocationView` this just specifies what should be allocated, but not the holdings that are backing the allocation.
+>
+> <div id="constr-splice-api-token-allocationv1-allocationspecification-66543">
+>
+> AllocationSpecification
+>
+> </div>
+>
+> > | Field         | Type                                                                             | Description                                                        |
+> > |---------------|----------------------------------------------------------------------------------|--------------------------------------------------------------------|
+> > | settlement    | SettlementInfo                                                                   | The settlement for whose execution the assets are being allocated. |
+> > | transferLegId | [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | A unique identifer for the transfer leg within the settlement.     |
+> > | transferLeg   | TransferLeg                                                                      | The transfer for which the assets are being allocated.             |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationSpecification
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationSpecification
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocation" AllocationView AllocationSpecification
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlement" AllocationSpecification SettlementInfo
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLeg" AllocationSpecification TransferLeg
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLegId" AllocationSpecification [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocation" AllocationView AllocationSpecification
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlement" AllocationSpecification SettlementInfo
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLeg" AllocationSpecification TransferLeg
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLegId" AllocationSpecification [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+
+<div id="type-splice-api-token-allocationv1-allocationview-9103">
+
+**data** AllocationView
+
+</div>
+
+> View of a funded allocation of assets to a specific leg of a settlement.
+>
+> <div id="constr-splice-api-token-allocationv1-allocationview-89090">
+>
+> AllocationView
+>
+> </div>
+>
+> > | Field       | Type                                                                                                          | Description                                                                                                                                                                                              |
+> > |-------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | allocation  | AllocationSpecification                                                                                       | The settlement for whose execution the assets are being allocated.                                                                                                                                       |
+> > | holdingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that are backing this allocation. Provided so that that wallets can correlate the allocation with the holdings. MAY be empty for registries that do not represent their holdings on-ledger. |
+> > | meta        | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility.                                                                                                                                  |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationView
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) Allocation AllocationView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) Allocation AllocationView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocation" AllocationView AllocationSpecification
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "holdingCids" AllocationView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationView Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocation" AllocationView AllocationSpecification
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "holdingCids" AllocationView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationView Metadata
+
+<div id="type-splice-api-token-allocationv1-allocationcancelresult-26037">
+
+**data** Allocation_CancelResult
+
+</div>
+
+> The result of the `Allocation_Cancel` choice.
+>
+> <div id="constr-splice-api-token-allocationv1-allocationcancelresult-74846">
+>
+> Allocation_CancelResult
+>
+> </div>
+>
+> > | Field             | Type                                                                                                          | Description                                                             |
+> > |-------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+> > | senderHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were released back to the sender.                     |
+> > | meta              | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Allocation_CancelResult
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Allocation_CancelResult
+>
+> **instance** HasMethod Allocation "allocation_cancelImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_CancelResult)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Allocation_CancelResult Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_CancelResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Allocation_CancelResult Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_CancelResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_Cancel Allocation_CancelResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_Cancel Allocation_CancelResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_Cancel Allocation_CancelResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_Cancel Allocation_CancelResult
+
+<div id="type-splice-api-token-allocationv1-allocationexecutetransferresult-74160">
+
+**data** Allocation_ExecuteTransferResult
+
+</div>
+
+> The result of the `Allocation_ExecuteTransfer` choice.
+>
+> <div id="constr-splice-api-token-allocationv1-allocationexecutetransferresult-50341">
+>
+> Allocation_ExecuteTransferResult
+>
+> </div>
+>
+> > | Field               | Type                                                                                                          | Description                                                                                              |
+> > |---------------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
+> > | senderHoldingCids   | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were created for the sender. Can be used to return "change" to the sender if required. |
+> > | receiverHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were created for the receiver.                                                         |
+> > | meta                | Metadata                                                                                                      | Additional metadata specific to the transfer instruction, used for extensibility.                        |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Allocation_ExecuteTransferResult
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Allocation_ExecuteTransferResult
+>
+> **instance** HasMethod Allocation "allocation_executeTransferImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Allocation_ExecuteTransferResult Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiverHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Allocation_ExecuteTransferResult Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiverHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+
+<div id="type-splice-api-token-allocationv1-allocationwithdrawresult-40879">
+
+**data** Allocation_WithdrawResult
+
+</div>
+
+> The result of the `Allocation_Withdraw` choice.
+>
+> <div id="constr-splice-api-token-allocationv1-allocationwithdrawresult-86620">
+>
+> Allocation_WithdrawResult
+>
+> </div>
+>
+> > | Field             | Type                                                                                                          | Description                                                             |
+> > |-------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+> > | senderHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were released back to the sender.                     |
+> > | meta              | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Allocation_WithdrawResult
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Allocation_WithdrawResult
+>
+> **instance** HasMethod Allocation "allocation_withdrawImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_WithdrawResult)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Allocation_WithdrawResult Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_WithdrawResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Allocation_WithdrawResult Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_WithdrawResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_Withdraw Allocation_WithdrawResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_Withdraw Allocation_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_Withdraw Allocation_WithdrawResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_Withdraw Allocation_WithdrawResult
+
+<div id="type-splice-api-token-allocationv1-reference-53456">
+
+**data** Reference
+
+</div>
+
+> A generic type to refer to data defined within an app.
+>
+> <div id="constr-splice-api-token-allocationv1-reference-11427">
+>
+> Reference
+>
+> </div>
+>
+> > | Field | Type                                                                                                             | Description                                                                                                                                                                                                                                                                |
+> > |-------|------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | id    | [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)                                 | The key that identifies the data. Can be set to the empty string if the contract-id is provided and is sufficient.                                                                                                                                                         |
+> > | cid   | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) AnyContractId | Optional contract-id to use for referring to contracts. This field is there for technical reasons, as contract-ids cannot be converted to text from within Daml, which is due to their full textual representation being only known after transactions have been prepared. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Reference
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Reference
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "cid" Reference ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) AnyContractId)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "id" Reference [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlementRef" SettlementInfo Reference
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "cid" Reference ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) AnyContractId)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "id" Reference [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlementRef" SettlementInfo Reference
+
+<div id="type-splice-api-token-allocationv1-settlementinfo-4367">
+
+**data** SettlementInfo
+
+</div>
+
+> The minimal set of information about a settlement that an app would like to execute.
+>
+> <div id="constr-splice-api-token-allocationv1-settlementinfo-25294">
+>
+> SettlementInfo
+>
+> </div>
+>
+> > | Field          | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                      |
+> > |----------------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | executor       | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is responsible for executing the settlement.                                                                                                                                                                                                                                                                                      |
+> > | settlementRef  | Reference                                                                               | Reference to the settlement that app would like to execute.                                                                                                                                                                                                                                                                                      |
+> > | requestedAt    | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)   | When the settlement was requested. Provided for display and debugging purposes, but SHOULD be in the past.                                                                                                                                                                                                                                       |
+> > | allocateBefore | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)   | Until when (exclusive) the senders are given time to allocate their assets. This field has a particular relevance with respect to instrument versioning / corporate actions, in that the settlement pertains to the instrument version resulting from the processing of all corporate actions falling strictly before the `allocateBefore` time. |
+> > | settleBefore   | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)   | Until when (exclusive) the executor is given time to execute the settlement. SHOULD be strictly after `allocateBefore`.                                                                                                                                                                                                                          |
+> > | meta           | Metadata                                                                                | Additional metadata about the settlement, used for extensibility.                                                                                                                                                                                                                                                                                |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) SettlementInfo
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) SettlementInfo
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocateBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "executor" SettlementInfo [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" SettlementInfo Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "requestedAt" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settleBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlement" AllocationSpecification SettlementInfo
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlementRef" SettlementInfo Reference
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocateBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "executor" SettlementInfo [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" SettlementInfo Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "requestedAt" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settleBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlement" AllocationSpecification SettlementInfo
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlementRef" SettlementInfo Reference
+
+<div id="type-splice-api-token-allocationv1-transferleg-71662">
+
+**data** TransferLeg
+
+</div>
+
+> A specification of a transfer of holdings between two parties for the purpose of a settlement, which often requires the atomic execution of multiple legs.
+>
+> <div id="constr-splice-api-token-allocationv1-transferleg-72717">
+>
+> TransferLeg
+>
+> </div>
+>
+> > | Field        | Type                                                                                    | Description                                                         |
+> > |--------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+> > | sender       | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The sender of the transfer.                                         |
+> > | receiver     | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The receiver of the transfer.                                       |
+> > | amount       | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | The amount to transfer.                                             |
+> > | instrumentId | InstrumentId                                                                            | The instrument identifier.                                          |
+> > | meta         | Metadata                                                                                | Additional metadata about the transfer leg, used for extensibility. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferLeg
+>
+> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) TransferLeg
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferLeg
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" TransferLeg [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" TransferLeg InstrumentId
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferLeg Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiver" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "sender" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLeg" AllocationSpecification TransferLeg
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" TransferLeg [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" TransferLeg InstrumentId
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferLeg Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiver" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "sender" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLeg" AllocationSpecification TransferLeg
+
+## Functions
+
+<div id="function-splice-api-token-allocationv1-allocationcontrollers-10222">
+
+allocationControllers
+: AllocationView -\> \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]
+
+Convenience function to refer to the union of sender, receiver, and executor of the settlement, which jointly control the execution of the allocation.
+
+</div>
+
+<div id="function-splice-api-token-allocationv1-allocationexecutetransferimpl-90251">
+
+allocation_executeTransferImpl
+: Allocation -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult
+
+</div>
+
+<div id="function-splice-api-token-allocationv1-allocationcancelimpl-12334">
+
+allocation_cancelImpl
+: Allocation -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_CancelResult
+
+</div>
+
+<div id="function-splice-api-token-allocationv1-allocationwithdrawimpl-40108">
+
+allocation_withdrawImpl
+: Allocation -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_WithdrawResult
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "splice-api-token-burn-mint-v1 docs"
+description: "Documentation for splice-api-token-burn-mint-v1 docs"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-burn-mint-v1/docs/index.rst" hash="878add30" */}
+
+## Modules
+
+- [Splice.Api.Token.BurnMintV1](/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1.mdx
@@ -1,0 +1,213 @@
+---
+title: "Splice.Api.Token.BurnMintV1"
+description: "Documentation for Splice.Api.Token.BurnMintV1"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-burn-mint-v1/docs/Splice-Api-Token-BurnMintV1.rst" hash="6973b713" */}
+
+An interface for registries to expose burn/mint operations in a generic way for bridges to use them, and for wallets to parse their use.
+
+## Interfaces
+
+<div id="type-splice-api-token-burnmintv1-burnmintfactory-79205">
+
+**interface** BurnMintFactory
+
+</div>
+
+> A factory for generic burn/mint operations.
+>
+> **viewtype** BurnMintFactoryView
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-api-token-burnmintv1-burnmintfactoryburnmint-20312">
+>
+>   **Choice** BurnMintFactory_BurnMint
+>
+>   </div>
+>
+>   Burn the holdings in `inputHoldingCids` and create holdings with the owners and amounts specified in outputs.
+>
+>   Note that this is jointly authorized by the admin and the `extraActors`. The `admin` thus controls all calls to this choice, and some implementations might required `extraActors` to be present, e.g., the owners of the minted and burnt holdings.
+>
+>   Implementations are free to restrict the implementation of this choice including failing on all inputs or not implementing this interface at all.
+>
+>   Controller: (DA.Internal.Record.getField @"admin" (view this)) :: extraActors
+>
+>   Returns: BurnMintFactory_BurnMintResult
+>
+>   | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+>   |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+>   | expectedAdmin    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The expected `admin` party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | instrumentId     | InstrumentId                                                                                                  | The instrument id of the holdings. All holdings in `inputHoldingCids` as well as the resulting output holdings MUST have this instrument id.                                                                                                                                                                                                                                                                                                                                      |
+>   | inputHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that should be burnt. All holdings in `inputHoldingCids` MUST be archived by this choice. Implementations MAY enforce additional restrictions such as all `inputHoldingCids` belonging to the same owner.                                                                                                                                                                                                                                                            |
+>   | outputs          | \[BurnMintOutput\]                                                                                            | The holdings that should be created. The choice MUST create new holdings with the given amounts.                                                                                                                                                                                                                                                                                                                                                                                  |
+>   | extraActors      | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                   | Extra actors, the full actors required are the admin + extraActors. This is often the owners of inputHoldingCids and outputs but we allow different sets of actors to support token implementations with different authorization setups.                                                                                                                                                                                                                                          |
+>   | extraArgs        | ExtraArgs                                                                                                     | Additional context. Implementations SHOULD include a `splice.lfdecentralizedtrust.org/reason` key in the metadata to provide a human readable description for explain why the `BurnMintFactory_BurnMint` choice was called, so that generic wallets can display it to the user.                                                                                                                                                                                                   |
+>
+> - <div id="type-splice-api-token-burnmintv1-burnmintfactorypublicfetch-64185">
+>
+>   **Choice** BurnMintFactory_PublicFetch
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: BurnMintFactoryView
+>
+>   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+>   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+>   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | actor         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party fetching the data.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+>
+> - **Method burnMintFactory_burnMintImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult
+>
+> - **Method burnMintFactory_publicFetchImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactoryView
+
+## Data Types
+
+<div id="type-splice-api-token-burnmintv1-burnmintfactoryview-72718">
+
+**data** BurnMintFactoryView
+
+</div>
+
+> The view of a `BurnMintFactory`.
+>
+> <div id="constr-splice-api-token-burnmintv1-burnmintfactoryview-23617">
+>
+> BurnMintFactoryView
+>
+> </div>
+>
+> > | Field | Type                                                                                    | Description                                                                                                             |
+> > |-------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this burnt-mint factory can be used. |
+> > | meta  | Metadata                                                                                | Additional metadata specific to the burn-mint factory, used for extensibility.                                          |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) BurnMintFactoryView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) BurnMintFactoryView
+>
+> **instance** HasMethod BurnMintFactory "burnMintFactory_publicFetchImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactoryView)
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) BurnMintFactory BurnMintFactoryView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) BurnMintFactory BurnMintFactoryView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" BurnMintFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" BurnMintFactoryView Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" BurnMintFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" BurnMintFactoryView Metadata
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+
+<div id="type-splice-api-token-burnmintv1-burnmintfactoryburnmintresult-61365">
+
+**data** BurnMintFactory_BurnMintResult
+
+</div>
+
+> The result of calling the `BurnMintFactory_BurnMint` choice.
+>
+> <div id="constr-splice-api-token-burnmintv1-burnmintfactoryburnmintresult-13976">
+>
+> BurnMintFactory_BurnMintResult
+>
+> </div>
+>
+> > | Field      | Type                                                                                                          | Description                                                                                                              |
+> > |------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+> > | outputCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings created by the choice. Must contain exactly the outputs specified in the choice argument in the same order. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) BurnMintFactory_BurnMintResult
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) BurnMintFactory_BurnMintResult
+>
+> **instance** HasMethod BurnMintFactory "burnMintFactory_burnMintImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "outputCids" BurnMintFactory_BurnMintResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "outputCids" BurnMintFactory_BurnMintResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+
+<div id="type-splice-api-token-burnmintv1-burnmintoutput-36483">
+
+**data** BurnMintOutput
+
+</div>
+
+> The specification of a holding to create as part of the burn/mint operation.
+>
+> <div id="constr-splice-api-token-burnmintv1-burnmintoutput-15750">
+>
+> BurnMintOutput
+>
+> </div>
+>
+> > | Field   | Type                                                                                    | Description                                                                                               |
+> > |---------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+> > | owner   | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The owner of the holding to create.                                                                       |
+> > | amount  | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | The amount of the holding to create.                                                                      |
+> > | context | ChoiceContext                                                                           | Context specific to this output which can be used to support locking or other registry-specific features. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) BurnMintOutput
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) BurnMintOutput
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" BurnMintOutput [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" BurnMintOutput ChoiceContext
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "owner" BurnMintOutput [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" BurnMintOutput [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" BurnMintOutput ChoiceContext
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "owner" BurnMintOutput [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+## Functions
+
+<div id="function-splice-api-token-burnmintv1-burnmintfactoryburnmintimpl-9738">
+
+burnMintFactory_burnMintImpl
+: BurnMintFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult
+
+</div>
+
+<div id="function-splice-api-token-burnmintv1-burnmintfactorypublicfetchimpl-75623">
+
+burnMintFactory_publicFetchImpl
+: BurnMintFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactoryView
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "splice-api-token-holding-v1 docs"
+description: "Documentation for splice-api-token-holding-v1 docs"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-holding-v1/docs/index.rst" hash="2990484d" */}
+
+## Modules
+
+- [Splice.Api.Token.HoldingV1](/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1.mdx
@@ -1,0 +1,166 @@
+---
+title: "Splice.Api.Token.HoldingV1"
+description: "Documentation for Splice.Api.Token.HoldingV1"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-holding-v1/docs/Splice-Api-Token-HoldingV1.rst" hash="513e31b9" */}
+
+Types and interfaces for retrieving an investor's holdings.
+
+## Interfaces
+
+<div id="type-splice-api-token-holdingv1-holding-25898">
+
+**interface** Holding
+
+</div>
+
+> Holding interface.
+>
+> **viewtype** HoldingView
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-api-token-holdingv1-holdingview-83501">
+
+**data** HoldingView
+
+</div>
+
+> View for `Holding`.
+>
+> <div id="constr-splice-api-token-holdingv1-holdingview-75848">
+>
+> HoldingView
+>
+> </div>
+>
+> > | Field        | Type                                                                                                    | Description                                                                                                                                  |
+> > |--------------|---------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+> > | owner        | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                 | Owner of the holding.                                                                                                                        |
+> > | instrumentId | InstrumentId                                                                                            | Instrument being held.                                                                                                                       |
+> > | amount       | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)                  | Size of the holding.                                                                                                                         |
+> > | lock         | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock | Lock on the holding. Registries SHOULD allow holdings with expired locks as inputs to transfers to enable a combined unlocking + use choice. |
+> > | meta         | Metadata                                                                                                | Metadata.                                                                                                                                    |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) HoldingView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) HoldingView
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) Holding HoldingView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) Holding HoldingView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" HoldingView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" HoldingView InstrumentId
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" HoldingView Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "owner" HoldingView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" HoldingView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" HoldingView InstrumentId
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" HoldingView Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "owner" HoldingView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+
+<div id="type-splice-api-token-holdingv1-instrumentid-28218">
+
+**data** InstrumentId
+
+</div>
+
+> A globally unique identifier for instruments.
+>
+> <div id="constr-splice-api-token-holdingv1-instrumentid-17961">
+>
+> InstrumentId
+>
+> </div>
+>
+> > | Field | Type                                                                                    | Description                                                                                                                          |
+> > |-------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instrument.                                                             |
+> > | id    | [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)        | The identifier used for the instrument by the instrument admin. This identifier MUST be unique and unambiguous per instrument admin. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) InstrumentId
+>
+> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) InstrumentId
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) InstrumentId
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" InstrumentId [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "id" InstrumentId [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" HoldingView InstrumentId
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" InstrumentId [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "id" InstrumentId [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" HoldingView InstrumentId
+
+<div id="type-splice-api-token-holdingv1-lock-70295">
+
+**data** Lock
+
+</div>
+
+> Details of a lock.
+>
+> <div id="constr-splice-api-token-holdingv1-lock-56452">
+>
+> Lock
+>
+> </div>
+>
+> > | Field        | Type                                                                                                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                          |
+> > |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | holders      | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                                                                                                   | Unique list of parties which are locking the contract. (Represented as a list, as that has the better JSON encoding.)                                                                                                                                                                                                                                |
+> > | expiresAt    | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)      | Absolute, inclusive deadline as of which the lock expires.                                                                                                                                                                                                                                                                                           |
+> > | expiresAfter | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082) | Duration after which the created lock expires. Measured relative to the ledger time that the locked holding contract was created. If both `expiresAt` and `expiresAfter` are set, the lock expires at the earlier of the two times.                                                                                                                  |
+> > | context      | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)           | Short, human-readable description of the context of the lock. Used by wallets to enable users to understand the reason for the lock. Note that the visibility of the content in this field might be wider than the visibility of the contracts in the context. You should thus carefully decide what information is safe to put in the lock context. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Lock
+>
+> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) Lock
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Lock
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "expiresAfter" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082))
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "expiresAt" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886))
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "holders" Lock \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "expiresAfter" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082))
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "expiresAt" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886))
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "holders" Lock \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "splice-api-token-metadata-v1 docs"
+description: "Documentation for splice-api-token-metadata-v1 docs"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-metadata-v1/docs/index.rst" hash="4931210e" */}
+
+## Modules
+
+- [Splice.Api.Token.MetadataV1](/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1.mdx
@@ -1,0 +1,294 @@
+---
+title: "Splice.Api.Token.MetadataV1"
+description: "Documentation for Splice.Api.Token.MetadataV1"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-metadata-v1/docs/Splice-Api-Token-MetadataV1.rst" hash="d2587cd6" */}
+
+Types and interfaces for retrieving metadata about tokens.
+
+## Interfaces
+
+<div id="type-splice-api-token-metadatav1-anycontract-39598">
+
+**interface** AnyContract
+
+</div>
+
+> Interface used to represent arbitrary contracts. Note that this is not expected to be implemented by any template, so it should only be used in the form `ContractId AnyContract` and through `coerceContractId` but not through any of the interface functions like `fetchFromInterface` that check whether the template actually implements the interface.
+>
+> **viewtype** AnyContractView
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-api-token-metadatav1-anycontractid-4875">
+
+**type** AnyContractId
+= [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AnyContract
+
+A reference to some contract id. Use `coerceContractId` to convert from and to this type.
+
+</div>
+
+<div id="type-splice-api-token-metadatav1-anycontractview-55353">
+
+**data** AnyContractView
+
+</div>
+
+> Not used. See the `AnyContract` interface for more information.
+>
+> <div id="constr-splice-api-token-metadatav1-anycontractview-50558">
+>
+> AnyContractView
+>
+> </div>
+>
+> > (no fields)
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AnyContract AnyContractView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AnyContract AnyContractView
+
+<div id="type-splice-api-token-metadatav1-anyvalue-34700">
+
+**data** AnyValue
+
+</div>
+
+> A generic representation of serializable Daml values.
+>
+> Used to pass arbitrary data across interface boundaries. For example to pass data from an an app backend to an interface choice implementation.
+>
+> <div id="constr-splice-api-token-metadatav1-avtext-20580">
+>
+> AV_Text [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+>
+> </div>
+>
+> <div id="constr-splice-api-token-metadatav1-avint-52425">
+>
+> AV_Int [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+>
+> </div>
+>
+> <div id="constr-splice-api-token-metadatav1-avdecimal-71267">
+>
+> AV_Decimal [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> </div>
+>
+> <div id="constr-splice-api-token-metadatav1-avbool-76457">
+>
+> AV_Bool [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
+>
+> </div>
+>
+> <div id="constr-splice-api-token-metadatav1-avdate-46205">
+>
+> AV_Date [Date](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-date-32253)
+>
+> </div>
+>
+> <div id="constr-splice-api-token-metadatav1-avtime-30398">
+>
+> AV_Time [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> </div>
+>
+> <div id="constr-splice-api-token-metadatav1-avreltime-31008">
+>
+> AV_RelTime [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082)
+>
+> </div>
+>
+> <div id="constr-splice-api-token-metadatav1-avparty-78344">
+>
+> AV_Party [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> </div>
+>
+> <div id="constr-splice-api-token-metadatav1-avcontractid-3242">
+>
+> AV_ContractId AnyContractId
+>
+> </div>
+>
+> <div id="constr-splice-api-token-metadatav1-avlist-50505">
+>
+> AV_List \[AnyValue\]
+>
+> </div>
+>
+> <div id="constr-splice-api-token-metadatav1-avmap-39932">
+>
+> AV_Map ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+>
+> </div>
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AnyValue
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AnyValue
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+
+<div id="type-splice-api-token-metadatav1-choicecontext-5566">
+
+**data** ChoiceContext
+
+</div>
+
+> A type for passing extra data from an app's backends to the choices of that app exercised in commands submitted by app users.
+>
+> <div id="constr-splice-api-token-metadatav1-choicecontext-36049">
+>
+> ChoiceContext
+>
+> </div>
+>
+> > | Field  | Type                                                                                                 | Description                                                                                                                                    |
+> > |--------|------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | values | [TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue | The values passed in by the app backend to the choice. The keys are considered internal to the app and should not be read by third-party code. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) ChoiceContext
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) ChoiceContext
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" ExtraArgs ChoiceContext
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" ExtraArgs ChoiceContext
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+
+<div id="type-splice-api-token-metadatav1-choiceexecutionmetadata-98464">
+
+**data** ChoiceExecutionMetadata
+
+</div>
+
+> A generic result for choices that do not need to return specific data.
+>
+> <div id="constr-splice-api-token-metadatav1-choiceexecutionmetadata-73543">
+>
+> ChoiceExecutionMetadata
+>
+> </div>
+>
+> > | Field | Type     | Description                                                                                  |
+> > |-------|----------|----------------------------------------------------------------------------------------------|
+> > | meta  | Metadata | Additional metadata specific to the result of exercising the choice, used for extensibility. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) ChoiceExecutionMetadata
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) ChoiceExecutionMetadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ChoiceExecutionMetadata Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ChoiceExecutionMetadata Metadata
+
+<div id="type-splice-api-token-metadatav1-extraargs-90869">
+
+**data** ExtraArgs
+
+</div>
+
+> A common type for passing both the choice context and the metadata to a choice.
+>
+> <div id="constr-splice-api-token-metadatav1-extraargs-16750">
+>
+> ExtraArgs
+>
+> </div>
+>
+> > | Field   | Type          | Description                                                                                                                                                                                                                                                                                      |
+> > |---------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | context | ChoiceContext | Extra arguments to be passed to the implementation of an interface choice. These are provided via an off-ledger API by the app implementing the interface.                                                                                                                                       |
+> > | meta    | Metadata      | Additional metadata to pass in. In contrast to the `extraArgs`, these are provided by the caller of the choice. The expectation is that the meaning of metadata fields will be agreed on in later standards, or on a case-by-case basis between the caller and the implementer of the interface. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) ExtraArgs
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) ExtraArgs
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" ExtraArgs ChoiceContext
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ExtraArgs Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" ExtraArgs ChoiceContext
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ExtraArgs Metadata
+
+<div id="type-splice-api-token-metadatav1-metadata-21206">
+
+**data** Metadata
+
+</div>
+
+> Machine-readable metadata intended for communicating additional information using well-known keys between systems. This is mainly used to allow for the post-hoc expansion of the information associated with contracts and choice arguments and results.
+>
+> Modeled after by k8s support for annotations: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/([https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)\\](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)\).
+>
+> Implementors SHOULD follow the same conventions for allocating keys as used by k8s; i.e., they SHOULD be prefixed using the DNS name of the app defining the key.
+>
+> Implementors SHOULD keep metadata small, as on-ledger data is costly.
+>
+> <div id="constr-splice-api-token-metadatav1-metadata-84299">
+>
+> Metadata
+>
+> </div>
+>
+> > | Field  | Type                                                                                                                                                                         | Description                          |
+> > |--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+> > | values | [TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | Key-value pairs of metadata entries. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Metadata
+>
+> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) Metadata
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ChoiceExecutionMetadata Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ExtraArgs Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "values" Metadata ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ChoiceExecutionMetadata Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ExtraArgs Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "values" Metadata ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+
+## Functions
+
+<div id="function-splice-api-token-metadatav1-emptychoicecontext-1208">
+
+emptyChoiceContext
+: ChoiceContext
+
+Empty choice context.
+
+</div>
+
+<div id="function-splice-api-token-metadatav1-emptymetadata-88176">
+
+emptyMetadata
+: Metadata
+
+Empty metadata.
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "splice-api-token-transfer-instruction-v1 docs"
+description: "Documentation for splice-api-token-transfer-instruction-v1 docs"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-transfer-instruction-v1/docs/index.rst" hash="556c03f6" */}
+
+## Modules
+
+- [Splice.Api.Token.TransferInstructionV1](/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1.mdx
@@ -1,0 +1,555 @@
+---
+title: "Splice.Api.Token.TransferInstructionV1"
+description: "Documentation for Splice.Api.Token.TransferInstructionV1"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-api-token-transfer-instruction-v1/docs/Splice-Api-Token-TransferInstructionV1.rst" hash="153e1c1b" */}
+
+Instruct transfers of holdings between parties.
+
+## Interfaces
+
+<div id="type-splice-api-token-transferinstructionv1-transferfactory-55548">
+
+**interface** TransferFactory
+
+</div>
+
+> A factory contract to instruct transfers of holdings between parties.
+>
+> **viewtype** TransferFactoryView
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-api-token-transferinstructionv1-transferfactorypublicfetch-56912">
+>
+>   **Choice** TransferFactory_PublicFetch
+>
+>   </div>
+>
+>   Fetch the view of the factory contract.
+>
+>   Controller: actor
+>
+>   Returns: TransferFactoryView
+>
+>   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+>   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+>   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | actor         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party fetching the contract.                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+>
+> - <div id="type-splice-api-token-transferinstructionv1-transferfactorytransfer-25365">
+>
+>   **Choice** TransferFactory_Transfer
+>
+>   </div>
+>
+>   Instruct the registry to execute a transfer. Implementations MUST ensure that this choice fails if `transfer.executeBefore` is in the past.
+>
+>   Controller: (DA.Internal.Record.getField @"sender" transfer)
+>
+>   Returns: TransferInstructionResult
+>
+>   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+>   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+>   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | transfer      | Transfer                                                                                | The transfer to execute.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+>   | extraArgs     | ExtraArgs                                                                               | The extra arguments to pass to the transfer implementation.                                                                                                                                                                                                                                                                                                                                                                                                                     |
+>
+> - **Method transferFactory_publicFetchImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferFactoryView
+>
+> - **Method transferFactory_transferImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+
+<div id="type-splice-api-token-transferinstructionv1-transferinstruction-69882">
+
+**interface** TransferInstruction
+
+</div>
+
+> An interface for tracking the status of a transfer instruction, i.e., a request to a registry app to execute a transfer.
+>
+> Registries MAY evolve the transfer instruction in multiple steps. They SHOULD do so using only the choices on this interface, so that wallets can reliably parse the transaction history and determine whether the instruction ultimately succeeded or failed.
+>
+> **viewtype** TransferInstructionView
+>
+> - **Choice** Archive
+>
+>   Controller: Signatories of implementing template
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-api-token-transferinstructionv1-transferinstructionaccept-36884">
+>
+>   **Choice** TransferInstruction_Accept
+>
+>   </div>
+>
+>   Accept the transfer as the receiver.
+>
+>   This choice is only available if the instruction is in `TransferPendingReceiverAcceptance` state.
+>
+>   Note that while implementations will typically return `TransferInstructionResult_Completed`, this is not guaranteed. The result of the choice is implementation-specific and MAY be any of the three possible results.
+>
+>   Controller: (DA.Internal.Record.getField @"receiver" (DA.Internal.Record.getField @"transfer" (view this)))
+>
+>   Returns: TransferInstructionResult
+>
+>   | Field     | Type      | Description                                                  |
+>   |-----------|-----------|--------------------------------------------------------------|
+>   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+>
+> - <div id="type-splice-api-token-transferinstructionv1-transferinstructionreject-89645">
+>
+>   **Choice** TransferInstruction_Reject
+>
+>   </div>
+>
+>   Reject the transfer as the receiver.
+>
+>   This choice is only available if the instruction is in `TransferPendingReceiverAcceptance` state.
+>
+>   Controller: (DA.Internal.Record.getField @"receiver" (DA.Internal.Record.getField @"transfer" (view this)))
+>
+>   Returns: TransferInstructionResult
+>
+>   | Field     | Type      | Description                                                  |
+>   |-----------|-----------|--------------------------------------------------------------|
+>   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+>
+> - <div id="type-splice-api-token-transferinstructionv1-transferinstructionupdate-27423">
+>
+>   **Choice** TransferInstruction_Update
+>
+>   </div>
+>
+>   Update the state of the transfer instruction. Used by the registry to execute registry internal workflow steps that advance the state of the transfer instruction. A reason may be communicated via the metadata.
+>
+>   Controller: (DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" (DA.Internal.Record.getField @"transfer" (view this)))), extraActors
+>
+>   Returns: TransferInstructionResult
+>
+>   | Field       | Type                                                                                        | Description                                                                                                                           |
+>   |-------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+>   | extraActors | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
+>   | extraArgs   | ExtraArgs                                                                                   | Additional context required in order to exercise the choice.                                                                          |
+>
+> - <div id="type-splice-api-token-transferinstructionv1-transferinstructionwithdraw-43648">
+>
+>   **Choice** TransferInstruction_Withdraw
+>
+>   </div>
+>
+>   Withdraw the transfer instruction as the sender.
+>
+>   Controller: (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transfer" (view this)))
+>
+>   Returns: TransferInstructionResult
+>
+>   | Field     | Type      | Description                                                  |
+>   |-----------|-----------|--------------------------------------------------------------|
+>   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
+>
+> - **Method transferInstruction_acceptImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+>
+> - **Method transferInstruction_rejectImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+>
+> - **Method transferInstruction_updateImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+>
+> - **Method transferInstruction_withdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+
+## Data Types
+
+<div id="type-splice-api-token-transferinstructionv1-transfer-51973">
+
+**data** Transfer
+
+</div>
+
+> A specification of a transfer of holdings between two parties.
+>
+> <div id="constr-splice-api-token-transferinstructionv1-transfer-5022">
+>
+> Transfer
+>
+> </div>
+>
+> > | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+> > |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | sender           | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The sender of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+> > | receiver         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The receiver of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+> > | amount           | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)                        | The amount to transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+> > | instrumentId     | InstrumentId                                                                                                  | The instrument identifier.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+> > | requestedAt      | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                         | Wallet provided timestamp when the transfer was requested. MUST be in the past when instructing the transfer.                                                                                                                                                                                                                                                                                                                                                               |
+> > | executeBefore    | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                         | Until when (exclusive) the transfer may be executed. MUST be in the future when instructing the transfer. Registries SHOULD NOT execute the transfer instruction after this time, so that senders can retry creating a new transfer instruction after this time.                                                                                                                                                                                                            |
+> > | inputHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holding contracts that should be used to fund the transfer. MAY be empty if the registry supports automatic selection of holdings for transfers or does not represent holdings on-ledger. If specified, then the transfer MUST archive all of these holdings, so that the execution of the transfer conflicts with any other transfers using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate transfers. |
+> > | meta             | Metadata                                                                                                      | Metadata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Transfer
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Transfer
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" Transfer [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "executeBefore" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "inputHoldingCids" Transfer \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" Transfer InstrumentId
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Transfer Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiver" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "requestedAt" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "sender" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transfer" TransferFactory_Transfer Transfer
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transfer" TransferInstructionView Transfer
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" Transfer [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "executeBefore" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "inputHoldingCids" Transfer \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" Transfer InstrumentId
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Transfer Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiver" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "requestedAt" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "sender" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transfer" TransferFactory_Transfer Transfer
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transfer" TransferInstructionView Transfer
+
+<div id="type-splice-api-token-transferinstructionv1-transferfactoryview-36679">
+
+**data** TransferFactoryView
+
+</div>
+
+> View for `TransferFactory`.
+>
+> <div id="constr-splice-api-token-transferinstructionv1-transferfactoryview-43930">
+>
+> TransferFactoryView
+>
+> </div>
+>
+> > | Field | Type                                                                                    | Description                                                                                                           |
+> > |-------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this transfer factory can be used. |
+> > | meta  | Metadata                                                                                | Additional metadata specific to the transfer factory, used for extensibility.                                         |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferFactoryView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferFactoryView
+>
+> **instance** HasMethod TransferFactory "transferFactory_publicFetchImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferFactoryView)
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) TransferFactory TransferFactoryView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) TransferFactory TransferFactoryView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" TransferFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferFactoryView Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" TransferFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferFactoryView Metadata
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+
+<div id="type-splice-api-token-transferinstructionv1-transferinstructionresult-24735">
+
+**data** TransferInstructionResult
+
+</div>
+
+> The result of instructing a transfer or advancing the state of a transfer instruction.
+>
+> <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresult-25274">
+>
+> TransferInstructionResult
+>
+> </div>
+>
+> > | Field            | Type                                                                                                          | Description                                                                                                                                                                    |
+> > |------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | output           | TransferInstructionResult_Output                                                                              | The output of the step.                                                                                                                                                        |
+> > | senderChangeCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple transfer instructions in a single Daml transaction. |
+> > | meta             | Metadata                                                                                                      | Additional metadata specific to the transfer instruction, used for extensibility; e.g., fees charged.                                                                          |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionResult
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionResult
+>
+> **instance** HasMethod TransferFactory "transferFactory_transferImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+>
+> **instance** HasMethod TransferInstruction "transferInstruction_acceptImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+>
+> **instance** HasMethod TransferInstruction "transferInstruction_rejectImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+>
+> **instance** HasMethod TransferInstruction "transferInstruction_updateImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+>
+> **instance** HasMethod TransferInstruction "transferInstruction_withdrawImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferInstructionResult Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" TransferInstructionResult TransferInstructionResult_Output
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderChangeCids" TransferInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferInstructionResult Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" TransferInstructionResult TransferInstructionResult_Output
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderChangeCids" TransferInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferFactory TransferFactory_Transfer TransferInstructionResult
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Update TransferInstructionResult
+>
+> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferFactory TransferFactory_Transfer TransferInstructionResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Update TransferInstructionResult
+>
+> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferFactory TransferFactory_Transfer TransferInstructionResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Update TransferInstructionResult
+>
+> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferFactory TransferFactory_Transfer TransferInstructionResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Update TransferInstructionResult
+>
+> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+
+<div id="type-splice-api-token-transferinstructionv1-transferinstructionresultoutput-59824">
+
+**data** TransferInstructionResult_Output
+
+</div>
+
+> The output of instructing a transfer or advancing the state of a transfer instruction.
+>
+> <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresultpending-18902">
+>
+> TransferInstructionResult_Pending
+>
+> </div>
+>
+> > Use this result to communicate that the transfer is pending further steps.
+> >
+> > | Field                  | Type                                                                                                                  | Description                                                             |
+> > |------------------------|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+> > | transferInstructionCid | [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction | Contract id of the transfer instruction representing the pending state. |
+>
+> <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresultcompleted-47798">
+>
+> TransferInstructionResult_Completed
+>
+> </div>
+>
+> > Use this result to communicate that the transfer succeeded and the receiver has received their holdings.
+> >
+> > | Field               | Type                                                                                                          | Description                                                                                       |
+> > |---------------------|---------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+> > | receiverHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The newly created holdings owned by the receiver as part of successfully completing the transfer. |
+>
+> <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresultfailed-21543">
+>
+> TransferInstructionResult_Failed
+>
+> </div>
+>
+> > Use this result to communicate that the transfer did not succeed and all holdings (minus fees) have been returned to the sender.
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionResult_Output
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionResult_Output
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" TransferInstructionResult TransferInstructionResult_Output
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiverHoldingCids" TransferInstructionResult_Output \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferInstructionCid" TransferInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction)
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" TransferInstructionResult TransferInstructionResult_Output
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiverHoldingCids" TransferInstructionResult_Output \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferInstructionCid" TransferInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction)
+
+<div id="type-splice-api-token-transferinstructionv1-transferinstructionstatus-36298">
+
+**data** TransferInstructionStatus
+
+</div>
+
+> Status of a transfer instruction.
+>
+> <div id="constr-splice-api-token-transferinstructionv1-transferpendingreceiveracceptance-84710">
+>
+> TransferPendingReceiverAcceptance
+>
+> </div>
+>
+> > The transfer is pending acceptance by the receiver.
+>
+> <div id="constr-splice-api-token-transferinstructionv1-transferpendinginternalworkflow-24806">
+>
+> TransferPendingInternalWorkflow
+>
+> </div>
+>
+> > The transfer is pending actions to be taken as part of registry internal workflows.
+> >
+> > | Field          | Type                                                                                                                                                                                                                                                         | Description                                                                                                                                            |
+> > |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | pendingActions | [Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | The actions that a party could take to advance the transfer. This field can by used to inform wallet users whether they need to take an action or not. |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionStatus
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionStatus
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "pendingActions" TransferInstructionStatus ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "status" TransferInstructionView TransferInstructionStatus
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "pendingActions" TransferInstructionStatus ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "status" TransferInstructionView TransferInstructionStatus
+
+<div id="type-splice-api-token-transferinstructionv1-transferinstructionview-46309">
+
+**data** TransferInstructionView
+
+</div>
+
+> View for `TransferInstruction`.
+>
+> <div id="constr-splice-api-token-transferinstructionv1-transferinstructionview-88808">
+>
+> TransferInstructionView
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                                                                                       | Description                                                                                                                                                                                                                          |
+> > |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | originalInstructionCid | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction) | The contract id of the original transfer instruction contract. Used by the wallet to track the lineage of transfer instructions through multiple steps. Only set if the registry evolves the transfer instruction in multiple steps. |
+> > | transfer               | Transfer                                                                                                                                                                                                                   | The transfer specified by the transfer instruction.                                                                                                                                                                                  |
+> > | status                 | TransferInstructionStatus                                                                                                                                                                                                  | The status of the transfer instruction.                                                                                                                                                                                              |
+> > | meta                   | Metadata                                                                                                                                                                                                                   | Additional metadata specific to the transfer instruction, used for extensibility; e.g., more detailed status information.                                                                                                            |
+>
+> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionView
+>
+> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionView
+>
+> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) TransferInstruction TransferInstructionView
+>
+> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) TransferInstruction TransferInstructionView
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferInstructionView Metadata
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "originalInstructionCid" TransferInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction))
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "status" TransferInstructionView TransferInstructionStatus
+>
+> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transfer" TransferInstructionView Transfer
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferInstructionView Metadata
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "originalInstructionCid" TransferInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction))
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "status" TransferInstructionView TransferInstructionStatus
+>
+> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transfer" TransferInstructionView Transfer
+
+## Functions
+
+<div id="function-splice-api-token-transferinstructionv1-transferinstructionacceptimpl-78274">
+
+transferInstruction_acceptImpl
+: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+
+</div>
+
+<div id="function-splice-api-token-transferinstructionv1-transferinstructionrejectimpl-50311">
+
+transferInstruction_rejectImpl
+: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+
+</div>
+
+<div id="function-splice-api-token-transferinstructionv1-transferinstructionwithdrawimpl-10586">
+
+transferInstruction_withdrawImpl
+: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+
+</div>
+
+<div id="function-splice-api-token-transferinstructionv1-transferinstructionupdateimpl-73329">
+
+transferInstruction_updateImpl
+: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+
+</div>
+
+<div id="function-splice-api-token-transferinstructionv1-transferfactorytransferimpl-82483">
+
+transferFactory_transferImpl
+: TransferFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+
+</div>
+
+<div id="function-splice-api-token-transferinstructionv1-transferfactorypublicfetchimpl-930">
+
+transferFactory_publicFetchImpl
+: TransferFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferFactoryView
+
+</div>
+
+{/* COPIED_END */}


### PR DESCRIPTION
## Summary

Closes #527, #420, #444, #445, #417, #537.

Six urgent issues against pages that were unreachable or rendering incorrectly on production (Mintlify Error 500 / blank content). Verified with local `mintlify dev` — all 23 touched URLs now return 200.

### Issue fixes

- **#527 / #420 — Monitoring Setup not rendering**: demote three body `# H1` headings to `## H2` (Example Monitoring Setup, Participant Node Health, Monitor ACS Commitments). Replace four `class="..."` HTML attributes with JSX-compatible `className="..."`. Convert four `<img style=\"width:100.0%\">` string attrs to `style={{width: \"100%\"}}` (MDX requires JSX style objects, not strings).
- **#444 — Splice APIs Overview not rendering**: replace the broken RST `<div className=\"toctree\">` (which Mintlify rendered as a paragraph of relative paths) with a hidden MDX comment referencing the tracking issue #539 for compiled packages.
- **#445 — Splice Daml APIs code snippets not rendering**: same toctree removal. Three of the four referenced packages now link to internal sub-pages (`splice-api-featured-app-v1/v2`, `splice-api-token-burn-mint-v1`); the fourth (`splice-util-featured-app-proxies`, compiled) keeps a TODO comment for #539.
- **#417 — sv-security TOC casing + missing page**: TOC casing was already fixed in `main` (frontmatter title is \"SV Security\"). Empty stub subsections (Third-party Daml apps, Google Cloud KMS, Amazon Web Services KMS) now carry hidden MDX TODO comments referencing #523 (the existing tracking issue for KMS docs).
- **#537 — Supported Cryptographic Configuration page missing**: page exists at `/global-synchronizer/reference/crypto-schemes` but was returning 500. Same fix pattern as the recently-shipped #423: demote body `# H1` to `## H2`; convert four pandoc-style HTML tables (with `<colgroup>`, `<blockquote>` in `<th>`, etc.) to clean Markdown tables.

### Port archived Splice Daml packages

The 9 archived (non-compiled) packages in the upstream `gen-daml-docs.sh` list have pre-rendered RST checked into `daml/<pkg>/docs/` and `token-standard/<pkg>/docs/`. Fetched from splice `0.6.4`, converted with `.internal/rst2mdx.py`, placed under `docs-main/sdks-tools/api-reference/splice-daml/<pkg>/`, and added to `docs.json` under the new \"Splice APIs > Splice Daml Packages\" group:

- splice-api-featured-app-v1
- splice-api-featured-app-v2
- splice-api-token-allocation-v1
- splice-api-token-allocation-instruction-v1
- splice-api-token-allocation-request-v1
- splice-api-token-burn-mint-v1
- splice-api-token-holding-v1
- splice-api-token-metadata-v1
- splice-api-token-transfer-instruction-v1

The remaining 11 compiled packages (splice-amulet, splice-wallet, etc.) still need a generator script; tracked in #539 (assigned to @danielporterda).