### PR TITLE
Copied-content formatting fixes (7 issues)

### DIFF
--- a/docs-main/appdev/modules/m3-working-with-time.mdx
+++ b/docs-main/appdev/modules/m3-working-with-time.mdx
@@ -24,13 +24,13 @@ import DamlAppdevModulesM3WorkingWithTimeL67 from "/snippets/daml-docs/appdev_mo
 
 Contract time constraints may be implemented using either:
 
-- ledger time primitives (i.e. isLedgerTimeLT, isLedgerTimeLE, isLedgerTimeGT and isLedgerTimeGE) or assertions (i.e. assertWithinDeadline and assertDeadlineExceeded)
+- ledger time primitives (i.e. `isLedgerTimeLT`, `isLedgerTimeLE`, `isLedgerTimeGT` and `isLedgerTimeGE`) or assertions (i.e. `assertWithinDeadline` and `assertDeadlineExceeded`)
 
   > - the use of ledger time primitives and assertions do not constrain the time bound between transaction preparation and submission - e.g. they are suitable for workflows using external parties to sign transactions
 
-- or, by calling getTime
+- or, by calling `getTime`
 
-  > - calls to getTime constrain transaction preparation and submission workflows to be (by default) within 1 minute.
+  > - calls to `getTime` constrain transaction preparation and submission workflows to be (by default) within 1 minute.
   > - the 1 minute value is the default value for the ledger time record time tolerance parameter (a dynamic synchronizer parameter).
 
 The next subsections demonstrate how the following Coin and TransferProposal contracts can be modified to use different types of ledger time constraints to control when parties are allowed to perform ledger writes.

--- a/docs-main/appdev/reference/error-codes.mdx
+++ b/docs-main/appdev/reference/error-codes.mdx
@@ -8,8 +8,6 @@ import DamlDocsAppdevReferenceErrorCodesL76 from "/snippets/daml-docs/appdev_ref
 
 Canton returns structured error information through gRPC responses. Every error carries a machine-readable code, a category that determines the gRPC status code, and a human-readable description. You can use these components to build automated error handling in your application.
 
