### PR TITLE
Update Canton Docker image references (#526, #533)

### DIFF
--- a/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
+++ b/docs-main/global-synchronizer/canton-console/getting-started-tutorial.mdx
@@ -67,7 +67,7 @@ Interested in Canton? This is the right place to start! You don't need any prere
 
 ## Installation
 
-Canton is a JVM application. To run it natively you need Java 11 or higher installed on your system. Alternatively Canton is available as a [docker image](https://hub.docker.com/r/digitalasset/canton-open-source) (see Canton docker instructions).
+Canton is a JVM application. To run it natively you need Java 11 or higher installed on your system. Alternatively Canton is available as a Docker image at `ghcr.io/digital-asset/decentralized-canton-sync/docker/canton`; published tags are listed on the [decentralized-canton-sync packages page](https://github.com/digital-asset/decentralized-canton-sync/pkgs/container/decentralized-canton-sync%2Fdocker%2Fcanton). See the [Version Compatibility Dashboard](/shared/version-compatibility-dashboard) for the current tag for each network.
 
 Canton is platform-agnostic. For development purposes, it runs on macOS, Linux, and Windows. Linux is the supported platform for production.
 

--- a/docs-main/global-synchronizer/production-operations/monitoring-setup.mdx
+++ b/docs-main/global-synchronizer/production-operations/monitoring-setup.mdx
@@ -21,6 +21,10 @@ how should this relate to the other observability docs that we have? we have the
 
 This section provides an example of how Canton can be run inside a connected network of Docker containers. The example also shows how you can monitor network activity. See the [glossary](/overview/understand/glossary) for monitoring term definitions and the [Monitoring Choices](#monitoring-choices) section for the reasoning behind the example monitoring setup.
 
+<Note>
+The Canton container image is published at `ghcr.io/digital-asset/decentralized-canton-sync/docker/canton`. The example Docker Compose snippets below use `${CANTON_VERSION}` as a placeholder for the tag — export `CANTON_VERSION` to the value for your target network before running them, or substitute it inline. See the [Version Compatibility Dashboard](/shared/version-compatibility-dashboard) for the current tag on MainNet, TestNet, and DevNet.
+</Note>
+
 ### Container Setup
 
 To configure [Docker Compose](https://docs.docker.com/compose/) to spin up the Docker container network shown in the diagram, use the information below. See the `compose` documentation for detailed information concerning the structure of the configuration files.
@@ -123,7 +127,7 @@ The participant container has two files mapped into it on container creation. Th
 ```yaml
 services:
   participant1:
-    image: digitalasset/canton-open-source:2.5.1
+    image: ghcr.io/digital-asset/decentralized-canton-sync/docker/canton:${CANTON_VERSION}
     container_name: participant1
     hostname: participant1
     volumes:
@@ -185,7 +189,7 @@ The setup for participant2 is identical, except that the name and ports are chan
 ```yaml
 services:
   participant2:
-    image: digitalasset/canton-open-source:2.5.1
+    image: ghcr.io/digital-asset/decentralized-canton-sync/docker/canton:${CANTON_VERSION}
     container_name: participant2
     hostname: participant2
     volumes:
@@ -575,7 +579,7 @@ services:
 
 The Docker images need to be pulled down before starting the network:
 
-- digitalasset/canton-open-source:2.5.1
+- `ghcr.io/digital-asset/decentralized-canton-sync/docker/canton:${CANTON_VERSION}`
 - docker.elastic.co/elasticsearch/elasticsearch:8.5.2
 - docker.elastic.co/kibana/kibana:8.5.2
 - docker.elastic.co/logstash/logstash:8.5.1


### PR DESCRIPTION
## Summary

Closes #526
Closes #533.

Two related fixes about how the Canton Docker image is referenced across the docs.

## Fixes

### #526 — Docker image location

The Canton Getting Started Tutorial linked at `hub.docker.com/r/digitalasset/canton-open-source`, which is no longer where the Canton image is published. Repointed at `ghcr.io/digital-asset/decentralized-canton-sync/docker/canton` (the location already referenced by `docker_repo_prefix` in `config/repo-version-config.json`) and linked the GitHub Packages page for browsing available tags. Added a pointer to the Version Compatibility Dashboard for picking the right tag per network.

### #533 — generalize hardcoded Canton version in Docker examples

`monitoring-setup.mdx` had three Docker Compose examples hardcoded to `digitalasset/canton-open-source:2.5.1` — Canton 2.x, several major versions stale (we're on 3.4.12 / 3.5.1 per #558). Replaced all three with `ghcr.io/digital-asset/decentralized-canton-sync/docker/canton:${CANTON_VERSION}` and added a `<Note>` at the top of the "Example Monitoring Setup" section telling readers to export `CANTON_VERSION` from the Version Compatibility Dashboard before running the examples.