### PR TITLE
Update Development Stack Overview diagram (#482)

### DIFF
--- a/docs-main/appdev/get-started/choose-your-path.mdx
+++ b/docs-main/appdev/get-started/choose-your-path.mdx
@@ -66,7 +66,7 @@ The developer documentation is organized into progressive modules:
 
 ## Development Stack Overview
 
-Canton development involves these components:
+Canton Network development involves these components:
 
 ```mermaid
 flowchart TB
@@ -76,8 +76,8 @@ flowchart TB
         SC[Smart Contracts<br>Daml]
     end
 
-    subgraph Canton[Canton Infrastructure]
-        PART[Participant Node]
+    subgraph Canton[Canton Network Infrastructure]
+        PART[Validator Node]
         PQS[PQS<br>SQL queries]
         SYNC[Synchronizer]
     end
@@ -85,6 +85,7 @@ flowchart TB
     FE --> BE
     BE --> PART
     BE --> PQS
+    PQS --> PART
     PART <--> SYNC
     SC --> PART
 ```


### PR DESCRIPTION
## Summary

Closes #482.

Updates the mermaid diagram in `choose-your-path.mdx` per the issue:

- Prose lede: "Canton development involves these components" → "Canton Network development involves these components".
- Subgraph label: "Canton Infrastructure" → "Canton Network Infrastructure".
- Node label: "Participant Node" → "Validator Node".
- Added the missing `PQS --> PART` edge.