### PR TITLE
Update Splice Daml stdlib links

### DIFF
--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1.mdx
@@ -61,7 +61,7 @@ The API for featured apps to record their activity.
 >   |---------------|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 >   | beneficiaries | \[AppRewardBeneficiary\] | The set of beneficiaries and weights that define how the rewards should be split up between the beneficiary parties. Implementations SHOULD check that the weights are positive and add up to 1.0. Implementations MAY also impose a limit on the maximum number of beneficiaries. |
 >
-> - **Method featuredAppRight_CreateActivityMarkerImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+> - **Method featuredAppRight_CreateActivityMarkerImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
 
 ## Data Types
 
@@ -81,26 +81,26 @@ The API for featured apps to record their activity.
 >
 > > | Field       | Type                                                                                    | Description                                                                                  |
 > > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+> > | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | [Decimal](/appdev/reference/daml-standard-library/prelude)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AppRewardBeneficiary
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) AppRewardBeneficiary
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) AppRewardBeneficiary
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude) AppRewardBeneficiary
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AppRewardBeneficiary
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) AppRewardBeneficiary
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "beneficiary" AppRewardBeneficiary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "weight" AppRewardBeneficiary [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "beneficiary" AppRewardBeneficiary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "weight" AppRewardBeneficiary [Decimal](/appdev/reference/daml-standard-library/prelude)
 
 <div id="type-splice-api-featuredapprightv1-featuredappactivitymarkerview-84352">
 
@@ -116,34 +116,34 @@ The API for featured apps to record their activity.
 >
 > > | Field       | Type                                                                                    | Description                                                                                  |
 > > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | dso         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.                                                                               |
-> > | provider    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider.                                                                   |
-> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+> > | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The DSO party.                                                                               |
+> > | provider    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The featured app provider.                                                                   |
+> > | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | [Decimal](/appdev/reference/daml-standard-library/prelude)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppActivityMarkerView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) FeaturedAppActivityMarkerView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppActivityMarkerView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) FeaturedAppActivityMarkerView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "beneficiary" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "dso" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "provider" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "weight" FeaturedAppActivityMarkerView [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "beneficiary" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "dso" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "provider" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "weight" FeaturedAppActivityMarkerView [Decimal](/appdev/reference/daml-standard-library/prelude)
 
 <div id="type-splice-api-featuredapprightv1-featuredapprightview-50078">
 
@@ -159,24 +159,24 @@ The API for featured apps to record their activity.
 >
 > > | Field    | Type                                                                                    | Description                |
 > > |----------|-----------------------------------------------------------------------------------------|----------------------------|
-> > | dso      | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.             |
-> > | provider | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider. |
+> > | dso      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The DSO party.             |
+> > | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The featured app provider. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppRightView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) FeaturedAppRightView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppRightView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) FeaturedAppRightView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppRight FeaturedAppRightView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppRight FeaturedAppRightView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppRight FeaturedAppRightView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppRight FeaturedAppRightView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "dso" FeaturedAppRightView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "provider" FeaturedAppRightView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "dso" FeaturedAppRightView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "provider" FeaturedAppRightView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 
 <div id="type-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerresult-54383">
 
@@ -194,28 +194,28 @@ The API for featured apps to record their activity.
 >
 > > | Field              | Type                                                                                                                            | Description                                        |
 > > |--------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
-> > | activityMarkerCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
+> > | activityMarkerCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
 >
-> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult)
+> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 
 ## Functions
 
 <div id="function-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerimpl-71588">
 
 featuredAppRight_CreateActivityMarkerImpl
-: FeaturedAppRight -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+: FeaturedAppRight -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2.mdx
@@ -60,9 +60,9 @@ The API for featured apps to record their activity. This package extends Feature
 >   | Field         | Type                                                                                                                                                                                      | Description                                                                                                                                                                                                                                                                                       |
 >   |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 >   | beneficiaries | \[AppRewardBeneficiary\]                                                                                                                                                                  | The set of beneficiaries and weights that define how the rewards should be split up between the beneficiary parties. Implementations SHOULD check that the weights are positive and add up to 1.0. Implementations MAY also impose a limit on the maximum number of beneficiaries.                |
->   | weight        | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135) | A weight for the resulting markers. None defaults to a weight of 1.0. Specifying a weight of 5 for example makes the resulting markers equivalent to 5 markers of weight 1 in terms of rewards they generate. The weight must be \>= 1.0 Implementations MAY impose an upper limit on the weight. |
+>   | weight        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude) | A weight for the resulting markers. None defaults to a weight of 1.0. Specifying a weight of 5 for example makes the resulting markers equivalent to 5 markers of weight 1 in terms of rewards they generate. The weight must be \>= 1.0 Implementations MAY impose an upper limit on the weight. |
 >
-> - **Method featuredAppRight_CreateActivityMarkerImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+> - **Method featuredAppRight_CreateActivityMarkerImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
 
 ## Data Types
 
@@ -82,26 +82,26 @@ The API for featured apps to record their activity. This package extends Feature
 >
 > > | Field       | Type                                                                                    | Description                                                                                  |
 > > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+> > | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | [Decimal](/appdev/reference/daml-standard-library/prelude)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AppRewardBeneficiary
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) AppRewardBeneficiary
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) AppRewardBeneficiary
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude) AppRewardBeneficiary
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AppRewardBeneficiary
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) AppRewardBeneficiary
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "beneficiary" AppRewardBeneficiary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "weight" AppRewardBeneficiary [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "beneficiary" AppRewardBeneficiary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "weight" AppRewardBeneficiary [Decimal](/appdev/reference/daml-standard-library/prelude)
 
 <div id="type-splice-api-featuredapprightv2-featuredappactivitymarkerview-70739">
 
@@ -117,34 +117,34 @@ The API for featured apps to record their activity. This package extends Feature
 >
 > > | Field       | Type                                                                                    | Description                                                                                  |
 > > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | dso         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.                                                                               |
-> > | provider    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider.                                                                   |
-> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+> > | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The DSO party.                                                                               |
+> > | provider    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The featured app provider.                                                                   |
+> > | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | [Decimal](/appdev/reference/daml-standard-library/prelude)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppActivityMarkerView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) FeaturedAppActivityMarkerView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppActivityMarkerView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) FeaturedAppActivityMarkerView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "beneficiary" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "dso" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "provider" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "weight" FeaturedAppActivityMarkerView [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "beneficiary" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "dso" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "provider" FeaturedAppActivityMarkerView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "weight" FeaturedAppActivityMarkerView [Decimal](/appdev/reference/daml-standard-library/prelude)
 
 <div id="type-splice-api-featuredapprightv2-featuredapprightview-58075">
 
@@ -160,24 +160,24 @@ The API for featured apps to record their activity. This package extends Feature
 >
 > > | Field    | Type                                                                                    | Description                |
 > > |----------|-----------------------------------------------------------------------------------------|----------------------------|
-> > | dso      | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.             |
-> > | provider | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider. |
+> > | dso      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The DSO party.             |
+> > | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The featured app provider. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppRightView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) FeaturedAppRightView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppRightView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) FeaturedAppRightView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppRight FeaturedAppRightView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppRight FeaturedAppRightView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppRight FeaturedAppRightView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppRight FeaturedAppRightView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "dso" FeaturedAppRightView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "provider" FeaturedAppRightView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "dso" FeaturedAppRightView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "provider" FeaturedAppRightView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 
 <div id="type-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerresult-27928">
 
@@ -195,28 +195,28 @@ The API for featured apps to record their activity. This package extends Feature
 >
 > > | Field              | Type                                                                                                                            | Description                                        |
 > > |--------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
-> > | activityMarkerCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
+> > | activityMarkerCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
 >
-> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult)
+> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 
 ## Functions
 
 <div id="function-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerimpl-7767">
 
 featuredAppRight_CreateActivityMarkerImpl
-: FeaturedAppRight -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+: FeaturedAppRight -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1.mdx
@@ -33,10 +33,10 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 >   | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 >   |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party.                                       |
+>   | expectedAdmin    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                       | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party.                                       |
 >   | allocation       | AllocationSpecification                                                                                       | The allocation which should be created.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
->   | requestedAt      | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                         | The time at which the allocation was requested.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
->   | inputHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that SHOULD be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger; or for registries that support automatic selection of holdings for allocations. If specified, then the successful allocation MUST archive all of these holdings, so that the execution of the allocation conflicts with any other allocations using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate allocations. |
+>   | requestedAt      | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                         | The time at which the allocation was requested.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+>   | inputHoldingCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | The holdings that SHOULD be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger; or for registries that support automatic selection of holdings for allocations. If specified, then the successful allocation MUST archive all of these holdings, so that the execution of the allocation conflicts with any other allocations using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate allocations. |
 >   | extraArgs        | ExtraArgs                                                                                                     | Additional choice arguments.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 >
 > - <div id="type-splice-api-token-allocationinstructionv1-allocationfactorypublicfetch-20324">
