### PR TITLE
Update advanced operations page and snippets

### DIFF
--- a/docs-main/global-synchronizer/canton-console/advanced-operations.mdx
+++ b/docs-main/global-synchronizer/canton-console/advanced-operations.mdx
@@ -8,6 +8,9 @@ import CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_1 from "/snippets/ex
 import CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_2 from "/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-2.mdx";
 import CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_3 from "/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-3.mdx";
 import CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_4 from "/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-4.mdx";
+import CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_5 from "/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-5.mdx";
+import CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_6 from "/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-6.mdx";
+import CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_7 from "/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-7.mdx";
 import CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_REPAIR_HOCON_0 from "/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/docs-global-synchronizer-canton-console-advanced-operations-repair-hocon-0.mdx";
 import CantonGlobalSynchronizerCantonConsoleAdvancedOperationsL114 from "/snippets/canton-docs/global-synchronizer_canton-console_advanced-operations_L114.mdx";
 import CantonGlobalSynchronizerCantonConsoleAdvancedOperationsL172 from "/snippets/canton-docs/global-synchronizer_canton-console_advanced-operations_L172.mdx";
@@ -62,7 +65,7 @@ Adding a new party to a participant:
 For more complex topology changes -- such as adjusting confirmation thresholds or adding hosting participants -- you work with the topology management commands:
 
 
-<CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_3 />
+<CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_4 />
 
 
 Topology changes propagate through the synchronizer's topology protocol. There is a built-in delay between when a topology change is proposed and when it becomes effective. This delay is configurable at the synchronizer level and exists to prevent rapid, potentially harmful changes.
@@ -76,7 +79,7 @@ Canton nodes use cryptographic keys for signing and encryption. Over time, you m
 View the keys currently registered on a participant:
 
 
-<CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_4 />
+<CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_5 />
 
 
 This shows key fingerprints, purposes (signing or encryption), and the key scheme.
@@ -86,13 +89,13 @@ This shows key fingerprints, purposes (signing or encryption), and the key schem
 Generate a new signing key:
 
 
-<CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_4 />
+<CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_6 />
 
 
 Generate a new encryption key:
 
 
-<CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_4 />
+<CANTON_DOCS_CN_GS_CANTON_CONSOLE_ADVANCED_OPERATIONS_7 />
 
 
 ### Key rotation

--- a/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-3.mdx
+++ b/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-3.mdx
@@ -2,20 +2,3 @@
 @ val aliceParty = participant1.parties.enable("Alice")
     aliceParty : PartyId = Alice::12201ff69b1d...
 ```
-
-```scala
-@ participant1.topology.party_to_participant_mappings.propose(party = aliceParty, newParticipants = Seq((participant2.id, ParticipantPermission.Observation)))
-    res5: SignedTopologyTransaction[TopologyChangeOp, PartyToParticipant] = SignedTopologyTransaction(
-      TopologyTransaction(
-        PartyToParticipant(
-          partyId = Alice::12201ff69b1d...,
-          participants = PAR::participant2::1220a4d7463b... -> Observation
-        ),
-        serial = 1,
-        operation = Replace,
-        hash = SHA-256:9360f5c90483...
-      ),
-      signatures = 12201ff69b1d...,
-      proposal
-    )
-```

--- a/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-4.mdx
+++ b/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-4.mdx
@@ -1,75 +1,16 @@
 ```scala
