### PR TITLE
hide visible issue urls

### DIFF
--- a/docs-main/global-synchronizer/extension-synchronizers/synchronizer-operations.mdx
+++ b/docs-main/global-synchronizer/extension-synchronizers/synchronizer-operations.mdx
@@ -430,7 +430,7 @@ If you encounter issues, refer to the troubleshooting guide.
 
 <div className="todo">
 
-#\. Link the reference documentation. \<[https://github.com/DACH-NY/canton/issues/25963](https://github.com/DACH-NY/canton/issues/25963)\>
+{/* Link the reference documentation. \<[https://github.com/DACH-NY/canton/issues/25963](https://github.com/DACH-NY/canton/issues/25963)\> */}
 
 </div>
 
@@ -553,7 +553,7 @@ The reverse procedure is documented in the Mediator decommissioning section.
 
 <div className="todo">
 
-#\. Link the reference documentation. \<[https://github.com/DACH-NY/canton/issues/25832](https://github.com/DACH-NY/canton/issues/25832)\>
+{/* Link the reference documentation. \<[https://github.com/DACH-NY/canton/issues/25832](https://github.com/DACH-NY/canton/issues/25832)\> */}
 
 </div>
 
@@ -593,13 +593,13 @@ You can set several dynamic parameters at the same time:
 
 <div className="todo">
 
-#\. Link to reference with all dynamic synchronizer parameters
+{/* Link to reference with all dynamic synchronizer parameters */}
 
 </div>
 
 <div className="todo">
 
-\<[https://github.com/DACH-NY/canton/issues/25684](https://github.com/DACH-NY/canton/issues/25684)\> \#. Explain the concept of synchronizer owner and that for changes to become affective one needs a threshold of them to submit the same proposal
+{/* \<[https://github.com/DACH-NY/canton/issues/25684](https://github.com/DACH-NY/canton/issues/25684)\> \#. Explain the concept of synchronizer owner and that for changes to become affective one needs a threshold of them to submit the same proposal */}
 
 </div>
 
@@ -758,7 +758,7 @@ Top ups must be submitted by a quorum of Sequencers to become effective. This is
 
 <div className="todo">
 
-\<[https://github.com/DACH-NY/canton/issues/25832](https://github.com/DACH-NY/canton/issues/25832)\> \#. Link to the reference documentation of the `SequencerSynchronizerState` topology mapping above.
+{/* \<[https://github.com/DACH-NY/canton/issues/25832](https://github.com/DACH-NY/canton/issues/25832)\> \#. Link to the reference documentation of the `SequencerSynchronizerState` topology mapping above. */}
 
 </div>
 
@@ -1049,7 +1049,7 @@ sequencers {
 
 <div className="todo">
 
-#\. Link the reference documentation. \<[https://github.com/DACH-NY/canton/issues/26126](https://github.com/DACH-NY/canton/issues/26126)\>
+{/* Link the reference documentation. \<[https://github.com/DACH-NY/canton/issues/26126](https://github.com/DACH-NY/canton/issues/26126)\> */}
 
 </div>
 
@@ -1139,7 +1139,7 @@ Transport Layer Security (TLS) is enabled by default for the external endpoint a
 
 <div className="todo">
 
-#\. Link the reference documentation. \<[https://github.com/DACH-NY/canton/issues/26126](https://github.com/DACH-NY/canton/issues/26126)\>
+{/* Link the reference documentation. \<[https://github.com/DACH-NY/canton/issues/26126](https://github.com/DACH-NY/canton/issues/26126)\> */}
 
 </div>
 
@@ -1184,7 +1184,7 @@ There are other (local) configuration parameters under `config` that can be chan
 
 <div className="todo">
 
-#\. Link the reference documentation. \<[https://github.com/DACH-NY/canton/issues/26126](https://github.com/DACH-NY/canton/issues/26126)\>
+{/* Link the reference documentation. \<[https://github.com/DACH-NY/canton/issues/26126](https://github.com/DACH-NY/canton/issues/26126)\> */}
 
 </div>
 
@@ -1449,7 +1449,7 @@ In the case of a restore, a participant can replay missing data from the synchro
 
 <div className="todo">
 
-#\. Ability to recover from partial data loss on a synchronizer.
+{/* Ability to recover from partial data loss on a synchronizer. */}
 
 </div>
 

--- a/docs-main/global-synchronizer/production-operations/monitoring-setup.mdx
+++ b/docs-main/global-synchronizer/production-operations/monitoring-setup.mdx
@@ -114,7 +114,7 @@ create database index2db;
 
 Run the synchronizer with the `--log-profile container` that writes plain text to standard out at debug level.
 
-#\. Add examples here \<[https://github.com/DACH-NY/canton/issues/23872](https://github.com/DACH-NY/canton/issues/23872)\>
+{/* Add examples here \<[https://github.com/DACH-NY/canton/issues/23872](https://github.com/DACH-NY/canton/issues/23872)\> */}
 
 #### Participant Setup
 

--- a/docs-main/global-synchronizer/production-operations/node-backup-restore.mdx
+++ b/docs-main/global-synchronizer/production-operations/node-backup-restore.mdx
@@ -13,7 +13,7 @@ In the case of a restore, a participant can replay missing data from the synchro
 
 <div className="todo">
 
-#\. Ability to recover from partial data loss on a synchronizer.
+{/* Ability to recover from partial data loss on a synchronizer. */}
 
 </div>
 

--- a/docs-main/global-synchronizer/reference/canton-configuration-guide.mdx
+++ b/docs-main/global-synchronizer/reference/canton-configuration-guide.mdx
@@ -125,7 +125,7 @@ _shared {
 
 Such a definition can subsequently be referenced in the actual node definition:
 
-#\. Add examples here \<[https://github.com/DACH-NY/canton/issues/23873](https://github.com/DACH-NY/canton/issues/23873)\>
+{/* Add examples here \<[https://github.com/DACH-NY/canton/issues/23873](https://github.com/DACH-NY/canton/issues/23873)\> */}
 
 ```hocon
 canton {


### PR DESCRIPTION
Hides previously visible issue URLs with MDX comment syntax
removes small `rst` "#\." residue 