@@ -51,8 +51,8 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 >   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 >   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
->   | actor         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+>   | expectedAdmin | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | actor         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 >
 > - **Choice** Archive
 >
@@ -62,9 +62,9 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 >   (no fields)
 >
-> - **Method allocationFactory_allocateImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+> - **Method allocationFactory_allocateImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationInstructionResult
 >
-> - **Method allocationFactory_publicFetchImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationFactoryView
+> - **Method allocationFactory_publicFetchImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationFactoryView
 
 <div id="type-splice-api-token-allocationinstructionv1-allocationinstruction-29622">
 
@@ -92,7 +92,7 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 >   | Field       | Type                                                                                        | Description                                                                                                                           |
 >   |-------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
->   | extraActors | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
+>   | extraActors | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
 >   | extraArgs   | ExtraArgs                                                                                   | Additional context required in order to exercise the choice.                                                                          |
 >
 > - <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionwithdraw-35988">
@@ -119,9 +119,9 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 >   (no fields)
 >
-> - **Method allocationInstruction_updateImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+> - **Method allocationInstruction_updateImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationInstructionResult
 >
-> - **Method allocationInstruction_withdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+> - **Method allocationInstruction_withdrawImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationInstructionResult
 
 ## Data Types
 
@@ -141,34 +141,34 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 > > | Field | Type                                                                                    | Description                                                                                                             |
 > > |-------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this allocation factory can be used. |
+> > | admin | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this allocation factory can be used. |
 > > | meta  | Metadata                                                                                | Additional metadata specific to the allocation factory, used for extensibility.                                         |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationFactoryView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) AllocationFactoryView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationFactoryView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) AllocationFactoryView
 >
-> **instance** HasMethod AllocationFactory "allocationFactory_publicFetchImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationFactoryView)
+> **instance** HasMethod AllocationFactory "allocationFactory_publicFetchImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationFactoryView)
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationFactory AllocationFactoryView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationFactory AllocationFactoryView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AllocationFactory AllocationFactoryView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) AllocationFactory AllocationFactoryView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" AllocationFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "admin" AllocationFactoryView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationFactoryView Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" AllocationFactoryView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" AllocationFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "admin" AllocationFactoryView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationFactoryView Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" AllocationFactoryView Metadata
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
 
 <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionresult-30943">
 
@@ -187,54 +187,54 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 > > | Field            | Type                                                                                                          | Description                                                                                                                                                                      |
 > > |------------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 > > | output           | AllocationInstructionResult_Output                                                                            | The output of the step.                                                                                                                                                          |
-> > | senderChangeCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple allocation instructions in a single Daml transaction. |
+> > | senderChangeCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple allocation instructions in a single Daml transaction. |
 > > | meta             | Metadata                                                                                                      | Additional metadata specific to the allocation instruction, used for extensibility; e.g., fees charged.                                                                          |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationInstructionResult
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) AllocationInstructionResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationInstructionResult
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) AllocationInstructionResult
 >
-> **instance** HasMethod AllocationFactory "allocationFactory_allocateImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult)
+> **instance** HasMethod AllocationFactory "allocationFactory_allocateImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationInstructionResult)
 >
-> **instance** HasMethod AllocationInstruction "allocationInstruction_updateImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult)
+> **instance** HasMethod AllocationInstruction "allocationInstruction_updateImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationInstructionResult)
 >
-> **instance** HasMethod AllocationInstruction "allocationInstruction_withdrawImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult)
+> **instance** HasMethod AllocationInstruction "allocationInstruction_withdrawImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationInstructionResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationInstructionResult Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" AllocationInstructionResult Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" AllocationInstructionResult AllocationInstructionResult_Output
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "output" AllocationInstructionResult AllocationInstructionResult_Output
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderChangeCids" AllocationInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "senderChangeCids" AllocationInstructionResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationInstructionResult Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" AllocationInstructionResult Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" AllocationInstructionResult AllocationInstructionResult_Output
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "output" AllocationInstructionResult AllocationInstructionResult_Output
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderChangeCids" AllocationInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "senderChangeCids" AllocationInstructionResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
 
 <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionresultoutput-46212">
 
@@ -254,7 +254,7 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 > >
 > > | Field                    | Type                                                                                                                    | Description                                                               |
 > > |--------------------------|-------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-> > | allocationInstructionCid | [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction | Contract id of the allocation instruction representing the pending state. |
+> > | allocationInstructionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction | Contract id of the allocation instruction representing the pending state. |
 >
 > <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultcompleted-89210">
 >
@@ -266,7 +266,7 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 > >
 > > | Field         | Type                                                                                                         | Description                   |
 > > |---------------|--------------------------------------------------------------------------------------------------------------|-------------------------------|
-> > | allocationCid | [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation | The newly created allocation. |
+> > | allocationCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation | The newly created allocation. |
 >
 > <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultfailed-56799">
 >
@@ -276,21 +276,21 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 > > Use this result to communicate that the creation of the allocation did not succeed and all holdings reserved for funding the allocation have been released.
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationInstructionResult_Output
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) AllocationInstructionResult_Output
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationInstructionResult_Output
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) AllocationInstructionResult_Output
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocationCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "allocationCid" AllocationInstructionResult_Output ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocationInstructionCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "allocationInstructionCid" AllocationInstructionResult_Output ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" AllocationInstructionResult AllocationInstructionResult_Output
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "output" AllocationInstructionResult AllocationInstructionResult_Output
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocationCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "allocationCid" AllocationInstructionResult_Output ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocationInstructionCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "allocationInstructionCid" AllocationInstructionResult_Output ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" AllocationInstructionResult AllocationInstructionResult_Output
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "output" AllocationInstructionResult AllocationInstructionResult_Output
 
 <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionview-72001">
 
@@ -308,72 +308,72 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 > > | Field                  | Type                                                                                                                                                                                                                                                         | Description                                                                                                                                                                                                                                |
 > > |------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | originalInstructionCid | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction)                                 | The contract id of the original allocation instruction contract. Used by the wallet to track the lineage of allocation instructions through multiple steps. Only set if the registry evolves the allocation instruction in multiple steps. |
+> > | originalInstructionCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction)                                 | The contract id of the original allocation instruction contract. Used by the wallet to track the lineage of allocation instructions through multiple steps. Only set if the registry evolves the allocation instruction in multiple steps. |
 > > | allocation             | AllocationSpecification                                                                                                                                                                                                                                      | The allocation that this instruction should create.                                                                                                                                                                                        |
