### PR TITLE
Fix synchronizer prerequisite link

### DIFF
--- a/docs-main/global-synchronizer/extension-synchronizers/deployment.mdx
+++ b/docs-main/global-synchronizer/extension-synchronizers/deployment.mdx
@@ -18,7 +18,7 @@ Before you begin:
 - PostgreSQL 14+ (managed service recommended for production)
 - TLS certificates for the sequencer endpoint
 - Canton release artifacts (Docker images or JARs)
-- Familiarity with [Canton's synchronizer architecture](/overview/learn/global-synchronizer-architecture)
+- Familiarity with [Canton's synchronizer architecture](/overview/reference/synchronizer-overview)
 
 ## Ordering backends
 


### PR DESCRIPTION
## Summary

Fixes #534.

Updates the Extension Synchronizer deployment prerequisite link so “Canton's synchronizer architecture” points to the general Synchronizer overview instead of the Global Synchronizer-specific architecture page.

## Screenshots

| Before | After |
| --- | --- |
| ![Before: clicking the prerequisite link reaches the Global Synchronizer Architecture page](https://raw.githubusercontent.com/canton-network/cf-docs/ef915b9fa6af2d195dd0bd535dbb00a05190e574/.github/pr-screenshots/cf-docs-issue-534/before.png) | ![After: clicking the prerequisite link reaches the general Synchronizer page](https://raw.githubusercontent.com/canton-network/cf-docs/ef915b9fa6af2d195dd0bd535dbb00a05190e574/.github/pr-screenshots/cf-docs-issue-534/after.png) |

The link text is unchanged, so these screenshots show the navigation result. Before, the prerequisite lands on the Global Synchronizer-specific architecture page. After, it lands on the general Synchronizer overview page.

## Validation

- `direnv exec . git diff --check`
- Targeted grep confirmed the prerequisite links to `/overview/reference/synchronizer-overview`
- Confirmed `docs-main/overview/reference/synchronizer-overview.mdx` exists
- `direnv exec .. npx mintlify validate` from `docs-main`
- Local Mintlify previews for `origin/main` and this branch were run one at a time on `localhost:3078`; Chromium screenshot verification confirmed the old and new link destinations.
