### PR TITLE
Update Canton Docker image docs

### DIFF
--- a/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
+++ b/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
@@ -67,7 +67,7 @@ Interested in Canton? This is the right place to start! You don't need any prere
 
 ## Installation
 
-Canton is a JVM application. To run it natively you need Java 11 or higher installed on your system. Alternatively Canton is available as a [docker image](https://hub.docker.com/r/digitalasset/canton-open-source) (see Canton docker instructions).
+Canton is a JVM application. To run it natively you need Java 11 or higher installed on your system. Alternatively, you can use the Canton Docker images listed in [Obtaining the Docker Images](/global-synchronizer/deployment/docker#obtaining-the-docker-images).
 
 Canton is platform-agnostic. For development purposes, it runs on macOS, Linux, and Windows. Linux is the supported platform for production.
 

--- a/docs-main/global-synchronizer/deployment/docker.mdx
+++ b/docs-main/global-synchronizer/deployment/docker.mdx
@@ -22,6 +22,8 @@ docker pull \
     europe-docker.pkg.dev/da-images/public/docker/canton-mediator:3.4.8
 ```
 
+Replace `3.4.8` in the examples with the Canton version tag you want to use.
+
 Visit `https://europe-docker.pkg.dev/v2/da-images/public/docker/canton-participant/tags/list` to see available tags.
 
 These docker images are published starting with Canton version 3.4.8.
@@ -114,4 +116,3 @@ docker run -e ADDITIONAL_CONFIG="canton.participants.participant1 {
 The `--console` flag starts canton in interactive console mode.
 
 {/* COPIED_END */}
-


### PR DESCRIPTION
Closes #526.

## Summary
- replace the old Docker Hub image link in the Canton getting-started tutorial with an internal link to the maintained Docker image instructions
- clarify that the Docker pull examples use an example version tag and readers should substitute the Canton version they want

## Validation
- `direnv exec . git diff --check`
- `direnv exec .. npx mintlify validate` from `docs-main`
- local Mintlify preview on `http://localhost:3026`

## Screenshots

Getting started installation now links to the Docker image instructions instead of Docker Hub.

![Getting started installation Docker link](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issue-526-screenshots/docs-main/images/pr-assets/cf-docs-issue-526/getting-started-installation.png)

Docker image instructions now tell readers to replace the example `3.4.8` tag with the version they want.

![Docker version substitution note](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issue-526-screenshots/docs-main/images/pr-assets/cf-docs-issue-526/docker-version-substitution.png)