-> > | pendingActions         | [Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | The pending actions to be taken by different actors to create the allocation. ^ This field can by used to report on the progress of registry specific workflows that are required to prepare the allocation.                               |
-> > | requestedAt            | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                                                                                                                                                                        | The time at which the allocation was requested.                                                                                                                                                                                            |
-> > | inputHoldingCids       | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]                                                                                                                                                | The holdings to be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger.                                                                                                                |
+> > | pendingActions         | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) [Text](/appdev/reference/daml-standard-library/prelude) | The pending actions to be taken by different actors to create the allocation. ^ This field can by used to report on the progress of registry specific workflows that are required to prepare the allocation.                               |
+> > | requestedAt            | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                                                        | The time at which the allocation was requested.                                                                                                                                                                                            |
+> > | inputHoldingCids       | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]                                                                                                                                                | The holdings to be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger.                                                                                                                |
 > > | meta                   | Metadata                                                                                                                                                                                                                                                     | Additional metadata specific to the allocation instruction, used for extensibility; e.g., more detailed status information.                                                                                                                |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationInstructionView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) AllocationInstructionView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationInstructionView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) AllocationInstructionView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationInstruction AllocationInstructionView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationInstruction AllocationInstructionView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AllocationInstruction AllocationInstructionView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) AllocationInstruction AllocationInstructionView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocation" AllocationInstructionView AllocationSpecification
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "allocation" AllocationInstructionView AllocationSpecification
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "inputHoldingCids" AllocationInstructionView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "inputHoldingCids" AllocationInstructionView \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationInstructionView Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" AllocationInstructionView Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "originalInstructionCid" AllocationInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction))
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "originalInstructionCid" AllocationInstructionView ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction))
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "pendingActions" AllocationInstructionView ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "pendingActions" AllocationInstructionView ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) [Text](/appdev/reference/daml-standard-library/prelude))
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "requestedAt" AllocationInstructionView [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "requestedAt" AllocationInstructionView [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocation" AllocationInstructionView AllocationSpecification
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "allocation" AllocationInstructionView AllocationSpecification
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "inputHoldingCids" AllocationInstructionView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "inputHoldingCids" AllocationInstructionView \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationInstructionView Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" AllocationInstructionView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "originalInstructionCid" AllocationInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction))
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "originalInstructionCid" AllocationInstructionView ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction))
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "pendingActions" AllocationInstructionView ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "pendingActions" AllocationInstructionView ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) [Text](/appdev/reference/daml-standard-library/prelude))
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "requestedAt" AllocationInstructionView [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "requestedAt" AllocationInstructionView [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 
 ## Functions
 
 <div id="function-splice-api-token-allocationinstructionv1-allocationinstructionwithdrawimpl-26170">
 
 allocationInstruction_withdrawImpl
-: AllocationInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+: AllocationInstruction -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-allocationinstructionv1-allocationinstructionupdateimpl-49061">
 
 allocationInstruction_updateImpl
-: AllocationInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+: AllocationInstruction -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-allocationinstructionv1-allocationfactoryallocateimpl-1231">
 
 allocationFactory_allocateImpl
-: AllocationFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+: AllocationFactory -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-allocationinstructionv1-allocationfactorypublicfetchimpl-77778">
 
 allocationFactory_publicFetchImpl
-: AllocationFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationFactoryView
+: AllocationFactory -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationFactoryView
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1.mdx
@@ -37,7 +37,7 @@ This module defines the interface for an `AllocationRequest`, which is an interf
 >
 >   | Field     | Type                                                                                    | Description                                                  |
 >   |-----------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------|
->   | actor     | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party rejecting the allocation request.                  |
+>   | actor     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party rejecting the allocation request.                  |
 >   | extraArgs | ExtraArgs                                                                               | Additional context required in order to exercise the choice. |
 >
 > - <div id="type-splice-api-token-allocationrequestv1-allocationrequestwithdraw-15628">
@@ -66,9 +66,9 @@ This module defines the interface for an `AllocationRequest`, which is an interf
 >
 >   (no fields)
 >
-> - **Method allocationRequest_RejectImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+> - **Method allocationRequest_RejectImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Reject -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
 >
-> - **Method allocationRequest_WithdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+> - **Method allocationRequest_WithdrawImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Withdraw -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
 
 ## Data Types
 
@@ -91,42 +91,42 @@ This module defines the interface for an `AllocationRequest`, which is an interf
 > > | Field        | Type                                                                                                    | Description                                                                                                                                                                                                                                                        |
 > > |--------------|---------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 > > | settlement   | SettlementInfo                                                                                          | Settlement for which the assets are requested to be allocated.                                                                                                                                                                                                     |
-> > | transferLegs | [TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) TransferLeg | Transfer legs that are requested to be allocated for the execution of the settlement keyed by their identifier. This may or may not be a complete list of transfer legs that are part of the settlement, depending on the confidentiality requirements of the app. |
+> > | transferLegs | [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) TransferLeg | Transfer legs that are requested to be allocated for the execution of the settlement keyed by their identifier. This may or may not be a complete list of transfer legs that are part of the settlement, depending on the confidentiality requirements of the app. |
 > > | meta         | Metadata                                                                                                | Additional metadata specific to the allocation request, used for extensibility.                                                                                                                                                                                    |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationRequestView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) AllocationRequestView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationRequestView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) AllocationRequestView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationRequest AllocationRequestView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationRequest AllocationRequestView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AllocationRequest AllocationRequestView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) AllocationRequest AllocationRequestView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationRequestView Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" AllocationRequestView Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlement" AllocationRequestView SettlementInfo
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "settlement" AllocationRequestView SettlementInfo
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLegs" AllocationRequestView ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) TransferLeg)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "transferLegs" AllocationRequestView ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) TransferLeg)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationRequestView Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" AllocationRequestView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlement" AllocationRequestView SettlementInfo
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "settlement" AllocationRequestView SettlementInfo
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLegs" AllocationRequestView ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) TransferLeg)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "transferLegs" AllocationRequestView ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) TransferLeg)
 
 ## Functions
 
 <div id="function-splice-api-token-allocationrequestv1-allocationrequestrejectimpl-48931">
 
 allocationRequest_RejectImpl
-: AllocationRequest -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+: AllocationRequest -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Reject -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
 
 </div>
 
 <div id="function-splice-api-token-allocationrequestv1-allocationrequestwithdrawimpl-31866">
 
 allocationRequest_WithdrawImpl
-: AllocationRequest -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+: AllocationRequest -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Withdraw -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1.mdx
@@ -79,11 +79,11 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 >   (no fields)
 >
-> - **Method allocation_cancelImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_CancelResult
+> - **Method allocation_cancelImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) Allocation_CancelResult
 >
-> - **Method allocation_executeTransferImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult
+> - **Method allocation_executeTransferImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult
 >
-> - **Method allocation_withdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_WithdrawResult
+> - **Method allocation_withdrawImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) Allocation_WithdrawResult
 
 ## Data Types
 
@@ -106,28 +106,28 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 > > | Field         | Type                                                                             | Description                                                        |
 > > |---------------|----------------------------------------------------------------------------------|--------------------------------------------------------------------|
 > > | settlement    | SettlementInfo                                                                   | The settlement for whose execution the assets are being allocated. |
-> > | transferLegId | [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | A unique identifer for the transfer leg within the settlement.     |
+> > | transferLegId | [Text](/appdev/reference/daml-standard-library/prelude) | A unique identifer for the transfer leg within the settlement.     |
 > > | transferLeg   | TransferLeg                                                                      | The transfer for which the assets are being allocated.             |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationSpecification
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) AllocationSpecification
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationSpecification
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) AllocationSpecification
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocation" AllocationView AllocationSpecification
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "allocation" AllocationView AllocationSpecification
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlement" AllocationSpecification SettlementInfo
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "settlement" AllocationSpecification SettlementInfo
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLeg" AllocationSpecification TransferLeg
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "transferLeg" AllocationSpecification TransferLeg
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLegId" AllocationSpecification [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "transferLegId" AllocationSpecification [Text](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocation" AllocationView AllocationSpecification
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "allocation" AllocationView AllocationSpecification
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlement" AllocationSpecification SettlementInfo
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "settlement" AllocationSpecification SettlementInfo
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLeg" AllocationSpecification TransferLeg
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "transferLeg" AllocationSpecification TransferLeg
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLegId" AllocationSpecification [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "transferLegId" AllocationSpecification [Text](/appdev/reference/daml-standard-library/prelude)
 
 <div id="type-splice-api-token-allocationv1-allocationview-9103">
 
@@ -146,28 +146,28 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 > > | Field       | Type                                                                                                          | Description                                                                                                                                                                                              |
 > > |-------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 > > | allocation  | AllocationSpecification                                                                                       | The settlement for whose execution the assets are being allocated.                                                                                                                                       |
-> > | holdingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that are backing this allocation. Provided so that that wallets can correlate the allocation with the holdings. MAY be empty for registries that do not represent their holdings on-ledger. |
+> > | holdingCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | The holdings that are backing this allocation. Provided so that that wallets can correlate the allocation with the holdings. MAY be empty for registries that do not represent their holdings on-ledger. |
 > > | meta        | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility.                                                                                                                                  |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) AllocationView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) AllocationView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) Allocation AllocationView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) Allocation AllocationView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) Allocation AllocationView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) Allocation AllocationView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocation" AllocationView AllocationSpecification
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "allocation" AllocationView AllocationSpecification
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "holdingCids" AllocationView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "holdingCids" AllocationView \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationView Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" AllocationView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocation" AllocationView AllocationSpecification
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "allocation" AllocationView AllocationSpecification
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "holdingCids" AllocationView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "holdingCids" AllocationView \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationView Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" AllocationView Metadata
 
 <div id="type-splice-api-token-allocationv1-allocationcancelresult-26037">
 
@@ -185,30 +185,30 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field             | Type                                                                                                          | Description                                                             |
 > > |-------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-> > | senderHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were released back to the sender.                     |
+> > | senderHoldingCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were released back to the sender.                     |
 > > | meta              | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Allocation_CancelResult
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) Allocation_CancelResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Allocation_CancelResult
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) Allocation_CancelResult
 >
-> **instance** HasMethod Allocation "allocation_cancelImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_CancelResult)
+> **instance** HasMethod Allocation "allocation_cancelImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) Allocation_CancelResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Allocation_CancelResult Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" Allocation_CancelResult Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_CancelResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_CancelResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Allocation_CancelResult Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" Allocation_CancelResult Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_CancelResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_CancelResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_Cancel Allocation_CancelResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_Cancel Allocation_CancelResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_Cancel Allocation_CancelResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_Cancel Allocation_CancelResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_Cancel Allocation_CancelResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_Cancel Allocation_CancelResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_Cancel Allocation_CancelResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_Cancel Allocation_CancelResult
 
 <div id="type-splice-api-token-allocationv1-allocationexecutetransferresult-74160">
 
