### PR TITLE
resolve issue 511

### DIFF
--- a/docs-main/appdev/quickstart/deploy-to-devnet.mdx
+++ b/docs-main/appdev/quickstart/deploy-to-devnet.mdx
@@ -155,36 +155,23 @@ users may need to change the validator port from 80 to 8080 to avoid
 
 ## Download the Splice node release bundle
 
-In `DevNet`, your Splice node validator runs locally and connects to the `DevNet` synchronizer. You will need the Splice node release bundle, which contains the Docker Compose files for the validator.
+In `DevNet`, your Splice node validator runs locally and connects to the `DevNet` synchronizer.
+Download and extract the Splice node bundle by following the Requirements
+step in the [Docker Compose Validator Deployment guide](/global-synchronizer/deployment/validator-docker-compose#requirements).
+
+The extracted `splice-node` directory and `cn-quickstart` should be
+siblings to one another:
+
+```bash
+.
+└── Canton_Network_App_Dev
+    ├── cn-quickstart
+    └── splice-node
+```
 
 <Note>
-Find the most recent Splice release on the [canton-network/splice releases page](https://github.com/canton-network/splice/releases). The version in the URL and filename below changes with each release — substitute the tag you want to install.
+Find the most recent Splice release on the [canton-network/splice releases page](https://github.com/canton-network/splice/releases).
 </Note>
-
-Download the `splice-node` tarball for your chosen version (the bundle is published as a release asset, e.g. `<VERSION>_splice-node.tar.gz` on `https://github.com/canton-network/splice/releases/tag/<VERSION>`) and move it to your desired location, then unzip it.
-
-<ExternalCnQuickstartMainCnQuickstartRstCodeSdkDocsSharableSdkQuickstartOperateDeployQuickstartToDevnetBash174 />
-
-The new `splice-node` repo and `cn-quickstart` should be siblings to one
-another.
-
-    .
-    ├── Canton_Network_App_Dev
-    │   ├── cn-quickstart
-    └── └── splice-node
-
-<div class="note" markdown="1">
-
-<div class="title" markdown="1">
-
-Note
-
-</div>
-
-You only need to complete this step one time for any given
-`splice-node release`.
-
-</div>
 
 ## Navigate to the validator's Docker Compose directory
 


### PR DESCRIPTION
Resolves [Issue 511](https://github.com/canton-network/cf-docs/issues/511)
Directs reader to Docker Compose Validator deployment guide to download most recent splice release.