-## Error message format
-
 ## Machine-readable error details
 
 Each gRPC error response includes structured details following the [rich gRPC error model](https://cloud.google.com/apis/design/errors#error_details):
@@ -23,20 +21,22 @@ Each gRPC error response includes structured details following the [rich gRPC er
 Some errors are redacted for security. The API response omits sensitive details, but the full error message appears in server-side logs. Work with your operator if you need the complete error context.
 </Warning>
 
-## Error categories
-
 ## Retry strategy by category
 
-**Automatic retry (categories 1-3):**
-Categories 1, 2, and 3 represent transient conditions. Your application should retry these automatically. For category 1 (UNAVAILABLE), retry quickly -- a load balancer can handle this. For category 2 (ABORTED), use exponential backoff since the issue is resource contention. For category 3 (DEADLINE_EXCEEDED), retry a limited number of times and use command deduplication to avoid duplicate submissions.
+### Automatic retry (categories 1-3)
 
-**Fix and retry (categories 6-8):**
+Categories 1, 2, and 3 represent transient conditions. Your application should retry these automatically. For category 1 (UNAVAILABLE), retry quickly — a load balancer can handle this. For category 2 (ABORTED), use exponential backoff since the issue is resource contention. For category 3 (DEADLINE_EXCEEDED), retry a limited number of times and use command deduplication to avoid duplicate submissions.
+
+### Fix and retry (categories 6-8)
+
 These errors indicate a problem with the request itself. Category 6 (UNAUTHENTICATED) means your JWT token is missing or invalid. Category 7 (PERMISSION_DENIED) means the token lacks the required rights. Category 8 (INVALID_ARGUMENT) means the request is malformed regardless of system state. Fix the issue in your application or configuration before retrying.
 
-**State-dependent (categories 9-12):**
+### State-dependent (categories 9-12)
+
 These errors depend on the current state of the ledger. A `CONTRACT_NOT_FOUND` (category 11) might be expected in a multi-party workflow where another party archived the contract, or it might indicate an application bug. Your handling strategy depends on your application's logic.
 
-**Do not retry (categories 4, 5, 14):**
+### Do not retry (categories 4, 5, 14)
+
 These indicate internal errors, security issues, or unimplemented operations. Escalate to your operator or check server-side logs for details.
 
 ## Common error codes for app developers

--- a/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
+++ b/docs-main/global-synchronizer/deployment/kubernetes-deployment.mdx
@@ -668,13 +668,13 @@ Connectivity to the following destinations is required throughout operation to e
 
 | Destination  | Url                                                                              | Protocol | Source pod                   |
 |--------------|----------------------------------------------------------------------------------|----------|------------------------------|
-| CometBft P2P | CometBft p2p IPs and ports 26\<S\>16, 26\<S\>26, 26\<S\>36, 26\<S\>46, 26\<S\>56 | TCP      | global-domain-\<S\>-cometbft |
-| All SV Scans | all returned from [https://scan.sv-1](https://scan.sv-1).\<TARGET_HOSTNAME\>/api/scan/v0/scans      | HTTPS    | scan-app                     |
+| CometBft P2P | CometBft p2p IPs and ports `26<S>16`, `26<S>26`, `26<S>36`, `26<S>46`, `26<S>56` | TCP      | `global-domain-<S>-cometbft` |
+| All SV Scans | all returned from `https://scan.sv-1.<TARGET_HOSTNAME>/api/scan/v0/scans`        | HTTPS    | scan-app                     |
 
 Connectivity from the local scan app to the scan instances of all other SVs is required so that the scan app can backfill its data in a `BFT` fashion. It might also be required in the future to support the operation of the ordering layer (post CometBFT). To get a list of all current scan instances, you can query the `/api/scan/v0/scans` endpoint on any scan instances known to you. For example using the sponsor's scan instance (and with some optional post-processing using [jq](https://jqlang.org/)):
 
 ```bash
-curl https://scan.sv-1.&lt;TARGET_HOSTNAME&gt;/api/scan/v0/scans | jq -r '.scans.[].scans.[].publicUrl'
+curl https://scan.sv-1.<TARGET_HOSTNAME>/api/scan/v0/scans | jq -r '.scans.[].scans.[].publicUrl'
 ```
 
 <div id="helm-sv-wallet-ui">
@@ -685,12 +685,12 @@ In addition to above destinations, the SV node must be able to reach its onboard
 
 | Destination          | Url                                                                      | Protocol | Source pod                   |
 |----------------------|--------------------------------------------------------------------------|----------|------------------------------|
-| Sponsor SV           | sv.sv-1.\<TARGET_HOSTNAME\>:443                                          | HTTPS    | sv-app                       |
-| CometBft JSON RPC    | sv.sv-1.\<TARGET_HOSTNAME\>:443/api/sv/v0/admin/domain/cometbft/json-rpc | HTTPS    | global-domain-\<S\>-cometbft |
-| Sponsor SV Sequencer | sequencer-\<S\>.sv-1.\<TARGET_HOSTNAME\>:443                             | HTTPS    | participant-\<S\>            |
-| Sponsor SV Scan      | scan.sv-1.\<TARGET_HOSTNAME\>:443                                        | HTTPS    | validator-app                |
+| Sponsor SV           | `sv.sv-1.<TARGET_HOSTNAME>:443`                                          | HTTPS    | sv-app                       |
+| CometBft JSON RPC    | `sv.sv-1.<TARGET_HOSTNAME>:443/api/sv/v0/admin/domain/cometbft/json-rpc` | HTTPS    | `global-domain-<S>-cometbft` |
+| Sponsor SV Sequencer | `sequencer-<S>.sv-1.<TARGET_HOSTNAME>:443`                               | HTTPS    | `participant-<S>`            |
+| Sponsor SV Scan      | `scan.sv-1.<TARGET_HOSTNAME>:443`                                        | HTTPS    | validator-app                |
 
-Note that you need to substitute both `&lt;TARGET_HOSTNAME&gt;` and `sv-1` in the above table to match the address of your SV onboarding sponsor. Note also that the address for the CometBft JSON RPC is configured in `cometbft-values.yaml` (under `stateSync.rpcServers`). Any onboarded SV can act as an SV onboarding sponsor.
+Note that you need to substitute both `<TARGET_HOSTNAME>` and `sv-1` in the above table to match the address of your SV onboarding sponsor. Note also that the address for the CometBft JSON RPC is configured in `cometbft-values.yaml` (under `stateSync.rpcServers`). Any onboarded SV can act as an SV onboarding sponsor.
 
 In general, connectivity to the sponsor SV (outside of scan) is only required during SV onboarding. Connectivity to the sponsor SV sequencer is required also for a limited transition time after onboarding during which the newly onboarded SV sequencer is not ready for use yet (60 seconds with the current Global Synchronizer configuration).
 

--- a/docs-main/global-synchronizer/deployment/validator-docker-compose.mdx
+++ b/docs-main/global-synchronizer/deployment/validator-docker-compose.mdx
@@ -106,13 +106,13 @@ services:
 3)  Run the following command to start the validator node, and wait for it to become ready (could take a few minutes):
 
 > ```bash
-> ./start.sh -s "&lt;SPONSOR_SV_URL&gt;" -o "&lt;ONBOARDING_SECRET&gt;" -p "&lt;party_hint&gt;" -m "&lt;MIGRATION_ID&gt;" -w
-> ```text
+> ./start.sh -s "<SPONSOR_SV_URL>" -o "<ONBOARDING_SECRET>" -p "<party_hint>" -m "<MIGRATION_ID>" -w
+> ```
 >
 > Where:
 >
-> `&lt;party_hint&gt;` will be used as the prefix of the Party ID of your validator's administrator.
-> This must be of format `\<organization\>-\<function\>-\<enumerator\>`, e.g. `myCompany-myWallet-1`. It cannot be changed over time as it is part of the validator operator party ID.
+> `<party_hint>` will be used as the prefix of the Party ID of your validator's administrator.
+> This must be of format `<organization>-<function>-<enumerator>`, e.g. `myCompany-myWallet-1`. It cannot be changed over time as it is part of the validator operator party ID.
 
 Note that the validator may be stopped with the command `./stop.sh` and restarted again with the same `start.sh` command as above. Its data will be retained between invocations. In subseqent invocations, the secret itself may be left empty, but the `-o` is still mandatory, so a `-o ""` argument should be provided.
 
@@ -177,20 +177,12 @@ Once you have set up your OAuth provider, you need to configure it by setting th
 <td>The URL of your OIDC provider for obtaining the <code>openid-configuration</code>, will typically be <code>${AUTH_URL}/.well-known/openid-configuration</code>.</td>
 </tr>
 <tr className="even">
-<td><ul>
-<li>**LEDGER_API_AUTH_AUDIENCE</li>
-</ul></td>
-<td><blockquote>
-<p>The audience for the participant ledger API. e.g. <code>https://ledger_api.example.com</code>.** — This will set the <code>ledger-api.auth-services.target-audience</code> configuration for the participant.</p>
-</blockquote></td>
+<td>LEDGER_API_AUTH_AUDIENCE</td>
+<td>The audience for the participant ledger API, e.g. <code>https://ledger_api.example.com</code>. This sets the <code>ledger-api.auth-services.target-audience</code> configuration for the participant.</td>
 </tr>
 <tr className="odd">
-<td><ul>
-<li>**LEDGER_API_AUTH_SCOPE</li>
-</ul></td>
-<td><blockquote>
-<p>The scope for the participant ledger API.** — This will set the participant's <code>ledger-api.auth-services.target-scope</code> configuration. Optional</p>
-</blockquote></td>
+<td>LEDGER_API_AUTH_SCOPE</td>
+<td>The scope for the participant ledger API. This sets the participant's <code>ledger-api.auth-services.target-scope</code> configuration. Optional.</td>
 </tr>
 <tr className="even">
 <td>VALIDATOR_AUTH_AUDIENCE</td>
@@ -230,7 +222,7 @@ Once you have set up your OAuth provider, you need to configure it by setting th
 In order to enable auth in the deployment, add the `-a` flag to the `start.sh` command, as follows:
 
 ```bash
-./start.sh -s "&lt;SPONSOR_SV_URL&gt;" -o "&lt;ONBOARDING_SECRET&gt;" -p "&lt;party_hint&gt;" -m "&lt;MIGRATION_ID&gt;" -w -a
+./start.sh -s "<SPONSOR_SV_URL>" -o "<ONBOARDING_SECRET>" -p "<party_hint>" -m "<MIGRATION_ID>" -w -a
 ```
 
 If you have already deployed a non-authenticated validator on your machine, you can migrate it to an authenticated one by stopping the validator with `./stop.sh` and restarting it with the `-a` flag as above. The validator operator user will be automatically migrated, and the user indicated by the `WALLET_ADMIN_USER` variable will be associated with the validator operator party. If you have also onboarded other users onto your validator, those will not be automatically migrated, and you need to manually associate the OAuth users with their corresponding parties. In order to do that, first take note of the party IDs of all relevant users (do this before stopping the unauthenticated validator), e.g. by copying them from the top-right corner of their wallet UIs. Now for every user that you wish to migrate, follow the instructions for associating a user with a party in the Users, Parties and Wallets in the Splice Wallet section, but replace the admin party ID with the party ID which you wish to associate with each user.

--- a/docs-main/global-synchronizer/deployment/validator-kubernetes.mdx
+++ b/docs-main/global-synchronizer/deployment/validator-kubernetes.mdx
@@ -308,7 +308,7 @@ scanClient:
 #   scanType: "bft-custom"
 #   svNames: ["TRUSTED_SV"] # replace with trusted SV names(s)
 #   seedUrls: ["TRUSTED_SCAN_URL"] # replace with actual scan seed urls(s)
-#   threshold: &lt;TRUST_THRESHOLD&gt; # optional integer indicating the number of matching responses required for validation
+#   threshold: <TRUST_THRESHOLD> # optional integer indicating the number of matching responses required for validation
 
 # Mode 3: trust-single
 # Connects to a single trusted scan address.
@@ -351,7 +351,7 @@ synchronizer:
 # synchronizer:
 #   connectionType: "bft-custom"
 #   svNames: ["TRUSTED_SV"] # replace with trusted SV name(s)
-#   threshold: &lt;TRUST_THRESHOLD&gt; # optional integer indicating the number of matching responses required for validation
+#   threshold: <TRUST_THRESHOLD> # optional integer indicating the number of matching responses required for validation
 
 # Mode 3: trust-Single
 # Connects to a single specified sequencer URL.
@@ -399,15 +399,15 @@ The following routes should be configured in your cluster ingress controller.
 
 | Services                     | Port | Routes                                                                                                                                                                     |
 |------------------------------|------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `wallet-web-ui`              |      | `https://wallet.validator.&lt;YOUR_HOSTNAME&gt;`                                                                                                                                 |
-| `validator-app` `ans-web-ui` | 5003 | `https://wallet.validator.&lt;YOUR_HOSTNAME&gt;/api/validator` `https://cns.validator.&lt;YOUR_HOSTNAME&gt;`                                                                           |
-| `validator-app`              | 5003 | `https://cns.validator.&lt;YOUR_HOSTNAME&gt;/api/validator`                                                                                                                      |
-| `participant`                | 7575 | `https://&lt;YOUR_HOSTNAME&gt;/api/json-api` (optional, not required by the validator itself but if you want to access the ledger API yourself. You can change the route freely) |
+| `wallet-web-ui`              |      | `https://wallet.validator.<YOUR_HOSTNAME>`                                                                                                                                 |
+| `validator-app` `ans-web-ui` | 5003 | `https://wallet.validator.<YOUR_HOSTNAME>/api/validator` `https://cns.validator.<YOUR_HOSTNAME>`                                                                           |
+| `validator-app`              | 5003 | `https://cns.validator.<YOUR_HOSTNAME>/api/validator`                                                                                                                      |
+| `participant`                | 7575 | `https://<YOUR_HOSTNAME>/api/json-api` (optional, not required by the validator itself but if you want to access the ledger API yourself. You can change the route freely) |
 
-- `https://wallet.validator.&lt;YOUR_HOSTNAME&gt;` should be routed to service `wallet-web-ui` in the `validator` namespace
-- `https://wallet.validator.&lt;YOUR_HOSTNAME&gt;/api/validator` should be routed to `/api/validator` at port 5003 of service `validator-app` in the `validator` namespace
-- `https://cns.validator.&lt;YOUR_HOSTNAME&gt;` should be routed to service `ans-web-ui` in the `validator` namespace
-- `https://cns.validator.&lt;YOUR_HOSTNAME&gt;/api/validator` should be routed to `/api/validator` at port 5003 of service `validator-app` in the `validator` namespace
+- `https://wallet.validator.<YOUR_HOSTNAME>` should be routed to service `wallet-web-ui` in the `validator` namespace
+- `https://wallet.validator.<YOUR_HOSTNAME>/api/validator` should be routed to `/api/validator` at port 5003 of service `validator-app` in the `validator` namespace
+- `https://cns.validator.<YOUR_HOSTNAME>` should be routed to service `ans-web-ui` in the `validator` namespace
+- `https://cns.validator.<YOUR_HOSTNAME>/api/validator` should be routed to `/api/validator` at port 5003 of service `validator-app` in the `validator` namespace
 
 <Warning>
 To keep the attack surface on your validator deployment small, please disallow ingress connections to all other services in your validator deployment. It should be assumed that opening up *any* additional port or service represents a security risk that needs to be carefully evaluated on a case-by-case basis. In addition, it is recommended to restrict access to above services to a limited number of explicitly trusted IP address ranges.

--- a/docs-main/global-synchronizer/production-operations/sv-security.mdx
+++ b/docs-main/global-synchronizer/production-operations/sv-security.mdx
@@ -73,11 +73,13 @@ Save this output to a file, e.g., `cometbft-governance-keys.json`.
 
 You inject the externally generated CometBFT governance key into the SV app via storing it in a k8s secret named `splice-app-sv-cometbft-governance-key`.
 
-Assuming that your SV deployment resides in the `sv` namespace, use the following command to create the secret from the JSON file generated above: :
+Assuming that your SV deployment resides in the `sv` namespace, use the following command to create the secret from the JSON file generated above:
 
-    kubectl create secret --namespace sv generic splice-app-sv-cometbft-governance-key \
-      --from-literal=publicKey="$(jq -r .public cometbft-governance-keys.json)" \
-      --from-literal=privateKey="$(jq -r .private cometbft-governance-keys.json)"
+```bash
+kubectl create secret --namespace sv generic splice-app-sv-cometbft-governance-key \
+  --from-literal=publicKey="$(jq -r .public cometbft-governance-keys.json)" \
+  --from-literal=privateKey="$(jq -r .private cometbft-governance-keys.json)"
+```
 
 To instruct the SV app to use the externally managed CometBFT governance key instead of generating a fresh one itself, set the `cometBFT.externalGovernanceKey` value in the `splice-sv-node` Helm chart to `true`. (You can comment out the respective line in `splice-node/examples/sv-helm/sv-values.yaml`.)
 


### PR DESCRIPTION
## Summary

Closes #522, #521, #519, #518, #517, #515, #490.

7 formatting bugs across 6 files. All affected pages verified rendering 200 via local `mintlify dev`.

## Fixes

- **#522 — malformed code in External management of CometBFT governance key** (`sv-security.mdx`): a `kubectl create secret` command was 4-space-indented (RST literal-block style) and Mintlify rendered it as a flowing paragraph. Wrapped it in a fenced ` ```bash ` block.

- **#521 — malformed code in Configuring the Cluster Egress** (`kubernetes-deployment.mdx`): egress destination tables had escaped angle brackets in cells (e.g. `26\<S\>16`) and HTML-entity placeholders (`&lt;TARGET_HOSTNAME&gt;`) in a bash code block. Replaced with backticked literals (`` `26<S>16` ``, etc.).

- **#519 — escaped quotes in Validator Users example**: confirmed not actionable. The `\"` escapes are required shell syntax for `--data-raw "{\"party_id\":\"$PARTY_ID\"…}"` (the outer double quotes allow `$PARTY_ID`/`$USER` to expand; switching to single quotes would break interpolation; `jq` or heredoc alternatives would rewrite the example significantly). I'd recommend closing the issue with this explanation when the PR merges.

- **#518 — formatting in Configuring the Cluster Ingress** (`validator-kubernetes.mdx`): `&lt;`/`&gt;` HTML entities inside code spans rendered as literal `&lt;YOUR_HOSTNAME&gt;` strings. Replaced with literal `<>` inside backticks across the table and the bullet list under it; also fixed two yaml-code-block lines with the same entity issue.

- **#517 — Docker Configuring Authentication has stray env vars** (`validator-docker-compose.mdx`): pandoc had split markdown `**bold**` across two `<td>` cells, leaving env var names wrapped in `<ul><li>**…</ul>` with the closing `**` stranded on the other side of the row. Flattened the two affected rows to plain `<td>` cells. Also fixed `&lt;`/`&gt;` HTML entities in the `start.sh` example and removed a stray ` ```text ` fence label.

- **#515 — Retry strategy by category needs formatting** (`error-codes.mdx`): removed two empty H2 headings (`## Error message format`, `## Error categories`) that orphaned the strategy section. Promoted the four bold-labelled `**Automatic retry**`-style paragraphs to proper `### H3` subheadings under "Retry strategy by category" so they appear in the right-hand TOC.

- **#490 — Daml primitives shown as plain text** (`m3-working-with-time.mdx`): wrapped `isLedgerTimeLT`, `isLedgerTimeLE`, `isLedgerTimeGT`, `isLedgerTimeGE`, `assertWithinDeadline`, `assertDeadlineExceeded`, and `getTime` in backticks so they render as code identifiers rather than prose words.

## Merge note

Some lines touched in `kubernetes-deployment.mdx` (Cluster Egress table) and `validator-docker-compose.mdx` may conflict with #541 (Group B's entity-fix sweep). Conflicts are small and compatible — both branches replace HTML entities with literal `<>` on adjacent lines.