@@ -226,35 +226,35 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field               | Type                                                                                                          | Description                                                                                              |
 > > |---------------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-> > | senderHoldingCids   | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were created for the sender. Can be used to return "change" to the sender if required. |
-> > | receiverHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were created for the receiver.                                                         |
+> > | senderHoldingCids   | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were created for the sender. Can be used to return "change" to the sender if required. |
+> > | receiverHoldingCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were created for the receiver.                                                         |
 > > | meta                | Metadata                                                                                                      | Additional metadata specific to the transfer instruction, used for extensibility.                        |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Allocation_ExecuteTransferResult
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) Allocation_ExecuteTransferResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Allocation_ExecuteTransferResult
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) Allocation_ExecuteTransferResult
 >
-> **instance** HasMethod Allocation "allocation_executeTransferImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult)
+> **instance** HasMethod Allocation "allocation_executeTransferImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Allocation_ExecuteTransferResult Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" Allocation_ExecuteTransferResult Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiverHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "receiverHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Allocation_ExecuteTransferResult Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" Allocation_ExecuteTransferResult Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiverHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "receiverHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
 
 <div id="type-splice-api-token-allocationv1-allocationwithdrawresult-40879">
 
@@ -272,30 +272,30 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field             | Type                                                                                                          | Description                                                             |
 > > |-------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-> > | senderHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were released back to the sender.                     |
+> > | senderHoldingCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were released back to the sender.                     |
 > > | meta              | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Allocation_WithdrawResult
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) Allocation_WithdrawResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Allocation_WithdrawResult
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) Allocation_WithdrawResult
 >
-> **instance** HasMethod Allocation "allocation_withdrawImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_WithdrawResult)
+> **instance** HasMethod Allocation "allocation_withdrawImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) Allocation_WithdrawResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Allocation_WithdrawResult Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" Allocation_WithdrawResult Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_WithdrawResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_WithdrawResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Allocation_WithdrawResult Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" Allocation_WithdrawResult Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_WithdrawResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_WithdrawResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_Withdraw Allocation_WithdrawResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_Withdraw Allocation_WithdrawResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_Withdraw Allocation_WithdrawResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_Withdraw Allocation_WithdrawResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_Withdraw Allocation_WithdrawResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_Withdraw Allocation_WithdrawResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_Withdraw Allocation_WithdrawResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_Withdraw Allocation_WithdrawResult
 
 <div id="type-splice-api-token-allocationv1-reference-53456">
 
@@ -313,24 +313,24 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field | Type                                                                                                             | Description                                                                                                                                                                                                                                                                |
 > > |-------|------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | id    | [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)                                 | The key that identifies the data. Can be set to the empty string if the contract-id is provided and is sufficient.                                                                                                                                                         |
-> > | cid   | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) AnyContractId | Optional contract-id to use for referring to contracts. This field is there for technical reasons, as contract-ids cannot be converted to text from within Daml, which is due to their full textual representation being only known after transactions have been prepared. |
+> > | id    | [Text](/appdev/reference/daml-standard-library/prelude)                                 | The key that identifies the data. Can be set to the empty string if the contract-id is provided and is sufficient.                                                                                                                                                         |
+> > | cid   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) AnyContractId | Optional contract-id to use for referring to contracts. This field is there for technical reasons, as contract-ids cannot be converted to text from within Daml, which is due to their full textual representation being only known after transactions have been prepared. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Reference
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) Reference
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Reference
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) Reference
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "cid" Reference ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) AnyContractId)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "cid" Reference ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) AnyContractId)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "id" Reference [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "id" Reference [Text](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlementRef" SettlementInfo Reference
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "settlementRef" SettlementInfo Reference
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "cid" Reference ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) AnyContractId)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "cid" Reference ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) AnyContractId)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "id" Reference [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "id" Reference [Text](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlementRef" SettlementInfo Reference
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "settlementRef" SettlementInfo Reference
 
 <div id="type-splice-api-token-allocationv1-settlementinfo-4367">
 
@@ -348,44 +348,44 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field          | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                      |
 > > |----------------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | executor       | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is responsible for executing the settlement.                                                                                                                                                                                                                                                                                      |
+> > | executor       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that is responsible for executing the settlement.                                                                                                                                                                                                                                                                                      |
 > > | settlementRef  | Reference                                                                               | Reference to the settlement that app would like to execute.                                                                                                                                                                                                                                                                                      |
-> > | requestedAt    | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)   | When the settlement was requested. Provided for display and debugging purposes, but SHOULD be in the past.                                                                                                                                                                                                                                       |
-> > | allocateBefore | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)   | Until when (exclusive) the senders are given time to allocate their assets. This field has a particular relevance with respect to instrument versioning / corporate actions, in that the settlement pertains to the instrument version resulting from the processing of all corporate actions falling strictly before the `allocateBefore` time. |
-> > | settleBefore   | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)   | Until when (exclusive) the executor is given time to execute the settlement. SHOULD be strictly after `allocateBefore`.                                                                                                                                                                                                                          |
+> > | requestedAt    | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | When the settlement was requested. Provided for display and debugging purposes, but SHOULD be in the past.                                                                                                                                                                                                                                       |
+> > | allocateBefore | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Until when (exclusive) the senders are given time to allocate their assets. This field has a particular relevance with respect to instrument versioning / corporate actions, in that the settlement pertains to the instrument version resulting from the processing of all corporate actions falling strictly before the `allocateBefore` time. |
+> > | settleBefore   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Until when (exclusive) the executor is given time to execute the settlement. SHOULD be strictly after `allocateBefore`.                                                                                                                                                                                                                          |
 > > | meta           | Metadata                                                                                | Additional metadata about the settlement, used for extensibility.                                                                                                                                                                                                                                                                                |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) SettlementInfo
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) SettlementInfo
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) SettlementInfo
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) SettlementInfo
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocateBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "allocateBefore" SettlementInfo [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "executor" SettlementInfo [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "executor" SettlementInfo [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" SettlementInfo Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" SettlementInfo Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "requestedAt" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "requestedAt" SettlementInfo [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settleBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "settleBefore" SettlementInfo [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlement" AllocationSpecification SettlementInfo
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "settlement" AllocationSpecification SettlementInfo
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlementRef" SettlementInfo Reference
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "settlementRef" SettlementInfo Reference
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocateBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "allocateBefore" SettlementInfo [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "executor" SettlementInfo [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "executor" SettlementInfo [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" SettlementInfo Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" SettlementInfo Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "requestedAt" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "requestedAt" SettlementInfo [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settleBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "settleBefore" SettlementInfo [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlement" AllocationSpecification SettlementInfo
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "settlement" AllocationSpecification SettlementInfo
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlementRef" SettlementInfo Reference
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "settlementRef" SettlementInfo Reference
 
 <div id="type-splice-api-token-allocationv1-transferleg-71662">
 
@@ -403,48 +403,48 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field        | Type                                                                                    | Description                                                         |
 > > |--------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------|
-> > | sender       | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The sender of the transfer.                                         |
-> > | receiver     | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The receiver of the transfer.                                       |
-> > | amount       | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | The amount to transfer.                                             |
+> > | sender       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The sender of the transfer.                                         |
+> > | receiver     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The receiver of the transfer.                                       |
+> > | amount       | [Decimal](/appdev/reference/daml-standard-library/prelude)  | The amount to transfer.                                             |
 > > | instrumentId | InstrumentId                                                                            | The instrument identifier.                                          |
 > > | meta         | Metadata                                                                                | Additional metadata about the transfer leg, used for extensibility. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferLeg
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) TransferLeg
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) TransferLeg
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude) TransferLeg
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferLeg
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) TransferLeg
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" TransferLeg [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "amount" TransferLeg [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" TransferLeg InstrumentId
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "instrumentId" TransferLeg InstrumentId
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferLeg Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" TransferLeg Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiver" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "receiver" TransferLeg [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "sender" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "sender" TransferLeg [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLeg" AllocationSpecification TransferLeg
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "transferLeg" AllocationSpecification TransferLeg
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" TransferLeg [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "amount" TransferLeg [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" TransferLeg InstrumentId
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "instrumentId" TransferLeg InstrumentId
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferLeg Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" TransferLeg Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiver" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "receiver" TransferLeg [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "sender" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "sender" TransferLeg [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLeg" AllocationSpecification TransferLeg
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "transferLeg" AllocationSpecification TransferLeg
 
 ## Functions
 
 <div id="function-splice-api-token-allocationv1-allocationcontrollers-10222">
 
 allocationControllers
-: AllocationView -\> \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]
+: AllocationView -\> \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]
 
 Convenience function to refer to the union of sender, receiver, and executor of the settlement, which jointly control the execution of the allocation.
 
@@ -453,21 +453,21 @@ Convenience function to refer to the union of sender, receiver, and executor of 
 <div id="function-splice-api-token-allocationv1-allocationexecutetransferimpl-90251">
 
 allocation_executeTransferImpl
-: Allocation -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult
+: Allocation -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult
 
 </div>
 
 <div id="function-splice-api-token-allocationv1-allocationcancelimpl-12334">
 
 allocation_cancelImpl
-: Allocation -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_CancelResult
+: Allocation -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) Allocation_CancelResult
 
 </div>
 
 <div id="function-splice-api-token-allocationv1-allocationwithdrawimpl-40108">
 
 allocation_withdrawImpl
-: Allocation -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_WithdrawResult
+: Allocation -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) Allocation_WithdrawResult
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1.mdx
@@ -45,11 +45,11 @@ An interface for registries to expose burn/mint operations in a generic way for 
 >
 >   | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 >   |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The expected `admin` party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | expectedAdmin    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                       | The expected `admin` party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
 >   | instrumentId     | InstrumentId                                                                                                  | The instrument id of the holdings. All holdings in `inputHoldingCids` as well as the resulting output holdings MUST have this instrument id.                                                                                                                                                                                                                                                                                                                                      |
->   | inputHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that should be burnt. All holdings in `inputHoldingCids` MUST be archived by this choice. Implementations MAY enforce additional restrictions such as all `inputHoldingCids` belonging to the same owner.                                                                                                                                                                                                                                                            |
+>   | inputHoldingCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | The holdings that should be burnt. All holdings in `inputHoldingCids` MUST be archived by this choice. Implementations MAY enforce additional restrictions such as all `inputHoldingCids` belonging to the same owner.                                                                                                                                                                                                                                                            |
 >   | outputs          | \[BurnMintOutput\]                                                                                            | The holdings that should be created. The choice MUST create new holdings with the given amounts.                                                                                                                                                                                                                                                                                                                                                                                  |
->   | extraActors      | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                   | Extra actors, the full actors required are the admin + extraActors. This is often the owners of inputHoldingCids and outputs but we allow different sets of actors to support token implementations with different authorization setups.                                                                                                                                                                                                                                          |
+>   | extraActors      | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]                   | Extra actors, the full actors required are the admin + extraActors. This is often the owners of inputHoldingCids and outputs but we allow different sets of actors to support token implementations with different authorization setups.                                                                                                                                                                                                                                          |
 >   | extraArgs        | ExtraArgs                                                                                                     | Additional context. Implementations SHOULD include a `splice.lfdecentralizedtrust.org/reason` key in the metadata to provide a human readable description for explain why the `BurnMintFactory_BurnMint` choice was called, so that generic wallets can display it to the user.                                                                                                                                                                                                   |
 >
 > - <div id="type-splice-api-token-burnmintv1-burnmintfactorypublicfetch-64185">
@@ -64,12 +64,12 @@ An interface for registries to expose burn/mint operations in a generic way for 
 >
 >   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 >   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
->   | actor         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party fetching the data.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+>   | expectedAdmin | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | actor         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party fetching the data.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 >
-> - **Method burnMintFactory_burnMintImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult
+> - **Method burnMintFactory_burnMintImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult
 >
-> - **Method burnMintFactory_publicFetchImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactoryView
+> - **Method burnMintFactory_publicFetchImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) BurnMintFactoryView
 
 ## Data Types
 
@@ -89,34 +89,34 @@ An interface for registries to expose burn/mint operations in a generic way for 
 >
 > > | Field | Type                                                                                    | Description                                                                                                             |
 > > |-------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this burnt-mint factory can be used. |
+> > | admin | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this burnt-mint factory can be used. |
 > > | meta  | Metadata                                                                                | Additional metadata specific to the burn-mint factory, used for extensibility.                                          |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) BurnMintFactoryView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) BurnMintFactoryView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) BurnMintFactoryView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) BurnMintFactoryView
 >