-@ participant1.keys.secret.list()
-    res6: Seq[com.digitalasset.canton.crypto.admin.grpc.PrivateKeyMetadata] = Vector(
-      PrivateKeyMetadata(
-        publicKeyWithName = SigningPublicKeyWithName(
-          publicKey = SigningPublicKey(
-            id = 12201ff69b1d...,
-            format = DER-encoded X.509 SubjectPublicKeyInfo,
-            keySpec = EC-Curve25519,
-            usage = namespace
-          ),
-          name = Some(KeyName(participant1-namespace))
+@ participant1.topology.party_to_participant_mappings.propose(party = aliceParty, newParticipants = Seq((participant2.id, ParticipantPermission.Observation)))
+    res5: SignedTopologyTransaction[TopologyChangeOp, PartyToParticipant] = SignedTopologyTransaction(
+      TopologyTransaction(
+        PartyToParticipant(
+          partyId = Alice::12201ff69b1d...,
+          participants = PAR::participant2::1220a4d7463b... -> Observation
         ),
-        wrapperKeyId = None,
-        kmsKeyId = None
+        serial = 1,
+        operation = Replace,
+        hash = SHA-256:9360f5c90483...
       ),
-      PrivateKeyMetadata(
-        publicKeyWithName = SigningPublicKeyWithName(
-          publicKey = SigningPublicKey(
-            id = 122044fb1b35...,
-            format = DER-encoded X.509 SubjectPublicKeyInfo,
-            keySpec = EC-Curve25519,
-            usage = Set(signing, proof-of-ownership)
-          ),
-          name = Some(KeyName(participant1-signing))
-        ),
-        wrapperKeyId = None,
-        kmsKeyId = None
-      ),
-      PrivateKeyMetadata(
-        publicKeyWithName = SigningPublicKeyWithName(
-          publicKey = SigningPublicKey(
-            id = 12202ac7545b...,
-            format = DER-encoded X.509 SubjectPublicKeyInfo,
-            keySpec = EC-Curve25519,
-            usage = Set(sequencer-auth, proof-of-ownership)
-          ),
-          name = Some(KeyName(participant1-sequencer-auth))
-        ),
-        wrapperKeyId = None,
-        kmsKeyId = None
-      ),
-      PrivateKeyMetadata(
-        publicKeyWithName = EncryptionPublicKeyWithName(
-          publicKey = EncryptionPublicKey(
-            id = 1220f78c3e7e...,
-            format = DER-encoded X.509 SubjectPublicKeyInfo,
-            keySpec = EC-P256
-          ),
-          name = Some(KeyName(participant1-encryption))
-        ),
-        wrapperKeyId = None,
-        kmsKeyId = None
-      )
-    )
-```
-
-```scala
-@ val newKey = participant1.keys.secret.generate_signing_key(name = "new-signing-key", usage = SigningKeyUsage.All)
-    newKey : SigningPublicKey = SigningPublicKey(
-      id = 122006262a3e...,
-      format = DER-encoded X.509 SubjectPublicKeyInfo,
-      keySpec = EC-Curve25519,
-      usage = Set(namespace, sequencer-auth, signing, proof-of-ownership)
-    )
-```
-
-```scala
-@ val newEncKey = participant1.keys.secret.generate_encryption_key(name = "new-encryption-key")
-    newEncKey : EncryptionPublicKey = EncryptionPublicKey(
-      id = 12209242c045...,
-      format = DER-encoded X.509 SubjectPublicKeyInfo,
-      keySpec = EC-P256
+      signatures = 12201ff69b1d...,
+      proposal
     )
 ```

--- a/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-5.mdx
+++ b/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-5.mdx
@@ -1,0 +1,56 @@
+```scala
+@ participant1.keys.secret.list()
+    res6: Seq[com.digitalasset.canton.crypto.admin.grpc.PrivateKeyMetadata] = Vector(
+      PrivateKeyMetadata(
+        publicKeyWithName = SigningPublicKeyWithName(
+          publicKey = SigningPublicKey(
+            id = 12201ff69b1d...,
+            format = DER-encoded X.509 SubjectPublicKeyInfo,
+            keySpec = EC-Curve25519,
+            usage = namespace
+          ),
+          name = Some(KeyName(participant1-namespace))
+        ),
+        wrapperKeyId = None,
+        kmsKeyId = None
+      ),
+      PrivateKeyMetadata(
+        publicKeyWithName = SigningPublicKeyWithName(
+          publicKey = SigningPublicKey(
+            id = 122044fb1b35...,
+            format = DER-encoded X.509 SubjectPublicKeyInfo,
+            keySpec = EC-Curve25519,
+            usage = Set(signing, proof-of-ownership)
+          ),
+          name = Some(KeyName(participant1-signing))
+        ),
+        wrapperKeyId = None,
+        kmsKeyId = None
+      ),
+      PrivateKeyMetadata(
+        publicKeyWithName = SigningPublicKeyWithName(
+          publicKey = SigningPublicKey(
+            id = 12202ac7545b...,
+            format = DER-encoded X.509 SubjectPublicKeyInfo,
+            keySpec = EC-Curve25519,
+            usage = Set(sequencer-auth, proof-of-ownership)
+          ),
+          name = Some(KeyName(participant1-sequencer-auth))
+        ),
+        wrapperKeyId = None,
+        kmsKeyId = None
+      ),
+      PrivateKeyMetadata(
+        publicKeyWithName = EncryptionPublicKeyWithName(
+          publicKey = EncryptionPublicKey(
+            id = 1220f78c3e7e...,
+            format = DER-encoded X.509 SubjectPublicKeyInfo,
+            keySpec = EC-P256
+          ),
+          name = Some(KeyName(participant1-encryption))
+        ),
+        wrapperKeyId = None,
+        kmsKeyId = None
+      )
+    )
+```

--- a/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-6.mdx
+++ b/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-6.mdx
@@ -1,0 +1,9 @@
+```scala
+@ val newKey = participant1.keys.secret.generate_signing_key(name = "new-signing-key", usage = SigningKeyUsage.All)
+    newKey : SigningPublicKey = SigningPublicKey(
+      id = 122006262a3e...,
+      format = DER-encoded X.509 SubjectPublicKeyInfo,
+      keySpec = EC-Curve25519,
+      usage = Set(namespace, sequencer-auth, signing, proof-of-ownership)
+    )
+```

--- a/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-7.mdx
+++ b/docs-main/snippets/external/canton/main/docs-open/target/snippet_json_data/docs-cn/global-synchronizer-canton-console-advanced-operations-7.mdx
@@ -1,0 +1,8 @@
+```scala
+@ val newEncKey = participant1.keys.secret.generate_encryption_key(name = "new-encryption-key")
+    newEncKey : EncryptionPublicKey = EncryptionPublicKey(
+      id = 12209242c045...,
+      format = DER-encoded X.509 SubjectPublicKeyInfo,
+      keySpec = EC-P256
+    )
+```


### PR DESCRIPTION
Fixes #481, split up snippets on the [docs-main/global-synchronizer/canton-console/advanced-operations.mdx](https://github.com/canton-network/cf-docs/compare/content/update-advanced-operations?expand=1#diff-3c374021156f1276f161b2acbe838ce0c5010ab6baf8d5f23f5d3698e8197010) file. Updates snippet files accordingly.