### PR TITLE
docs.json nav restructure (4 issues)

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -148,8 +148,7 @@
             "group": "Get Started",
             "pages": [
               "appdev/get-started/choose-your-path",
-              "appdev/get-started/whats-new",
-              "appdev/get-started/upgrading-from-previous-versions"
+              "appdev/get-started/whats-new"
             ]
           },
           {
@@ -251,11 +250,16 @@
               "appdev/deep-dives/composition-multi-party",
               "appdev/deep-dives/decentralization",
               "appdev/deep-dives/multi-hosting",
-              "appdev/deep-dives/external-signing",
-              "appdev/deep-dives/external-signing-onboarding",
-              "appdev/deep-dives/external-signing-transactions",
-              "appdev/deep-dives/external-signing-topology",
-              "appdev/deep-dives/external-signing-hashing-algorithm",
+              {
+                "group": "External Signing",
+                "pages": [
+                  "appdev/deep-dives/external-signing",
+                  "appdev/deep-dives/external-signing-onboarding",
+                  "appdev/deep-dives/external-signing-transactions",
+                  "appdev/deep-dives/external-signing-topology",
+                  "appdev/deep-dives/external-signing-hashing-algorithm"
+                ]
+              },
               "appdev/deep-dives/performance-optimization",
               "appdev/deep-dives/manage-daml-parties",
               "appdev/deep-dives/contracts-and-transactions-in-java",
@@ -369,6 +373,7 @@
               "global-synchronizer/deployment/sv-network-resets",
               "global-synchronizer/production-operations/sv-security",
               "global-synchronizer/production-operations/sv-upgrades",
+              "global-synchronizer/production-operations/sv-major-upgrade",
               "global-synchronizer/production-operations/logical-synchronizer-upgrade",
               "global-synchronizer/deployment/sv-operations",
               "global-synchronizer/deployment/sv-scratchnet"
@@ -403,7 +408,6 @@
               "global-synchronizer/production-operations/key-metrics",
               "global-synchronizer/production-operations/splice-metrics-overview",
               "global-synchronizer/production-operations/validator-major-upgrade",
-              "global-synchronizer/production-operations/sv-major-upgrade",
               "global-synchronizer/production-operations/performance-optimization",
               "global-synchronizer/production-operations/key-management",
               "global-synchronizer/production-operations/party-management",
@@ -601,12 +605,12 @@
               {
                 "group": "Splice APIs",
                 "pages": [
+                  "sdks-tools/api-reference/splice-architecture",
                   "sdks-tools/api-reference/splice-apis",
                   "sdks-tools/api-reference/splice-overview",
                   "sdks-tools/api-reference/splice-http-apis",
                   "sdks-tools/api-reference/splice-daml-apis",
                   "sdks-tools/api-reference/splice-daml-models",
-                  "sdks-tools/api-reference/splice-architecture",
                   {
                     "group": "Scan APIs",
                     "pages": [


### PR DESCRIPTION
## Summary

Closes #528, #486, #479, #495.

Single `docs.json` change (+13/-9) addressing four nav restructure issues. Verified with local `mintlify dev`: nav renders cleanly, all affected URLs return 200.

## Fixes

- **#528 — move `sv-major-upgrade` to Super Validator Deployment**: moved `global-synchronizer/production-operations/sv-major-upgrade` out of the "Production Operations" group and into "Super Validator Deployment", positioned next to `sv-upgrades` and `logical-synchronizer-upgrade` (the existing upgrade-flow entries). The issue suggested placing it "under 'How to Bootstrap a Network'", but no such subgroup exists in the SV Deployment nav today — I placed it with the existing upgrade entries as the closest logical fit. **If the intent was to create a new "How to Bootstrap a Network" subgroup, please flag and I'll do that as a follow-up.**

- **#486 — drop "Upgrading from Previous Versions" from App Dev TOC**: removed `appdev/get-started/upgrading-from-previous-versions` from the "Get Started" group. Per the issue, the content is too sparse to be useful. The `.mdx` file is left in place — direct URL access still works for anyone with a saved link — but the page is no longer surfaced in nav until it has more useful content.

- **#479 — `splice-architecture` as first item in Splice APIs nav**: moved `sdks-tools/api-reference/splice-architecture` to the top of the "Splice APIs" group under "SDKs and Tools > API Reference", matching the "After" mockup in the issue.

- **#495 — consolidate External Signing TOC**: wrapped the five external-signing pages (`external-signing`, `-onboarding`, `-transactions`, `-topology`, `-hashing-algorithm`) in an "External Signing" sub-group so they collapse into one expanding TOC entry instead of taking five sibling lines under Deep Dives.