-> **instance** HasMethod BurnMintFactory "burnMintFactory_publicFetchImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactoryView)
+> **instance** HasMethod BurnMintFactory "burnMintFactory_publicFetchImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) BurnMintFactoryView)
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) BurnMintFactory BurnMintFactoryView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) BurnMintFactory BurnMintFactoryView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) BurnMintFactory BurnMintFactoryView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) BurnMintFactory BurnMintFactoryView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" BurnMintFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "admin" BurnMintFactoryView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" BurnMintFactoryView Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" BurnMintFactoryView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" BurnMintFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "admin" BurnMintFactoryView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" BurnMintFactoryView Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" BurnMintFactoryView Metadata
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
 
 <div id="type-splice-api-token-burnmintv1-burnmintfactoryburnmintresult-61365">
 
@@ -134,25 +134,25 @@ An interface for registries to expose burn/mint operations in a generic way for 
 >
 > > | Field      | Type                                                                                                          | Description                                                                                                              |
 > > |------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-> > | outputCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings created by the choice. Must contain exactly the outputs specified in the choice argument in the same order. |
+> > | outputCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | The holdings created by the choice. Must contain exactly the outputs specified in the choice argument in the same order. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) BurnMintFactory_BurnMintResult
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) BurnMintFactory_BurnMintResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) BurnMintFactory_BurnMintResult
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) BurnMintFactory_BurnMintResult
 >
-> **instance** HasMethod BurnMintFactory "burnMintFactory_burnMintImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult)
+> **instance** HasMethod BurnMintFactory "burnMintFactory_burnMintImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "outputCids" BurnMintFactory_BurnMintResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "outputCids" BurnMintFactory_BurnMintResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "outputCids" BurnMintFactory_BurnMintResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "outputCids" BurnMintFactory_BurnMintResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
 
 <div id="type-splice-api-token-burnmintv1-burnmintoutput-36483">
 
@@ -170,43 +170,43 @@ An interface for registries to expose burn/mint operations in a generic way for 
 >
 > > | Field   | Type                                                                                    | Description                                                                                               |
 > > |---------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
-> > | owner   | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The owner of the holding to create.                                                                       |
-> > | amount  | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | The amount of the holding to create.                                                                      |
+> > | owner   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The owner of the holding to create.                                                                       |
+> > | amount  | [Decimal](/appdev/reference/daml-standard-library/prelude)  | The amount of the holding to create.                                                                      |
 > > | context | ChoiceContext                                                                           | Context specific to this output which can be used to support locking or other registry-specific features. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) BurnMintOutput
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) BurnMintOutput
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) BurnMintOutput
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) BurnMintOutput
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" BurnMintOutput [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "amount" BurnMintOutput [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" BurnMintOutput ChoiceContext
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "context" BurnMintOutput ChoiceContext
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "owner" BurnMintOutput [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "owner" BurnMintOutput [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" BurnMintOutput [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "amount" BurnMintOutput [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" BurnMintOutput ChoiceContext
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "context" BurnMintOutput ChoiceContext
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "owner" BurnMintOutput [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "owner" BurnMintOutput [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 
 ## Functions
 
 <div id="function-splice-api-token-burnmintv1-burnmintfactoryburnmintimpl-9738">
 
 burnMintFactory_burnMintImpl
-: BurnMintFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult
+: BurnMintFactory -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult
 
 </div>
 
 <div id="function-splice-api-token-burnmintv1-burnmintfactorypublicfetchimpl-75623">
 
 burnMintFactory_publicFetchImpl
-: BurnMintFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactoryView
+: BurnMintFactory -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) BurnMintFactoryView
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1.mdx
@@ -45,39 +45,39 @@ Types and interfaces for retrieving an investor's holdings.
 >
 > > | Field        | Type                                                                                                    | Description                                                                                                                                  |
 > > |--------------|---------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-> > | owner        | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                 | Owner of the holding.                                                                                                                        |
+> > | owner        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                 | Owner of the holding.                                                                                                                        |
 > > | instrumentId | InstrumentId                                                                                            | Instrument being held.                                                                                                                       |
-> > | amount       | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)                  | Size of the holding.                                                                                                                         |
-> > | lock         | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock | Lock on the holding. Registries SHOULD allow holdings with expired locks as inputs to transfers to enable a combined unlocking + use choice. |
+> > | amount       | [Decimal](/appdev/reference/daml-standard-library/prelude)                  | Size of the holding.                                                                                                                         |
+> > | lock         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Lock | Lock on the holding. Registries SHOULD allow holdings with expired locks as inputs to transfers to enable a combined unlocking + use choice. |
 > > | meta         | Metadata                                                                                                | Metadata.                                                                                                                                    |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) HoldingView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) HoldingView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) HoldingView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) HoldingView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) Holding HoldingView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) Holding HoldingView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) Holding HoldingView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) Holding HoldingView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" HoldingView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "amount" HoldingView [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" HoldingView InstrumentId
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "instrumentId" HoldingView InstrumentId
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "lock" HoldingView ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Lock)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" HoldingView Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" HoldingView Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "owner" HoldingView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "owner" HoldingView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" HoldingView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "amount" HoldingView [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" HoldingView InstrumentId
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "instrumentId" HoldingView InstrumentId
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "lock" HoldingView ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Lock)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" HoldingView Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" HoldingView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "owner" HoldingView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "owner" HoldingView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 
 <div id="type-splice-api-token-holdingv1-instrumentid-28218">
 
