### PR TITLE
Remove stray editorial content (3 issues)

### DIFF
--- a/docs-main/appdev/quickstart/prerequisites.mdx
+++ b/docs-main/appdev/quickstart/prerequisites.mdx
@@ -26,8 +26,6 @@ This guide walks through the installation and `LocalNet` deployment of the CN Qu
 
 Access to the [CN-Quickstart GitHub repository](https://github.com/digital-asset/cn-quickstart) is public.  It does pull some artifacts provided by Digital Asset.
 
-[Contact us](https://www.digitalasset.com/contact-us?comments=I%27m%20requesting%20access%20to%20jFrog) if you need access or additional support.
-
 The CN Quickstart is a Dockerized application and requires [Docker Desktop](https://www.docker.com/products/docker-desktop/). We recommend allocating 8 GB of memory to Docker Desktop. Allocate additional resources if you witness unhealthy containers, if possible. Decline Observability if your machine does not have sufficient memory.
 
 Other requirements include:

--- a/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
+++ b/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
@@ -797,13 +797,6 @@ The certificate is explicitly provided, as the self-signed test certificates are
 2.  The administration API should be secured using client certificates as described in TLS documentation section.
 3.  The Public API needs to be properly secured using TLS. Please follow the corresponding instructions.
 
-### Next steps
-
-The above configuration provides you with an initial setup. Without going into details, the next steps would be:
-
-1.  Control who can join the Synchronizer by configuring the Synchronizer to be permissioned (default is "everyone can join").
-2.  Create high availability setups for ref:your synchronizer \ or ref:your participants \.
-
 ## Multi-node setup
 
 If desired, you can run many nodes in the same process. This is convenient for testing and demonstration purposes. You can either do this by listing several node configurations in the same configuration file or by invoking the Canton process with several separate configuration files (which get merged together).

--- a/docs-main/global-synchronizer/production-operations/key-management.mdx
+++ b/docs-main/global-synchronizer/production-operations/key-management.mdx
@@ -132,14 +132,11 @@ This page explains how to limit the usage of cryptographic keys of a Canton node
 ### Signing key usage
 Canton defines the following key usages for signing keys:
 
-Link to appropriate reference page \<[https://github.com/DACH-NY/canton/issues/25832](https://github.com/DACH-NY/canton/issues/25832)\>
-
 - `Namespace`: a key that defines a node's identity and signs topology requests (see namespace key management)
 - `SequencerAuthentication`: a key that authenticates members of the network towards a sequencer
 - `Protocol`: a key that signs various structures as part of the synchronization protocol execution
 
 #### Restrict the usage of a signing key
-fix `deleting-canton-keys` and other references in `key_management.rst` \<[https://github.com/DACH-NY/canton/issues/26155](https://github.com/DACH-NY/canton/issues/26155)\>
 
 Set the `usage` parameter with the desired usages when you generate a new key.
 
@@ -183,8 +180,6 @@ All the keys that have been assigned at least one of the usages specified in `fi
 As described in the identity management page, Canton uses topology transactions to manage identities, and these transactions are signed by keys with `Namespace` usage. Namespace key management shows that you can create intermediate keys to sign topology transactions, thereby limiting exposure of the root namespace key. These intermediate keys can be further restricted in terms of which kind of topology transactions they can sign using fine-grained delegation restrictions.
 
 Canton defines the following restrictions for namespace keys:
-
-Link to appropriate reference page and remove start/end markers in `topology.proto` \<[https://github.com/DACH-NY/canton/issues/25832](https://github.com/DACH-NY/canton/issues/25832)\>
 
 ``` none
 // the key can sign all currently known mappings and all mappings that will be added in future releases
@@ -235,11 +230,6 @@ By default, the Canton node creates a root namespace key during the initializati
 If a Canton node is configured to use a KMS system, then the root key can be administratively isolated, using the KMS Administration controls to remove node access to the root key. As the root key is only required when authorizing a new intermediate key or revoking an existing authorization, it is sufficient to just selectively allow the node to access the key only whenever such operations are performed.
 
 Only the root key can be isolated. All the other keys are essential for Canton to operate correctly. Optionally, the intermediate key can also be isolated but will have to be turned on and off as needed during administrative operations such as uploading DARs or adding parties.
-
-[\#25262: Improve how to identify and disable root keys](https://github.com/DACH-NY/canton/issues/25262)
-
-- Explain how to identify the root key (look up what the root key is and how to find it in the KMS)
-- Explain how to disable access to the root key in Cloud KMS.
 
 ### Offline Root Namespace Key
 A more secure way to manage the root namespace key is to use an offline root namespace key. In this case, the root namespace key is stored in a secure, possibly air gapped location, inaccessible from the Canton node.


### PR DESCRIPTION
## Summary

Closes #493, #529, #419.

Three removals of editorial cruft that leaked from upstream RST sources into the rendered docs. 19 lines removed across 3 files.
## Fixes

- **#493** — delete the "Contact us if you need access or additional support." line from `appdev/quickstart/prerequisites.mdx`. The CN Quickstart repo is public and the jFrog access prompt no longer applies.

- **#529** — remove four embedded canton-repo issue references that rendered as malformed-link prose in `global-synchronizer/production-operations/key-management.mdx` (each was an upstream Sphinx `.. todo::` directive that converted to angle-bracket-wrapped GitHub URLs):
  - "Link to appropriate reference page" in the Signing key usage section
  - "fix `deleting-canton-keys` and other references in `key_management.rst`" in the Restrict the usage of a signing key section
  - "Link to appropriate reference page and remove start/end markers in `topology.proto`" in the Namespace key delegation restrictions section
  - "[#25262: Improve how to identify and disable root keys]" plus its two-bullet description in the Online Root Namespace Key section

  The hidden MDX `{/* TODO */}` comment at line 64 (referencing canton issue #27699) is left in place — it's a hidden authoring note, not user-visible.

- **#419** — remove the out-of-place "### Next steps" subsection from `global-synchronizer/canton-console/getting-started-tutorial.mdx`. Buried inside "Setting up a Synchronizer > Using Microservices" with broken RST `:ref:` link syntax (`ref:your synchronizer \`). The two bullets had no working links.

## Follow-up

The content gaps that the removed TODOs flagged are tracked in **#544** so the missing reference pages and HA-setup docs can be backfilled in a future PR.

## Note on COPIED divergence

All three deletions are inside `{/* COPIED_START */}` blocks (verbatim-from-upstream content). The removed editorial notes don't exist in user-facing form in the upstream Sphinx render (they're auto-stripped by Sphinx's `.. todo::` handling); they leaked here because the RST → MDX converter treats them as regular prose. If upstream re-imports happen, these strays could re-appear and need the same treatment.