### PR TITLE
Link fixes across 10 pages (13 issues)

### DIFF
--- a/docs-main/appdev/deep-dives/token-standard.mdx
+++ b/docs-main/appdev/deep-dives/token-standard.mdx
@@ -294,13 +294,9 @@ Note that `AllocationRequest_Reject` and `AllocationRequest_Withdraw` should be 
 
 Calling the token standard choices from custom Daml code is useful when integrating one's own app workflows with the token standard. Example workflows relevant to a wallet provider are merging of holdings for a user to keep their ACS small, doing bulk transfers, or marking a user's action as activity of the wallet app.
 
-Splice releases the optional `splice-util-token-standard-wallet.dar` file, which packages common workflows that improve the operations of a wallet app. See its documentation below for the reference of the templates provided.
+Splice releases the optional `splice-util-token-standard-wallet.dar` file, which packages common workflows that improve the operations of a wallet app.
 
-<div className="toctree" maxdepth="1">
-
-../api/splice-util-token-standard-wallet/index
-
-</div>
+{/* TODO(#539): Port per-package reference for splice-util-token-standard-wallet into this site. */}
 
 ## API References
 
@@ -308,57 +304,37 @@ Refer to [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/
 
 ### Token Metadata
 
-> <div className="toctree" maxdepth="1">
->
-> Daml reference \<../api/splice-api-token-metadata-v1/index\> OpenAPI reference \<./openapi/token_metadata\>
->
-> </div>
+- Daml reference: [splice-api-token-metadata-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1)
+- OpenAPI reference: [Token Metadata Service](/reference/splice-token-metadata-service/get-registry-metadata-v1-info)
 
 ### Holding
 
 This allows implementation of a [Portfolio View](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md#wallet-client--portfolio-view).
 
-> <div className="toctree" maxdepth="1">
->
-> Daml reference \<../api/splice-api-token-holding-v1/index\>
->
-> </div>
+- Daml reference: [splice-api-token-holding-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1)
 
 ### Transfer Instruction
 
 This allows implementation of [Direct Peer-to-Peer / Free of Payment (FOP) Transfers](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md#direct-peer-to-peer--free-of-payment-fop-transfer-workflow).
 
-> <div className="toctree" maxdepth="1">
->
-> Daml reference \<../api/splice-api-token-transfer-instruction-v1/index\> OpenAPI reference \<./openapi/transfer_instruction\>
->
-> </div>
+- Daml reference: [splice-api-token-transfer-instruction-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1)
+- OpenAPI reference: [Transfer Instruction API](/reference/splice-transfer-instruction-api/post-registry-transfer-instruction-v1-transfer-factory)
 
 ### Allocation
 
 This allows implementation of [Delivery versus Payment (DVP) Transfer Workflows](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md#delivery-versus-payment-dvp-transfer-workflows), jointly with the Allocation Instruction and Allocation Request APIs below.
 
-> <div className="toctree" maxdepth="1">
->
-> Daml reference \<../api/splice-api-token-allocation-v1/index\> OpenAPI reference \<./openapi/allocation\>
->
-> </div>
+- Daml reference: [splice-api-token-allocation-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1)
+- OpenAPI reference: [Allocation API](/reference/splice-allocation-api/post-registry-allocations-v1-allocationid-choice-contexts-execute-transfer)
 
 ### Allocation Instruction
 
-> <div className="toctree" maxdepth="1">
->
-> Daml reference \<../api/splice-api-token-allocation-instruction-v1/index\> OpenAPI reference \<./openapi/allocation_instruction\>
->
-> </div>
+- Daml reference: [splice-api-token-allocation-instruction-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1)
+- OpenAPI reference: [Allocation Instruction API](/reference/splice-allocation-instruction-api/post-registry-allocation-instruction-v1-allocation-factory)
 
 ### Allocation Request
 
-> <div className="toctree" maxdepth="1">
->
-> Daml reference \<../api/splice-api-token-allocation-request-v1/index\>
->
-> </div>
+- Daml reference: [splice-api-token-allocation-request-v1](/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1)
 
 
 {/* COPIED_END */}

--- a/docs-main/appdev/get-started/choose-your-path.mdx
+++ b/docs-main/appdev/get-started/choose-your-path.mdx
@@ -109,11 +109,11 @@ Before starting development:
 
 <CardGroup cols={2}>
 
-<Card title="Daml SDK" icon="download">
+<Card title="Daml SDK" icon="download" href="/sdks-tools/sdks/daml-sdk">
   Install the SDK including Daml compiler and tools.
 </Card>
 
-<Card title="VS Code Extension" icon="code">
+<Card title="VS Code Extension" icon="code" href="https://marketplace.visualstudio.com/items?itemName=DigitalAssetHoldingsLLC.daml">
   Install the Daml VS Code extension for syntax highlighting and IDE support.
 </Card>
 

--- a/docs-main/appdev/get-started/whats-new.mdx
+++ b/docs-main/appdev/get-started/whats-new.mdx
@@ -5,9 +5,9 @@ description: "Pointers to release notes for Canton Network components"
 
 For changes shipping in each component, see the corresponding release notes:
 
-- **Splice and the Global Synchronizer** — [Release notes](/global-synchronizer/release-notes/release-notes), [release history](/global-synchronizer/release-notes/release-history), [weekly patch releases](/global-synchronizer/release-notes/weekly-patch-releases)
-- **Wallet SDK** — [Wallet SDK release notes](/integrations/wallet/release-notes)
-- **Canton and Daml SDK** — [GitHub releases (digital-asset/daml)](https://github.com/digital-asset/daml/releases)
+- **Splice and the Global Synchronizer** — [Splice release notes](/global-synchronizer/release-notes/splice), [release history](/global-synchronizer/release-notes/release-history), [weekly patch releases](/global-synchronizer/release-notes/weekly-patch-releases)
+- **Wallet SDK** — [Wallet SDK release notes](/integrations/release-notes/wallet-sdk)
+- **Canton and Daml SDK** — [Canton release notes](/global-synchronizer/release-notes/canton)
 - **CIPs** — [Canton Improvement Proposals](https://github.com/global-synchronizer-foundation/cips)
 
 ## Version compatibility

--- a/docs-main/appdev/modules/m2-migration-checklist.mdx
+++ b/docs-main/appdev/modules/m2-migration-checklist.mdx
@@ -42,8 +42,8 @@ If your app heavily relies on global state queries (e.g., "show all NFTs"), you'
 <Accordion title="Set up your development environment">
 
 - [ ] Install the [Daml SDK](/sdks-tools/sdks/daml-sdk)
-- [ ] Install VS Code with the Daml extension
-- [ ] Clone the [CN Quickstart](https://github.com/digital-asset/cn-quickstart) repository
+- [ ] Install VS Code with the [Daml extension](https://marketplace.visualstudio.com/items?itemName=DigitalAssetHoldingsLLC.daml)
+- [ ] Clone the [CN Quickstart](/sdks-tools/reference-projects/cn-quickstart)
 - [ ] Run `make setup && make build && make start` to verify your setup works
 
 </Accordion>
@@ -260,7 +260,7 @@ Avoid these common mistakes when migrating from Ethereum.
   Start building with Daml.
 </Card>
 
-<Card title="CN Quickstart" icon="rocket" href="https://github.com/digital-asset/cn-quickstart">
+<Card title="CN Quickstart" icon="rocket" href="/sdks-tools/reference-projects/cn-quickstart">
   Get hands-on with a working example.
 </Card>
 

--- a/docs-main/appdev/modules/m3-building-packaging.mdx
+++ b/docs-main/appdev/modules/m3-building-packaging.mdx
@@ -43,7 +43,7 @@ You'll get a whole lot of output. Under the header "DAR archive contains the fol
 3.  `*.hi` and `*.hie` files for each `*.daml` file
 4.  Some meta-inf and config files
 
-The first file is something like `intro7-1.0.0-887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625.dalf` which is the actual compiled package for the project. `*.dalf` files contain Daml-LF, which is Daml's intermediate language. The file contents are a binary encoded protobuf message from the [daml-lf schema](https://github.com/digital-asset/daml/tree/main/daml-lf/archive). Daml-LF is evaluated on the ledger by the Daml Engine, which is a JVM component that is part of tools like the IDE's script runner, the Sandbox, or proper production ledgers. If Daml-LF is to Daml what Java Bytecode is to Java, the Daml Engine is to Daml what the JVM is to Java.
+The first file is something like `intro7-1.0.0-887056cbb313b94ab9a6caf34f7fe4fbfe19cb0c861e50d1594c665567ab7625.dalf` which is the actual compiled package for the project. `*.dalf` files contain Daml-LF, which is Daml's intermediate language. The file contents are a binary encoded protobuf message defined by the [Daml-LF tooling in the `digital-asset/daml` repository](https://github.com/digital-asset/daml/tree/main/sdk/daml-lf). Daml-LF is evaluated on the ledger by the Daml Engine, which is a JVM component that is part of tools like the IDE's script runner, the Sandbox, or proper production ledgers. If Daml-LF is to Daml what Java Bytecode is to Java, the Daml Engine is to Daml what the JVM is to Java.
 
 ## Hashes and identifiers
 

--- a/docs-main/appdev/modules/m3-design-patterns.mdx
+++ b/docs-main/appdev/modules/m3-design-patterns.mdx
@@ -30,7 +30,7 @@ import DamlAppdevModulesM3DesignPatternsL92 from "/snippets/daml-docs/appdev_mod
 
 # Compose choices
 
-It's time to put everything you've learned so far together into a complete and secure Daml model for asset issuance, management, transfer, and trading. This application will have capabilities similar to the one in `/app-dev/bindings-java/quickstart`. In the process you will learn about a few more concepts:
+It's time to put everything you've learned so far together into a complete and secure Daml model for asset issuance, management, transfer, and trading. This application will have capabilities similar to the one in the [CN Quickstart](/sdks-tools/reference-projects/cn-quickstart). In the process you will learn about a few more concepts:
 
 - Daml projects, packages, and modules
 - Composition of transactions
@@ -387,7 +387,7 @@ One party kicks off the workflow by creating a `Pending` contract listing only t
 
 # Compose choices
 
-It's time to put everything you've learned so far together into a complete and secure Daml model for asset issuance, management, transfer, and trading. This application will have capabilities similar to the one in `/app-dev/bindings-java/quickstart`. In the process you will learn about a few more concepts:
+It's time to put everything you've learned so far together into a complete and secure Daml model for asset issuance, management, transfer, and trading. This application will have capabilities similar to the one in the [CN Quickstart](/sdks-tools/reference-projects/cn-quickstart). In the process you will learn about a few more concepts:
 
 - Daml projects, packages, and modules
 - Composition of transactions

--- a/docs-main/appdev/modules/m3-testing.mdx
+++ b/docs-main/appdev/modules/m3-testing.mdx
@@ -118,8 +118,6 @@ The first part of the summary is a list of each executed script. For each script
 
 The second part of the summary is the coverage report. It shows you how many templates and choices are tested by the complete set of scripts in the package, in proportion of the total number of templates and choices.
 
-To learn more about Daml test coverage, read the [Daml test coverage guide](/appdev/modules/m3-testing).
-
 ## Debug, trace, and stacktraces
 
 The above demonstrates nicely how to test the happy path, but what if a function doesn't behave as you expected? Daml has two functions that allow you to do fine-grained printf debugging: `debug` and `trace`. Both allow you to print something to StdOut if the code is reached. The difference between `debug` and `trace` is similar to the relationship between `abort` and `error`:
@@ -168,7 +166,7 @@ Once the sandbox is running, you can interact with it through the Ledger API (gR
 
 ### When to use a local Canton Network
 
-The [cn-quickstart](https://github.com/digital-asset/cn-quickstart) project includes a LocalNet configuration that runs a full Canton Network locally (participant, sequencer, mediator, and Splice applications). Use LocalNet instead of the sandbox when you need to test:
+The [CN Quickstart](/sdks-tools/reference-projects/cn-quickstart) project includes a LocalNet configuration that runs a full Canton Network locally (participant, sequencer, mediator, and Splice applications). Use LocalNet instead of the sandbox when you need to test:
 
 - Canton Coin transfers and traffic purchases
 - Wallet SDK integration

--- a/docs-main/appdev/quickstart/deploy-to-devnet.mdx
+++ b/docs-main/appdev/quickstart/deploy-to-devnet.mdx
@@ -153,40 +153,15 @@ The nginx proxy routes based on hostname. Default port is 80. MacOS
 users may need to change the validator port from 80 to 8080 to avoid
 `vmnetd` errors. See `vmnetd-error` in the Troubleshooting section.
 
-## Clone the Splice-Node Validator repository
+## Download the Splice node release bundle
 
-In `DevNet`, your Splice node validator runs locally and connects to the
-`DevNet` synchronizer.
+In `DevNet`, your Splice node validator runs locally and connects to the `DevNet` synchronizer. You will need the Splice node release bundle, which contains the Docker Compose files for the validator.
 
-Clone the correct version of the Splice-node repository and navigate to
-the validator Docker Compose directory. As of the writing of this
-document, the most up to date version is 0.5.8.
+<Note>
+Find the most recent Splice release on the [canton-network/splice releases page](https://github.com/canton-network/splice/releases). The version in the URL and filename below changes with each release — substitute the tag you want to install.
+</Note>
 
-<div class="note" markdown="1">
-
-<div class="title" markdown="1">
-
-Note
-
-</div>
-
-You can check for the most up to date release for yourself by navigating
-to [https://github.com/digital-asset/decentralized-canton-sync](https://github.com/digital-asset/decentralized-canton-sync). Click
-on "Main" then search through the `release-line` options.
-
-</div>
-
-![Release selection](/images/quickstart-devnet/devnet-decentralized-canton-sync-release-line-056.png)
-
-The following link downloads the `0.5.8 splice-node` release. Move the
-downloaded file to the location of your choice. (To download a different
-release, simply edit the version numbers in the URL).
-
-Click the link to download the splice node release:
-[https://github.com/digital-asset/decentralized-canton-sync/releases/download/v0.5.8/0.5.8_splice-node.tar.gz](https://github.com/digital-asset/decentralized-canton-sync/releases/download/v0.5.8/0.5.8_splice-node.tar.gz)
-
-Move the `splice-node` tarball to your desired location and then unzip
-it.
+Download the `splice-node` tarball for your chosen version (the bundle is published as a release asset, e.g. `<VERSION>_splice-node.tar.gz` on `https://github.com/canton-network/splice/releases/tag/<VERSION>`) and move it to your desired location, then unzip it.
 
 <ExternalCnQuickstartMainCnQuickstartRstCodeSdkDocsSharableSdkQuickstartOperateDeployQuickstartToDevnetBash174 />
 
@@ -259,7 +234,7 @@ In terminal, from the `/validator` directory run:
 Verify that the Splice version matches the splice-node version that you
 recently downloaded and unzipped. Minor Splice versions change on a
 regular basis. You may elect to hard code `SPLICE_VERSION` rather than
-saving the most recent version. e.g. `SPLICE_VERSION=0.5.8`
+saving the most recent version, e.g. `SPLICE_VERSION=0.6.4`
 
 ### Get the onboarding secret
 

--- a/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
+++ b/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
@@ -555,12 +555,12 @@ Note also that `Pod` restarts may happen during bringup, particularly if all hel
 
 The SV operators have decided to follow the following convention for all SV hostnames and URLs:
 
-- For DevNet, all hostnames should be in the format `&lt;service-name&gt;.sv-<enumerator>.dev.global.canton.network.<companyTLD>`, where:
-  - `&lt;service-name&gt;` is the name of the service, e.g., `sv`, `wallet`, `scan`
+- For DevNet, all hostnames should be in the format `<service-name>.sv-<enumerator>.dev.global.canton.network.<companyTLD>`, where:
+  - `<service-name>` is the name of the service, e.g., `sv`, `wallet`, `scan`
   - `<enumerator>` is a unique number for each SV node operated by the same organization, starting at 1, e.g. `sv-1` for the first node operated by an organization.
   - `<companyTLD>` is the top-level domain of the company operating the SV node, e.g. `digitalasset.com` for Digital Asset.
-- For TestNet, all hostnames should similarly be in the format `&lt;service-name&gt;.sv-<enumerator>.test.global.canton.network.<companyTLD>`.
-- For MainNet, all hostnames should be in the format all hostnames should be in the format `&lt;service-name&gt;.sv-<enumerator>.global.canton.network.<companyTLD>` (note that for MainNet, the name of the network, e.g. dev/test/main is ommitted from the hostname).
+- For TestNet, all hostnames should similarly be in the format `<service-name>.sv-<enumerator>.test.global.canton.network.<companyTLD>`.
+- For MainNet, all hostnames should be in the format all hostnames should be in the format `<service-name>.sv-<enumerator>.global.canton.network.<companyTLD>` (note that for MainNet, the name of the network, e.g. dev/test/main is ommitted from the hostname).
 
 Note that the reference ingress charts provided below do not fully satisfy these requirements, as they ommit the `enumerator` part of the hostname.
 
@@ -574,18 +574,18 @@ To keep the attack surface on your SV deployment and the Global Synchronizer sma
 
 Each SV is required to configure their cluster ingress to allow traffic from these IPs to be operational.
 
-- `https://wallet.sv.&lt;YOUR_HOSTNAME&gt;` should be routed to service `wallet-web-ui` in the `sv` namespace.
-- `https://wallet.sv.&lt;YOUR_HOSTNAME&gt;/api/validator` should be routed to `/api/validator` at port 5003 of service `validator-app` in the `sv` namespace.
-- `https://sv.sv.&lt;YOUR_HOSTNAME&gt;` should be routed to service `sv-web-ui` in the `sv` namespace.
-- `https://sv.sv.&lt;YOUR_HOSTNAME&gt;/api/sv` should be routed to `/api/sv` at port 5014 of service `sv-app` in the `sv` namespace.
-- `https://scan.sv.&lt;YOUR_HOSTNAME&gt;` should be routed to service `scan-web-ui` in the `sv` namespace.
-- `https://scan.sv.&lt;YOUR_HOSTNAME&gt;/api/scan` should be routed to `/api/scan` at port 5012 in service `scan-app` in the `sv` namespace.
-- `https://scan.sv.&lt;YOUR_HOSTNAME&gt;/registry` should be routed to `/registry` at port 5012 in service `scan-app` in the `sv` namespace.
-- `global-domain-&lt;SERIAL_ID&gt;-cometbft.sv.&lt;YOUR_HOSTNAME&gt;:26&lt;SERIAL_ID&gt;56` should be routed to port 26656 of service `global-domain-&lt;SERIAL_ID&gt;-cometbft-cometbft-p2p` in the `sv` namespace using the TCP protocol. Please note that cometBFT traffic is purely TCP. TLS is not supported so SNI host routing for these traffic is not possible.
-- `https://cns.sv.&lt;YOUR_HOSTNAME&gt;` should be routed to service `ans-web-ui` in the `sv` namespace.
-- `https://cns.sv.&lt;YOUR_HOSTNAME&gt;/api/validator` should be routed to `/api/validator` at port 5003 of service `validator-app` in the `sv` namespace.
-- `https://sequencer-&lt;SERIAL_ID&gt;.sv.&lt;YOUR_HOSTNAME&gt;` should be routed to port 5008 of service `global-domain-&lt;SERIAL_ID&gt;-sequencer` in the `sv` namespace.
-- `https://info.sv.&lt;YOUR_HOSTNAME&gt;` should be routed to service `info` in the `sv` namespace. This endpoint should be publicly accessible without any IP restrictions.
+- `https://wallet.sv.<YOUR_HOSTNAME>` should be routed to service `wallet-web-ui` in the `sv` namespace.
+- `https://wallet.sv.<YOUR_HOSTNAME>/api/validator` should be routed to `/api/validator` at port 5003 of service `validator-app` in the `sv` namespace.
+- `https://sv.sv.<YOUR_HOSTNAME>` should be routed to service `sv-web-ui` in the `sv` namespace.
+- `https://sv.sv.<YOUR_HOSTNAME>/api/sv` should be routed to `/api/sv` at port 5014 of service `sv-app` in the `sv` namespace.
+- `https://scan.sv.<YOUR_HOSTNAME>` should be routed to service `scan-web-ui` in the `sv` namespace.
+- `https://scan.sv.<YOUR_HOSTNAME>/api/scan` should be routed to `/api/scan` at port 5012 in service `scan-app` in the `sv` namespace.
+- `https://scan.sv.<YOUR_HOSTNAME>/registry` should be routed to `/registry` at port 5012 in service `scan-app` in the `sv` namespace.
+- `global-domain-<SERIAL_ID>-cometbft.sv.<YOUR_HOSTNAME>:26<SERIAL_ID>56` should be routed to port 26656 of service `global-domain-<SERIAL_ID>-cometbft-cometbft-p2p` in the `sv` namespace using the TCP protocol. Please note that cometBFT traffic is purely TCP. TLS is not supported so SNI host routing for these traffic is not possible.
+- `https://cns.sv.<YOUR_HOSTNAME>` should be routed to service `ans-web-ui` in the `sv` namespace.
+- `https://cns.sv.<YOUR_HOSTNAME>/api/validator` should be routed to `/api/validator` at port 5003 of service `validator-app` in the `sv` namespace.
+- `https://sequencer-<SERIAL_ID>.sv.<YOUR_HOSTNAME>` should be routed to port 5008 of service `global-domain-<SERIAL_ID>-sequencer` in the `sv` namespace.
+- `https://info.sv.<YOUR_HOSTNAME>` should be routed to service `info` in the `sv` namespace. This endpoint should be publicly accessible without any IP restrictions.
 
 <Warning>
 To keep the attack surface on your SV deployment and the Global Synchronizer small, please disallow ingress connections to all other services in your SV deployment. It should be assumed that opening up *any* additional port or service represents a security risk that needs to be carefully evaluated on a case-by-case basis.
@@ -674,7 +674,7 @@ Connectivity to the following destinations is required throughout operation to e
 Connectivity from the local scan app to the scan instances of all other SVs is required so that the scan app can backfill its data in a `BFT` fashion. It might also be required in the future to support the operation of the ordering layer (post CometBFT). To get a list of all current scan instances, you can query the `/api/scan/v0/scans` endpoint on any scan instances known to you. For example using the sponsor's scan instance (and with some optional post-processing using [jq](https://jqlang.org/)):
 
 ```bash
-curl https://scan.sv-1.&lt;TARGET_HOSTNAME&gt;/api/scan/v0/scans | jq -r '.scans.[].scans.[].publicUrl'
+curl https://scan.sv-1.<TARGET_HOSTNAME>/api/scan/v0/scans | jq -r '.scans.[].scans.[].publicUrl'
 ```
 
 <div id="helm-sv-wallet-ui">
@@ -690,7 +690,7 @@ In addition to above destinations, the SV node must be able to reach its onboard
 | Sponsor SV Sequencer | sequencer-\<S\>.sv-1.\<TARGET_HOSTNAME\>:443                             | HTTPS    | participant-\<S\>            |
 | Sponsor SV Scan      | scan.sv-1.\<TARGET_HOSTNAME\>:443                                        | HTTPS    | validator-app                |
 
-Note that you need to substitute both `&lt;TARGET_HOSTNAME&gt;` and `sv-1` in the above table to match the address of your SV onboarding sponsor. Note also that the address for the CometBft JSON RPC is configured in `cometbft-values.yaml` (under `stateSync.rpcServers`). Any onboarded SV can act as an SV onboarding sponsor.
+Note that you need to substitute both `<TARGET_HOSTNAME>` and `sv-1` in the above table to match the address of your SV onboarding sponsor. Note also that the address for the CometBft JSON RPC is configured in `cometbft-values.yaml` (under `stateSync.rpcServers`). Any onboarded SV can act as an SV onboarding sponsor.
 
 In general, connectivity to the sponsor SV (outside of scan) is only required during SV onboarding. Connectivity to the sponsor SV sequencer is required also for a limited transition time after onboarding during which the newly onboarded SV sequencer is not ready for use yet (60 seconds with the current Global Synchronizer configuration).
 

--- a/docs-main/global-synchronizer/splice-fundamentals/rewards-minting.mdx
+++ b/docs-main/global-synchronizer/splice-fundamentals/rewards-minting.mdx
@@ -115,7 +115,7 @@ Before creating a proposal, the beneficiary must have:
 
 1.  **Hosting on the validator node**: The beneficiary party must be hosted on the validator node where they want to delegate minting.
 2.  **Ledger API access**: Authenticated access to the validator's Ledger API endpoint, including:
-    - The Ledger API URL (e.g., `https://&lt;validator-host&gt;:<port>`)
+    - The Ledger API URL (e.g., `https://<validator-host>:<port>`)
     - Valid authentication credentials (OAuth2 token or other configured auth method)
     - The beneficiary's party ID
 3.  **The delegate's party ID**: The delegate is typically the validator operator party, but could be another internal party on the validator node.


### PR DESCRIPTION
## Summary

Closes #525, #520, #514, #512, #511, #492, #491, #485, #484, #483, #487, #488, #489.

13 link-related issues, 10 files touched, +50/-101 lines. All affected pages verified rendering 200 via local `mintlify dev`.

## Fixes

- **#525 / #520 — entity-encoded placeholders in code spans**: replace `&lt;`/`&gt;` with literal `<`/`>` inside backticks in `rewards-minting.mdx` and across 12 lines of `kubernetes-deployment.mdx` (hostname placeholders like `<service-name>`, `<YOUR_HOSTNAME>`, `<SERIAL_ID>`, `<TARGET_HOSTNAME>`).

- **#514 — Token Standard API References broken**: replace 6 pandoc-converted `<div className=\"toctree\">` blocks (which rendered as raw RST paths) with bulleted lists linking to the internal splice-daml/* package pages (added in #540) and to OpenAPI reference pages already in nav. The compiled-only `splice-util-token-standard-wallet` toctree is replaced with a TODO comment tracked in #539.

- **#512 — wallet kernel reference**: confirmed already resolved in `main` — line 96 links to `canton-network/splice-wallet-kernel` source and `/integrations/wallet/guidance`. No change needed.

- **#511 — stale splice bundle reference**: rewrite the \"Clone the Splice-Node Validator repository\" section to point to `canton-network/splice` (not the renamed-away `digital-asset/decentralized-canton-sync`), drop hardcoded version references, replace `<div class=\"note\">` with `<Note>` component, bump example `SPLICE_VERSION` to 0.6.4.

- **#492 — daml-lf schema link 404**: replace `digital-asset/daml/tree/main/daml-lf/archive` with `digital-asset/daml/tree/main/sdk/daml-lf` (verified exists at current `main`).

- **#491 — test coverage guide self-link**: drop the self-referencing link — the paragraph in `m3-testing` already IS the coverage guide.

- **#485 — What's New broken release-notes links**: point Splice release notes to `/global-synchronizer/release-notes/splice`, Wallet SDK to `/integrations/release-notes/wallet-sdk`, Canton/Daml SDK to `/global-synchronizer/release-notes/canton`.

- **#484 — Getting Help cards**: confirmed already resolved in `main` — Slack, Forum, and FAQ cards all have `href` attributes.

- **#483 — Choose Your Path Development Environment cards**: add `href` to \"Daml SDK\" and \"VS Code Extension\" cards (previously had none — clicking did nothing).

- **#487 — VS Code extension link**: add VS Code Marketplace link to the Daml extension reference in `m2-migration-checklist`.

- **#488 — CN Quickstart card → internal page**: switch CN Quickstart card href in `m2-migration-checklist#next-steps` from GitHub to `/sdks-tools/reference-projects/cn-quickstart`.

- **#489 — replace Sphinx-style CN Quickstart path with URL**: replace `/app-dev/bindings-java/quickstart` references in `m3-design-patterns` (both COPIED occurrences) with a link to the internal CN Quickstart page; switch the `m3-testing` `[cn-quickstart](github)` link to the internal page.

## Dependency note

The token-standard.mdx internal links to `/sdks-tools/api-reference/splice-daml/*` resolve only after #540 is merged. Pages still render either way; if you preview-test this PR before #540 lands, those links will 404.