@@ -95,26 +95,26 @@ Types and interfaces for retrieving an investor's holdings.
 >
 > > | Field | Type                                                                                    | Description                                                                                                                          |
 > > |-------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instrument.                                                             |
-> > | id    | [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)        | The identifier used for the instrument by the instrument admin. This identifier MUST be unique and unambiguous per instrument admin. |
+> > | admin | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instrument.                                                             |
+> > | id    | [Text](/appdev/reference/daml-standard-library/prelude)        | The identifier used for the instrument by the instrument admin. This identifier MUST be unique and unambiguous per instrument admin. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) InstrumentId
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) InstrumentId
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) InstrumentId
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude) InstrumentId
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) InstrumentId
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) InstrumentId
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" InstrumentId [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "admin" InstrumentId [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "id" InstrumentId [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "id" InstrumentId [Text](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" HoldingView InstrumentId
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "instrumentId" HoldingView InstrumentId
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" InstrumentId [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "admin" InstrumentId [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "id" InstrumentId [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "id" InstrumentId [Text](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" HoldingView InstrumentId
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "instrumentId" HoldingView InstrumentId
 
 <div id="type-splice-api-token-holdingv1-lock-70295">
 
@@ -132,35 +132,35 @@ Types and interfaces for retrieving an investor's holdings.
 >
 > > | Field        | Type                                                                                                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                          |
 > > |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | holders      | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                                                                                                   | Unique list of parties which are locking the contract. (Represented as a list, as that has the better JSON encoding.)                                                                                                                                                                                                                                |
-> > | expiresAt    | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)      | Absolute, inclusive deadline as of which the lock expires.                                                                                                                                                                                                                                                                                           |
-> > | expiresAfter | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082) | Duration after which the created lock expires. Measured relative to the ledger time that the locked holding contract was created. If both `expiresAt` and `expiresAfter` are set, the lock expires at the earlier of the two times.                                                                                                                  |
-> > | context      | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)           | Short, human-readable description of the context of the lock. Used by wallets to enable users to understand the reason for the lock. Note that the visibility of the content in this field might be wider than the visibility of the contracts in the context. You should thus carefully decide what information is safe to put in the lock context. |
+> > | holders      | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]                                                                                                   | Unique list of parties which are locking the contract. (Represented as a list, as that has the better JSON encoding.)                                                                                                                                                                                                                                |
+> > | expiresAt    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)      | Absolute, inclusive deadline as of which the lock expires.                                                                                                                                                                                                                                                                                           |
+> > | expiresAfter | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | Duration after which the created lock expires. Measured relative to the ledger time that the locked holding contract was created. If both `expiresAt` and `expiresAfter` are set, the lock expires at the earlier of the two times.                                                                                                                  |
+> > | context      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude)           | Short, human-readable description of the context of the lock. Used by wallets to enable users to understand the reason for the lock. Note that the visibility of the content in this field might be wider than the visibility of the contracts in the context. You should thus carefully decide what information is safe to put in the lock context. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Lock
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) Lock
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) Lock
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude) Lock
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Lock
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) Lock
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "context" Lock ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude))
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "expiresAfter" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082))
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "expiresAfter" Lock ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082))
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "expiresAt" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886))
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "expiresAt" Lock ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "holders" Lock \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "holders" Lock \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "lock" HoldingView ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Lock)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "context" Lock ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude))
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "expiresAfter" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082))
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "expiresAfter" Lock ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082))
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "expiresAt" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886))
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "expiresAt" Lock ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "holders" Lock \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "holders" Lock \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "lock" HoldingView ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Lock)
 
 {/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1.mdx
@@ -32,7 +32,7 @@ Types and interfaces for retrieving metadata about tokens.
 <div id="type-splice-api-token-metadatav1-anycontractid-4875">
 
 **type** AnyContractId
-= [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AnyContract
+= [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnyContract
 
 A reference to some contract id. Use `coerceContractId` to convert from and to this type.
 
@@ -54,9 +54,9 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 >
 > > (no fields)
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AnyContract AnyContractView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) AnyContract AnyContractView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AnyContract AnyContractView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) AnyContract AnyContractView
 
 <div id="type-splice-api-token-metadatav1-anyvalue-34700">
 
@@ -70,49 +70,49 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 >
 > <div id="constr-splice-api-token-metadatav1-avtext-20580">
 >
-> AV_Text [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> AV_Text [Text](/appdev/reference/daml-standard-library/prelude)
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avint-52425">
 >
-> AV_Int [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> AV_Int [Int](/appdev/reference/daml-standard-library/prelude)
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avdecimal-71267">
 >
-> AV_Decimal [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> AV_Decimal [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avbool-76457">
 >
-> AV_Bool [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
+> AV_Bool [Bool](/appdev/reference/daml-standard-library/prelude)
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avdate-46205">
 >
-> AV_Date [Date](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-date-32253)
+> AV_Date [Date](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-date-32253)
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avtime-30398">
 >
-> AV_Time [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> AV_Time [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avreltime-31008">
 >
-> AV_RelTime [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082)
+> AV_RelTime [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avparty-78344">
 >
-> AV_Party [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> AV_Party [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
 > </div>
 >
@@ -130,17 +130,17 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 >
 > <div id="constr-splice-api-token-metadatav1-avmap-39932">
 >
-> AV_Map ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+> AV_Map ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AnyValue)
 >
 > </div>
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AnyValue
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) AnyValue
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AnyValue
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) AnyValue
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "values" ChoiceContext ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AnyValue)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "values" ChoiceContext ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AnyValue)
 
 <div id="type-splice-api-token-metadatav1-choicecontext-5566">
 
@@ -158,19 +158,19 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 >
 > > | Field  | Type                                                                                                 | Description                                                                                                                                    |
 > > |--------|------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | values | [TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue | The values passed in by the app backend to the choice. The keys are considered internal to the app and should not be read by third-party code. |
+> > | values | [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AnyValue | The values passed in by the app backend to the choice. The keys are considered internal to the app and should not be read by third-party code. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) ChoiceContext
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) ChoiceContext
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) ChoiceContext
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) ChoiceContext
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" ExtraArgs ChoiceContext
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "context" ExtraArgs ChoiceContext
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "values" ChoiceContext ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AnyValue)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" ExtraArgs ChoiceContext
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "context" ExtraArgs ChoiceContext
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "values" ChoiceContext ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AnyValue)
 
 <div id="type-splice-api-token-metadatav1-choiceexecutionmetadata-98464">
 
@@ -190,13 +190,13 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 > > |-------|----------|----------------------------------------------------------------------------------------------|
 > > | meta  | Metadata | Additional metadata specific to the result of exercising the choice, used for extensibility. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) ChoiceExecutionMetadata
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) ChoiceExecutionMetadata
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) ChoiceExecutionMetadata
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) ChoiceExecutionMetadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ChoiceExecutionMetadata Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" ChoiceExecutionMetadata Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ChoiceExecutionMetadata Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" ChoiceExecutionMetadata Metadata
 
 <div id="type-splice-api-token-metadatav1-extraargs-90869">
 
@@ -217,17 +217,17 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 > > | context | ChoiceContext | Extra arguments to be passed to the implementation of an interface choice. These are provided via an off-ledger API by the app implementing the interface.                                                                                                                                       |
 > > | meta    | Metadata      | Additional metadata to pass in. In contrast to the `extraArgs`, these are provided by the caller of the choice. The expectation is that the meaning of metadata fields will be agreed on in later standards, or on a case-by-case basis between the caller and the implementer of the interface. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) ExtraArgs
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) ExtraArgs
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) ExtraArgs
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) ExtraArgs
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" ExtraArgs ChoiceContext
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "context" ExtraArgs ChoiceContext
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ExtraArgs Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" ExtraArgs Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" ExtraArgs ChoiceContext
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "context" ExtraArgs ChoiceContext
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ExtraArgs Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" ExtraArgs Metadata
 
 <div id="type-splice-api-token-metadatav1-metadata-21206">
 
