### PR TITLE
Keep MainNet and TestNet version tabs separate

### DIFF
--- a/docs-main/snippets/components/version.mdx
+++ b/docs-main/snippets/components/version.mdx
@@ -228,12 +228,13 @@ export const Version = ({ children, title, description, defaultLabel, networkDat
   const networksForVersion = (version) => {
     return networkOrder.filter((networkKey) => networkData[networkKey]?.versions?.splice === version);
   };
-  const networkNames = (networkKeys) => {
-    return networkKeys.map((networkKey) => networkData[networkKey]?.name ?? networkKey).join(' / ');
-  };
   const labelForVersion = (version) => {
     const networks = networksForVersion(version);
-    return networks.length ? `${networkNames(networks)} (${version})` : `CN ${version}`;
+    if (networks.length === 1) {
+      const networkKey = networks[0];
+      return `${networkData[networkKey]?.name ?? networkKey} (${version})`;
+    }
+    return `CN ${version}`;
   };
   const labelWithVersion = (label, version) => {
     return version ? `${label} (${version})` : label;
@@ -253,14 +254,29 @@ export const Version = ({ children, title, description, defaultLabel, networkDat
     return option;
   };
   const options = React.Children.toArray(children).filter((child) => child?.props?.label || child?.props?.version);
+  const tabOptions = options.flatMap((option) => {
+    if (option.props.label) {
+      return [{ label: optionLabel(option), option }];
+    }
+
+    const networks = networksForVersion(option.props.version);
+    if (!networks.length) {
+      return [{ label: optionLabel(option), option }];
+    }
+
+    return networks.map((networkKey) => ({
+      label: labelWithVersion(networkData[networkKey]?.name ?? networkKey, option.props.version),
+      option,
+    }));
+  });
   const defaultIndex = Math.max(
     0,
-    options.findIndex((child) => optionLabel(child) === defaultLabel),
+    tabOptions.findIndex((tab) => tab.label === defaultLabel),
   );
   const [activeIndex, setActiveIndex] = React.useState(defaultIndex);
-  const activeOption = options[activeIndex] ?? options[0];
+  const activeOption = tabOptions[activeIndex]?.option ?? tabOptions[0]?.option;
 
-  if (!options.length) {
+  if (!tabOptions.length) {
     return null;
   }
 
@@ -273,9 +289,8 @@ export const Version = ({ children, title, description, defaultLabel, networkDat
         </div>
       )}
       <div role="tablist" className="flex gap-1 border-b border-gray-200 bg-gray-50 p-1 dark:border-gray-800 dark:bg-gray-900">
-        {options.map((option, index) => {
+        {tabOptions.map(({ label }, index) => {
           const isActive = index === activeIndex;
-          const label = optionLabel(option);
           const buttonClass = isActive
             ? 'rounded-md bg-white text-gray-950 shadow-sm dark:bg-gray-800 dark:text-gray-100'
             : 'rounded-md text-gray-600 hover:bg-white/80 hover:text-gray-950 dark:text-gray-400 dark:hover:bg-gray-800/70 dark:hover:text-gray-100';


### PR DESCRIPTION
## Summary

- expand version-backed tabs into one tab per network instead of merging networks that share the same Splice version
- keep MainNet and TestNet visible as separate tabs while reusing the same version-specific content

Fixes #524.

## Screenshot

![After: separate MainNet, TestNet, and DevNet tabs](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issue-524-screenshots/pr-assets/issue-524/tabs-after.png)

The affected LSU recovery section now shows distinct `MainNet (0.5.18)`, `TestNet (0.5.18)`, and `DevNet (0.6.3)` tabs.

## Validation

- `direnv exec /Users/danielporter/control/.worktrees/cf-docs-issue-524-mainnet-testnet-tabs npm --prefix /Users/danielporter/control/.worktrees/cf-docs-issue-524-mainnet-testnet-tabs exec -- mintlify validate`
- `git diff --check`
- Local Mintlify preview at `http://localhost:3000/global-synchronizer/production-operations/logical-synchronizer-upgrade#disaster-recovery-through-roll-forward-lsu`; verified all three tab controls render and TestNet/DevNet tab selection works.
