### PR TITLE
Wire Getting Help Slack card

### DIFF
--- a/docs-main/appdev/get-started/choose-your-path.mdx
+++ b/docs-main/appdev/get-started/choose-your-path.mdx
@@ -128,9 +128,8 @@ Ready to build? [Module 4: Building Applications](/appdev/modules/m4-building-ap
 
 <CardGroup cols={3}>
 
-{/* TODO: Add Slack link once available */}
-<Card title="Community Slack" icon="slack" href="/shared/support-channels">
-  #gsf-global-synchronizer-appdev channel
+<Card title="Community Slack" icon="slack" href="mailto:cf-global-synchronize-aaaapqznpatdmupdm5thaarsly@daholdings.slack.com">
+  #cf-global-synchronizer-appdev (Slack)
 </Card>
 
 <Card title="Forum" icon="comments" href="https://forum.canton.network/">

--- a/docs-main/appdev/get-started/choose-your-path.mdx
+++ b/docs-main/appdev/get-started/choose-your-path.mdx
@@ -129,7 +129,7 @@ Ready to build? [Module 4: Building Applications](/appdev/modules/m4-building-ap
 <CardGroup cols={3}>
 
 <Card title="Community Slack" icon="slack" href="mailto:cf-global-synchronize-aaaapqznpatdmupdm5thaarsly@daholdings.slack.com">
-  #cf-global-synchronizer-appdev (Slack)
+  Email a request to join the app developer Slack channel.
 </Card>
 
 <Card title="Forum" icon="comments" href="https://forum.canton.network/">


### PR DESCRIPTION
## Summary

Fixes #484.

Updates the Getting Help Slack card to use the Slack contact provided in the issue while making the visible card copy say it emails a request to join, so the mailto action is clear. The Forum card already points at `https://forum.canton.network/` on current `main`.

## Screenshots

Not included: this is a small card href/text correction with no layout change.

## Validation

- `direnv exec . git diff --check`
- Targeted grep confirmed the mailto contact and email-join-request copy are present
- Targeted grep confirmed the old `#cf-global-synchronizer-appdev`, `#gsf-global-synchronizer-appdev`, and Slack TODO visible text are absent
- `direnv exec .. npx mintlify validate` from `docs-main`