@@ -251,25 +251,25 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 >
 > > | Field  | Type                                                                                                                                                                         | Description                          |
 > > |--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-> > | values | [TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | Key-value pairs of metadata entries. |
+> > | values | [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude) | Key-value pairs of metadata entries. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Metadata
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) Metadata
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) Metadata
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude) Metadata
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Metadata
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ChoiceExecutionMetadata Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" ChoiceExecutionMetadata Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ExtraArgs Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" ExtraArgs Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "values" Metadata ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "values" Metadata ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude))
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ChoiceExecutionMetadata Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" ChoiceExecutionMetadata Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ExtraArgs Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" ExtraArgs Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "values" Metadata ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "values" Metadata ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude))
 
 ## Functions
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1.mdx
@@ -41,8 +41,8 @@ Instruct transfers of holdings between parties.
 >
 >   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 >   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
->   | actor         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party fetching the contract.                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+>   | expectedAdmin | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | actor         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party fetching the contract.                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 >
 > - <div id="type-splice-api-token-transferinstructionv1-transferfactorytransfer-25365">
 >
@@ -58,13 +58,13 @@ Instruct transfers of holdings between parties.
 >
 >   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 >   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | expectedAdmin | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
 >   | transfer      | Transfer                                                                                | The transfer to execute.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 >   | extraArgs     | ExtraArgs                                                                               | The extra arguments to pass to the transfer implementation.                                                                                                                                                                                                                                                                                                                                                                                                                     |
 >
-> - **Method transferFactory_publicFetchImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferFactoryView
+> - **Method transferFactory_publicFetchImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferFactoryView
 >
-> - **Method transferFactory_transferImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+> - **Method transferFactory_transferImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
 
 <div id="type-splice-api-token-transferinstructionv1-transferinstruction-69882">
 
@@ -138,7 +138,7 @@ Instruct transfers of holdings between parties.
 >
 >   | Field       | Type                                                                                        | Description                                                                                                                           |
 >   |-------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
->   | extraActors | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
+>   | extraActors | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
 >   | extraArgs   | ExtraArgs                                                                                   | Additional context required in order to exercise the choice.                                                                          |
 >
 > - <div id="type-splice-api-token-transferinstructionv1-transferinstructionwithdraw-43648">
@@ -157,13 +157,13 @@ Instruct transfers of holdings between parties.
 >   |-----------|-----------|--------------------------------------------------------------|
 >   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
 >
-> - **Method transferInstruction_acceptImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+> - **Method transferInstruction_acceptImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
 >
-> - **Method transferInstruction_rejectImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+> - **Method transferInstruction_rejectImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
 >
-> - **Method transferInstruction_updateImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+> - **Method transferInstruction_updateImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
 >
-> - **Method transferInstruction_withdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+> - **Method transferInstruction_withdrawImpl :** [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
 
 ## Data Types
 
@@ -183,58 +183,58 @@ Instruct transfers of holdings between parties.
 >
 > > | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 > > |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | sender           | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The sender of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-> > | receiver         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The receiver of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-> > | amount           | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)                        | The amount to transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+> > | sender           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                       | The sender of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+> > | receiver         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                       | The receiver of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+> > | amount           | [Decimal](/appdev/reference/daml-standard-library/prelude)                        | The amount to transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 > > | instrumentId     | InstrumentId                                                                                                  | The instrument identifier.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-> > | requestedAt      | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                         | Wallet provided timestamp when the transfer was requested. MUST be in the past when instructing the transfer.                                                                                                                                                                                                                                                                                                                                                               |
-> > | executeBefore    | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                         | Until when (exclusive) the transfer may be executed. MUST be in the future when instructing the transfer. Registries SHOULD NOT execute the transfer instruction after this time, so that senders can retry creating a new transfer instruction after this time.                                                                                                                                                                                                            |
-> > | inputHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holding contracts that should be used to fund the transfer. MAY be empty if the registry supports automatic selection of holdings for transfers or does not represent holdings on-ledger. If specified, then the transfer MUST archive all of these holdings, so that the execution of the transfer conflicts with any other transfers using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate transfers. |
+> > | requestedAt      | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                         | Wallet provided timestamp when the transfer was requested. MUST be in the past when instructing the transfer.                                                                                                                                                                                                                                                                                                                                                               |
+> > | executeBefore    | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                         | Until when (exclusive) the transfer may be executed. MUST be in the future when instructing the transfer. Registries SHOULD NOT execute the transfer instruction after this time, so that senders can retry creating a new transfer instruction after this time.                                                                                                                                                                                                            |
+> > | inputHoldingCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | The holding contracts that should be used to fund the transfer. MAY be empty if the registry supports automatic selection of holdings for transfers or does not represent holdings on-ledger. If specified, then the transfer MUST archive all of these holdings, so that the execution of the transfer conflicts with any other transfers using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate transfers. |
 > > | meta             | Metadata                                                                                                      | Metadata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Transfer
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) Transfer
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Transfer
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) Transfer
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" Transfer [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "amount" Transfer [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "executeBefore" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "executeBefore" Transfer [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "inputHoldingCids" Transfer \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "inputHoldingCids" Transfer \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" Transfer InstrumentId
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "instrumentId" Transfer InstrumentId
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Transfer Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" Transfer Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiver" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "receiver" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "requestedAt" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "requestedAt" Transfer [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "sender" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "sender" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transfer" TransferFactory_Transfer Transfer
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "transfer" TransferFactory_Transfer Transfer
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transfer" TransferInstructionView Transfer
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "transfer" TransferInstructionView Transfer
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" Transfer [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "amount" Transfer [Decimal](/appdev/reference/daml-standard-library/prelude)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "executeBefore" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "executeBefore" Transfer [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "inputHoldingCids" Transfer \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "inputHoldingCids" Transfer \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" Transfer InstrumentId
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "instrumentId" Transfer InstrumentId
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Transfer Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" Transfer Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiver" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "receiver" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "requestedAt" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "requestedAt" Transfer [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "sender" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "sender" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transfer" TransferFactory_Transfer Transfer
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "transfer" TransferFactory_Transfer Transfer
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transfer" TransferInstructionView Transfer
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "transfer" TransferInstructionView Transfer
 
 <div id="type-splice-api-token-transferinstructionv1-transferfactoryview-36679">
 
@@ -252,34 +252,34 @@ Instruct transfers of holdings between parties.
 >
 > > | Field | Type                                                                                    | Description                                                                                                           |
 > > |-------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this transfer factory can be used. |
+> > | admin | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this transfer factory can be used. |
 > > | meta  | Metadata                                                                                | Additional metadata specific to the transfer factory, used for extensibility.                                         |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferFactoryView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) TransferFactoryView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferFactoryView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) TransferFactoryView
 >
-> **instance** HasMethod TransferFactory "transferFactory_publicFetchImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferFactoryView)
+> **instance** HasMethod TransferFactory "transferFactory_publicFetchImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferFactoryView)
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) TransferFactory TransferFactoryView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) TransferFactory TransferFactoryView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) TransferFactory TransferFactoryView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) TransferFactory TransferFactoryView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" TransferFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "admin" TransferFactoryView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferFactoryView Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" TransferFactoryView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" TransferFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "admin" TransferFactoryView [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferFactoryView Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" TransferFactoryView Metadata
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferFactory TransferFactory_PublicFetch TransferFactoryView
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) TransferFactory TransferFactory_PublicFetch TransferFactoryView
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferFactory TransferFactory_PublicFetch TransferFactoryView
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferFactory TransferFactory_PublicFetch TransferFactoryView
 
 <div id="type-splice-api-token-transferinstructionv1-transferinstructionresult-24735">
 
@@ -298,74 +298,74 @@ Instruct transfers of holdings between parties.
 > > | Field            | Type                                                                                                          | Description                                                                                                                                                                    |
 > > |------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 > > | output           | TransferInstructionResult_Output                                                                              | The output of the step.                                                                                                                                                        |
-> > | senderChangeCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple transfer instructions in a single Daml transaction. |
+> > | senderChangeCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple transfer instructions in a single Daml transaction. |
 > > | meta             | Metadata                                                                                                      | Additional metadata specific to the transfer instruction, used for extensibility; e.g., fees charged.                                                                          |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionResult
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) TransferInstructionResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionResult
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) TransferInstructionResult
 >
-> **instance** HasMethod TransferFactory "transferFactory_transferImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+> **instance** HasMethod TransferFactory "transferFactory_transferImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult)
 >
-> **instance** HasMethod TransferInstruction "transferInstruction_acceptImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+> **instance** HasMethod TransferInstruction "transferInstruction_acceptImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult)
 >
-> **instance** HasMethod TransferInstruction "transferInstruction_rejectImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+> **instance** HasMethod TransferInstruction "transferInstruction_rejectImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult)
 >
-> **instance** HasMethod TransferInstruction "transferInstruction_updateImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+> **instance** HasMethod TransferInstruction "transferInstruction_updateImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult)
 >
-> **instance** HasMethod TransferInstruction "transferInstruction_withdrawImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+> **instance** HasMethod TransferInstruction "transferInstruction_withdrawImpl" ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferInstructionResult Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" TransferInstructionResult Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" TransferInstructionResult TransferInstructionResult_Output
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "output" TransferInstructionResult TransferInstructionResult_Output
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderChangeCids" TransferInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "senderChangeCids" TransferInstructionResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferInstructionResult Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" TransferInstructionResult Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" TransferInstructionResult TransferInstructionResult_Output
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "output" TransferInstructionResult TransferInstructionResult_Output
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderChangeCids" TransferInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "senderChangeCids" TransferInstructionResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferFactory TransferFactory_Transfer TransferInstructionResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferFactory TransferFactory_Transfer TransferInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Accept TransferInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Reject TransferInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Update TransferInstructionResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Update TransferInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferFactory TransferFactory_Transfer TransferInstructionResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) TransferFactory TransferFactory_Transfer TransferInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Accept TransferInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Reject TransferInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Update TransferInstructionResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Update TransferInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+> **instance** [HasExerciseGuarded](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferFactory TransferFactory_Transfer TransferInstructionResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferFactory TransferFactory_Transfer TransferInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Accept TransferInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Reject TransferInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Update TransferInstructionResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Update TransferInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferFactory TransferFactory_Transfer TransferInstructionResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferFactory TransferFactory_Transfer TransferInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Accept TransferInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Reject TransferInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Update TransferInstructionResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Update TransferInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
 
 <div id="type-splice-api-token-transferinstructionv1-transferinstructionresultoutput-59824">
 
@@ -385,7 +385,7 @@ Instruct transfers of holdings between parties.
 > >
 > > | Field                  | Type                                                                                                                  | Description                                                             |
 > > |------------------------|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-> > | transferInstructionCid | [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction | Contract id of the transfer instruction representing the pending state. |
+> > | transferInstructionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction | Contract id of the transfer instruction representing the pending state. |
 >
 > <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresultcompleted-47798">
 >
@@ -397,7 +397,7 @@ Instruct transfers of holdings between parties.
 > >
 > > | Field               | Type                                                                                                          | Description                                                                                       |
 > > |---------------------|---------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
-> > | receiverHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The newly created holdings owned by the receiver as part of successfully completing the transfer. |
+> > | receiverHoldingCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] | The newly created holdings owned by the receiver as part of successfully completing the transfer. |
 >
 > <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresultfailed-21543">
 >
@@ -407,21 +407,21 @@ Instruct transfers of holdings between parties.
 >
 > > Use this result to communicate that the transfer did not succeed and all holdings (minus fees) have been returned to the sender.
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionResult_Output
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) TransferInstructionResult_Output
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionResult_Output
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) TransferInstructionResult_Output
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" TransferInstructionResult TransferInstructionResult_Output
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "output" TransferInstructionResult TransferInstructionResult_Output
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiverHoldingCids" TransferInstructionResult_Output \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "receiverHoldingCids" TransferInstructionResult_Output \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferInstructionCid" TransferInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction)
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "transferInstructionCid" TransferInstructionResult_Output ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" TransferInstructionResult TransferInstructionResult_Output
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "output" TransferInstructionResult TransferInstructionResult_Output
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiverHoldingCids" TransferInstructionResult_Output \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "receiverHoldingCids" TransferInstructionResult_Output \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferInstructionCid" TransferInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction)
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "transferInstructionCid" TransferInstructionResult_Output ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction)
 
 <div id="type-splice-api-token-transferinstructionv1-transferinstructionstatus-36298">
 
@@ -449,19 +449,19 @@ Instruct transfers of holdings between parties.
 > >
 > > | Field          | Type                                                                                                                                                                                                                                                         | Description                                                                                                                                            |
 > > |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | pendingActions | [Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | The actions that a party could take to advance the transfer. This field can by used to inform wallet users whether they need to take an action or not. |
+> > | pendingActions | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) [Text](/appdev/reference/daml-standard-library/prelude) | The actions that a party could take to advance the transfer. This field can by used to inform wallet users whether they need to take an action or not. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionStatus
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) TransferInstructionStatus
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionStatus
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) TransferInstructionStatus
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "pendingActions" TransferInstructionStatus ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "pendingActions" TransferInstructionStatus ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) [Text](/appdev/reference/daml-standard-library/prelude))
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "status" TransferInstructionView TransferInstructionStatus
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "status" TransferInstructionView TransferInstructionStatus
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "pendingActions" TransferInstructionStatus ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "pendingActions" TransferInstructionStatus ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) [Text](/appdev/reference/daml-standard-library/prelude))
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "status" TransferInstructionView TransferInstructionStatus
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "status" TransferInstructionView TransferInstructionStatus
 
 <div id="type-splice-api-token-transferinstructionv1-transferinstructionview-46309">
 
@@ -479,76 +479,76 @@ Instruct transfers of holdings between parties.
 >
 > > | Field                  | Type                                                                                                                                                                                                                       | Description                                                                                                                                                                                                                          |
 > > |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | originalInstructionCid | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction) | The contract id of the original transfer instruction contract. Used by the wallet to track the lineage of transfer instructions through multiple steps. Only set if the registry evolves the transfer instruction in multiple steps. |
+> > | originalInstructionCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction) | The contract id of the original transfer instruction contract. Used by the wallet to track the lineage of transfer instructions through multiple steps. Only set if the registry evolves the transfer instruction in multiple steps. |
 > > | transfer               | Transfer                                                                                                                                                                                                                   | The transfer specified by the transfer instruction.                                                                                                                                                                                  |
 > > | status                 | TransferInstructionStatus                                                                                                                                                                                                  | The status of the transfer instruction.                                                                                                                                                                                              |
 > > | meta                   | Metadata                                                                                                                                                                                                                   | Additional metadata specific to the transfer instruction, used for extensibility; e.g., more detailed status information.                                                                                                            |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionView
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude) TransferInstructionView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionView
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude) TransferInstructionView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) TransferInstruction TransferInstructionView
+> **instance** [HasFromAnyView](/appdev/reference/daml-standard-library/da-internal-interface-anyview#class-da-internal-interface-anyview-hasfromanyview-30108) TransferInstruction TransferInstructionView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) TransferInstruction TransferInstructionView
+> **instance** [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) TransferInstruction TransferInstructionView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferInstructionView Metadata
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "meta" TransferInstructionView Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "originalInstructionCid" TransferInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction))
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "originalInstructionCid" TransferInstructionView ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction))
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "status" TransferInstructionView TransferInstructionStatus
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "status" TransferInstructionView TransferInstructionStatus
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transfer" TransferInstructionView Transfer
+> **instance** [GetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-getfield-53979) "transfer" TransferInstructionView Transfer
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferInstructionView Metadata
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "meta" TransferInstructionView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "originalInstructionCid" TransferInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction))
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "originalInstructionCid" TransferInstructionView ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction))
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "status" TransferInstructionView TransferInstructionStatus
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "status" TransferInstructionView TransferInstructionStatus
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transfer" TransferInstructionView Transfer
+> **instance** [SetField](/appdev/reference/daml-standard-library/da-record#class-da-internal-record-setfield-4311) "transfer" TransferInstructionView Transfer
 
 ## Functions
 
 <div id="function-splice-api-token-transferinstructionv1-transferinstructionacceptimpl-78274">
 
 transferInstruction_acceptImpl
-: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+: TransferInstruction -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-transferinstructionv1-transferinstructionrejectimpl-50311">
 
 transferInstruction_rejectImpl
-: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+: TransferInstruction -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-transferinstructionv1-transferinstructionwithdrawimpl-10586">
 
 transferInstruction_withdrawImpl
-: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+: TransferInstruction -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-transferinstructionv1-transferinstructionupdateimpl-73329">
 
 transferInstruction_updateImpl
-: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+: TransferInstruction -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-transferinstructionv1-transferfactorytransferimpl-82483">
 
 transferFactory_transferImpl
-: TransferFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+: TransferFactory -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-transferinstructionv1-transferfactorypublicfetchimpl-930">
 
 transferFactory_publicFetchImpl
-: TransferFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferFactoryView
+: TransferFactory -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferFactoryView
 
 </div>
 


### PR DESCRIPTION
## Summary

- Replace migrated Splice Daml API reference links that still pointed at `docs.daml.com/daml/stdlib`.
- Point those references at the migrated Daml standard-library pages under `/appdev/reference/daml-standard-library`.
- Preserve hash anchors where the migrated target page exposes the same anchor; use page-level Prelude links for old anchors that are not present in the migrated output.

## Validation

- `rg -n 'docs\\.daml\\.com' docs-main` returns no matches.
- Checked retained standard-library hash anchors used by the Splice Daml pages resolve to spans in the migrated target files.
- `git diff --cached --check` passed before commit.