### PR TITLE
Codegen and port the 12 compiled Splice Daml packages (#451)

### DIFF
--- a/docs-main/appdev/deep-dives/token-standard.mdx
+++ b/docs-main/appdev/deep-dives/token-standard.mdx
@@ -294,9 +294,7 @@ Note that `AllocationRequest_Reject` and `AllocationRequest_Withdraw` should be 
 
 Calling the token standard choices from custom Daml code is useful when integrating one's own app workflows with the token standard. Example workflows relevant to a wallet provider are merging of holdings for a user to keep their ACS small, doing bulk transfers, or marking a user's action as activity of the wallet app.
 
-Splice releases the optional `splice-util-token-standard-wallet.dar` file, which packages common workflows that improve the operations of a wallet app.
-
-{/* TODO(#539): Port per-package reference for splice-util-token-standard-wallet into this site. */}
+Splice releases the optional `splice-util-token-standard-wallet.dar` file, which packages common workflows that improve the operations of a wallet app. See [splice-util-token-standard-wallet](/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet) for the per-template reference.
 
 ## API References
 

--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -615,6 +615,38 @@
                     "group": "Splice Daml Packages",
                     "pages": [
                       {
+                        "group": "splice-amulet",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/index",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-round",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-types",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense"
+                        ]
+                      },
+                      {
+                        "group": "splice-amulet-name-service",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/index",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed",
+                          "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans"
+                        ]
+                      },
+                      {
                         "group": "splice-api-featured-app-v1",
                         "pages": [
                           "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/index",
@@ -629,13 +661,6 @@
                         ]
                       },
                       {
-                        "group": "splice-api-token-allocation-v1",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/index",
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1"
-                        ]
-                      },
-                      {
                         "group": "splice-api-token-allocation-instruction-v1",
                         "pages": [
                           "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/index",
@@ -647,6 +672,13 @@
                         "pages": [
                           "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/index",
                           "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-api-token-allocation-v1",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/index",
+                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1"
                         ]
                       },
                       {
@@ -675,6 +707,95 @@
                         "pages": [
                           "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/index",
                           "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1"
+                        ]
+                      },
+                      {
+                        "group": "splice-dso-governance",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/index",
+                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft",
+                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice",
+                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer",
+                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate",
+                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap",
+                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules",
+                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding"
+                        ]
+                      },
+                      {
+                        "group": "splice-token-standard-test",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/index",
+                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry-parameters",
+                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry",
+                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-registryapi",
+                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-walletclient",
+                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-utils",
+                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokendvp",
+                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokentransfer"
+                        ]
+                      },
+                      {
+                        "group": "splice-token-test-trading-app",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/index",
+                          "sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp"
+                        ]
+                      },
+                      {
+                        "group": "splice-util",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-util/index",
+                          "sdks-tools/api-reference/splice-daml/splice-util/splice-util"
+                        ]
+                      },
+                      {
+                        "group": "splice-util-batched-markers",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-util-batched-markers/index",
+                          "sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy"
+                        ]
+                      },
+                      {
+                        "group": "splice-util-featured-app-proxies",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/index",
+                          "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy",
+                          "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy"
+                        ]
+                      },
+                      {
+                        "group": "splice-util-token-standard-wallet",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/index",
+                          "sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation"
+                        ]
+                      },
+                      {
+                        "group": "splice-validator-lifecycle",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/index",
+                          "sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding"
+                        ]
+                      },
+                      {
+                        "group": "splice-wallet",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-wallet/index",
+                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-buytrafficrequest",
+                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-install",
+                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-mintingdelegation",
+                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-topupstate",
+                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferoffer",
+                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferpreapproval"
+                        ]
+                      },
+                      {
+                        "group": "splice-wallet-payments",
+                        "pages": [
+                          "sdks-tools/api-reference/splice-daml/splice-wallet-payments/index",
+                          "sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment",
+                          "sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions"
                         ]
                       }
                     ]

--- a/docs-main/sdks-tools/api-reference/splice-daml-apis.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml-apis.mdx
@@ -25,9 +25,7 @@ Refer to the [Token Standard documentation](/appdev/deep-dives/token-standard) s
   - [splice-api-featured-app-v2](/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2) — current API
   - [splice-api-featured-app-v1](/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1) — previous API
 
-- The utility package `splice-util-featured-app-proxies` provides templates that allow to delegate the usage of featured app rights to other parties for the purpose of executing token standard actions. Use these templates to earn app rewards on token standard operations, and to potentially share some of them with your users.
-
-  {/* TODO(#539): Port per-package reference for splice-util-featured-app-proxies into this site. */}
+- The utility package [splice-util-featured-app-proxies](/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies) provides templates that allow to delegate the usage of featured app rights to other parties for the purpose of executing token standard actions. Use these templates to earn app rewards on token standard operations, and to potentially share some of them with your users.
 
 ### How to earn featured app rewards for wallet user activity
 

--- a/docs-main/sdks-tools/api-reference/splice-daml-models.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml-models.mdx
@@ -7,7 +7,16 @@ description: "The Daml model packages shipped with Splice"
 
 Use the docs below when interacting with the on-ledger state of the decentralized applications that are part of Splice.
 
-{/* TODO(#539): Port per-package Daml reference content into this site: splice-amulet, splice-amulet-name-service, splice-dso-governance, splice-util, splice-validator-lifecycle, splice-wallet, splice-wallet-payments, splice-token-test-trading-app, splice-token-standard-test, splice-util-batched-markers. */}
+- [splice-amulet](/sdks-tools/api-reference/splice-daml/splice-amulet) — Canton Coin (CC) token, transfer, allocation, fees, and rounds.
+- [splice-amulet-name-service](/sdks-tools/api-reference/splice-daml/splice-amulet-name-service) — Canton Name Service (CNS) for human-readable party names.
+- [splice-dso-governance](/sdks-tools/api-reference/splice-daml/splice-dso-governance) — Decentralized Synchronizer Operator governance contracts.
+- [splice-util](/sdks-tools/api-reference/splice-daml/splice-util) — shared utility functions used across Splice apps.
+- [splice-util-batched-markers](/sdks-tools/api-reference/splice-daml/splice-util-batched-markers) — batched featured-app activity markers.
+- [splice-validator-lifecycle](/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle) — validator onboarding and lifecycle contracts.
+- [splice-wallet](/sdks-tools/api-reference/splice-daml/splice-wallet) — user wallet, transfer offers, top-ups, and pre-approvals.
+- [splice-wallet-payments](/sdks-tools/api-reference/splice-daml/splice-wallet-payments) — payment and subscription contracts.
+- [splice-token-standard-test](/sdks-tools/api-reference/splice-daml/splice-token-standard-test) — test utilities for Canton Network Token Standard implementations.
+- [splice-token-test-trading-app](/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app) — example trading app exercising the token standard.
 
 For an overview of the apps and their relation, see [Splice Architecture](/sdks-tools/api-reference/splice-architecture).
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/index.mdx
@@ -1,0 +1,11 @@
+---
+title: "splice-amulet-name-service docs"
+description: "Documentation for splice-amulet-name-service docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet-name-service/docs/index.rst" tag="0.6.4" hash="88d9960a" */}
+
+- [Splice.Ans](/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans)
+- [Splice.Ans.AmuletConversionRateFeed](/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed.mdx
@@ -1,0 +1,153 @@
+---
+title: "Splice.Ans.AmuletConversionRateFeed"
+description: "Documentation for Splice.Ans.AmuletConversionRateFeed"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet-name-service/docs/Splice-Ans-AmuletConversionRateFeed.rst" tag="0.6.4" hash="463d54ac" */}
+
+Templates to communicate amulet conversion rates.
+
+This does not fit a narrow interpretation of "Amulet Name Service", but it fits very well if we widen the role of the ANS to serve as a store for public data of high-value to network participants. Evolving ANS in this direction is a long-standing plan.
+
+## Templates
+
+<div id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeed-90528">
+
+**template** AmuletConversionRateFeed
+
+</div>
+
+> Amulet conversion rate feed published by a given 'publisher'. Publisher must only create one feed per publisher. The feed can only be updated every 0.5 tickDuration as the SVs also only change the price on round boundaries and this avoids unnecessary load.
+>
+> Signatory: publisher
+>
+> | Field                | Type                                                                                                                                                                                                                                             | Description                                                                 |
+> |----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+> | publisher            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              |                                                                             |
+> | dso                  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              |                                                                             |
+> | nextUpdateAfter      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The earliest time after which the publisher is allowed to update this feed. |
+> | amuletConversionRate | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                               | conversion rate in USD/Amulet                                               |
+>
+> - <div id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdso-84096">
+>
+>   **Choice** AmuletConversionRateFeed_ArchiveAsDso
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletConversionRateFeed_ArchiveAsDsoResult
+>
+>   | Field  | Type                                                                                                         | Description |
+>   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> - <div id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdate-913">
+>
+>   **Choice** AmuletConversionRateFeed_Update
+>
+>   </div>
+>
+>   Controller: publisher
+>
+>   Returns: AmuletConversionRateFeed_UpdateResult
+>
+>   | Field                | Type                                                                                                                                         | Description                                    |
+>   |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------|
+>   | amuletConversionRate | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                           |                                                |
+>   | amuletRulesCid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules    |                                                |
+>   | markerContextO       | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MarkerContext |                                                |
+>   | newNextUpdateAfter   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                            | Must be set to at least now + 0.5 tickDuration |
+>
+> - **Choice** Archive
+>
+>   Controller: publisher
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Orphan Typeclass Instances
+
+**instance** HasCheckedFetch FeaturedAppRightView ForOwner
+
+## Data Types
+
+<div id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdsoresult-71133">
+
+**data** AmuletConversionRateFeed_ArchiveAsDsoResult
+
+</div>
+
+> <div id="constr-splice-ans-amuletconversionratefeed-amuletconversionratefeedarchiveasdsoresult-72702">
+>
+> AmuletConversionRateFeed_ArchiveAsDsoResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletConversionRateFeed AmuletConversionRateFeed_ArchiveAsDso AmuletConversionRateFeed_ArchiveAsDsoResult
+
+<div id="type-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdateresult-36312">
+
+**data** AmuletConversionRateFeed_UpdateResult
+
+</div>
+
+> <div id="constr-splice-ans-amuletconversionratefeed-amuletconversionratefeedupdateresult-68907">
+>
+> AmuletConversionRateFeed_UpdateResult
+>
+> </div>
+>
+> > | Field | Type                                                                                                                                                   | Description |
+> > |-------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletConversionRateFeed |             |
+>
+> **instance** GetField "cid" AmuletConversionRateFeed_UpdateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletConversionRateFeed)
+>
+> **instance** SetField "cid" AmuletConversionRateFeed_UpdateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletConversionRateFeed)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletConversionRateFeed AmuletConversionRateFeed_Update AmuletConversionRateFeed_UpdateResult
+
+<div id="type-splice-ans-amuletconversionratefeed-markercontext-2172">
+
+**data** MarkerContext
+
+</div>
+
+> <div id="constr-splice-ans-amuletconversionratefeed-markercontext-1187">
+>
+> MarkerContext
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                           | Description |
+> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
+> > | beneficiaries       | \[AppRewardBeneficiary\]                                                                                                                       |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MarkerContext
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MarkerContext
+>
+> **instance** GetField "beneficiaries" MarkerContext \[AppRewardBeneficiary\]
+>
+> **instance** GetField "featuredAppRightCid" MarkerContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** GetField "markerContextO" AmuletConversionRateFeed_Update ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MarkerContext)
+>
+> **instance** SetField "beneficiaries" MarkerContext \[AppRewardBeneficiary\]
+>
+> **instance** SetField "featuredAppRightCid" MarkerContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** SetField "markerContextO" AmuletConversionRateFeed_Update ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MarkerContext)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans.mdx
@@ -1,0 +1,655 @@
+---
+title: "Splice.Ans"
+description: "Documentation for Splice.Ans"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet-name-service/docs/Splice-Ans.rst" tag="0.6.4" hash="d9f9bd5b" */}
+
+## Templates
+
+<div id="type-splice-ans-ansentry-10233">
+
+**template** AnsEntry
+
+</div>
+
+> A ans entry that needs to be renewed continuously. Renewal recreates this contract with an updated `expiresAt` field.
+>
+> Signatory: user, dso
+>
+> | Field       | Type                                                                                                                | Description |
+> |-------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | user        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | name        | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+> | url         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+> | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+> | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
+>
+> - <div id="type-splice-ans-ansentryexpire-47228">
+>
+>   **Choice** AnsEntry_Expire
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: AnsEntry_ExpireResult
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | actor | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-ans-ansentryrenew-67717">
+>
+>   **Choice** AnsEntry_Renew
+>
+>   </div>
+>
+>   Controller: user, dso
+>
+>   Returns: AnsEntry_RenewResult
+>
+>   | Field     | Type                                                                                                                   | Description |
+>   |-----------|------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | extension | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: user, dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-ans-ansentrycontext-23879">
+
+**template** AnsEntryContext
+
+</div>
+
+> Signatory: dso, user
+>
+> | Field       | Type                                                                                                                                              | Description                                                                                                              |
+> |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
+> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |                                                                                                                          |
+> | user        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |                                                                                                                          |
+> | name        | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                      |                                                                                                                          |
+> | url         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                      |                                                                                                                          |
+> | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                      |                                                                                                                          |
+> | reference   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest | Reference to the corresponding subscription, note that the contract may already be archived. This is just a tracking id. |
+>
+> - <div id="type-splice-ans-ansentrycontextcollectentryrenewalpayment-76943">
+>
+>   **Choice** AnsEntryContext_CollectEntryRenewalPayment
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AnsEntryContext_CollectEntryRenewalPaymentResult
+>
+>   | Field           | Type                                                                                                                                              | Description                 |
+>   |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
+>   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment |                             |
+>   | entryCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry            | The currently active entry. |
+>   | transferContext | AppTransferContext                                                                                                                                |                             |
+>   | ansRulesCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsRules            |                             |
+>
+> - <div id="type-splice-ans-ansentrycontextcollectinitialentrypayment-71811">
+>
+>   **Choice** AnsEntryContext_CollectInitialEntryPayment
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AnsEntryContext_CollectInitialEntryPaymentResult
+>
+>   | Field           | Type                                                                                                                                                     | Description |
+>   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment |             |
+>   | transferContext | AppTransferContext                                                                                                                                       |             |
+>   | ansRulesCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsRules                   |             |
+>
+> - <div id="type-splice-ans-ansentrycontextrejectentryinitialpayment-22257">
+>
+>   **Choice** AnsEntryContext_RejectEntryInitialPayment
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AnsEntryContext_RejectEntryInitialPaymentResult
+>
+>   | Field           | Type                                                                                                                                                     | Description |
+>   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment |             |
+>   | transferContext | AppTransferContext                                                                                                                                       |             |
+>   | ansRulesCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsRules                   |             |
+>
+> - <div id="type-splice-ans-ansentrycontextterminate-64657">
+>
+>   **Choice** AnsEntryContext_Terminate
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: AnsEntryContext_TerminateResult
+>
+>   | Field                     | Type                                                                                                                                                 | Description |
+>   |---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | actor                     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                  |             |
+>   | terminatedSubscriptionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso, user
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-ans-ansrules-7552">
+
+**template** AnsRules
+
+</div>
+
+> The rules governing how users can pay to use the Amulet Name service.
+>
+> Signatory: dso
+>
+> | Field  | Type                                                                                                                | Description |
+> |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | config | AnsRulesConfig                                                                                                      |             |
+>
+> - <div id="type-splice-ans-ansrulescollectentryrenewalpayment-11710">
+>
+>   **Choice** AnsRules_CollectEntryRenewalPayment
+>
+>   </div>
+>
+>   Controller: dso, user
+>
+>   Returns: AnsRules_CollectEntryRenewalPaymentResult
+>
+>   | Field           | Type                                                                                                                                              | Description                 |
+>   |-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------|
+>   | user            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |                             |
+>   | entryContext    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext     |                             |
+>   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment |                             |
+>   | entryCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry            | The currently active entry. |
+>   | transferContext | AppTransferContext                                                                                                                                |                             |
+>
+> - <div id="type-splice-ans-ansrulescollectinitialentrypayment-44970">
+>
+>   **Choice** AnsRules_CollectInitialEntryPayment
+>
+>   </div>
+>
+>   Controller: dso, user
+>
+>   Returns: AnsRules_CollectInitialEntryPaymentResult
+>
+>   | Field           | Type                                                                                                                                                     | Description |
+>   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | user            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                      |             |
+>   | entryContext    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext            |             |
+>   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment |             |
+>   | transferContext | AppTransferContext                                                                                                                                       |             |
+>
+> - <div id="type-splice-ans-ansrulesrejectentryinitialpayment-30886">
+>
+>   **Choice** AnsRules_RejectEntryInitialPayment
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AnsRules_RejectEntryInitialPaymentResult
+>
+>   | Field           | Type                                                                                                                                                     | Description |
+>   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | paymentCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment |             |
+>   | transferContext | AppTransferContext                                                                                                                                       |             |
+>
+> - <div id="type-splice-ans-ansrulesrequestentry-90125">
+>
+>   **Choice** AnsRules_RequestEntry
+>
+>   </div>
+>
+>   Controller: user
+>
+>   Returns: AnsRules_RequestEntryResult
+>
+>   | Field       | Type                                                                                                                | Description |
+>   |-------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | name        | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | url         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | user        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-ans-ansentrycontextcollectentryrenewalpaymentresult-69826">
+
+**data** AnsEntryContext_CollectEntryRenewalPaymentResult
+
+</div>
+
+> <div id="constr-splice-ans-ansentrycontextcollectentryrenewalpaymentresult-18109">
+>
+> AnsEntryContext_CollectEntryRenewalPaymentResult
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                                                | Description |
+> > |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | entryCid             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry              |             |
+> > | subscriptionStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
+>
+> **instance** GetField "entryCid" AnsEntryContext_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** GetField "subscriptionStateCid" AnsEntryContext_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** SetField "entryCid" AnsEntryContext_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** SetField "subscriptionStateCid" AnsEntryContext_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntryContext AnsEntryContext_CollectEntryRenewalPayment AnsEntryContext_CollectEntryRenewalPaymentResult
+
+<div id="type-splice-ans-ansentrycontextcollectinitialentrypaymentresult-28518">
+
+**data** AnsEntryContext_CollectInitialEntryPaymentResult
+
+</div>
+
+> <div id="constr-splice-ans-ansentrycontextcollectinitialentrypaymentresult-16577">
+>
+> AnsEntryContext_CollectInitialEntryPaymentResult
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                                                | Description |
+> > |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | entryCid             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry              |             |
+> > | subscriptionStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
+>
+> **instance** GetField "entryCid" AnsEntryContext_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** GetField "subscriptionStateCid" AnsEntryContext_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** SetField "entryCid" AnsEntryContext_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** SetField "subscriptionStateCid" AnsEntryContext_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntryContext AnsEntryContext_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPaymentResult
+
+<div id="type-splice-ans-ansentrycontextrejectentryinitialpaymentresult-4316">
+
+**data** AnsEntryContext_RejectEntryInitialPaymentResult
+
+</div>
+
+> <div id="constr-splice-ans-ansentrycontextrejectentryinitialpaymentresult-49933">
+>
+> AnsEntryContext_RejectEntryInitialPaymentResult
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                                       | Description |
+> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "amuletSum" AnsEntryContext_RejectEntryInitialPaymentResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "amuletSum" AnsEntryContext_RejectEntryInitialPaymentResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntryContext AnsEntryContext_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPaymentResult
+
+<div id="type-splice-ans-ansentrycontextterminateresult-94524">
+
+**data** AnsEntryContext_TerminateResult
+
+</div>
+
+> <div id="constr-splice-ans-ansentrycontextterminateresult-84145">
+>
+> AnsEntryContext_TerminateResult
+>
+> </div>
+>
+> > (no fields)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntryContext AnsEntryContext_Terminate AnsEntryContext_TerminateResult
+
+<div id="type-splice-ans-ansentryexpireresult-89925">
+
+**data** AnsEntry_ExpireResult
+
+</div>
+
+> <div id="constr-splice-ans-ansentryexpireresult-16032">
+>
+> AnsEntry_ExpireResult
+>
+> </div>
+>
+> > (no fields)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntry AnsEntry_Expire AnsEntry_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntry AnsEntry_Expire AnsEntry_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntry AnsEntry_Expire AnsEntry_ExpireResult
+
+<div id="type-splice-ans-ansentryrenewresult-81012">
+
+**data** AnsEntry_RenewResult
+
+</div>
+
+> <div id="constr-splice-ans-ansentryrenewresult-69331">
+>
+> AnsEntry_RenewResult
+>
+> </div>
+>
+> > | Field    | Type                                                                                                                                   | Description |
+> > |----------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | entryCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry |             |
+>
+> **instance** GetField "entryCid" AnsEntry_RenewResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** SetField "entryCid" AnsEntry_RenewResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsEntry AnsEntry_Renew AnsEntry_RenewResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsEntry AnsEntry_Renew AnsEntry_RenewResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsEntry AnsEntry_Renew AnsEntry_RenewResult
+
+<div id="type-splice-ans-ansrulesconfig-16984">
+
+**data** AnsRulesConfig
+
+</div>
+
+> <div id="constr-splice-ans-ansrulesconfig-70959">
+>
+> AnsRulesConfig
+>
+> </div>
+>
+> > | Field             | Type                                                                                                                   | Description |
+> > |-------------------|------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | renewalDuration   | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) |             |
+> > | entryLifetime     | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) |             |
+> > | entryFee          | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)     |             |
+> > | descriptionPrefix | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)           |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AnsRulesConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AnsRulesConfig
+>
+> **instance** GetField "config" AnsRules AnsRulesConfig
+>
+> **instance** GetField "descriptionPrefix" AnsRulesConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "entryFee" AnsRulesConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "entryLifetime" AnsRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** GetField "renewalDuration" AnsRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "config" AnsRules AnsRulesConfig
+>
+> **instance** SetField "descriptionPrefix" AnsRulesConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "entryFee" AnsRulesConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "entryLifetime" AnsRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "renewalDuration" AnsRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+
+<div id="type-splice-ans-ansrulescollectentryrenewalpaymentresult-39091">
+
+**data** AnsRules_CollectEntryRenewalPaymentResult
+
+</div>
+
+> <div id="constr-splice-ans-ansrulescollectentryrenewalpaymentresult-73922">
+>
+> AnsRules_CollectEntryRenewalPaymentResult
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                                                | Description |
+> > |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | entryCid             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry              |             |
+> > | subscriptionStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
+>
+> **instance** GetField "entryCid" AnsRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** GetField "subscriptionStateCid" AnsRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** SetField "entryCid" AnsRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** SetField "subscriptionStateCid" AnsRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsRules AnsRules_CollectEntryRenewalPayment AnsRules_CollectEntryRenewalPaymentResult
+
+<div id="type-splice-ans-ansrulescollectinitialentrypaymentresult-64239">
+
+**data** AnsRules_CollectInitialEntryPaymentResult
+
+</div>
+
+> <div id="constr-splice-ans-ansrulescollectinitialentrypaymentresult-27238">
+>
+> AnsRules_CollectInitialEntryPaymentResult
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                                                | Description |
+> > |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | entryCid             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry              |             |
+> > | subscriptionStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
+>
+> **instance** GetField "entryCid" AnsRules_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** GetField "subscriptionStateCid" AnsRules_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** SetField "entryCid" AnsRules_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** SetField "subscriptionStateCid" AnsRules_CollectInitialEntryPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsRules AnsRules_CollectInitialEntryPayment AnsRules_CollectInitialEntryPaymentResult
+
+<div id="type-splice-ans-ansrulesrejectentryinitialpaymentresult-67395">
+
+**data** AnsRules_RejectEntryInitialPaymentResult
+
+</div>
+
+> <div id="constr-splice-ans-ansrulesrejectentryinitialpaymentresult-46056">
+>
+> AnsRules_RejectEntryInitialPaymentResult
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                                       | Description |
+> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "amuletSum" AnsRules_RejectEntryInitialPaymentResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "amuletSum" AnsRules_RejectEntryInitialPaymentResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsRules AnsRules_RejectEntryInitialPayment AnsRules_RejectEntryInitialPaymentResult
+
+<div id="type-splice-ans-ansrulesrequestentryresult-71096">
+
+**data** AnsRules_RequestEntryResult
+
+</div>
+
+> <div id="constr-splice-ans-ansrulesrequestentryresult-91097">
+>
+> AnsRules_RequestEntryResult
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                              | Description |
+> > |------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | entryCid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext     |             |
+> > | requestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest |             |
+>
+> **instance** GetField "entryCid" AnsRules_RequestEntryResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext)
+>
+> **instance** GetField "requestCid" AnsRules_RequestEntryResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest)
+>
+> **instance** SetField "entryCid" AnsRules_RequestEntryResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext)
+>
+> **instance** SetField "requestCid" AnsRules_RequestEntryResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AnsRules AnsRules_RequestEntry AnsRules_RequestEntryResult
+
+<div id="type-splice-ans-expectedentrycontext-86972">
+
+**data** ExpectedEntryContext
+
+</div>
+
+> <div id="constr-splice-ans-expectedentrycontext-22467">
+>
+> ExpectedEntryContext
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                              | Description |
+> > |-----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |             |
+> > | user      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |             |
+> > | reference | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExpectedEntryContext
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExpectedEntryContext
+>
+> **instance** GetField "dso" ExpectedEntryContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "reference" ExpectedEntryContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest)
+>
+> **instance** GetField "user" ExpectedEntryContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "dso" ExpectedEntryContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "reference" ExpectedEntryContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest)
+>
+> **instance** SetField "user" ExpectedEntryContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+<div id="type-splice-ans-expectedpayment-99084">
+
+**data** ExpectedPayment
+
+</div>
+
+> <div id="constr-splice-ans-expectedpayment-84341">
+>
+> ExpectedPayment
+>
+> </div>
+>
+> > | Field  | Type                                                                                                                | Description |
+> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | sender | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExpectedPayment
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExpectedPayment
+>
+> **instance** GetField "dso" ExpectedPayment [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "sender" ExpectedPayment [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "dso" ExpectedPayment [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "sender" ExpectedPayment [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+## Functions
+
+<div id="function-splice-ans-fetchandvalidateinitialpayment-51068">
+
+fetchAndValidateInitialPayment
+: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment -\> ExpectedPayment -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) SubscriptionInitialPayment
+
+</div>
+
+<div id="function-splice-ans-fetchandvalidatepayment-2827">
+
+fetchAndValidatePayment
+: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment -\> ExpectedPayment -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) SubscriptionPayment
+
+</div>
+
+<div id="function-splice-ans-fetchandvalidateentrycontext-91041">
+
+fetchAndValidateEntryContext
+: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext -\> ExpectedEntryContext -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AnsEntryContext
+
+</div>
+
+<div id="function-splice-ans-validansconfig-37443">
+
+validAnsConfig
+: AnsRulesConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/index.mdx
@@ -1,0 +1,27 @@
+---
+title: "splice-amulet docs"
+description: "Documentation for splice-amulet docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/index.rst" tag="0.6.4" hash="c1fc8b73" */}
+
+- [Splice.Amulet](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet)
+- [Splice.Amulet.TokenApiUtils](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils)
+- [Splice.Amulet.TwoStepTransfer](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer)
+- [Splice.AmuletAllocation](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation)
+- [Splice.AmuletConfig](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig)
+- [Splice.AmuletRules](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules)
+- [Splice.AmuletTransferInstruction](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction)
+- [Splice.DecentralizedSynchronizer](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer)
+- [Splice.Expiry](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry)
+- [Splice.ExternalPartyAmuletRules](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules)
+- [Splice.ExternalPartyConfigState](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate)
+- [Splice.Fees](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees)
+- [Splice.Issuance](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance)
+- [Splice.RelRound](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround)
+- [Splice.Round](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-round)
+- [Splice.Schedule](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule)
+- [Splice.Types](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-types)
+- [Splice.ValidatorLicense](/sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils.mdx
@@ -1,0 +1,445 @@
+---
+title: "Splice.Amulet.TokenApiUtils"
+description: "Documentation for Splice.Amulet.TokenApiUtils"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Amulet-TokenApiUtils.rst" tag="0.6.4" hash="545e6b9f" */}
+
+Common utilities for implementing the token APIs for Amulet.
+
+## Typeclasses
+
+<div id="class-splice-amulet-tokenapiutils-toanyvalue-45157">
+
+**class** ToAnyValue a **where**
+
+</div>
+
+> Values that can be converted to AnyValue
+>
+> <div id="function-splice-amulet-tokenapiutils-toanyvalue-91682">
+>
+> toAnyValue
+> : a -\> AnyValue
+>
+> </div>
+>
+> **instance** ToAnyValue TimeLock
+>
+> **instance** ToAnyValue [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** ToAnyValue [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** ToAnyValue [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** ToAnyValue [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** ToAnyValue ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t)
+>
+> **instance** ToAnyValue [Date](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-date-32253)
+>
+> **instance** ToAnyValue [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** ToAnyValue [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** ToAnyValue [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** ToAnyValue ChoiceContext
+>
+> **instance** ToAnyValue a =\> ToAnyValue \[a\]
+
+<div id="class-splice-amulet-tokenapiutils-fromanyvalue-31164">
+
+**class** FromAnyValue a **where**
+
+</div>
+
+> Attempt to parse a value from AnyValue.
+>
+> If a type implements both `ToAnyValue` and `FromAnyValue` then it must hold that `fromAnyValue (toAnyValue x) = Right x` for all `x`.
+>
+> <div id="function-splice-amulet-tokenapiutils-fromanyvalue-32255">
+>
+> fromAnyValue
+> : AnyValue -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) a
+>
+> </div>
+>
+> **instance** FromAnyValue TimeLock
+>
+> **instance** FromAnyValue [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** FromAnyValue [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** FromAnyValue [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** FromAnyValue [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** [Template](/appdev/reference/daml-standard-library/prelude#type-da-internal-template-functions-template-31804) t =\> FromAnyValue ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t)
+>
+> **instance** FromAnyValue [Date](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-date-32253)
+>
+> **instance** FromAnyValue [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** FromAnyValue [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** FromAnyValue [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** FromAnyValue ChoiceContext
+>
+> **instance** FromAnyValue a =\> FromAnyValue \[a\]
+
+## Orphan Typeclass Instances
+
+**instance** [Semigroup](/appdev/reference/daml-standard-library/prelude#class-da-internal-prelude-semigroup-78998) Metadata
+
+**instance** [Monoid](/appdev/reference/daml-standard-library/prelude#class-da-internal-prelude-monoid-6742) Metadata
+
+## Data Types
+
+<div id="type-splice-amulet-tokenapiutils-txkind-33822">
+
+**data** TxKind
+
+</div>
+
+> Internal type for the transaction kind.
+>
+> <div id="constr-splice-amulet-tokenapiutils-txkindtransfer-31504">
+>
+> TxKind_Transfer
+>
+> </div>
+>
+> <div id="constr-splice-amulet-tokenapiutils-txkindunlock-53359">
+>
+> TxKind_Unlock
+>
+> </div>
+>
+> <div id="constr-splice-amulet-tokenapiutils-txkindmergesplit-69091">
+>
+> TxKind_MergeSplit
+>
+> </div>
+>
+> <div id="constr-splice-amulet-tokenapiutils-txkindburn-1830">
+>
+> TxKind_Burn
+>
+> </div>
+>
+> <div id="constr-splice-amulet-tokenapiutils-txkindmint-40517">
+>
+> TxKind_Mint
+>
+> </div>
+>
+> <div id="constr-splice-amulet-tokenapiutils-txkindexpiredust-93818">
+>
+> TxKind_ExpireDust
+>
+> </div>
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TxKind
+
+## Functions
+
+<div id="function-splice-amulet-tokenapiutils-spliceprefix-80926">
+
+splicePrefix
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-amuletprefix-59772">
+
+amuletPrefix
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-amuletinstrumentid-11366">
+
+amuletInstrumentId
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> InstrumentId
+
+Shared definition of the instrument-id used for amulets.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-optionalmetadata-95597">
+
+optionalMetadata
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> (a -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+Add an optional metadata entry.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-nonzerometadata-67227">
+
+nonZeroMetadata
+: ([Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a, [Additive](/appdev/reference/daml-standard-library/prelude#class-ghc-num-additive-25881) a, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a) =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> a -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+Add an metadata entry if it is non-zero number.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-optionalnonzerometadata-8763">
+
+optionalNonZeroMetadata
+: ([Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a, [Additive](/appdev/reference/daml-standard-library/prelude#class-ghc-num-additive-25881) a, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a) =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+Add an metadata entry for an optional value if it is non-zero number.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-createdinroundmetakey-43020">
+
+createdInRoundMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-rateperroundmetakey-80476">
+
+ratePerRoundMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-svrewardamountmetakey-76087">
+
+svRewardAmountMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-apprewardamountmetakey-17776">
+
+appRewardAmountMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-unclaimedactivityrecordamountmetakey-33086">
+
+unclaimedActivityRecordAmountMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-validatorrewardamountmetakey-47315">
+
+validatorRewardAmountMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-apprewardbeneficiariesmetakey-63876">
+
+appRewardBeneficiariesMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-apprewardbeneficiaryweightsmetakey-52370">
+
+appRewardBeneficiaryWeightsMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-developmentfundamountmetakey-16464">
+
+developmentFundAmountMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-reasonmetakey-98413">
+
+reasonMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+Short, human-readable reason for the transaction.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-txkindmetakey-86963">
+
+txKindMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+Kind of the transaction.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-sendermetakey-57316">
+
+senderMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+The sender of a transfer.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-burnedmetakey-57705">
+
+burnedMetaKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+The amount of token holdings burned as part of a transaction.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-holdingtxmeta-93547">
+
+holdingTxMeta
+: TxKind -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Metadata
+
+Build the metadata for a transaction affecting the amulet holdings.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-txkindtotext-55602">
+
+txKindToText
+: TxKind -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+Exported for testing only
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-simpleholdingtxmeta-84235">
+
+simpleHoldingTxMeta
+: TxKind -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Metadata
+
+Simplified version for a few of the common cases.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-externalpartyconfigstatecontextkey-59994">
+
+externalPartyConfigStateContextKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-featuredapprightcontextkey-84565">
+
+featuredAppRightContextKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-transferpreapprovalcontextkey-6006">
+
+transferPreapprovalContextKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-lockcontextkey-29271">
+
+lockContextKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+The key used to embed all the lock specification in the choice context.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-lockexpiresatcontextkey-3269">
+
+lockExpiresAtContextKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-lockholderscontextkey-51785">
+
+lockHoldersContextKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-lockcontextcontextkey-63153">
+
+lockContextContextKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+The context description of a lock.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-expirelockkey-74460">
+
+expireLockKey
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+Key used to signal to a choice whether an expired locked amulet should be unlocked.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-beneficiariesfrommetadata-93977">
+
+beneficiariesFromMetadata
+: Metadata -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[AppRewardBeneficiary\])
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-parsecommaseparated-63776">
+
+parseCommaSeparated
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> ([Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) \[a\]
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-addoptionalanyvalue-87443">
+
+addOptionalAnyValue
+: ToAnyValue a =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AnyValue -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AnyValue
+
+Convenience function to create maps that contain an optional value if it is set. See its use sites for examples.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-lookupfromcontext-26074">
+
+lookupFromContext
+: FromAnyValue a =\> ChoiceContext -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a)
+
+Lookup and decode a value within a choice context.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-getfromcontext-35521">
+
+getFromContext
+: FromAnyValue a =\> ChoiceContext -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) a
+
+Get a value from a choice context, failing if it is not present or fails to parse.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-lookupfromcontextu-72244">
+
+lookupFromContextU
+: FromAnyValue a =\> ChoiceContext -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a)
+
+Convenience version of `lookupFromContext` that raises the failure within the `Update`.
+
+</div>
+
+<div id="function-splice-amulet-tokenapiutils-getfromcontextu-55645">
+
+getFromContextU
+: FromAnyValue a =\> ChoiceContext -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) a
+
+Convenience version of `getFromContext` that raises the failure within the `Update`.
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer.mdx
@@ -1,0 +1,106 @@
+---
+title: "Splice.Amulet.TwoStepTransfer"
+description: "Documentation for Splice.Amulet.TwoStepTransfer"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Amulet-TwoStepTransfer.rst" tag="0.6.4" hash="c2645962" */}
+
+Generic code for a two-step transfer of amulet. The first step is to lock the amulet, the second step is to transfer it.
+
+## Data Types
+
+<div id="type-splice-amulet-twosteptransfer-twosteptransfer-31697">
+
+**data** TwoStepTransfer
+
+</div>
+
+> <div id="constr-splice-amulet-twosteptransfer-twosteptransfer-922">
+>
+> TwoStepTransfer
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                | Description                                                                                  |
+> > |------------------------|---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+> > | dso                    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                              |
+> > | sender                 | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                              |
+> > | receiver               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                              |
+> > | amount                 | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |                                                                                              |
+> > | lockContext            | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | Context description of the lock. This is used to display the reason for the lock in wallets. |
+> > | transferBefore         | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |                                                                                              |
+> > | transferBeforeDeadline | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | Name of the deadline for the transfer                                                        |
+> > | provider               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | Provider that should be marked as the app provider on the second step.                       |
+> > | allowFeaturing         | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)        | Whether the second step can be featured.                                                     |
+>
+> **instance** GetField "allowFeaturing" TwoStepTransfer [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** GetField "amount" TwoStepTransfer [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "dso" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "lockContext" TwoStepTransfer [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "provider" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "receiver" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "sender" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "transferBefore" TwoStepTransfer [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "transferBeforeDeadline" TwoStepTransfer [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "allowFeaturing" TwoStepTransfer [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** SetField "amount" TwoStepTransfer [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "dso" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "lockContext" TwoStepTransfer [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "provider" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "receiver" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "sender" TwoStepTransfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "transferBefore" TwoStepTransfer [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "transferBeforeDeadline" TwoStepTransfer [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+## Functions
+
+<div id="function-splice-amulet-twosteptransfer-holdingtotransferinputs-13824">
+
+holdingToTransferInputs
+: ForOwner -\> \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) \[TransferInput\]
+
+Converting a set of holding inputs to inputs for an amulet transfer, unlocking any expired LockedAmulet holdings on the fly.
+
+</div>
+
+<div id="function-splice-amulet-twosteptransfer-preparetwosteptransfer-60675">
+
+prepareTwoStepTransfer
+: TwoStepTransfer -\> [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\] -\> ExternalPartyTransferContext -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet, \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\], Metadata)
+
+Prepare a two-step transfer of amulet by locking the funds.
+
+</div>
+
+<div id="function-splice-amulet-twosteptransfer-executetwosteptransfer-18767">
+
+executeTwoStepTransfer
+: TwoStepTransfer -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet -\> ExtraArgs -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (\[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\], \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\], Metadata)
+
+</div>
+
+<div id="function-splice-amulet-twosteptransfer-aborttwosteptransfer-11048">
+
+abortTwoStepTransfer
+: TwoStepTransfer -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet -\> ExtraArgs -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet.mdx
@@ -1,0 +1,1325 @@
+---
+title: "Splice.Amulet"
+description: "Documentation for Splice.Amulet"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Amulet.rst" tag="0.6.4" hash="48e2f479" */}
+
+The contracts representing the long-term state of Splice.
+
+## Templates
+
+<div id="type-splice-amulet-amulet-63582">
+
+**template** Amulet
+
+</div>
+
+> A amulet, which can be locked and whose amount expires over time.
+>
+> The expiry serves to charge an inactivity fee, and thereby ensures that the SVs can reclaim the corresponding storage space at some point in the future.
+>
+> Signatory: dso, owner
+>
+> | Field  | Type                                                                                                                | Description |
+> |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | owner  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | amount | ExpiringAmount                                                                                                      |             |
+>
+> - <div id="type-splice-amulet-amuletexpire-87297">
+>
+>   **Choice** Amulet_Expire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: Amulet_ExpireResult
+>
+>   | Field    | Type                                                                                                                                          | Description |
+>   |----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | roundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>
+> - <div id="type-splice-amulet-amuletexpirev2-59227">
+>
+>   **Choice** Amulet_ExpireV2
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: Amulet_ExpireV2Result
+>
+>   | Field                        | Type                                                                                                                                                   | Description |
+>   |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | externalPartyConfigState0Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
+>   | externalPartyConfigState1Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso, owner
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - **interface instance** Holding **for** Amulet
+
+<div id="type-splice-amulet-apprewardcoupon-57229">
+
+**template** AppRewardCoupon
+
+</div>
+
+> A coupon for receiving app rewards proportional to the usage fee paid as part of a Amulet transfer coordinated by the app of a provider.
+>
+> Signatory: dso
+>
+> | Field       | Type                                                                                                                                                                                                                                               | Description                                                           |
+> |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
+> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |                                                                       |
+> | provider    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                | Application provider                                                  |
+> | featured    | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                                                                                                                       |                                                                       |
+> | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                 |                                                                       |
+> | round       | Round                                                                                                                                                                                                                                              |                                                                       |
+> | beneficiary | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that can mint this reward. If not set, this is the provider |
+>
+> - <div id="type-splice-amulet-apprewardcoupondsoexpire-84081">
+>
+>   **Choice** AppRewardCoupon_DsoExpire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AppRewardCoupon_DsoExpireResult
+>
+>   | Field          | Type                                                                                                                                            | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-amulet-developmentfundcoupon-75673">
+
+**template** DevelopmentFundCoupon
+
+</div>
+
+> A coupon recording an emission for the Development Fund under CIP-0082, which can be collected by the designated beneficiary.
+>
+> Signatory: dso
+>
+> | Field       | Type                                                                                                                | Description                                                                                                         |
+> |-------------|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                                                     |
+> | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The owner of the `Amulet` to be minted.                                                                             |
+> | fundManager | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that executed the assignment of the coupon to the beneficiary so they can mint from the development fund. |
+> | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The total amount of `Amulet` to mint on collection.                                                                 |
+> | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Until when the minting can be completed.                                                                            |
+> | reason      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | Reason for the emission of the coupon.                                                                              |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-developmentfundcoupondsoexpire-7301">
+>
+>   **Choice** DevelopmentFundCoupon_DsoExpire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DevelopmentFundCoupon_DsoExpireResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-developmentfundcouponreject-89668">
+>
+>   **Choice** DevelopmentFundCoupon_Reject
+>
+>   </div>
+>
+>   Controller: beneficiary
+>
+>   Returns: DevelopmentFundCoupon_RejectResult
+>
+>   | Field  | Type                                                                                                         | Description                      |
+>   |--------|--------------------------------------------------------------------------------------------------------------|----------------------------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Reason for rejecting the coupon. |
+>
+> - <div id="type-splice-amulet-developmentfundcouponwithdraw-58125">
+>
+>   **Choice** DevelopmentFundCoupon_Withdraw
+>
+>   </div>
+>
+>   Controller: fundManager
+>
+>   Returns: DevelopmentFundCoupon_WithdrawResult
+>
+>   | Field  | Type                                                                                                         | Description                        |
+>   |--------|--------------------------------------------------------------------------------------------------------------|------------------------------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Reason for withdrawing the coupon. |
+
+<div id="type-splice-amulet-featuredappactivitymarker-16451">
+
+**template** FeaturedAppActivityMarker
+
+</div>
+
+> A marker created by a featured application for activity generated from that app. This is used to record activity other than amulet transfers where regular AppRewardCoupons are not created directly.
+>
+> Will be converted to a AppRewardCoupon through automation run by the SVs and can then be minted as part of the normal minting process.
+>
+> Signatory: dso
+>
+> | Field       | Type                                                                                                                | Description                                                                                                                                                                                                                                                  |
+> |-------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                                                                                                                                                                                              |
+> | provider    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The featured app provider that created the activity marker.                                                                                                                                                                                                  |
+> | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that has the right to mint the reward.                                                                                                                                                                                                             |
+> | weight      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The weight of the marker. This is used to split the rewards for a single action, e.g., multiple parties collaborating to enable a transfer, by creating several FeaturedAppActivityMarkers with different beneficiaries such that the weights add up to 1.0. |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - **interface instance** FeaturedAppActivityMarker **for** FeaturedAppActivityMarker
+>
+> - **interface instance** FeaturedAppActivityMarker **for** FeaturedAppActivityMarker
+
+<div id="type-splice-amulet-featuredappright-765">
+
+**template** FeaturedAppRight
+
+</div>
+
+> The right for an application provider to earn featured app rewards.
+>
+> Signatory: dso
+>
+> | Field    | Type                                                                                                                | Description |
+> |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-featuredapprightcancel-96535">
+>
+>   **Choice** FeaturedAppRight_Cancel
+>
+>   </div>
+>
+>   Controller: provider
+>
+>   Returns: FeaturedAppRight_CancelResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-featuredapprightwithdraw-8217">
+>
+>   **Choice** FeaturedAppRight_Withdraw
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: FeaturedAppRight_WithdrawResult
+>
+>   | Field  | Type                                                                                                         | Description |
+>   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> - **interface instance** FeaturedAppRight **for** FeaturedAppRight
+>
+> - **interface instance** FeaturedAppRight **for** FeaturedAppRight
+
+<div id="type-splice-amulet-lockedamulet-7030">
+
+**template** LockedAmulet
+
+</div>
+
+> Signatory: (DA.Internal.Record.getField @"holders" lock), signatory amulet
+>
+> | Field  | Type     | Description |
+> |--------|----------|-------------|
+> | amulet | Amulet   |             |
+> | lock   | TimeLock |             |
+>
+> - **Choice** Archive
+>
+>   Controller: (DA.Internal.Record.getField @"holders" lock), signatory amulet
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-lockedamuletexpireamulet-28333">
+>
+>   **Choice** LockedAmulet_ExpireAmulet
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"dso" amulet)
+>
+>   Returns: LockedAmulet_ExpireAmuletResult
+>
+>   | Field    | Type                                                                                                                                          | Description |
+>   |----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | roundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>
+> - <div id="type-splice-amulet-lockedamuletexpireamuletv2-51335">
+>
+>   **Choice** LockedAmulet_ExpireAmuletV2
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"dso" amulet)
+>
+>   Returns: LockedAmulet_ExpireAmuletV2Result
+>
+>   | Field                        | Type                                                                                                                                                   | Description |
+>   |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | externalPartyConfigState0Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
+>   | externalPartyConfigState1Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
+>
+> - <div id="type-splice-amulet-lockedamuletownerexpirelock-79102">
+>
+>   **Choice** LockedAmulet_OwnerExpireLock
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"owner" amulet)
+>
+>   Returns: LockedAmulet_OwnerExpireLockResult
+>
+>   | Field        | Type                                                                                                                                          | Description |
+>   |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | openRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>
+> - <div id="type-splice-amulet-lockedamuletownerexpirelockv2-20152">
+>
+>   **Choice** LockedAmulet_OwnerExpireLockV2
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"owner" amulet)
+>
+>   Returns: LockedAmulet_OwnerExpireLockV2Result
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-lockedamuletunlock-59352">
+>
+>   **Choice** LockedAmulet_Unlock
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"owner" amulet) :: (DA.Internal.Record.getField @"holders" lock)
+>
+>   Returns: LockedAmulet_UnlockResult
+>
+>   | Field        | Type                                                                                                                                          | Description |
+>   |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | openRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>
+> - <div id="type-splice-amulet-lockedamuletunlockv2-31390">
+>
+>   **Choice** LockedAmulet_UnlockV2
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"owner" amulet) :: (DA.Internal.Record.getField @"holders" lock)
+>
+>   Returns: LockedAmulet_UnlockV2Result
+>
+>   (no fields)
+>
+> - **interface instance** Holding **for** LockedAmulet
+
+<div id="type-splice-amulet-svrewardcoupon-68580">
+
+**template** SvRewardCoupon
+
+</div>
+
+> A coupon for a beneficiary to receive part of the SV issuance for a specific SV node and round.
+>
+> Signatory: dso
+>
+> | Field       | Type                                                                                                                | Description                                                              |
+> |-------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                          |
+> | sv          | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party identifying the SV node for which the reward is issued.        |
+> | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The beneficiary allowed to receive the reward.                           |
+> | round       | Round                                                                                                               |                                                                          |
+> | weight      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | Coupons receive a share of the SV issuance proportional to their weight. |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-svrewardcouponarchiveasbeneficiary-26109">
+>
+>   **Choice** SvRewardCoupon_ArchiveAsBeneficiary
+>
+>   </div>
+>
+>   Controller: beneficiary
+>
+>   Returns: SvRewardCoupon_ArchiveAsBeneficiaryResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-svrewardcoupondsoexpire-92140">
+>
+>   **Choice** SvRewardCoupon_DsoExpire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: SvRewardCoupon_DsoExpireResult
+>
+>   | Field          | Type                                                                                                                                            | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
+
+<div id="type-splice-amulet-unclaimedactivityrecord-97331">
+
+**template** UnclaimedActivityRecord
+
+</div>
+
+> A record of activity that can be minted by the beneficiary. Note that these do not come out of the per-round issuance but are instead created by burning UnclaimedRewardCoupon as defined through a vote by the SVs. That's also why expiry is a separate time-based expiry instead of being tied to a round like the other activity records.
+>
+> Signatory: dso
+>
+> | Field       | Type                                                                                                                | Description                                               |
+> |-------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                           |
+> | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The owner of the `Amulet` to be minted.                   |
+> | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The amount of `Amulet` to be minted.                      |
+> | reason      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | A reason to mint the `Amulet`.                            |
+> | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Selected timestamp defining the lifetime of the contract. |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-unclaimedactivityrecorddsoexpire-41307">
+>
+>   **Choice** UnclaimedActivityRecord_DsoExpire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: UnclaimedActivityRecord_DsoExpireResult
+>
+>   (no fields)
+
+<div id="type-splice-amulet-unclaimeddevelopmentfundcoupon-41000">
+
+**template** UnclaimedDevelopmentFundCoupon
+
+</div>
+
+> A coupon recording an emission for the Development Fund from CIP-0082 that was not yet assigned to a specific beneficiary.
+>
+> Signatory: dso
+>
+> | Field  | Type                                                                                                                | Description                                         |
+> |--------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                     |
+> | amount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The total amount of `Amulet` to mint on collection. |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-amulet-unclaimedreward-7814">
+
+**template** UnclaimedReward
+
+</div>
+
+> Rewards that have not been claimed and are thus at the disposal of the foundation.
+>
+> Signatory: dso
+>
+> | Field  | Type                                                                                                                | Description |
+> |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | amount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-amulet-validatorrewardcoupon-76808">
+
+**template** ValidatorRewardCoupon
+
+</div>
+
+> A coupon for receiving validator rewards proportional to the usage fee paid by a user hosted by a validator operator.
+>
+> Signatory: dso
+>
+> | Field  | Type                                                                                                                | Description |
+> |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | user   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | amount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |             |
+> | round  | Round                                                                                                               |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-validatorrewardcouponarchiveasvalidator-99406">
+>
+>   **Choice** ValidatorRewardCoupon_ArchiveAsValidator
+>
+>   </div>
+>
+>   This choice is used by validators to archive the burn receipt upon claiming its corresponding issuance.
+>
+>   Controller: dso, validator
+>
+>   Returns: ValidatorRewardCoupon_ArchiveAsValidatorResult
+>
+>   | Field     | Type                                                                                                                                         | Description |
+>   |-----------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | validator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                          |             |
+>   | rightCid  | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight |             |
+>
+> - <div id="type-splice-amulet-validatorrewardcoupondsoexpire-85552">
+>
+>   **Choice** ValidatorRewardCoupon_DsoExpire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: ValidatorRewardCoupon_DsoExpireResult
+>
+>   | Field          | Type                                                                                                                                            | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
+
+<div id="type-splice-amulet-validatorright-15964">
+
+**template** ValidatorRight
+
+</div>
+
+> The right to claim amulet issuances for a user's burns as their validator.
+>
+> Signatory: user, validator
+>
+> | Field     | Type                                                                                                                | Description |
+> |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | user      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | validator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: user, validator
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-validatorrightarchiveasuser-43276">
+>
+>   **Choice** ValidatorRight_ArchiveAsUser
+>
+>   </div>
+>
+>   Controller: user
+>
+>   Returns: ValidatorRight_ArchiveAsUserResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-amulet-validatorrightarchiveasvalidator-83210">
+>
+>   **Choice** ValidatorRight_ArchiveAsValidator
+>
+>   </div>
+>
+>   Controller: validator
+>
+>   Returns: ValidatorRight_ArchiveAsValidatorResult
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-amulet-amuletcreatesummary-15609">
+
+**data** AmuletCreateSummary amuletContractId
+
+</div>
+
+> Result of an operation that created a new amulet, e.g., by minting a fresh amulet, or by unlocking a locked amulet.
+>
+> <div id="constr-splice-amulet-amuletcreatesummary-64070">
+>
+> AmuletCreateSummary
+>
+> </div>
+>
+> > | Field       | Type                                                                                                               | Description                                          |
+> > |-------------|--------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+> > | amulet      | amuletContractId                                                                                                   | The new amulet that was created                      |
+> > | amuletPrice | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | The amulet price at the round the amulet was created |
+> > | round       | Round                                                                                                              | Round for which this amulet was created.             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) amuletContractId =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (AmuletCreateSummary amuletContractId)
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) amuletContractId =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (AmuletCreateSummary amuletContractId)
+>
+> **instance** GetField "amulet" (AmuletCreateSummary amuletContractId) amuletContractId
+>
+> **instance** GetField "amuletPrice" (AmuletCreateSummary amuletContractId) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "amuletSum" LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "amuletSum" LockedAmulet_UnlockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "amuletSum" AmuletRules_DevNet_TapResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "amuletSum" AmuletRules_MintResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "round" (AmuletCreateSummary amuletContractId) Round
+>
+> **instance** SetField "amulet" (AmuletCreateSummary amuletContractId) amuletContractId
+>
+> **instance** SetField "amuletPrice" (AmuletCreateSummary amuletContractId) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "amuletSum" LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "amuletSum" LockedAmulet_UnlockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "amuletSum" AmuletRules_DevNet_TapResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "amuletSum" AmuletRules_MintResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "round" (AmuletCreateSummary amuletContractId) Round
+
+<div id="type-splice-amulet-amuletexpiresummary-4706">
+
+**data** AmuletExpireSummary
+
+</div>
+
+> <div id="constr-splice-amulet-amuletexpiresummary-31721">
+>
+> AmuletExpireSummary
+>
+> </div>
+>
+> > | Field                              | Type                                                                                                                | Description                                                     |
+> > |------------------------------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
+> > | owner                              | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                 |
+> > | round                              | Round                                                                                                               | Round for which this expiry was registered.                     |
+> > | changeToInitialAmountAsOfRoundZero | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |                                                                 |
+> > | changeToHoldingFeesRate            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The change of total holding fees introduced by a amulet expiry. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletExpireSummary
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletExpireSummary
+>
+> **instance** GetField "changeToHoldingFeesRate" AmuletExpireSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "changeToInitialAmountAsOfRoundZero" AmuletExpireSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "expireSum" Amulet_ExpireResult AmuletExpireSummary
+>
+> **instance** GetField "expireSum" LockedAmulet_ExpireAmuletResult AmuletExpireSummary
+>
+> **instance** GetField "owner" AmuletExpireSummary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "round" AmuletExpireSummary Round
+>
+> **instance** SetField "changeToHoldingFeesRate" AmuletExpireSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "changeToInitialAmountAsOfRoundZero" AmuletExpireSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "expireSum" Amulet_ExpireResult AmuletExpireSummary
+>
+> **instance** SetField "expireSum" LockedAmulet_ExpireAmuletResult AmuletExpireSummary
+>
+> **instance** SetField "owner" AmuletExpireSummary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "round" AmuletExpireSummary Round
+
+<div id="type-splice-amulet-amuletexpirev2summary-45428">
+
+**data** AmuletExpireV2Summary
+
+</div>
+
+> <div id="constr-splice-amulet-amuletexpirev2summary-89407">
+>
+> AmuletExpireV2Summary
+>
+> </div>
+>
+> > | Field | Type                                                                                                                | Description |
+> > |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | owner | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletExpireV2Summary
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletExpireV2Summary
+>
+> **instance** GetField "expireSum" Amulet_ExpireV2Result AmuletExpireV2Summary
+>
+> **instance** GetField "expireSum" LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
+>
+> **instance** GetField "owner" AmuletExpireV2Summary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "expireSum" Amulet_ExpireV2Result AmuletExpireV2Summary
+>
+> **instance** SetField "expireSum" LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
+>
+> **instance** SetField "owner" AmuletExpireV2Summary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+<div id="type-splice-amulet-amuletexpireresult-11748">
+
+**data** Amulet_ExpireResult
+
+</div>
+
+> <div id="constr-splice-amulet-amuletexpireresult-71583">
+>
+> Amulet_ExpireResult
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                    | Description |
+> > |-----------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | expireSum | AmuletExpireSummary                                                                                                                     |             |
+> > | meta      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata |             |
+>
+> **instance** GetField "expireSum" Amulet_ExpireResult AmuletExpireSummary
+>
+> **instance** GetField "meta" Amulet_ExpireResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** SetField "expireSum" Amulet_ExpireResult AmuletExpireSummary
+>
+> **instance** SetField "meta" Amulet_ExpireResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) Amulet Amulet_Expire Amulet_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) Amulet Amulet_Expire Amulet_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) Amulet Amulet_Expire Amulet_ExpireResult
+
+<div id="type-splice-amulet-amuletexpirev2result-68414">
+
+**data** Amulet_ExpireV2Result
+
+</div>
+
+> <div id="constr-splice-amulet-amuletexpirev2result-95029">
+>
+> Amulet_ExpireV2Result
+>
+> </div>
+>
+> > | Field     | Type                  | Description |
+> > |-----------|-----------------------|-------------|
+> > | expireSum | AmuletExpireV2Summary |             |
+> > | meta      | Metadata              |             |
+>
+> **instance** GetField "expireSum" Amulet_ExpireV2Result AmuletExpireV2Summary
+>
+> **instance** GetField "meta" Amulet_ExpireV2Result Metadata
+>
+> **instance** SetField "expireSum" Amulet_ExpireV2Result AmuletExpireV2Summary
+>
+> **instance** SetField "meta" Amulet_ExpireV2Result Metadata
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) Amulet Amulet_ExpireV2 Amulet_ExpireV2Result
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) Amulet Amulet_ExpireV2 Amulet_ExpireV2Result
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) Amulet Amulet_ExpireV2 Amulet_ExpireV2Result
+
+<div id="type-splice-amulet-apprewardcoupondsoexpireresult-15772">
+
+**data** AppRewardCoupon_DsoExpireResult
+
+</div>
+
+> <div id="constr-splice-amulet-apprewardcoupondsoexpireresult-84547">
+>
+> AppRewardCoupon_DsoExpireResult
+>
+> </div>
+>
+> > | Field    | Type                                                                                                               | Description |
+> > |----------|--------------------------------------------------------------------------------------------------------------------|-------------|
+> > | featured | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)       |             |
+> > | amount   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
+>
+> **instance** GetField "amount" AppRewardCoupon_DsoExpireResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "featured" AppRewardCoupon_DsoExpireResult [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** SetField "amount" AppRewardCoupon_DsoExpireResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "featured" AppRewardCoupon_DsoExpireResult [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AppRewardCoupon AppRewardCoupon_DsoExpire AppRewardCoupon_DsoExpireResult
+
+<div id="type-splice-amulet-developmentfundcoupondsoexpireresult-6252">
+
+**data** DevelopmentFundCoupon_DsoExpireResult
+
+</div>
+
+> <div id="constr-splice-amulet-developmentfundcoupondsoexpireresult-48451">
+>
+> DevelopmentFundCoupon_DsoExpireResult
+>
+> </div>
+>
+> > | Field                             | Type                                                                                                                                                         | Description |
+> > |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unclaimedDevelopmentFundCouponCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon |             |
+>
+> **instance** GetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_DsoExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
+>
+> **instance** SetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_DsoExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DevelopmentFundCoupon DevelopmentFundCoupon_DsoExpire DevelopmentFundCoupon_DsoExpireResult
+
+<div id="type-splice-amulet-developmentfundcouponrejectresult-16689">
+
+**data** DevelopmentFundCoupon_RejectResult
+
+</div>
+
+> <div id="constr-splice-amulet-developmentfundcouponrejectresult-31260">
+>
+> DevelopmentFundCoupon_RejectResult
+>
+> </div>
+>
+> > | Field                             | Type                                                                                                                                                         | Description |
+> > |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unclaimedDevelopmentFundCouponCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon |             |
+>
+> **instance** GetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
+>
+> **instance** SetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DevelopmentFundCoupon DevelopmentFundCoupon_Reject DevelopmentFundCoupon_RejectResult
+
+<div id="type-splice-amulet-developmentfundcouponwithdrawresult-40988">
+
+**data** DevelopmentFundCoupon_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-amulet-developmentfundcouponwithdrawresult-40985">
+>
+> DevelopmentFundCoupon_WithdrawResult
+>
+> </div>
+>
+> > | Field                             | Type                                                                                                                                                         | Description |
+> > |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unclaimedDevelopmentFundCouponCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon |             |
+>
+> **instance** GetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
+>
+> **instance** SetField "unclaimedDevelopmentFundCouponCid" DevelopmentFundCoupon_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DevelopmentFundCoupon DevelopmentFundCoupon_Withdraw DevelopmentFundCoupon_WithdrawResult
+
+<div id="type-splice-amulet-featuredapprightcancelresult-22074">
+
+**data** FeaturedAppRight_CancelResult
+
+</div>
+
+> <div id="constr-splice-amulet-featuredapprightcancelresult-30485">
+>
+> FeaturedAppRight_CancelResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_Cancel FeaturedAppRight_CancelResult
+
+<div id="type-splice-amulet-featuredapprightwithdrawresult-98740">
+
+**data** FeaturedAppRight_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-amulet-featuredapprightwithdrawresult-88987">
+>
+> FeaturedAppRight_WithdrawResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_Withdraw FeaturedAppRight_WithdrawResult
+
+<div id="type-splice-amulet-lockedamuletexpireamuletresult-88432">
+
+**data** LockedAmulet_ExpireAmuletResult
+
+</div>
+
+> <div id="constr-splice-amulet-lockedamuletexpireamuletresult-82939">
+>
+> LockedAmulet_ExpireAmuletResult
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                    | Description |
+> > |-----------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | expireSum | AmuletExpireSummary                                                                                                                     |             |
+> > | meta      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata |             |
+>
+> **instance** GetField "expireSum" LockedAmulet_ExpireAmuletResult AmuletExpireSummary
+>
+> **instance** GetField "meta" LockedAmulet_ExpireAmuletResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** SetField "expireSum" LockedAmulet_ExpireAmuletResult AmuletExpireSummary
+>
+> **instance** SetField "meta" LockedAmulet_ExpireAmuletResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_ExpireAmulet LockedAmulet_ExpireAmuletResult
+
+<div id="type-splice-amulet-lockedamuletexpireamuletv2result-81066">
+
+**data** LockedAmulet_ExpireAmuletV2Result
+
+</div>
+
+> <div id="constr-splice-amulet-lockedamuletexpireamuletv2result-89449">
+>
+> LockedAmulet_ExpireAmuletV2Result
+>
+> </div>
+>
+> > | Field     | Type                  | Description |
+> > |-----------|-----------------------|-------------|
+> > | expireSum | AmuletExpireV2Summary |             |
+> > | meta      | Metadata              |             |
+>
+> **instance** GetField "expireSum" LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
+>
+> **instance** GetField "meta" LockedAmulet_ExpireAmuletV2Result Metadata
+>
+> **instance** SetField "expireSum" LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
+>
+> **instance** SetField "meta" LockedAmulet_ExpireAmuletV2Result Metadata
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_ExpireAmuletV2 LockedAmulet_ExpireAmuletV2Result
+
+<div id="type-splice-amulet-lockedamuletownerexpirelockresult-44583">
+
+**data** LockedAmulet_OwnerExpireLockResult
+
+</div>
+
+> <div id="constr-splice-amulet-lockedamuletownerexpirelockresult-40926">
+>
+> LockedAmulet_OwnerExpireLockResult
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                                       | Description |
+> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+> > | meta      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                    |             |
+>
+> **instance** GetField "amuletSum" LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "meta" LockedAmulet_OwnerExpireLockResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** SetField "amuletSum" LockedAmulet_OwnerExpireLockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "meta" LockedAmulet_OwnerExpireLockResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_OwnerExpireLock LockedAmulet_OwnerExpireLockResult
+
+<div id="type-splice-amulet-lockedamuletownerexpirelockv2result-70273">
+
+**data** LockedAmulet_OwnerExpireLockV2Result
+
+</div>
+
+> <div id="constr-splice-amulet-lockedamuletownerexpirelockv2result-66952">
+>
+> LockedAmulet_OwnerExpireLockV2Result
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                 | Description |
+> > |-----------|--------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet |             |
+> > | meta      | Metadata                                                                                                                             |             |
+>
+> **instance** GetField "amuletCid" LockedAmulet_OwnerExpireLockV2Result ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+>
+> **instance** GetField "meta" LockedAmulet_OwnerExpireLockV2Result Metadata
+>
+> **instance** SetField "amuletCid" LockedAmulet_OwnerExpireLockV2Result ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+>
+> **instance** SetField "meta" LockedAmulet_OwnerExpireLockV2Result Metadata
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_OwnerExpireLockV2 LockedAmulet_OwnerExpireLockV2Result
+
+<div id="type-splice-amulet-lockedamuletunlockresult-29457">
+
+**data** LockedAmulet_UnlockResult
+
+</div>
+
+> <div id="constr-splice-amulet-lockedamuletunlockresult-40430">
+>
+> LockedAmulet_UnlockResult
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                                       | Description |
+> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+> > | meta      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                    |             |
+>
+> **instance** GetField "amuletSum" LockedAmulet_UnlockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "meta" LockedAmulet_UnlockResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** SetField "amuletSum" LockedAmulet_UnlockResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "meta" LockedAmulet_UnlockResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_Unlock LockedAmulet_UnlockResult
+
+<div id="type-splice-amulet-lockedamuletunlockv2result-80903">
+
+**data** LockedAmulet_UnlockV2Result
+
+</div>
+
+> <div id="constr-splice-amulet-lockedamuletunlockv2result-28736">
+>
+> LockedAmulet_UnlockV2Result
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                 | Description |
+> > |-----------|--------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet |             |
+> > | meta      | Metadata                                                                                                                             |             |
+>
+> **instance** GetField "amuletCid" LockedAmulet_UnlockV2Result ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+>
+> **instance** GetField "meta" LockedAmulet_UnlockV2Result Metadata
+>
+> **instance** SetField "amuletCid" LockedAmulet_UnlockV2Result ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+>
+> **instance** SetField "meta" LockedAmulet_UnlockV2Result Metadata
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) LockedAmulet LockedAmulet_UnlockV2 LockedAmulet_UnlockV2Result
+
+<div id="type-splice-amulet-svrewardcouponarchiveasbeneficiaryresult-20724">
+
+**data** SvRewardCoupon_ArchiveAsBeneficiaryResult
+
+</div>
+
+> <div id="constr-splice-amulet-svrewardcouponarchiveasbeneficiaryresult-19239">
+>
+> SvRewardCoupon_ArchiveAsBeneficiaryResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SvRewardCoupon SvRewardCoupon_ArchiveAsBeneficiary SvRewardCoupon_ArchiveAsBeneficiaryResult
+
+<div id="type-splice-amulet-svrewardcoupondsoexpireresult-4801">
+
+**data** SvRewardCoupon_DsoExpireResult
+
+</div>
+
+> <div id="constr-splice-amulet-svrewardcoupondsoexpireresult-59696">
+>
+> SvRewardCoupon_DsoExpireResult
+>
+> </div>
+>
+> > | Field  | Type                                                                                                       | Description |
+> > |--------|------------------------------------------------------------------------------------------------------------|-------------|
+> > | weight | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+>
+> **instance** GetField "weight" SvRewardCoupon_DsoExpireResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "weight" SvRewardCoupon_DsoExpireResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SvRewardCoupon SvRewardCoupon_DsoExpire SvRewardCoupon_DsoExpireResult
+
+<div id="type-splice-amulet-unclaimedactivityrecordarchiveasbeneficiaryresult-59553">
+
+**data** UnclaimedActivityRecord_ArchiveAsBeneficiaryResult
+
+</div>
+
+> <div id="constr-splice-amulet-unclaimedactivityrecordarchiveasbeneficiaryresult-59904">
+>
+> UnclaimedActivityRecord_ArchiveAsBeneficiaryResult
+>
+> </div>
+
+<div id="type-splice-amulet-unclaimedactivityrecorddsoexpireresult-73042">
+
+**data** UnclaimedActivityRecord_DsoExpireResult
+
+</div>
+
+> <div id="constr-splice-amulet-unclaimedactivityrecorddsoexpireresult-28805">
+>
+> UnclaimedActivityRecord_DsoExpireResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                          | Description |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unclaimedRewardCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward |             |
+>
+> **instance** GetField "unclaimedRewardCid" UnclaimedActivityRecord_DsoExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
+>
+> **instance** SetField "unclaimedRewardCid" UnclaimedActivityRecord_DsoExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) UnclaimedActivityRecord UnclaimedActivityRecord_DsoExpire UnclaimedActivityRecord_DsoExpireResult
+
+<div id="type-splice-amulet-validatorrewardcouponarchiveasvalidatorresult-41727">
+
+**data** ValidatorRewardCoupon_ArchiveAsValidatorResult
+
+</div>
+
+> <div id="constr-splice-amulet-validatorrewardcouponarchiveasvalidatorresult-51782">
+>
+> ValidatorRewardCoupon_ArchiveAsValidatorResult
+>
+> </div>
+>
+> > (no fields)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorRewardCoupon ValidatorRewardCoupon_ArchiveAsValidator ValidatorRewardCoupon_ArchiveAsValidatorResult
+
+<div id="type-splice-amulet-validatorrewardcoupondsoexpireresult-94761">
+
+**data** ValidatorRewardCoupon_DsoExpireResult
+
+</div>
+
+> <div id="constr-splice-amulet-validatorrewardcoupondsoexpireresult-92822">
+>
+> ValidatorRewardCoupon_DsoExpireResult
+>
+> </div>
+>
+> > | Field  | Type                                                                                                               | Description |
+> > |--------|--------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
+>
+> **instance** GetField "amount" ValidatorRewardCoupon_DsoExpireResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "amount" ValidatorRewardCoupon_DsoExpireResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorRewardCoupon ValidatorRewardCoupon_DsoExpire ValidatorRewardCoupon_DsoExpireResult
+
+<div id="type-splice-amulet-validatorrightarchiveasuserresult-3193">
+
+**data** ValidatorRight_ArchiveAsUserResult
+
+</div>
+
+> <div id="constr-splice-amulet-validatorrightarchiveasuserresult-47620">
+>
+> ValidatorRight_ArchiveAsUserResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorRight ValidatorRight_ArchiveAsUser ValidatorRight_ArchiveAsUserResult
+
+<div id="type-splice-amulet-validatorrightarchiveasvalidatorresult-59299">
+
+**data** ValidatorRight_ArchiveAsValidatorResult
+
+</div>
+
+> <div id="constr-splice-amulet-validatorrightarchiveasvalidatorresult-93588">
+>
+> ValidatorRight_ArchiveAsValidatorResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorRight ValidatorRight_ArchiveAsValidator ValidatorRight_ArchiveAsValidatorResult
+
+## Functions
+
+<div id="function-splice-amulet-amuletmetadata-81241">
+
+amuletMetadata
+: Amulet -\> Metadata
+
+</div>
+
+<div id="function-splice-amulet-validateapprewardbeneficiaries-84669">
+
+validateAppRewardBeneficiaries
+: \[AppRewardBeneficiary\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-amulet-validateapprewardbeneficiariesv2-38479">
+
+validateAppRewardBeneficiariesV2
+: \[AppRewardBeneficiary\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-amulet-requireamuletexpiredforallrounds-81885">
+
+requireAmuletExpiredForAllRounds
+: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState -\> Amulet -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation.mdx
@@ -1,0 +1,86 @@
+---
+title: "Splice.AmuletAllocation"
+description: "Documentation for Splice.AmuletAllocation"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-AmuletAllocation.rst" tag="0.6.4" hash="2dd0a06d" */}
+
+## Templates
+
+<div id="type-splice-amuletallocation-amuletallocation-39850">
+
+**template** AmuletAllocation
+
+</div>
+
+> Amulet allocated in locked form to a trade.
+>
+> Signatory: allocationInstrumentAdmin allocation, (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))
+>
+> | Field        | Type                                                                                                                                       | Description                                           |
+> |--------------|--------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+> | lockedAmulet | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet | Locked amulet that holds the funds for the allocation |
+> | allocation   | AllocationSpecification                                                                                                                    |                                                       |
+>
+> - <div id="type-splice-amuletallocation-amuletallocationdsoexpire-72174">
+>
+>   **Choice** AmuletAllocation_DsoExpire
+>
+>   </div>
+>
+>   Controller: allocationInstrumentAdmin allocation
+>
+>   Returns: AmuletAllocation_DsoExpireResult
+>
+>   | Field      | Type                                                                                                         | Description |
+>   |------------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | expireLock | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: allocationInstrumentAdmin allocation, (DA.Internal.Record.getField @"sender" (DA.Internal.Record.getField @"transferLeg" allocation))
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-amuletallocation-amuletallocationdsoexpireresult-36603">
+
+**data** AmuletAllocation_DsoExpireResult
+
+</div>
+
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletAllocation_DsoExpireResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletAllocation_DsoExpireResult
+>
+> **instance** GetField "meta" AmuletAllocation_DsoExpireResult Metadata
+>
+> **instance** GetField "results" ExternalPartyAmuletRules_ExpireAmuletAllocationsResult \[AmuletAllocation_DsoExpireResult\]
+>
+> **instance** GetField "senderHoldingCids" AmuletAllocation_DsoExpireResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** SetField "meta" AmuletAllocation_DsoExpireResult Metadata
+>
+> **instance** SetField "results" ExternalPartyAmuletRules_ExpireAmuletAllocationsResult \[AmuletAllocation_DsoExpireResult\]
+>
+> **instance** SetField "senderHoldingCids" AmuletAllocation_DsoExpireResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletAllocation AmuletAllocation_DsoExpire AmuletAllocation_DsoExpireResult
+
+## Functions
+
+<div id="function-splice-amuletallocation-allocationtotwosteptransfer-63709">
+
+allocationToTwoStepTransfer
+: AllocationSpecification -\> TwoStepTransfer
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig.mdx
@@ -1,0 +1,395 @@
+---
+title: "Splice.AmuletConfig"
+description: "Documentation for Splice.AmuletConfig"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-AmuletConfig.rst" tag="0.6.4" hash="29e34f10" */}
+
+## Data Types
+
+<div id="type-splice-amuletconfig-amulet-69874">
+
+**data** Amulet
+
+</div>
+
+> Deprecated type for specifying amounts and fees in units of Amulet. Use Splice.Amulet.Amulet directly instead.
+>
+> <div id="constr-splice-amuletconfig-amulet-76435">
+>
+> Amulet
+>
+> </div>
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Amulet
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Amulet
+
+<div id="type-splice-amuletconfig-amuletconfig-37414">
+
+**data** AmuletConfig unit
+
+</div>
+
+> Configuration includes TransferConfig, issuance curve and tickDuration
+>
+> See Splice.Scripts.Parameters for concrete values.
+>
+> <div id="constr-splice-amuletconfig-amuletconfig-91595">
+>
+> AmuletConfig
+>
+> </div>
+>
+> > | Field                                | Type                                                                                                                                                                                                                                                  | Description                                                                                                                                                                                                                                                                                       |
+> > |--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | transferConfig                       | TransferConfig unit                                                                                                                                                                                                                                   | Configuration determining the fees and limits for Amulet transfers                                                                                                                                                                                                                                |
+> > | issuanceCurve                        | Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig                                                                                                        | Issuance curve to use.                                                                                                                                                                                                                                                                            |
+> > | decentralizedSynchronizer            | AmuletDecentralizedSynchronizerConfig                                                                                                                                                                                                                 | Configuration for the decentralized synchronizer and its fees. TODO(M4-85): the values in here are likely quite large (several URls and long synchronizerIds) and not required for executing transfers. Split this part of the config out into a separate contract as a performance optimization. |
+> > | tickDuration                         | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | Duration of a tick, which is the duration of half a round.                                                                                                                                                                                                                                        |
+> > | packageConfig                        | PackageConfig                                                                                                                                                                                                                                         | Configuration determining the version of each package that should be used for command submissions.                                                                                                                                                                                                |
+> > | transferPreapprovalFee               | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)     | Fee for keeping a transfer pre-approval around.                                                                                                                                                                                                                                                   |
+> > | featuredAppActivityMarkerAmount      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)     | \$-amount used for the conversion from FeaturedAppActivityMarker -\> AppRewardCoupon                                                                                                                                                                                                              |
+> > | optDevelopmentFundManager            | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)    | Party authorized to manage and allocate minting rights from the Development Fund.                                                                                                                                                                                                                 |
+> > | externalPartyConfigStateTickDuration | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | Half the lifetime of an `ExternalPartyConfigState` contract and the overlap between two successive contracts. Default: 24h.                                                                                                                                                                       |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (AmuletConfig unit)
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (AmuletConfig unit)
+>
+> **instance** GetField "baseConfig" AmuletRules_SetConfig (AmuletConfig USD)
+>
+> **instance** GetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
+>
+> **instance** GetField "decentralizedSynchronizer" (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig
+>
+> **instance** GetField "externalPartyConfigStateTickDuration" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082))
+>
+> **instance** GetField "featuredAppActivityMarkerAmount" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** GetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
+>
+> **instance** GetField "newConfig" AmuletRules_SetConfig (AmuletConfig USD)
+>
+> **instance** GetField "newScheduleItem" AmuletRules_AddFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
+>
+> **instance** GetField "optDevelopmentFundManager" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
+>
+> **instance** GetField "packageConfig" (AmuletConfig unit) PackageConfig
+>
+> **instance** GetField "scheduleItem" AmuletRules_UpdateFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
+>
+> **instance** GetField "tickDuration" (AmuletConfig unit) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** GetField "transferConfig" (AmuletConfig unit) (TransferConfig unit)
+>
+> **instance** GetField "transferPreapprovalFee" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** SetField "baseConfig" AmuletRules_SetConfig (AmuletConfig USD)
+>
+> **instance** SetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
+>
+> **instance** SetField "decentralizedSynchronizer" (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig
+>
+> **instance** SetField "externalPartyConfigStateTickDuration" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082))
+>
+> **instance** SetField "featuredAppActivityMarkerAmount" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** SetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
+>
+> **instance** SetField "newConfig" AmuletRules_SetConfig (AmuletConfig USD)
+>
+> **instance** SetField "newScheduleItem" AmuletRules_AddFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
+>
+> **instance** SetField "optDevelopmentFundManager" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
+>
+> **instance** SetField "packageConfig" (AmuletConfig unit) PackageConfig
+>
+> **instance** SetField "scheduleItem" AmuletRules_UpdateFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
+>
+> **instance** SetField "tickDuration" (AmuletConfig unit) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "transferConfig" (AmuletConfig unit) (TransferConfig unit)
+>
+> **instance** SetField "transferPreapprovalFee" (AmuletConfig unit) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** Patchable (AmuletConfig USD)
+
+<div id="type-splice-amuletconfig-packageconfig-59903">
+
+**data** PackageConfig
+
+</div>
+
+> The package config defines for each daml package (identified by name) the package version that should be used for command submissions at that point.
+>
+> <div id="constr-splice-amuletconfig-packageconfig-69032">
+>
+> PackageConfig
+>
+> </div>
+>
+> > | Field              | Type                                                                                                         | Description |
+> > |--------------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | amulet             | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+> > | amuletNameService  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+> > | dsoGovernance      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+> > | validatorLifecycle | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+> > | wallet             | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+> > | walletPayments     | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) PackageConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) PackageConfig
+>
+> **instance** GetField "amulet" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "amuletNameService" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "dsoGovernance" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "packageConfig" (AmuletConfig unit) PackageConfig
+>
+> **instance** GetField "validatorLifecycle" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "wallet" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "walletPayments" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "amulet" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "amuletNameService" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "dsoGovernance" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "packageConfig" (AmuletConfig unit) PackageConfig
+>
+> **instance** SetField "validatorLifecycle" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "wallet" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "walletPayments" PackageConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** Patchable PackageConfig
+
+<div id="type-splice-amuletconfig-transferconfig-45691">
+
+**data** TransferConfig unit
+
+</div>
+
+> Configuration determining the fees and limits for Amulet transfers granted by the AmuletRules.
+>
+> See Splice.Scripts.Parameters for concrete values.
+>
+> <div id="constr-splice-amuletconfig-transferconfig-20622">
+>
+> TransferConfig
+>
+> </div>
+>
+> > | Field                        | Type                                                                                                               | Description                                                 |
+> > |------------------------------|--------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+> > | createFee                    | FixedFee                                                                                                           | Fee to create a new amulet.                                 |
+> > | holdingFee                   | RatePerRound                                                                                                       | Fee for keeping an amulet around.                           |
+> > | transferFee                  | SteppedRate                                                                                                        | Fee for transferring some amount of amulet to a new owner.  |
+> > | lockHolderFee                | FixedFee                                                                                                           | Fee per lock holder of a locked amulet.                     |
+> > | extraFeaturedAppRewardAmount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Extra \$-amount of reward for featured apps.                |
+> > | maxNumInputs                 | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)         | Maximum number of batch inputs for a transfer.              |
+> > | maxNumOutputs                | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)         | Maximum number of batch outputs for a transfer.             |
+> > | maxNumLockHolders            | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)         | Maximum number of lock holders allowed for a locked amulet. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (TransferConfig unit)
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (TransferConfig unit)
+>
+> **instance** GetField "config" TransferContextSummary (TransferConfig Amulet)
+>
+> **instance** GetField "createFee" (TransferConfig unit) FixedFee
+>
+> **instance** GetField "extraFeaturedAppRewardAmount" (TransferConfig unit) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "holdingFee" (TransferConfig unit) RatePerRound
+>
+> **instance** GetField "lockHolderFee" (TransferConfig unit) FixedFee
+>
+> **instance** GetField "maxNumInputs" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "maxNumLockHolders" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "maxNumOutputs" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "transferConfig" (AmuletConfig unit) (TransferConfig unit)
+>
+> **instance** GetField "transferConfigUsd" OpenMiningRound (TransferConfig USD)
+>
+> **instance** GetField "transferFee" (TransferConfig unit) SteppedRate
+>
+> **instance** SetField "config" TransferContextSummary (TransferConfig Amulet)
+>
+> **instance** SetField "createFee" (TransferConfig unit) FixedFee
+>
+> **instance** SetField "extraFeaturedAppRewardAmount" (TransferConfig unit) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "holdingFee" (TransferConfig unit) RatePerRound
+>
+> **instance** SetField "lockHolderFee" (TransferConfig unit) FixedFee
+>
+> **instance** SetField "maxNumInputs" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "maxNumLockHolders" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "maxNumOutputs" (TransferConfig unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "transferConfig" (AmuletConfig unit) (TransferConfig unit)
+>
+> **instance** SetField "transferConfigUsd" OpenMiningRound (TransferConfig USD)
+>
+> **instance** SetField "transferFee" (TransferConfig unit) SteppedRate
+>
+> **instance** Patchable (TransferConfig USD)
+
+<div id="type-splice-amuletconfig-transferconfigv2-59993">
+
+**data** TransferConfigV2 unit
+
+</div>
+
+> Stripped down TransferConfig after CIP 78 removed fees.
+>
+> <div id="constr-splice-amuletconfig-transferconfigv2-42628">
+>
+> TransferConfigV2
+>
+> </div>
+>
+> > | Field             | Type                                                                                                       | Description |
+> > |-------------------|------------------------------------------------------------------------------------------------------------|-------------|
+> > | holdingFee        | RatePerRound                                                                                               |             |
+> > | maxNumInputs      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+> > | maxNumOutputs     | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+> > | maxNumLockHolders | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (TransferConfigV2 unit)
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (TransferConfigV2 unit)
+>
+> **instance** GetField "config" TransferContextSummaryV2 (TransferConfigV2 Amulet)
+>
+> **instance** GetField "holdingFee" (TransferConfigV2 unit) RatePerRound
+>
+> **instance** GetField "maxNumInputs" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "maxNumLockHolders" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "maxNumOutputs" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "transferConfig" ExternalPartyConfigState (TransferConfigV2 USD)
+>
+> **instance** SetField "config" TransferContextSummaryV2 (TransferConfigV2 Amulet)
+>
+> **instance** SetField "holdingFee" (TransferConfigV2 unit) RatePerRound
+>
+> **instance** SetField "maxNumInputs" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "maxNumLockHolders" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "maxNumOutputs" (TransferConfigV2 unit) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "transferConfig" ExternalPartyConfigState (TransferConfigV2 USD)
+
+<div id="type-splice-amuletconfig-usd-42527">
+
+**data** USD
+
+</div>
+
+> <div id="constr-splice-amuletconfig-usd-28992">
+>
+> USD
+>
+> </div>
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) USD
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) USD
+>
+> **instance** GetField "baseConfig" AmuletRules_SetConfig (AmuletConfig USD)
+>
+> **instance** GetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
+>
+> **instance** GetField "newConfig" AmuletRules_SetConfig (AmuletConfig USD)
+>
+> **instance** GetField "newScheduleItem" AmuletRules_AddFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
+>
+> **instance** GetField "scheduleItem" AmuletRules_UpdateFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
+>
+> **instance** GetField "transferConfig" ExternalPartyConfigState (TransferConfigV2 USD)
+>
+> **instance** GetField "transferConfigUsd" OpenMiningRound (TransferConfig USD)
+>
+> **instance** SetField "baseConfig" AmuletRules_SetConfig (AmuletConfig USD)
+>
+> **instance** SetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
+>
+> **instance** SetField "newConfig" AmuletRules_SetConfig (AmuletConfig USD)
+>
+> **instance** SetField "newScheduleItem" AmuletRules_AddFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
+>
+> **instance** SetField "scheduleItem" AmuletRules_UpdateFutureAmuletConfigSchedule ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD)
+>
+> **instance** SetField "transferConfig" ExternalPartyConfigState (TransferConfigV2 USD)
+>
+> **instance** SetField "transferConfigUsd" OpenMiningRound (TransferConfig USD)
+>
+> **instance** Patchable (AmuletConfig USD)
+>
+> **instance** Patchable (TransferConfig USD)
+
+## Functions
+
+<div id="function-splice-amuletconfig-transferconfigtotransferconfigv2-63497">
+
+transferConfigToTransferConfigV2
+: TransferConfig unit -\> TransferConfigV2 unit
+
+</div>
+
+<div id="function-splice-amuletconfig-getexternalpartyconfigstatetickduration-34672">
+
+getExternalPartyConfigStateTickDuration
+: AmuletConfig a -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+
+</div>
+
+<div id="function-splice-amuletconfig-defaulttransferpreapprovalfee-76073">
+
+defaultTransferPreapprovalFee
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-amuletconfig-validamuletconfig-8963">
+
+validAmuletConfig
+: AmuletConfig unit -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-amuletconfig-validtransferconfig-77162">
+
+validTransferConfig
+: TransferConfig unit -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-amuletconfig-validpackageconfig-27952">
+
+validPackageConfig
+: PackageConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+Package configs are not constrained at the Daml level to maximize flexibility. In particular, empty packages versions might be used in the future to indicate that no version of that package should be vetted.
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules.mdx
@@ -1,0 +1,3056 @@
+---
+title: "Splice.AmuletRules"
+description: "Documentation for Splice.AmuletRules"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-AmuletRules.rst" tag="0.6.4" hash="7bf8da92" */}
+
+## Templates
+
+<div id="type-splice-amuletrules-amuletrules-32426">
+
+**template** AmuletRules
+
+</div>
+
+> The rules governing how Amulet users can modify the Amulet state managed by the DSO party.
+>
+> Signatory: dso
+>
+> | Field                      | Type                                                                                                                                                                                                                                      | Description |
+> |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso                        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                       |             |
+> | configSchedule             | Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD)                                                                                             |             |
+> | isDevNet                   | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                                                                                                              |             |
+> | contractStateSchemaVersion | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesaddfutureamuletconfigschedule-17078">
+>
+>   **Choice** AmuletRules_AddFutureAmuletConfigSchedule
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_AddFutureAmuletConfigScheduleResult
+>
+>   | Field           | Type                                                                                                                                  | Description |
+>   |-----------------|---------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | newScheduleItem | ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesadvanceopenminingrounds-86978">
+>
+>   **Choice** AmuletRules_AdvanceOpenMiningRounds
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_AdvanceOpenMiningRoundsResult
+>
+>   | Field             | Type                                                                                                                                          | Description |
+>   |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletPrice       | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                            |             |
+>   | roundToArchiveCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>   | middleRoundCid    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>   | latestRoundCid    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesallocatedevelopmentfundcoupon-20234">
+>
+>   **Choice** AmuletRules_AllocateDevelopmentFundCoupon
+>
+>   </div>
+>
+>   Allows the Development Fund manager to allocate a specified amount from a collection of UnclaimedDevelopmentFundCoupons to a beneficiary, generating a DevelopmentFundCoupon and producing a leftover unclaimed coupon if applicable.
+>
+>   Controller: fundManager
+>
+>   Returns: AmuletRules_AllocateDevelopmentFundCouponResult
+>
+>   | Field                              | Type                                                                                                                                                             | Description |
+>   |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | unclaimedDevelopmentFundCouponCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon\] |             |
+>   | beneficiary                        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                              |             |
+>   | amount                             | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                               |             |
+>   | expiresAt                          | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                |             |
+>   | reason                             | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                     |             |
+>   | fundManager                        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                              |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesamuletexpiretransferinstructions-2487">
+>
+>   **Choice** AmuletRules_Amulet_ExpireTransferInstructions
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_Amulet_ExpireTransferInstructionsResult
+>
+>   | Field       | Type                                                                                                                    | Description |
+>   |-------------|-------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | expectedDso | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)     |             |
+>   | inputs      | \[AmuletRules_ExpireTransferInstructionInput\]                                                                          |             |
+>   | observers   | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstate-17751">
+>
+>   **Choice** AmuletRules_BootstrapExternalPartyConfigState
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_BootstrapExternalPartyConfigStateResult
+>
+>   | Field                 | Type                                                                                                                | Description |
+>   |-----------------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | openMiningRoundTriple | OpenMiningRoundTriple                                                                                               |             |
+>   | expectedDso           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesbootstraprounds-81536">
+>
+>   **Choice** AmuletRules_Bootstrap_Rounds
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_Bootstrap_RoundsResult
+>
+>   | Field          | Type                                                                                                                                                                                                                                      | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletPrice    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                        |             |
+>   | round0Duration | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                    |             |
+>   | initialRound   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesbuymembertraffic-66391">
+>
+>   **Choice** AmuletRules_BuyMemberTraffic
+>
+>   </div>
+>
+>   Controller: provider
+>
+>   Returns: AmuletRules_BuyMemberTrafficResult
+>
+>   | Field          | Type                                                                                                                                                                                                                                               | Description |
+>   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | inputs         | \[TransferInput\]                                                                                                                                                                                                                                  |             |
+>   | context        | TransferContext                                                                                                                                                                                                                                    |             |
+>   | provider       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
+>   | memberId       | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                       |             |
+>   | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                       |             |
+>   | migrationId    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                         |             |
+>   | trafficAmount  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                         |             |
+>   | expectedDso    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesclaimexpiredrewards-90526">
+>
+>   **Choice** AmuletRules_ClaimExpiredRewards
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_ClaimExpiredRewardsResult
+>
+>   | Field                                  | Type                                                                                                                                                                                                                                                                                             | Description |
+>   |----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | closedRoundCid                         | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound                                                                                                                                                  |             |
+>   | validatorRewardCouponCids              | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRewardCoupon\]                                                                                                                                          |             |
+>   | appCouponCids                          | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppRewardCoupon\]                                                                                                                                                |             |
+>   | svRewardCouponCids                     | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardCoupon\]                                                                                                                                                 |             |
+>   | optValidatorFaucetCouponCids           | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon\]           |             |
+>   | optValidatorLivenessActivityRecordCids | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLivenessActivityRecord\] |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulescomputefees-56243">
+>
+>   **Choice** AmuletRules_ComputeFees
+>
+>   </div>
+>
+>   Compute the output fees for transfer against the given context
+>
+>   Controller: sender
+>
+>   Returns: AmuletRules_ComputeFeesResult
+>
+>   | Field       | Type                                                                                                                                                                                                                                               | Description |
+>   |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | context     | TransferContext                                                                                                                                                                                                                                    |             |
+>   | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
+>   | outputs     | \[TransferOutput\]                                                                                                                                                                                                                                 |             |
+>   | expectedDso | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkers-99721">
+>
+>   **Choice** AmuletRules_ConvertFeaturedAppActivityMarkers
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_ConvertFeaturedAppActivityMarkersResult
+>
+>   | Field              | Type                                                                                                                                                                                                                                                   | Description                                                                                                                                       |
+>   |--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+>   | markerCids         | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]                                                                                            |                                                                                                                                                   |
+>   | openMiningRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                          |                                                                                                                                                   |
+>   | observers          | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] | A list of choice observers. This is expected to be set to the union of all providers and beneficiaries to ensure that this creates only one view. |
+>
+> - <div id="type-splice-amuletrules-amuletrulescreateexternalpartysetupproposal-53882">
+>
+>   **Choice** AmuletRules_CreateExternalPartySetupProposal
+>
+>   </div>
+>
+>   Propose to host an external party The provider pre-pays the fees for the creation of a TransferPreapproval contract on behalf of the external party when exercising this choice
+>
+>   Controller: validator
+>
+>   Returns: AmuletRules_CreateExternalPartySetupProposalResult
+>
+>   | Field                | Type                                                                                                                                                                                                                                               | Description |
+>   |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | context              | PaymentTransferContext                                                                                                                                                                                                                             |             |
+>   | inputs               | \[TransferInput\]                                                                                                                                                                                                                                  |             |
+>   | user                 | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
+>   | validator            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
+>   | preapprovalExpiresAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                  |             |
+>   | expectedDso          | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulescreatetransferpreapproval-31932">
+>
+>   **Choice** AmuletRules_CreateTransferPreapproval
+>
+>   </div>
+>
+>   Pre-approve incoming amulet transfers
+>
+>   Controller: provider, receiver
+>
+>   Returns: AmuletRules_CreateTransferPreapprovalResult
+>
+>   | Field       | Type                                                                                                                                                                                                                                               | Description |
+>   |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | context     | PaymentTransferContext                                                                                                                                                                                                                             |             |
+>   | inputs      | \[TransferInput\]                                                                                                                                                                                                                                  |             |
+>   | receiver    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
+>   | provider    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
+>   | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                  |             |
+>   | expectedDso | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesdevnetfeatureapp-42587">
+>
+>   **Choice** AmuletRules_DevNet_FeatureApp
+>
+>   </div>
+>
+>   Controller: provider
+>
+>   Returns: AmuletRules_DevNet_FeatureAppResult
+>
+>   | Field    | Type                                                                                                                | Description |
+>   |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesdevnettap-82572">
+>
+>   **Choice** AmuletRules_DevNet_Tap
+>
+>   </div>
+>
+>   Controller: receiver
+>
+>   Returns: AmuletRules_DevNet_TapResult
+>
+>   | Field     | Type                                                                                                                                          | Description |
+>   |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | receiver  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                           |             |
+>   | amount    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                            |             |
+>   | openRound | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesfetch-60873">
+>
+>   **Choice** AmuletRules_Fetch
+>
+>   </div>
+>
+>   Controller: p
+>
+>   Returns: AmuletRules
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | p     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesmergemembertrafficcontracts-58585">
+>
+>   **Choice** AmuletRules_MergeMemberTrafficContracts
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_MergeMemberTrafficContractsResult
+>
+>   | Field       | Type                                                                                                                                            | Description |
+>   |-------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | trafficCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic\] |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcoupons-89321">
+>
+>   **Choice** AmuletRules_MergeUnclaimedDevelopmentFundCoupons
+>
+>   </div>
+>
+>   Batch merge of unclaimed development fund coupons
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
+>
+>   | Field                              | Type                                                                                                                                                             | Description |
+>   |------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | unclaimedDevelopmentFundCouponCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon\] |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesmergeunclaimedrewards-76493">
+>
+>   **Choice** AmuletRules_MergeUnclaimedRewards
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_MergeUnclaimedRewardsResult
+>
+>   | Field               | Type                                                                                                                                              | Description |
+>   |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | unclaimedRewardCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward\] |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesminingroundarchive-33308">
+>
+>   **Choice** AmuletRules_MiningRound_Archive
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_MiningRound_ArchiveResult
+>
+>   | Field          | Type                                                                                                                                            | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesminingroundclose-27964">
+>
+>   **Choice** AmuletRules_MiningRound_Close
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_MiningRound_CloseResult
+>
+>   | Field           | Type                                                                                                                                             | Description |
+>   |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | issuingRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesminingroundstartissuing-80649">
+>
+>   **Choice** AmuletRules_MiningRound_StartIssuing
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_MiningRound_StartIssuingResult
+>
+>   | Field          | Type                                                                                                                                                 | Description |
+>   |----------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | miningRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound |             |
+>   | summary        | OpenMiningRoundSummary                                                                                                                               |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesmint-76046">
+>
+>   **Choice** AmuletRules_Mint
+>
+>   </div>
+>
+>   Controller: dso, receiver
+>
+>   Returns: AmuletRules_MintResult
+>
+>   | Field     | Type                                                                                                                                          | Description |
+>   |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | receiver  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                           |             |
+>   | amount    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                            |             |
+>   | openRound | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesremovefutureamuletconfigschedule-69936">
+>
+>   **Choice** AmuletRules_RemoveFutureAmuletConfigSchedule
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_RemoveFutureAmuletConfigScheduleResult
+>
+>   | Field        | Type                                                                                                              | Description |
+>   |--------------|-------------------------------------------------------------------------------------------------------------------|-------------|
+>   | scheduleTime | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulessetconfig-85439">
+>
+>   **Choice** AmuletRules_SetConfig
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_SetConfigResult
+>
+>   | Field      | Type             | Description |
+>   |------------|------------------|-------------|
+>   | newConfig  | AmuletConfig USD |             |
+>   | baseConfig | AmuletConfig USD |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulestransfer-23235">
+>
+>   **Choice** AmuletRules_Transfer
+>
+>   </div>
+>
+>   Controller: Set.toList (transferControllers transfer)
+>
+>   Returns: TransferResult
+>
+>   | Field       | Type                                                                                                                                                                                                                                               | Description |
+>   |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | transfer    | Transfer                                                                                                                                                                                                                                           |             |
+>   | context     | TransferContext                                                                                                                                                                                                                                    |             |
+>   | expectedDso | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesupdateexternalpartyconfigstates-76929">
+>
+>   **Choice** AmuletRules_UpdateExternalPartyConfigStates
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_UpdateExternalPartyConfigStatesResult
+>
+>   | Field                        | Type                                                                                                                                                   | Description |
+>   |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | externalPartyConfigStateCid0 | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
+>   | externalPartyConfigStateCid1 | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
+>   | openMiningRoundTriple        | OpenMiningRoundTriple                                                                                                                                  |             |
+>
+> - <div id="type-splice-amuletrules-amuletrulesupdatefutureamuletconfigschedule-15159">
+>
+>   **Choice** AmuletRules_UpdateFutureAmuletConfigSchedule
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: AmuletRules_UpdateFutureAmuletConfigScheduleResult
+>
+>   | Field        | Type                                                                                                                                  | Description |
+>   |--------------|---------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | scheduleItem | ([Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886), AmuletConfig USD) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-amuletrules-externalpartysetupproposal-90414">
+
+**template** ExternalPartySetupProposal
+
+</div>
+
+> Signatory: validator, dso
+>
+> | Field                | Type                                                                                                                | Description |
+> |----------------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | validator            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | user                 | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | dso                  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | createdAt            | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
+> | preapprovalExpiresAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
+>
+> - **Choice** Archive
+>
+>   Controller: validator, dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-amuletrules-externalpartysetupproposalaccept-68720">
+>
+>   **Choice** ExternalPartySetupProposal_Accept
+>
+>   </div>
+>
+>   Controller: user
+>
+>   Returns: ExternalPartySetupProposal_AcceptResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-amuletrules-externalpartysetupproposalreject-30733">
+>
+>   **Choice** ExternalPartySetupProposal_Reject
+>
+>   </div>
+>
+>   Controller: user
+>
+>   Returns: ExternalPartySetupProposal_RejectResult
+>
+>   | Field  | Type                                                                                                         | Description |
+>   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> - <div id="type-splice-amuletrules-externalpartysetupproposalwithdraw-43220">
+>
+>   **Choice** ExternalPartySetupProposal_Withdraw
+>
+>   </div>
+>
+>   Controller: validator
+>
+>   Returns: ExternalPartySetupProposal_WithdrawResult
+>
+>   | Field  | Type                                                                                                         | Description |
+>   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+
+<div id="type-splice-amuletrules-transferpreapproval-36220">
+
+**template** TransferPreapproval
+
+</div>
+
+> A pre-approval by a receiver to receive Amulet from anybody.
+>
+> Pre-approvals are indexed by the SVs and served from scan for easy discovery until they expire. The cost of providing this discovery service is charged by burning Amulet.
+>
+> Receivers can either purchase and renew these pre-approvals by themselves, or have an app provider do so for them in exchange for the app rewards for the amulet transfers completed via the managed pre-approval.
+>
+> Signatory: receiver, provider, dso
+>
+> | Field         | Type                                                                                                                | Description                                                                                                            |
+> |---------------|---------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+> | dso           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                                                        |
+> | receiver      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The receiver party                                                                                                     |
+> | provider      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The app provider that manages the pre-approval for the receiver. Equal to the receiver for self-managed pre-approvals. |
+> | validFrom     | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | This timestamp marks the start of the period for which fees were paid for the pre-approval. Preserved across renewals. |
+> | lastRenewedAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | When the pre-approval was last renewed. Set equal to `validFrom` on creation and updated on each renewal.              |
+> | expiresAt     | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Provider selected timestamp defining the lifetime of the contract. Can be extended by renewing the contract.           |
+>
+> - **Choice** Archive
+>
+>   Controller: receiver, provider, dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-amuletrules-transferpreapprovalcancel-70216">
+>
+>   **Choice** TransferPreapproval_Cancel
+>
+>   </div>
+>
+>   Controller: p
+>
+>   Returns: TransferPreapproval_CancelResult
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | p     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-amuletrules-transferpreapprovalexpire-84167">
+>
+>   **Choice** TransferPreapproval_Expire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: TransferPreapproval_ExpireResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-amuletrules-transferpreapprovalfetch-15083">
+>
+>   **Choice** TransferPreapproval_Fetch
+>
+>   </div>
+>
+>   Controller: p
+>
+>   Returns: TransferPreapproval
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | p     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-amuletrules-transferpreapprovalrenew-31244">
+>
+>   **Choice** TransferPreapproval_Renew
+>
+>   </div>
+>
+>   Controller: provider
+>
+>   Returns: TransferPreapproval_RenewResult
+>
+>   | Field        | Type                                                                                                              | Description |
+>   |--------------|-------------------------------------------------------------------------------------------------------------------|-------------|
+>   | context      | PaymentTransferContext                                                                                            |             |
+>   | inputs       | \[TransferInput\]                                                                                                 |             |
+>   | newExpiresAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) |             |
+>
+> - <div id="type-splice-amuletrules-transferpreapprovalsend-62554">
+>
+>   **Choice** TransferPreapproval_Send
+>
+>   </div>
+>
+>   Deprecated: Use TransferPreapproval_SendV2 instead.
+>
+>   Controller: sender
+>
+>   Returns: TransferPreapproval_SendResult
+>
+>   | Field       | Type                                                                                                                                                                                                                                        | Description |
+>   |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | context     | PaymentTransferContext                                                                                                                                                                                                                      |             |
+>   | inputs      | \[TransferInput\]                                                                                                                                                                                                                           |             |
+>   | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                          |             |
+>   | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |             |
+>   | description | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> - <div id="type-splice-amuletrules-transferpreapprovalsendv2-66036">
+>
+>   **Choice** TransferPreapproval_SendV2
+>
+>   </div>
+>
+>   Controller: sender
+>
+>   Returns: TransferPreapproval_SendV2Result
+>
+>   | Field       | Type                                                                                                                                                                                                                                        | Description |
+>   |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | context     | ExternalPartyTransferContext                                                                                                                                                                                                                |             |
+>   | inputs      | \[TransferInput\]                                                                                                                                                                                                                           |             |
+>   | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                          |             |
+>   | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |             |
+>   | description | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+
+## Data Types
+
+<div id="type-splice-amuletrules-amuletrulesaddfutureamuletconfigscheduleresult-28167">
+
+**data** AmuletRules_AddFutureAmuletConfigScheduleResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesaddfutureamuletconfigscheduleresult-43322">
+>
+> AmuletRules_AddFutureAmuletConfigScheduleResult
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                                      | Description |
+> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newAmuletRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
+>
+> **instance** GetField "newAmuletRules" AmuletRules_AddFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** SetField "newAmuletRules" AmuletRules_AddFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigScheduleResult
+
+<div id="type-splice-amuletrules-amuletrulesadvanceopenminingroundsresult-46823">
+
+**data** AmuletRules_AdvanceOpenMiningRoundsResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesadvanceopenminingroundsresult-34806">
+>
+> AmuletRules_AdvanceOpenMiningRoundsResult
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                                 | Description |
+> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | summarizingRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound |             |
+> > | openRoundCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound        |             |
+>
+> **instance** GetField "openRoundCid" AmuletRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** GetField "summarizingRoundCid" AmuletRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound)
+>
+> **instance** SetField "openRoundCid" AmuletRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** SetField "summarizingRoundCid" AmuletRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_AdvanceOpenMiningRounds AmuletRules_AdvanceOpenMiningRoundsResult
+
+<div id="type-splice-amuletrules-amuletrulesallocatedevelopmentfundcouponresult-49827">
+
+**data** AmuletRules_AllocateDevelopmentFundCouponResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesallocatedevelopmentfundcouponresult-81038">
+>
+> AmuletRules_AllocateDevelopmentFundCouponResult
+>
+> </div>
+>
+> > | Field                                | Type                                                                                                                                                                                                                                                                                          | Description |
+> > |--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | developmentFundCouponCid             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DevelopmentFundCoupon                                                                                                                                           |             |
+> > | optUnclaimedDevelopmentFundCouponCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon) |             |
+>
+> **instance** GetField "developmentFundCouponCid" AmuletRules_AllocateDevelopmentFundCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DevelopmentFundCoupon)
+>
+> **instance** GetField "optUnclaimedDevelopmentFundCouponCid" AmuletRules_AllocateDevelopmentFundCouponResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon))
+>
+> **instance** SetField "developmentFundCouponCid" AmuletRules_AllocateDevelopmentFundCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DevelopmentFundCoupon)
+>
+> **instance** SetField "optUnclaimedDevelopmentFundCouponCid" AmuletRules_AllocateDevelopmentFundCouponResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_AllocateDevelopmentFundCoupon AmuletRules_AllocateDevelopmentFundCouponResult
+
+<div id="type-splice-amuletrules-amuletrulesamuletexpiretransferinstructionsresult-58846">
+
+**data** AmuletRules_Amulet_ExpireTransferInstructionsResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesamuletexpiretransferinstructionsresult-66147">
+>
+> AmuletRules_Amulet_ExpireTransferInstructionsResult
+>
+> </div>
+>
+> > | Field   | Type                          | Description |
+> > |---------|-------------------------------|-------------|
+> > | results | \[TransferInstructionResult\] |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_Amulet_ExpireTransferInstructionsResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_Amulet_ExpireTransferInstructionsResult
+>
+> **instance** GetField "results" AmuletRules_Amulet_ExpireTransferInstructionsResult \[TransferInstructionResult\]
+>
+> **instance** SetField "results" AmuletRules_Amulet_ExpireTransferInstructionsResult \[TransferInstructionResult\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_Amulet_ExpireTransferInstructions AmuletRules_Amulet_ExpireTransferInstructionsResult
+
+<div id="type-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstateresult-72638">
+
+**data** AmuletRules_BootstrapExternalPartyConfigStateResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesbootstrapexternalpartyconfigstateresult-91611">
+>
+> AmuletRules_BootstrapExternalPartyConfigStateResult
+>
+> </div>
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_BootstrapExternalPartyConfigStateResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_BootstrapExternalPartyConfigStateResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_BootstrapExternalPartyConfigState AmuletRules_BootstrapExternalPartyConfigStateResult
+
+<div id="type-splice-amuletrules-amuletrulesbootstraproundsresult-84997">
+
+**data** AmuletRules_Bootstrap_RoundsResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesbootstraproundsresult-21662">
+>
+> AmuletRules_Bootstrap_RoundsResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                          | Description |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | openMiningRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+> > | initialRound       | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Round          |             |
+>
+> **instance** GetField "initialRound" AmuletRules_Bootstrap_RoundsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Round)
+>
+> **instance** GetField "openMiningRoundCid" AmuletRules_Bootstrap_RoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** SetField "initialRound" AmuletRules_Bootstrap_RoundsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Round)
+>
+> **instance** SetField "openMiningRoundCid" AmuletRules_Bootstrap_RoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_Bootstrap_Rounds AmuletRules_Bootstrap_RoundsResult
+
+<div id="type-splice-amuletrules-amuletrulesbuymembertrafficresult-65734">
+
+**data** AmuletRules_BuyMemberTrafficResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesbuymembertrafficresult-62493">
+>
+> AmuletRules_BuyMemberTrafficResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                                                                                                                                                  | Description |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | round              | Round                                                                                                                                                                                                                                                                 |             |
+> > | summary            | TransferSummary                                                                                                                                                                                                                                                       |             |
+> > | amuletPaid         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                                    |             |
+> > | purchasedTraffic   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic                                                                                                                           |             |
+> > | senderChangeAmulet | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+> > | meta               | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                                                                                                                               |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_BuyMemberTrafficResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_BuyMemberTrafficResult
+>
+> **instance** GetField "amuletPaid" AmuletRules_BuyMemberTrafficResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "meta" AmuletRules_BuyMemberTrafficResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** GetField "purchasedTraffic" AmuletRules_BuyMemberTrafficResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
+>
+> **instance** GetField "round" AmuletRules_BuyMemberTrafficResult Round
+>
+> **instance** GetField "senderChangeAmulet" AmuletRules_BuyMemberTrafficResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "summary" AmuletRules_BuyMemberTrafficResult TransferSummary
+>
+> **instance** SetField "amuletPaid" AmuletRules_BuyMemberTrafficResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "meta" AmuletRules_BuyMemberTrafficResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** SetField "purchasedTraffic" AmuletRules_BuyMemberTrafficResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
+>
+> **instance** SetField "round" AmuletRules_BuyMemberTrafficResult Round
+>
+> **instance** SetField "senderChangeAmulet" AmuletRules_BuyMemberTrafficResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "summary" AmuletRules_BuyMemberTrafficResult TransferSummary
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_BuyMemberTraffic AmuletRules_BuyMemberTrafficResult
+
+<div id="type-splice-amuletrules-amuletrulesclaimexpiredrewardsresult-1315">
+
+**data** AmuletRules_ClaimExpiredRewardsResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesclaimexpiredrewardsresult-54946">
+>
+> AmuletRules_ClaimExpiredRewardsResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                                                                                                                                                           | Description |
+> > |--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unclaimedRewardCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward) |             |
+>
+> **instance** GetField "unclaimedRewardCid" AmuletRules_ClaimExpiredRewardsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
+>
+> **instance** SetField "unclaimedRewardCid" AmuletRules_ClaimExpiredRewardsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_ClaimExpiredRewards AmuletRules_ClaimExpiredRewardsResult
+
+<div id="type-splice-amuletrules-amuletrulescomputefeesresult-44934">
+
+**data** AmuletRules_ComputeFeesResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulescomputefeesresult-49467">
+>
+> AmuletRules_ComputeFeesResult
+>
+> </div>
+>
+> > | Field | Type                                                                                                                   | Description |
+> > |-------|------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | fees  | \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\] |             |
+>
+> **instance** GetField "fees" AmuletRules_ComputeFeesResult \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\]
+>
+> **instance** SetField "fees" AmuletRules_ComputeFeesResult \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_ComputeFees AmuletRules_ComputeFeesResult
+
+<div id="type-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkersresult-77612">
+
+**data** AmuletRules_ConvertFeaturedAppActivityMarkersResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesconvertfeaturedappactivitymarkersresult-46141">
+>
+> AmuletRules_ConvertFeaturedAppActivityMarkersResult
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                              | Description |
+> > |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | appRewardCouponCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppRewardCoupon\] |             |
+>
+> **instance** GetField "appRewardCouponCids" AmuletRules_ConvertFeaturedAppActivityMarkersResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppRewardCoupon\]
+>
+> **instance** SetField "appRewardCouponCids" AmuletRules_ConvertFeaturedAppActivityMarkersResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppRewardCoupon\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_ConvertFeaturedAppActivityMarkers AmuletRules_ConvertFeaturedAppActivityMarkersResult
+
+<div id="type-splice-amuletrules-amuletrulescreateexternalpartysetupproposalresult-7515">
+
+**data** AmuletRules_CreateExternalPartySetupProposalResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulescreateexternalpartysetupproposalresult-29120">
+>
+> AmuletRules_CreateExternalPartySetupProposalResult
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                                                     | Description |
+> > |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | proposalCid    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartySetupProposal |             |
+> > | user           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                      |             |
+> > | validator      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                      |             |
+> > | transferResult | TransferResult                                                                                                                                           |             |
+> > | amuletPaid     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                       |             |
+> > | meta           | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                  |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_CreateExternalPartySetupProposalResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_CreateExternalPartySetupProposalResult
+>
+> **instance** GetField "amuletPaid" AmuletRules_CreateExternalPartySetupProposalResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "meta" AmuletRules_CreateExternalPartySetupProposalResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** GetField "proposalCid" AmuletRules_CreateExternalPartySetupProposalResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartySetupProposal)
+>
+> **instance** GetField "transferResult" AmuletRules_CreateExternalPartySetupProposalResult TransferResult
+>
+> **instance** GetField "user" AmuletRules_CreateExternalPartySetupProposalResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "validator" AmuletRules_CreateExternalPartySetupProposalResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "amuletPaid" AmuletRules_CreateExternalPartySetupProposalResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "meta" AmuletRules_CreateExternalPartySetupProposalResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** SetField "proposalCid" AmuletRules_CreateExternalPartySetupProposalResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartySetupProposal)
+>
+> **instance** SetField "transferResult" AmuletRules_CreateExternalPartySetupProposalResult TransferResult
+>
+> **instance** SetField "user" AmuletRules_CreateExternalPartySetupProposalResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "validator" AmuletRules_CreateExternalPartySetupProposalResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_CreateExternalPartySetupProposal AmuletRules_CreateExternalPartySetupProposalResult
+
+<div id="type-splice-amuletrules-amuletrulescreatetransferpreapprovalresult-96401">
+
+**data** AmuletRules_CreateTransferPreapprovalResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulescreatetransferpreapprovalresult-40608">
+>
+> AmuletRules_CreateTransferPreapprovalResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                              | Description |
+> > |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | transferPreapprovalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval |             |
+> > | transferResult         | TransferResult                                                                                                                                    |             |
+> > | amuletPaid             | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                |             |
+> > | meta                   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata           |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_CreateTransferPreapprovalResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_CreateTransferPreapprovalResult
+>
+> **instance** GetField "amuletPaid" AmuletRules_CreateTransferPreapprovalResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "meta" AmuletRules_CreateTransferPreapprovalResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** GetField "transferPreapprovalCid" AmuletRules_CreateTransferPreapprovalResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> **instance** GetField "transferResult" AmuletRules_CreateTransferPreapprovalResult TransferResult
+>
+> **instance** SetField "amuletPaid" AmuletRules_CreateTransferPreapprovalResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "meta" AmuletRules_CreateTransferPreapprovalResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** SetField "transferPreapprovalCid" AmuletRules_CreateTransferPreapprovalResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> **instance** SetField "transferResult" AmuletRules_CreateTransferPreapprovalResult TransferResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_CreateTransferPreapproval AmuletRules_CreateTransferPreapprovalResult
+
+<div id="type-splice-amuletrules-amuletrulesdevnetfeatureappresult-75066">
+
+**data** AmuletRules_DevNet_FeatureAppResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesdevnetfeatureappresult-18203">
+>
+> AmuletRules_DevNet_FeatureAppResult
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                           | Description |
+> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
+>
+> **instance** GetField "featuredAppRightCid" AmuletRules_DevNet_FeatureAppResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** SetField "featuredAppRightCid" AmuletRules_DevNet_FeatureAppResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_DevNet_FeatureApp AmuletRules_DevNet_FeatureAppResult
+
+<div id="type-splice-amuletrules-amuletrulesdevnettapresult-1845">
+
+**data** AmuletRules_DevNet_TapResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesdevnettapresult-50542">
+>
+> AmuletRules_DevNet_TapResult
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                                       | Description |
+> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+> > | meta      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                    |             |
+>
+> **instance** GetField "amuletSum" AmuletRules_DevNet_TapResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "meta" AmuletRules_DevNet_TapResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** SetField "amuletSum" AmuletRules_DevNet_TapResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "meta" AmuletRules_DevNet_TapResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_DevNet_Tap AmuletRules_DevNet_TapResult
+
+<div id="type-splice-amuletrules-amuletrulesexpiretransferinstructioninput-68344">
+
+**data** AmuletRules_ExpireTransferInstructionInput
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesexpiretransferinstructioninput-66803">
+>
+> AmuletRules_ExpireTransferInstructionInput
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                              | Description |
+> > |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | transferInstructionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
+> > | expireLock             | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                      |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_ExpireTransferInstructionInput
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_ExpireTransferInstructionInput
+>
+> **instance** GetField "expireLock" AmuletRules_ExpireTransferInstructionInput [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** GetField "inputs" AmuletRules_Amulet_ExpireTransferInstructions \[AmuletRules_ExpireTransferInstructionInput\]
+>
+> **instance** GetField "transferInstructionCid" AmuletRules_ExpireTransferInstructionInput ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction)
+>
+> **instance** SetField "expireLock" AmuletRules_ExpireTransferInstructionInput [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** SetField "inputs" AmuletRules_Amulet_ExpireTransferInstructions \[AmuletRules_ExpireTransferInstructionInput\]
+>
+> **instance** SetField "transferInstructionCid" AmuletRules_ExpireTransferInstructionInput ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction)
+
+<div id="type-splice-amuletrules-amuletrulesmergemembertrafficcontractsresult-2448">
+
+**data** AmuletRules_MergeMemberTrafficContractsResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesmergemembertrafficcontractsresult-32033">
+>
+> AmuletRules_MergeMemberTrafficContractsResult
+>
+> </div>
+>
+> > | Field            | Type                                                                                                                                        | Description |
+> > |------------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | mergedTrafficCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic |             |
+>
+> **instance** GetField "mergedTrafficCid" AmuletRules_MergeMemberTrafficContractsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
+>
+> **instance** SetField "mergedTrafficCid" AmuletRules_MergeMemberTrafficContractsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MergeMemberTrafficContracts AmuletRules_MergeMemberTrafficContractsResult
+
+<div id="type-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcouponsresult-42676">
+
+**data** AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesmergeunclaimeddevelopmentfundcouponsresult-50551">
+>
+> AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
+>
+> </div>
+>
+> > | Field                             | Type                                                                                                                                                         | Description |
+> > |-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unclaimedDevelopmentFundCouponCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon |             |
+>
+> **instance** GetField "unclaimedDevelopmentFundCouponCid" AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
+>
+> **instance** SetField "unclaimedDevelopmentFundCouponCid" AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MergeUnclaimedDevelopmentFundCoupons AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
+
+<div id="type-splice-amuletrules-amuletrulesmergeunclaimedrewardsresult-41840">
+
+**data** AmuletRules_MergeUnclaimedRewardsResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesmergeunclaimedrewardsresult-46793">
+>
+> AmuletRules_MergeUnclaimedRewardsResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                          | Description |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unclaimedRewardCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward |             |
+>
+> **instance** GetField "unclaimedRewardCid" AmuletRules_MergeUnclaimedRewardsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
+>
+> **instance** SetField "unclaimedRewardCid" AmuletRules_MergeUnclaimedRewardsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MergeUnclaimedRewards AmuletRules_MergeUnclaimedRewardsResult
+
+<div id="type-splice-amuletrules-amuletrulesminingroundarchiveresult-65797">
+
+**data** AmuletRules_MiningRound_ArchiveResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesminingroundarchiveresult-73420">
+>
+> AmuletRules_MiningRound_ArchiveResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MiningRound_Archive AmuletRules_MiningRound_ArchiveResult
+
+<div id="type-splice-amuletrules-amuletrulesminingroundcloseresult-67441">
+
+**data** AmuletRules_MiningRound_CloseResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesminingroundcloseresult-19004">
+>
+> AmuletRules_MiningRound_CloseResult
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                                            | Description |
+> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
+>
+> **instance** GetField "closedRoundCid" AmuletRules_MiningRound_CloseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound)
+>
+> **instance** SetField "closedRoundCid" AmuletRules_MiningRound_CloseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MiningRound_Close AmuletRules_MiningRound_CloseResult
+
+<div id="type-splice-amuletrules-amuletrulesminingroundstartissuingresult-26220">
+
+**data** AmuletRules_MiningRound_StartIssuingResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesminingroundstartissuingresult-95691">
+>
+> AmuletRules_MiningRound_StartIssuingResult
+>
+> </div>
+>
+> > | Field                             | Type                                                                                                                                                                                                                                                                                          | Description |
+> > |-----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | issuingRoundCid                   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound                                                                                                                                              |             |
+> > | unclaimedDevelopmentFundCouponCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon) |             |
+>
+> **instance** GetField "issuingRoundCid" AmuletRules_MiningRound_StartIssuingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound)
+>
+> **instance** GetField "unclaimedDevelopmentFundCouponCid" AmuletRules_MiningRound_StartIssuingResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon))
+>
+> **instance** SetField "issuingRoundCid" AmuletRules_MiningRound_StartIssuingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound)
+>
+> **instance** SetField "unclaimedDevelopmentFundCouponCid" AmuletRules_MiningRound_StartIssuingResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedDevelopmentFundCoupon))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuingResult
+
+<div id="type-splice-amuletrules-amuletrulesmintresult-5311">
+
+**data** AmuletRules_MintResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesmintresult-82812">
+>
+> AmuletRules_MintResult
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                                       | Description |
+> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "amuletSum" AmuletRules_MintResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "amuletSum" AmuletRules_MintResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_Mint AmuletRules_MintResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_Mint AmuletRules_MintResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_Mint AmuletRules_MintResult
+
+<div id="type-splice-amuletrules-amuletrulesremovefutureamuletconfigscheduleresult-69237">
+
+**data** AmuletRules_RemoveFutureAmuletConfigScheduleResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesremovefutureamuletconfigscheduleresult-56166">
+>
+> AmuletRules_RemoveFutureAmuletConfigScheduleResult
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                                      | Description |
+> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newAmuletRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
+>
+> **instance** GetField "newAmuletRules" AmuletRules_RemoveFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** SetField "newAmuletRules" AmuletRules_RemoveFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigScheduleResult
+
+<div id="type-splice-amuletrules-amuletrulessetconfigresult-68086">
+
+**data** AmuletRules_SetConfigResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulessetconfigresult-73787">
+>
+> AmuletRules_SetConfigResult
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                                      | Description |
+> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newAmuletRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
+>
+> **instance** GetField "newAmuletRules" AmuletRules_SetConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** SetField "newAmuletRules" AmuletRules_SetConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_SetConfig AmuletRules_SetConfigResult
+
+<div id="type-splice-amuletrules-amuletrulesupdateexternalpartyconfigstatesresult-25160">
+
+**data** AmuletRules_UpdateExternalPartyConfigStatesResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesupdateexternalpartyconfigstatesresult-25761">
+>
+> AmuletRules_UpdateExternalPartyConfigStatesResult
+>
+> </div>
+>
+> > | Field                          | Type                                                                                                                                                   | Description |
+> > |--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newExternalPartyConfigStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_UpdateExternalPartyConfigStatesResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_UpdateExternalPartyConfigStatesResult
+>
+> **instance** GetField "newExternalPartyConfigStateCid" AmuletRules_UpdateExternalPartyConfigStatesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
+>
+> **instance** SetField "newExternalPartyConfigStateCid" AmuletRules_UpdateExternalPartyConfigStatesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_UpdateExternalPartyConfigStates AmuletRules_UpdateExternalPartyConfigStatesResult
+
+<div id="type-splice-amuletrules-amuletrulesupdatefutureamuletconfigscheduleresult-96070">
+
+**data** AmuletRules_UpdateFutureAmuletConfigScheduleResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-amuletrulesupdatefutureamuletconfigscheduleresult-12117">
+>
+> AmuletRules_UpdateFutureAmuletConfigScheduleResult
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                                      | Description |
+> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newAmuletRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
+>
+> **instance** GetField "newAmuletRules" AmuletRules_UpdateFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** SetField "newAmuletRules" AmuletRules_UpdateFutureAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigScheduleResult
+
+<div id="type-splice-amuletrules-apptransfercontext-68083">
+
+**data** AppTransferContext
+
+</div>
+
+> <div id="constr-splice-amuletrules-apptransfercontext-19128">
+>
+> AppTransferContext
+>
+> </div>
+>
+> > | Field            | Type                                                                                                                                                                                                                                                                            | Description |
+> > |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletRules      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                                                       |             |
+> > | openMiningRound  | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                                                   |             |
+> > | featuredAppRight | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AppTransferContext
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AppTransferContext
+>
+> **instance** GetField "amuletRules" AppTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** GetField "featuredAppRight" AppTransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
+>
+> **instance** GetField "openMiningRound" AppTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** SetField "amuletRules" AppTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** SetField "featuredAppRight" AppTransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
+>
+> **instance** SetField "openMiningRound" AppTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+
+<div id="type-splice-amuletrules-balancechange-24411">
+
+**data** BalanceChange
+
+</div>
+
+> <div id="constr-splice-amuletrules-balancechange-6762">
+>
+> BalanceChange
+>
+> </div>
+>
+> > | Field                              | Type                                                                                                               | Description                                                                                                                                                                                            |
+> > |------------------------------------|--------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | changeToInitialAmountAsOfRoundZero | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | The change to the total balance introduced by this balance change, normalized to round zero, i.e., a amulet created in round 3 is treated as a amulet created in round 0 with a higher initial amount. |
+> > | changeToHoldingFeesRate            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | The change of total holding fees introduced by this balance change.                                                                                                                                    |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) BalanceChange
+>
+> **instance** [Additive](/appdev/reference/daml-standard-library/prelude#class-ghc-num-additive-25881) BalanceChange
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) BalanceChange
+>
+> **instance** GetField "balanceChanges" TransferSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) BalanceChange)
+>
+> **instance** GetField "changeToHoldingFeesRate" BalanceChange [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "changeToInitialAmountAsOfRoundZero" BalanceChange [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "balanceChanges" TransferSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) BalanceChange)
+>
+> **instance** SetField "changeToHoldingFeesRate" BalanceChange [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "changeToInitialAmountAsOfRoundZero" BalanceChange [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+<div id="type-splice-amuletrules-createdamulet-4205">
+
+**data** CreatedAmulet
+
+</div>
+
+> <div id="constr-splice-amuletrules-transferresultamulet-871">
+>
+> TransferResultAmulet ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+>
+> </div>
+>
+> <div id="constr-splice-amuletrules-transferresultlockedamulet-28147">
+>
+> TransferResultLockedAmulet ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet)
+>
+> </div>
+>
+> <div id="constr-splice-amuletrules-extcreatedamulet-9390">
+>
+> ExtCreatedAmulet
+>
+> </div>
+>
+> > | Field          | Type | Description                                                                                             |
+> > |----------------|------|---------------------------------------------------------------------------------------------------------|
+> > | dummyUnitField | ()   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) CreatedAmulet
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) CreatedAmulet
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) CreatedAmulet
+>
+> **instance** GetField "createdAmulets" TransferResult \[CreatedAmulet\]
+>
+> **instance** GetField "dummyUnitField" CreatedAmulet ()
+>
+> **instance** SetField "createdAmulets" TransferResult \[CreatedAmulet\]
+>
+> **instance** SetField "dummyUnitField" CreatedAmulet ()
+
+<div id="type-splice-amuletrules-externalpartysetupproposalacceptresult-45221">
+
+**data** ExternalPartySetupProposal_AcceptResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-externalpartysetupproposalacceptresult-28452">
+>
+> ExternalPartySetupProposal_AcceptResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                              | Description |
+> > |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | validatorRightCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight      |             |
+> > | transferPreapprovalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartySetupProposal_AcceptResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartySetupProposal_AcceptResult
+>
+> **instance** GetField "transferPreapprovalCid" ExternalPartySetupProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> **instance** GetField "validatorRightCid" ExternalPartySetupProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight)
+>
+> **instance** SetField "transferPreapprovalCid" ExternalPartySetupProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> **instance** SetField "validatorRightCid" ExternalPartySetupProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ExternalPartySetupProposal ExternalPartySetupProposal_Accept ExternalPartySetupProposal_AcceptResult
+
+<div id="type-splice-amuletrules-externalpartysetupproposalrejectresult-76848">
+
+**data** ExternalPartySetupProposal_RejectResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-externalpartysetupproposalrejectresult-73325">
+>
+> ExternalPartySetupProposal_RejectResult
+>
+> </div>
+>
+> > | Field    | Type | Description |
+> > |----------|------|-------------|
+> > | dummyArg | ()   |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartySetupProposal_RejectResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartySetupProposal_RejectResult
+>
+> **instance** GetField "dummyArg" ExternalPartySetupProposal_RejectResult ()
+>
+> **instance** SetField "dummyArg" ExternalPartySetupProposal_RejectResult ()
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ExternalPartySetupProposal ExternalPartySetupProposal_Reject ExternalPartySetupProposal_RejectResult
+
+<div id="type-splice-amuletrules-externalpartysetupproposalwithdrawresult-88253">
+
+**data** ExternalPartySetupProposal_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-externalpartysetupproposalwithdrawresult-17304">
+>
+> ExternalPartySetupProposal_WithdrawResult
+>
+> </div>
+>
+> > | Field    | Type | Description |
+> > |----------|------|-------------|
+> > | dummyArg | ()   |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartySetupProposal_WithdrawResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartySetupProposal_WithdrawResult
+>
+> **instance** GetField "dummyArg" ExternalPartySetupProposal_WithdrawResult ()
+>
+> **instance** SetField "dummyArg" ExternalPartySetupProposal_WithdrawResult ()
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ExternalPartySetupProposal ExternalPartySetupProposal_Withdraw ExternalPartySetupProposal_WithdrawResult
+
+<div id="type-splice-amuletrules-externalpartytransfercontext-70523">
+
+**data** ExternalPartyTransferContext
+
+</div>
+
+> Contracts that need to be passed in to a Transfer so that we can reference them by contract id instead of by key.
+>
+> <div id="constr-splice-amuletrules-externalpartytransfercontext-43164">
+>
+> ExternalPartyTransferContext
+>
+> </div>
+>
+> > | Field                    | Type                                                                                                                                                                                                                                                                            | Description                                                  |
+> > |--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+> > | externalPartyConfigState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState                                                                                                                          |                                                              |
+> > | featuredAppRight         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight) | Optional proof that the provider is a featured app provider. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartyTransferContext
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartyTransferContext
+>
+> **instance** GetField "context" TransferPreapproval_SendV2 ExternalPartyTransferContext
+>
+> **instance** GetField "externalPartyConfigState" ExternalPartyTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
+>
+> **instance** GetField "featuredAppRight" ExternalPartyTransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
+>
+> **instance** SetField "context" TransferPreapproval_SendV2 ExternalPartyTransferContext
+>
+> **instance** SetField "externalPartyConfigState" ExternalPartyTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
+>
+> **instance** SetField "featuredAppRight" ExternalPartyTransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
+
+<div id="type-splice-amuletrules-invalidtransferreason-16587">
+
+**data** InvalidTransferReason
+
+</div>
+
+> <div id="constr-splice-amuletrules-itrinsufficientfunds-49975">
+>
+> ITR_InsufficientFunds
+>
+> </div>
+>
+> > | Field         | Type                                                                                                               | Description |
+> > |---------------|--------------------------------------------------------------------------------------------------------------------|-------------|
+> > | missingAmount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
+>
+> <div id="constr-splice-amuletrules-itrunknownsynchronizer-472">
+>
+> ITR_UnknownSynchronizer
+>
+> </div>
+>
+> > | Field          | Type                                                                                                         | Description |
+> > |----------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-splice-amuletrules-itrinsufficienttopupamount-60775">
+>
+> ITR_InsufficientTopupAmount
+>
+> </div>
+>
+> > | Field                | Type                                                                                                       | Description |
+> > |----------------------|------------------------------------------------------------------------------------------------------------|-------------|
+> > | requestedTopupAmount | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+> > | minTopupAmount       | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+>
+> <div id="constr-splice-amuletrules-itrother-36638">
+>
+> ITR_Other
+>
+> </div>
+>
+> > | Field       | Type                                                                                                         | Description |
+> > |-------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> <div id="constr-splice-amuletrules-extinvalidtransferreason-71060">
+>
+> ExtInvalidTransferReason
+>
+> </div>
+>
+> > | Field          | Type | Description                                                                                             |
+> > |----------------|------|---------------------------------------------------------------------------------------------------------|
+> > | dummyUnitField | ()   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) InvalidTransferReason
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) InvalidTransferReason
+>
+> **instance** GetField "description" InvalidTransferReason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "dummyUnitField" InvalidTransferReason ()
+>
+> **instance** GetField "minTopupAmount" InvalidTransferReason [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "missingAmount" InvalidTransferReason [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "reason" TransferCommandResult InvalidTransferReason
+>
+> **instance** GetField "requestedTopupAmount" InvalidTransferReason [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "synchronizerId" InvalidTransferReason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "description" InvalidTransferReason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "dummyUnitField" InvalidTransferReason ()
+>
+> **instance** SetField "minTopupAmount" InvalidTransferReason [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "missingAmount" InvalidTransferReason [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "reason" TransferCommandResult InvalidTransferReason
+>
+> **instance** SetField "requestedTopupAmount" InvalidTransferReason [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "synchronizerId" InvalidTransferReason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+<div id="type-splice-amuletrules-openminingroundtriple-84091">
+
+**data** OpenMiningRoundTriple
+
+</div>
+
+> <div id="constr-splice-amuletrules-openminingroundtriple-73258">
+>
+> OpenMiningRoundTriple
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                          | Description |
+> > |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | round0Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+> > | round1Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+> > | round2Cid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) OpenMiningRoundTriple
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) OpenMiningRoundTriple
+>
+> **instance** GetField "openMiningRoundTriple" AmuletRules_BootstrapExternalPartyConfigState OpenMiningRoundTriple
+>
+> **instance** GetField "openMiningRoundTriple" AmuletRules_UpdateExternalPartyConfigStates OpenMiningRoundTriple
+>
+> **instance** GetField "round0Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** GetField "round1Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** GetField "round2Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** SetField "openMiningRoundTriple" AmuletRules_BootstrapExternalPartyConfigState OpenMiningRoundTriple
+>
+> **instance** SetField "openMiningRoundTriple" AmuletRules_UpdateExternalPartyConfigStates OpenMiningRoundTriple
+>
+> **instance** SetField "round0Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** SetField "round1Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** SetField "round2Cid" OpenMiningRoundTriple ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+
+<div id="type-splice-amuletrules-paymenttransfercontext-72190">
+
+**data** PaymentTransferContext
+
+</div>
+
+> <div id="constr-splice-amuletrules-paymenttransfercontext-9413">
+>
+> PaymentTransferContext
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                      | Description |
+> > |-------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
+> > | context     | TransferContext                                                                                                                           |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) PaymentTransferContext
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) PaymentTransferContext
+>
+> **instance** GetField "amuletRules" PaymentTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** GetField "context" AmuletRules_CreateExternalPartySetupProposal PaymentTransferContext
+>
+> **instance** GetField "context" AmuletRules_CreateTransferPreapproval PaymentTransferContext
+>
+> **instance** GetField "context" PaymentTransferContext TransferContext
+>
+> **instance** GetField "context" TransferPreapproval_Renew PaymentTransferContext
+>
+> **instance** GetField "context" TransferPreapproval_Send PaymentTransferContext
+>
+> **instance** GetField "context" TransferCommand_Send PaymentTransferContext
+>
+> **instance** SetField "amuletRules" PaymentTransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** SetField "context" AmuletRules_CreateExternalPartySetupProposal PaymentTransferContext
+>
+> **instance** SetField "context" AmuletRules_CreateTransferPreapproval PaymentTransferContext
+>
+> **instance** SetField "context" PaymentTransferContext TransferContext
+>
+> **instance** SetField "context" TransferPreapproval_Renew PaymentTransferContext
+>
+> **instance** SetField "context" TransferPreapproval_Send PaymentTransferContext
+>
+> **instance** SetField "context" TransferCommand_Send PaymentTransferContext
+
+<div id="type-splice-amuletrules-preprocessedtransferoutput-12209">
+
+**data** PreprocessedTransferOutput
+
+</div>
+
+> <div id="constr-splice-amuletrules-preprocessedtransferoutput-93914">
+>
+> PreprocessedTransferOutput
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                    | Description                                                 |
+> > |-----------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+> > | owner     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                     | Owner of the output                                         |
+> > | outputFee | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                      | Fee charged to create this output                           |
+> > | amount    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                      | Amount of amulet held by this output (after deducting fees) |
+> > | lock      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock | Whether to lock the amulet or not                           |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) PreprocessedTransferOutput
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) PreprocessedTransferOutput
+>
+> **instance** GetField "amount" PreprocessedTransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "lock" PreprocessedTransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
+>
+> **instance** GetField "outputFee" PreprocessedTransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "owner" PreprocessedTransferOutput [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "amount" PreprocessedTransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "lock" PreprocessedTransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
+>
+> **instance** SetField "outputFee" PreprocessedTransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "owner" PreprocessedTransferOutput [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+<div id="type-splice-amuletrules-rewardsissuanceconfig-37252">
+
+**data** RewardsIssuanceConfig
+
+</div>
+
+> An easy way to configure `exucuteTransfer` wrt what rewards to issue. We currently only use two configurations: but all of the options in here make sense, so we keep them.
+>
+> <div id="constr-splice-amuletrules-rewardsissuanceconfig-46673">
+>
+> RewardsIssuanceConfig
+>
+> </div>
+>
+> > | Field                 | Type                                                                                                         | Description |
+> > |-----------------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | issueAppRewards       | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) |             |
+> > | issueValidatorRewards | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) |             |
+>
+> **instance** GetField "issueAppRewards" RewardsIssuanceConfig [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** GetField "issueValidatorRewards" RewardsIssuanceConfig [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** SetField "issueAppRewards" RewardsIssuanceConfig [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** SetField "issueValidatorRewards" RewardsIssuanceConfig [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+<div id="type-splice-amuletrules-transfer-72721">
+
+**data** Transfer
+
+</div>
+
+> Representation of a batch transfer.
+>
+> <div id="constr-splice-amuletrules-transfer-1214">
+>
+> Transfer
+>
+> </div>
+>
+> > | Field         | Type                                                                                                                                                    | Description                                          |
+> > |---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+> > | sender        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                     |                                                      |
+> > | provider      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                     |                                                      |
+> > | inputs        | \[TransferInput\]                                                                                                                                       |                                                      |
+> > | outputs       | \[TransferOutput\]                                                                                                                                      |                                                      |
+> > | beneficiaries | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[AppRewardBeneficiary\] | Beneficiaries between which the app reward is split. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Transfer
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) Transfer
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Transfer
+>
+> **instance** GetField "beneficiaries" Transfer ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[AppRewardBeneficiary\])
+>
+> **instance** GetField "inputs" Transfer \[TransferInput\]
+>
+> **instance** GetField "outputs" Transfer \[TransferOutput\]
+>
+> **instance** GetField "provider" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "sender" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "transfer" AmuletRules_Transfer Transfer
+>
+> **instance** SetField "beneficiaries" Transfer ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[AppRewardBeneficiary\])
+>
+> **instance** SetField "inputs" Transfer \[TransferInput\]
+>
+> **instance** SetField "outputs" Transfer \[TransferOutput\]
+>
+> **instance** SetField "provider" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "sender" Transfer [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "transfer" AmuletRules_Transfer Transfer
+
+<div id="type-splice-amuletrules-transfercontext-68991">
+
+**data** TransferContext
+
+</div>
+
+> Contracts that need to be passed in to a Transfer so that we can reference them by contract id instead of by key.
+>
+> <div id="constr-splice-amuletrules-transfercontext-56806">
+>
+> TransferContext
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                                                                                                                                                                                                                                                               | Description                                                  |
+> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+> > | openMiningRound     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                                                                                                                                                      |                                                              |
+> > | issuingMiningRounds | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound)                                                                                                           |                                                              |
+> > | validatorRights     | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight) | Map from user to ValidatorRight contract.                    |
+> > | featuredAppRight    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)                                                                                                    | Optional proof that the provider is a featured app provider. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferContext
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferContext
+>
+> **instance** GetField "context" AmuletRules_BuyMemberTraffic TransferContext
+>
+> **instance** GetField "context" AmuletRules_ComputeFees TransferContext
+>
+> **instance** GetField "context" AmuletRules_Transfer TransferContext
+>
+> **instance** GetField "context" PaymentTransferContext TransferContext
+>
+> **instance** GetField "featuredAppRight" TransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
+>
+> **instance** GetField "issuingMiningRounds" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound))
+>
+> **instance** GetField "openMiningRound" TransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** GetField "validatorRights" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
+>
+> **instance** SetField "context" AmuletRules_BuyMemberTraffic TransferContext
+>
+> **instance** SetField "context" AmuletRules_ComputeFees TransferContext
+>
+> **instance** SetField "context" AmuletRules_Transfer TransferContext
+>
+> **instance** SetField "context" PaymentTransferContext TransferContext
+>
+> **instance** SetField "featuredAppRight" TransferContext ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
+>
+> **instance** SetField "issuingMiningRounds" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound))
+>
+> **instance** SetField "openMiningRound" TransferContext ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** SetField "validatorRights" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
+
+<div id="type-splice-amuletrules-transfercontextsummary-99392">
+
+**data** TransferContextSummary
+
+</div>
+
+> Deprecated: unused, we just can't remove it yet due to upgrading rules
+>
+> <div id="constr-splice-amuletrules-transfercontextsummary-98359">
+>
+> TransferContextSummary
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                                                                                                                                                                                                                                                               | Description |
+> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | featuredAppProvider | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                 |             |
+> > | config              | TransferConfig Amulet                                                                                                                                                                                                                                                                                                                                                              |             |
+> > | openRound           | OpenMiningRound                                                                                                                                                                                                                                                                                                                                                                    |             |
+> > | issuingMiningRounds | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound                                                                                                                                                                                                                                           |             |
+> > | validatorRights     | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferContextSummary
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferContextSummary
+>
+> **instance** GetField "config" TransferContextSummary (TransferConfig Amulet)
+>
+> **instance** GetField "featuredAppProvider" TransferContextSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
+>
+> **instance** GetField "issuingMiningRounds" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
+>
+> **instance** GetField "openRound" TransferContextSummary OpenMiningRound
+>
+> **instance** GetField "validatorRights" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
+>
+> **instance** SetField "config" TransferContextSummary (TransferConfig Amulet)
+>
+> **instance** SetField "featuredAppProvider" TransferContextSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
+>
+> **instance** SetField "issuingMiningRounds" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
+>
+> **instance** SetField "openRound" TransferContextSummary OpenMiningRound
+>
+> **instance** SetField "validatorRights" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
+
+<div id="type-splice-amuletrules-transfercontextsummaryv2-75114">
+
+**data** TransferContextSummaryV2
+
+</div>
+
+> <div id="constr-splice-amuletrules-transfercontextsummaryv2-63237">
+>
+> TransferContextSummaryV2
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                                                                                                                                                                                                                                                               | Description |
+> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | dso                 | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                                                                                                                                                |             |
+> > | featuredAppProvider | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                 |             |
+> > | config              | TransferConfigV2 Amulet                                                                                                                                                                                                                                                                                                                                                            |             |
+> > | openRoundNumber     | Round                                                                                                                                                                                                                                                                                                                                                                              |             |
+> > | amuletPrice         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                                                                                                                                                 |             |
+> > | issuingMiningRounds | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound                                                                                                                                                                                                                                           |             |
+> > | validatorRights     | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferContextSummaryV2
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferContextSummaryV2
+>
+> **instance** GetField "amuletPrice" TransferContextSummaryV2 [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "config" TransferContextSummaryV2 (TransferConfigV2 Amulet)
+>
+> **instance** GetField "dso" TransferContextSummaryV2 [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "featuredAppProvider" TransferContextSummaryV2 ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
+>
+> **instance** GetField "issuingMiningRounds" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
+>
+> **instance** GetField "openRoundNumber" TransferContextSummaryV2 Round
+>
+> **instance** GetField "validatorRights" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
+>
+> **instance** SetField "amuletPrice" TransferContextSummaryV2 [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "config" TransferContextSummaryV2 (TransferConfigV2 Amulet)
+>
+> **instance** SetField "dso" TransferContextSummaryV2 [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "featuredAppProvider" TransferContextSummaryV2 ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
+>
+> **instance** SetField "issuingMiningRounds" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
+>
+> **instance** SetField "openRoundNumber" TransferContextSummaryV2 Round
+>
+> **instance** SetField "validatorRights" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight))
+
+<div id="type-splice-amuletrules-transferinput-61796">
+
+**data** TransferInput
+
+</div>
+
+> An individual input for a batch transfer.
+>
+> <div id="constr-splice-amuletrules-inputapprewardcoupon-60885">
+>
+> InputAppRewardCoupon ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppRewardCoupon)
+>
+> </div>
+>
+> <div id="constr-splice-amuletrules-inputvalidatorrewardcoupon-18692">
+>
+> InputValidatorRewardCoupon ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRewardCoupon)
+>
+> </div>
+>
+> <div id="constr-splice-amuletrules-inputsvrewardcoupon-94444">
+>
+> InputSvRewardCoupon ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardCoupon)
+>
+> </div>
+>
+> <div id="constr-splice-amuletrules-inputamulet-35826">
+>
+> InputAmulet ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+>
+> </div>
+>
+> <div id="constr-splice-amuletrules-exttransferinput-5819">
+>
+> ExtTransferInput
+>
+> </div>
+>
+> > | Field                         | Type                                                                                                                                                                                                                                                                                 | Description                                                                                             |
+> > |-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+> > | dummyUnitField                | ()                                                                                                                                                                                                                                                                                   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+> > | optInputValidatorFaucetCoupon | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon) | Added in CIP-3. Optional validator faucet coupon input into this transfer.                              |
+>
+> <div id="constr-splice-amuletrules-inputvalidatorlivenessactivityrecord-59154">
+>
+> InputValidatorLivenessActivityRecord ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLivenessActivityRecord)
+>
+> </div>
+>
+> <div id="constr-splice-amuletrules-inputunclaimedactivityrecord-17727">
+>
+> InputUnclaimedActivityRecord ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedActivityRecord)
+>
+> </div>
+>
+> <div id="constr-splice-amuletrules-inputdevelopmentfundcoupon-48881">
+>
+> InputDevelopmentFundCoupon ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DevelopmentFundCoupon)
+>
+> </div>
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferInput
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) TransferInput
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferInput
+>
+> **instance** GetField "dummyUnitField" TransferInput ()
+>
+> **instance** GetField "inputs" AmuletRules_BuyMemberTraffic \[TransferInput\]
+>
+> **instance** GetField "inputs" AmuletRules_CreateExternalPartySetupProposal \[TransferInput\]
+>
+> **instance** GetField "inputs" AmuletRules_CreateTransferPreapproval \[TransferInput\]
+>
+> **instance** GetField "inputs" Transfer \[TransferInput\]
+>
+> **instance** GetField "inputs" TransferPreapproval_Renew \[TransferInput\]
+>
+> **instance** GetField "inputs" TransferPreapproval_Send \[TransferInput\]
+>
+> **instance** GetField "inputs" TransferPreapproval_SendV2 \[TransferInput\]
+>
+> **instance** GetField "inputs" TransferCommand_Send \[TransferInput\]
+>
+> **instance** GetField "optInputValidatorFaucetCoupon" TransferInput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon))
+>
+> **instance** SetField "dummyUnitField" TransferInput ()
+>
+> **instance** SetField "inputs" AmuletRules_BuyMemberTraffic \[TransferInput\]
+>
+> **instance** SetField "inputs" AmuletRules_CreateExternalPartySetupProposal \[TransferInput\]
+>
+> **instance** SetField "inputs" AmuletRules_CreateTransferPreapproval \[TransferInput\]
+>
+> **instance** SetField "inputs" Transfer \[TransferInput\]
+>
+> **instance** SetField "inputs" TransferPreapproval_Renew \[TransferInput\]
+>
+> **instance** SetField "inputs" TransferPreapproval_Send \[TransferInput\]
+>
+> **instance** SetField "inputs" TransferPreapproval_SendV2 \[TransferInput\]
+>
+> **instance** SetField "inputs" TransferCommand_Send \[TransferInput\]
+>
+> **instance** SetField "optInputValidatorFaucetCoupon" TransferInput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon))
+
+<div id="type-splice-amuletrules-transferinputssummary-46693">
+
+**data** TransferInputsSummary
+
+</div>
+
+> <div id="constr-splice-amuletrules-transferinputssummary-65268">
+>
+> TransferInputsSummary
+>
+> </div>
+>
+> > | Field                              | Type                                                                                                                                                                                                                                              | Description                                                                                                                                                       |
+> > |------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | totalAmuletAmount                  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
+> > | totalAppRewardAmount               | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
+> > | totalValidatorRewardAmount         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
+> > | totalValidatorFaucetAmount         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Note that the validator faucet amount does not need to be optional in this type, as it is not stored on the ledger.                                               |
+> > | totalSvRewardAmount                | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
+> > | totalHoldingFees                   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
+> > | amountArchivedAsOfRoundZero        | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
+> > | changeToHoldingFeesRate            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                   |
+> > | totalUnclaimedActivityRecordAmount | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Note: Made optional as the addition of this field is checked by the upgrade checker on package upload because `TransferInputsSummary` is serializable.            |
+> > | totalDevelopmentFundAmount         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Note: Same rationale as above — made optional to ensure compatibility with the upgrade checker on package upload because `TransferInputsSummary` is serializable. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferInputsSummary
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferInputsSummary
+>
+> **instance** GetField "amountArchivedAsOfRoundZero" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "changeToHoldingFeesRate" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "totalAmuletAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "totalAppRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "totalDevelopmentFundAmount" TransferInputsSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** GetField "totalHoldingFees" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "totalSvRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "totalUnclaimedActivityRecordAmount" TransferInputsSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** GetField "totalValidatorFaucetAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "totalValidatorRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "amountArchivedAsOfRoundZero" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "changeToHoldingFeesRate" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "totalAmuletAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "totalAppRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "totalDevelopmentFundAmount" TransferInputsSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** SetField "totalHoldingFees" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "totalSvRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "totalUnclaimedActivityRecordAmount" TransferInputsSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** SetField "totalValidatorFaucetAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "totalValidatorRewardAmount" TransferInputsSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+<div id="type-splice-amuletrules-transferoutput-70512">
+
+**data** TransferOutput
+
+</div>
+
+> An individual output for a batch transfer.
+>
+> <div id="constr-splice-amuletrules-transferoutput-68311">
+>
+> TransferOutput
+>
+> </div>
+>
+> > | Field            | Type                                                                                                                                    | Description                                                                                                                                                                                                                                                                                      |
+> > |------------------|-----------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | receiver         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                     | The receiver who will own the created output amulet.                                                                                                                                                                                                                                             |
+> > | receiverFeeRatio | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                      | The ratio of the output fee paid from receiver's output amount. 1.0 means the whole fee is deducted from the specified output amount, 0.0 the whole fee is deducted from the sender's input balance. If a receiver's fee is not covered by the specified output amount, the transfer is aborted. |
+> > | amount           | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                      | The amount of amulet to receive, before deducting the receiver's part of the output fee.                                                                                                                                                                                                         |
+> > | lock             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock | The lock to be added, if any.                                                                                                                                                                                                                                                                    |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferOutput
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) TransferOutput
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferOutput
+>
+> **instance** GetField "amount" TransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "lock" TransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
+>
+> **instance** GetField "outputs" AmuletRules_ComputeFees \[TransferOutput\]
+>
+> **instance** GetField "outputs" Transfer \[TransferOutput\]
+>
+> **instance** GetField "receiver" TransferOutput [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "receiverFeeRatio" TransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "amount" TransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "lock" TransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
+>
+> **instance** SetField "outputs" AmuletRules_ComputeFees \[TransferOutput\]
+>
+> **instance** SetField "outputs" Transfer \[TransferOutput\]
+>
+> **instance** SetField "receiver" TransferOutput [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "receiverFeeRatio" TransferOutput [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+<div id="type-splice-amuletrules-transferoutputssummary-22405">
+
+**type** TransferOutputsSummary
+= \[PreprocessedTransferOutput\]
+
+</div>
+
+<div id="type-splice-amuletrules-transferpreapprovalcancelresult-51361">
+
+**data** TransferPreapproval_CancelResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-transferpreapprovalcancelresult-83086">
+>
+> TransferPreapproval_CancelResult
+>
+> </div>
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferPreapproval_CancelResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferPreapproval_CancelResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferPreapproval TransferPreapproval_Cancel TransferPreapproval_CancelResult
+
+<div id="type-splice-amuletrules-transferpreapprovalexpireresult-89274">
+
+**data** TransferPreapproval_ExpireResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-transferpreapprovalexpireresult-36569">
+>
+> TransferPreapproval_ExpireResult
+>
+> </div>
+>
+> > (no fields)
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferPreapproval_ExpireResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferPreapproval_ExpireResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferPreapproval TransferPreapproval_Expire TransferPreapproval_ExpireResult
+
+<div id="type-splice-amuletrules-transferpreapprovalrenewresult-23849">
+
+**data** TransferPreapproval_RenewResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-transferpreapprovalrenewresult-61232">
+>
+> TransferPreapproval_RenewResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                              | Description |
+> > |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | transferPreapprovalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval |             |
+> > | transferResult         | TransferResult                                                                                                                                    |             |
+> > | receiver               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |             |
+> > | provider               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |             |
+> > | amuletPaid             | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                |             |
+> > | meta                   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata           |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferPreapproval_RenewResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferPreapproval_RenewResult
+>
+> **instance** GetField "amuletPaid" TransferPreapproval_RenewResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "meta" TransferPreapproval_RenewResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** GetField "provider" TransferPreapproval_RenewResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "receiver" TransferPreapproval_RenewResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "transferPreapprovalCid" TransferPreapproval_RenewResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> **instance** GetField "transferResult" TransferPreapproval_RenewResult TransferResult
+>
+> **instance** SetField "amuletPaid" TransferPreapproval_RenewResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "meta" TransferPreapproval_RenewResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** SetField "provider" TransferPreapproval_RenewResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "receiver" TransferPreapproval_RenewResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "transferPreapprovalCid" TransferPreapproval_RenewResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> **instance** SetField "transferResult" TransferPreapproval_RenewResult TransferResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferPreapproval TransferPreapproval_Renew TransferPreapproval_RenewResult
+
+<div id="type-splice-amuletrules-transferpreapprovalsendresult-68419">
+
+**data** TransferPreapproval_SendResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-transferpreapprovalsendresult-67472">
+>
+> TransferPreapproval_SendResult
+>
+> </div>
+>
+> > | Field  | Type                                                                                                                                    | Description |
+> > |--------|-----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | result | TransferResult                                                                                                                          |             |
+> > | meta   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferPreapproval_SendResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferPreapproval_SendResult
+>
+> **instance** GetField "meta" TransferPreapproval_SendResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** GetField "result" TransferPreapproval_SendResult TransferResult
+>
+> **instance** SetField "meta" TransferPreapproval_SendResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** SetField "result" TransferPreapproval_SendResult TransferResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferPreapproval TransferPreapproval_Send TransferPreapproval_SendResult
+
+<div id="type-splice-amuletrules-transferpreapprovalsendv2result-94909">
+
+**data** TransferPreapproval_SendV2Result
+
+</div>
+
+> <div id="constr-splice-amuletrules-transferpreapprovalsendv2result-33038">
+>
+> TransferPreapproval_SendV2Result
+>
+> </div>
+>
+> > | Field  | Type           | Description |
+> > |--------|----------------|-------------|
+> > | result | TransferResult |             |
+> > | meta   | Metadata       |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferPreapproval_SendV2Result
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferPreapproval_SendV2Result
+>
+> **instance** GetField "meta" TransferPreapproval_SendV2Result Metadata
+>
+> **instance** GetField "result" TransferPreapproval_SendV2Result TransferResult
+>
+> **instance** SetField "meta" TransferPreapproval_SendV2Result Metadata
+>
+> **instance** SetField "result" TransferPreapproval_SendV2Result TransferResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferPreapproval TransferPreapproval_SendV2 TransferPreapproval_SendV2Result
+
+<div id="type-splice-amuletrules-transferresult-93164">
+
+**data** TransferResult
+
+</div>
+
+> <div id="constr-splice-amuletrules-transferresult-68399">
+>
+> TransferResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                                                                                                                                                  | Description                                                                                                                                                                |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | round              | Round                                                                                                                                                                                                                                                                 | Round for which this transfer was registered.                                                                                                                              |
+> > | summary            | TransferSummary                                                                                                                                                                                                                                                       | Summary of amount input and outputs, and fees paid.                                                                                                                        |
+> > | createdAmulets     | \[CreatedAmulet\]                                                                                                                                                                                                                                                     | References to the created output amulets.                                                                                                                                  |
+> > | senderChangeAmulet | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) | Optional reference to the amulet for the change returned to the sender. Only created if there was some change to be returned after deducting the fee for returning change. |
+> > | meta               | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata                                                                                                                               |                                                                                                                                                                            |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferResult
+>
+> **instance** GetField "createdAmulets" TransferResult \[CreatedAmulet\]
+>
+> **instance** GetField "meta" TransferResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** GetField "result" TransferPreapproval_SendResult TransferResult
+>
+> **instance** GetField "result" TransferPreapproval_SendV2Result TransferResult
+>
+> **instance** GetField "result" TransferCommandResult TransferResult
+>
+> **instance** GetField "round" TransferResult Round
+>
+> **instance** GetField "senderChangeAmulet" TransferResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "summary" TransferResult TransferSummary
+>
+> **instance** GetField "transferResult" AmuletRules_CreateExternalPartySetupProposalResult TransferResult
+>
+> **instance** GetField "transferResult" AmuletRules_CreateTransferPreapprovalResult TransferResult
+>
+> **instance** GetField "transferResult" TransferPreapproval_RenewResult TransferResult
+>
+> **instance** SetField "createdAmulets" TransferResult \[CreatedAmulet\]
+>
+> **instance** SetField "meta" TransferResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Metadata)
+>
+> **instance** SetField "result" TransferPreapproval_SendResult TransferResult
+>
+> **instance** SetField "result" TransferPreapproval_SendV2Result TransferResult
+>
+> **instance** SetField "result" TransferCommandResult TransferResult
+>
+> **instance** SetField "round" TransferResult Round
+>
+> **instance** SetField "senderChangeAmulet" TransferResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "summary" TransferResult TransferSummary
+>
+> **instance** SetField "transferResult" AmuletRules_CreateExternalPartySetupProposalResult TransferResult
+>
+> **instance** SetField "transferResult" AmuletRules_CreateTransferPreapprovalResult TransferResult
+>
+> **instance** SetField "transferResult" TransferPreapproval_RenewResult TransferResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AmuletRules AmuletRules_Transfer TransferResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AmuletRules AmuletRules_Transfer TransferResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AmuletRules AmuletRules_Transfer TransferResult
+
+<div id="type-splice-amuletrules-transfersummary-17366">
+
+**data** TransferSummary
+
+</div>
+
+> Summary of input and output amounts and fees paid. This summary is intended to be used together with the `Transfer` specification used to initiate the transfer when displaying a transaction summary. Its fields are intended to provide shortcuts for key numbers that are complex to compute off-ledger.
+>
+> All amounts are denominated in Splice.
+>
+> <div id="constr-splice-amuletrules-transfersummary-72851">
+>
+> TransferSummary
+>
+> </div>
+>
+> > | Field                              | Type                                                                                                                                                                                                                                              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+> > |------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | inputAppRewardAmount               | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Total amount of app reward coupon issunace input into this transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+> > | inputValidatorRewardAmount         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Total amount of validator rewards coupon issuance input into this transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+> > | inputSvRewardAmount                | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Total amount of SV reward coupon issuance input into this transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+> > | inputAmuletAmount                  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Total input amount of amulet input into this transfer, before deducting holding fees.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+> > | balanceChanges                     | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) BalanceChange | Balance changes per party                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+> > | holdingFees                        | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Holding fees paid by the sender on their input amulets.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+> > | outputFees                         | \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\]                                                                                                                            | Fees paid for the individual output amulets in the order they were specified.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+> > | senderChangeFee                    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Fee charged for returning change to the sender, which is the smaller of the left-over balance after paying for all outputs or one amulet create fee. In case the left-over balance after paying for all outputs is smaller than a create fee, all of that balance is consumed by the fee for returning change, and no actual amulet is created for the sender, i.e., the `senderChangeAmount` is zero. The transfer does though succeed. For transfers that do not allow returning change to the sender, the left-over balance after paying for all outputs must be zero, and thus the `senderChangeFee` must be zero as well. |
+> > | senderChangeAmount                 | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | The final amount of amulet returned to the sender after paying for all outputs and fees. If it is zero, then no amulet is created for the sender.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+> > | amuletPrice                        | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | The amulet price at the round this transfer was executed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+> > | inputValidatorFaucetAmount         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Added in CIP-3. Total amount of validator faucet coupon issuance input into this transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+> > | inputUnclaimedActivityRecordAmount | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Total amount of unclaimed activity record issuance input into this transfer. Note: Made optional as the addition of this field is checked by the upgrade checker.                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+> > | inputDevelopmentFundAmount         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Total amount of development fund coupon issuance input into this transfer. Note: Made optional as the addition of this field is checked by the upgrade checker.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferSummary
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferSummary
+>
+> **instance** GetField "amuletPrice" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "balanceChanges" TransferSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) BalanceChange)
+>
+> **instance** GetField "holdingFees" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "inputAmuletAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "inputAppRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "inputDevelopmentFundAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** GetField "inputSvRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "inputUnclaimedActivityRecordAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** GetField "inputValidatorFaucetAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** GetField "inputValidatorRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "outputFees" TransferSummary \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\]
+>
+> **instance** GetField "senderChangeAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "senderChangeFee" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "summary" AmuletRules_BuyMemberTrafficResult TransferSummary
+>
+> **instance** GetField "summary" TransferResult TransferSummary
+>
+> **instance** SetField "amuletPrice" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "balanceChanges" TransferSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) BalanceChange)
+>
+> **instance** SetField "holdingFees" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "inputAmuletAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "inputAppRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "inputDevelopmentFundAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** SetField "inputSvRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "inputUnclaimedActivityRecordAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** SetField "inputValidatorFaucetAmount" TransferSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** SetField "inputValidatorRewardAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "outputFees" TransferSummary \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\]
+>
+> **instance** SetField "senderChangeAmount" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "senderChangeFee" TransferSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "summary" AmuletRules_BuyMemberTrafficResult TransferSummary
+>
+> **instance** SetField "summary" TransferResult TransferSummary
+
+<div id="type-splice-amuletrules-validatedopenminingrounds-3458">
+
+**data** ValidatedOpenMiningRounds
+
+</div>
+
+> <div id="constr-splice-amuletrules-validatedopenminingrounds-35727">
+>
+> ValidatedOpenMiningRounds
+>
+> </div>
+>
+> > | Field             | Type            | Description |
+> > |-------------------|-----------------|-------------|
+> > | oldestRound       | OpenMiningRound |             |
+> > | latestUsableRound | OpenMiningRound |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ValidatedOpenMiningRounds
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ValidatedOpenMiningRounds
+>
+> **instance** GetField "latestUsableRound" ValidatedOpenMiningRounds OpenMiningRound
+>
+> **instance** GetField "oldestRound" ValidatedOpenMiningRounds OpenMiningRound
+>
+> **instance** SetField "latestUsableRound" ValidatedOpenMiningRounds OpenMiningRound
+>
+> **instance** SetField "oldestRound" ValidatedOpenMiningRounds OpenMiningRound
+
+## Functions
+
+<div id="function-splice-amuletrules-validateopenminingroundtriple-43417">
+
+validateOpenMiningRoundTriple
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> OpenMiningRoundTriple -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ValidatedOpenMiningRounds
+
+</div>
+
+<div id="function-splice-amuletrules-transfercontrollers-28233">
+
+transferControllers
+: Transfer -\> Set [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+The controllers for a transfer.
+
+</div>
+
+<div id="function-splice-amuletrules-mkunknownsynchronizerfailure-15784">
+
+mkUnknownSynchronizerFailure
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> FailureStatus
+
+</div>
+
+<div id="function-splice-amuletrules-mkinsufficienttopupamountfailure-2645">
+
+mkInsufficientTopupAmountFailure
+: [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) -\> FailureStatus
+
+</div>
+
+<div id="function-splice-amuletrules-mkmaximuminputsexceededfailure-60046">
+
+mkMaximumInputsExceededFailure
+: FailureStatus
+
+</div>
+
+<div id="function-splice-amuletrules-mkmaximumoutputsexceededfailure-21438">
+
+mkMaximumOutputsExceededFailure
+: FailureStatus
+
+</div>
+
+<div id="function-splice-amuletrules-mkinsufficientfundsfailure-76389">
+
+mkInsufficientFundsFailure
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> FailureStatus
+
+</div>
+
+<div id="function-splice-amuletrules-spliceerrorid-85022">
+
+spliceErrorId
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+</div>
+
+<div id="function-splice-amuletrules-mkfailurestatus-89025">
+
+mkFailureStatus
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> FailureCategory -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> FailureStatus
+
+</div>
+
+<div id="function-splice-amuletrules-checktransferconstraints-43087">
+
+checkTransferConstraints
+: Transfer -\> TransferSummary -\> TransferConfigV2 unit -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) FailureStatus ()
+
+</div>
+
+<div id="function-splice-amuletrules-executetransfer-52573">
+
+executeTransfer
+: RewardsIssuanceConfig -\> TransferContext -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferResult
+
+Execute a transfer.
+
+</div>
+
+<div id="function-splice-amuletrules-executeexternalpartytransfer-86681">
+
+executeExternalPartyTransfer
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> ExternalPartyTransferContext -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferResult
+
+Execute a transfer for external parties so that the prepared tx remains valid for 24h
+
+</div>
+
+<div id="function-splice-amuletrules-executetransfertick-55439">
+
+executeTransfer'
+: RewardsIssuanceConfig -\> TransferContextSummaryV2 -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferResult
+
+</div>
+
+<div id="function-splice-amuletrules-summarizeandvalidatecontext-19960">
+
+summarizeAndValidateContext
+: TransferContext -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferContextSummaryV2
+
+</div>
+
+<div id="function-splice-amuletrules-summarizeandvalidateexternalpartycontext-23832">
+
+summarizeAndValidateExternalPartyContext
+: ExternalPartyTransferContext -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferContextSummaryV2
+
+</div>
+
+<div id="function-splice-amuletrules-getvalidatorright-23495">
+
+getValidatorRight
+: TransferContextSummaryV2 -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorRight)
+
+</div>
+
+<div id="function-splice-amuletrules-getissuingmininground-54647">
+
+getIssuingMiningRound
+: TransferContextSummaryV2 -\> Round -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) IssuingMiningRound
+
+</div>
+
+<div id="function-splice-amuletrules-summarizeandconsumeinputs-14652">
+
+summarizeAndConsumeInputs
+: TransferContextSummaryV2 -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> \[TransferInput\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInputsSummary
+
+</div>
+
+<div id="function-splice-amuletrules-dedupoutputlockholders-88329">
+
+dedupOutputLockHolders
+: TransferOutput -\> TransferOutput
+
+Deduplicate lock-holders to store them and charge for them at most once
+
+</div>
+
+<div id="function-splice-amuletrules-preprocessoutputs-54475">
+
+preprocessOutputs
+: TransferConfigV2 Amulet -\> \[TransferOutput\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferOutputsSummary
+
+</div>
+
+<div id="function-splice-amuletrules-summarizetransfer-82621">
+
+summarizeTransfer
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Round -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> TransferConfigV2 Amulet -\> TransferInputsSummary -\> TransferOutputsSummary -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferSummary
+
+</div>
+
+<div id="function-splice-amuletrules-issuerewards-17863">
+
+issueRewards
+: RewardsIssuanceConfig -\> TransferContextSummaryV2 -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[AppRewardBeneficiary\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-amuletrules-createtransferoutputs-14910">
+
+createTransferOutputs
+: Round -\> TransferConfigV2 Amulet -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> TransferSummary -\> TransferOutputsSummary -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (\[CreatedAmulet\], [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+
+</div>
+
+<div id="function-splice-amuletrules-scalefees-202">
+
+scaleFees
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> TransferConfig USD -\> TransferConfig Amulet
+
+Scale the 'AmuletConfig' such that the fees charged are scaled by the same scale factor.
+
+</div>
+
+<div id="function-splice-amuletrules-scalefees2-95743">
+
+scaleFees2
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> TransferConfigV2 USD -\> TransferConfigV2 Amulet
+
+Scale the 'TranserConfigV2' such that the fees charged are scaled by the same scale factor.
+
+</div>
+
+<div id="function-splice-amuletrules-transferconfigamuletfromopenround-39144">
+
+transferConfigAmuletFromOpenRound
+: OpenMiningRound -\> TransferConfig Amulet
+
+</div>
+
+<div id="function-splice-amuletrules-validatebuymembertrafficinputs-62954">
+
+validateBuyMemberTrafficInputs
+: AmuletConfig USD -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) -\> [Either](/appdev/reference/daml-standard-library/prelude#type-da-types-either-56020) FailureStatus ()
+
+</div>
+
+<div id="function-splice-amuletrules-computesynchronizerfees-53837">
+
+computeSynchronizerFees
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) -\> AmuletRules -\> TransferContext -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+
+Computing synchronizer fees
+
+</div>
+
+<div id="function-splice-amuletrules-legacyamuletcreatesummary-16866">
+
+legacyAmuletCreateSummary
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+
+</div>
+
+<div id="function-splice-amuletrules-checkexpecteddso-85182">
+
+checkExpectedDso
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-amuletrules-exerciseapptransfer-15159">
+
+exerciseAppTransfer
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> AppTransferContext -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferResult
+
+</div>
+
+<div id="function-splice-amuletrules-exercisepaymenttransfer-78288">
+
+exercisePaymentTransfer
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> PaymentTransferContext -\> Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferResult
+
+</div>
+
+<div id="function-splice-amuletrules-amulettransfercontext-70307">
+
+amuletTransferContext
+: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight) -\> TransferContext
+
+Helper to construct transfer context with only amulet inputs
+
+</div>
+
+<div id="function-splice-amuletrules-createdamulettoholding-42008">
+
+createdAmuletToHolding
+: CreatedAmulet -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding
+
+</div>
+
+<div id="function-splice-amuletrules-mkinputvalidatorfaucetcoupon-66284">
+
+mkInputValidatorFaucetCoupon
+: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon -\> TransferInput
+
+Smart constructor for inputing validator faucet coupons into a transfer.
+
+</div>
+
+<div id="function-splice-amuletrules-computetransferpreapprovalfee-40643">
+
+computeTransferPreapprovalFee
+: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> AmuletConfig USD -\> TransferContext -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+
+</div>
+
+<div id="function-splice-amuletrules-splitandburn-28460">
+
+splitAndBurn
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> \[TransferInput\] -\> TransferContext -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (TransferResult, Metadata)
+
+</div>
+
+<div id="function-splice-amuletrules-totalburnfromsummary-61907">
+
+totalBurnFromSummary
+: TransferSummary -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+Compute the total burn done as part of the transfer.
+
+</div>
+
+<div id="function-splice-amuletrules-externalpartytransferfromchoicecontext-27714">
+
+externalPartyTransferFromChoiceContext
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> ChoiceContext -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ExternalPartyTransferContext
+
+</div>
+
+<div id="function-splice-amuletrules-unfeaturedpaymentcontextfromchoicecontext-64473">
+
+unfeaturedPaymentContextFromChoiceContext
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> ChoiceContext -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ExternalPartyTransferContext
+
+Used when we want to ignore a featured app right, even if it is present in the context.
+
+</div>
+
+<div id="function-splice-amuletrules-bootstrapexternalpartyconfigstate-17433">
+
+bootstrapExternalPartyConfigState
+: AmuletRules -\> OpenMiningRoundTriple -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction.mdx
@@ -1,0 +1,42 @@
+---
+title: "Splice.AmuletTransferInstruction"
+description: "Documentation for Splice.AmuletTransferInstruction"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-AmuletTransferInstruction.rst" tag="0.6.4" hash="afde74aa" */}
+
+## Templates
+
+<div id="type-splice-amulettransferinstruction-amulettransferinstruction-76678">
+
+**template** AmuletTransferInstruction
+
+</div>
+
+> A transfer instruction for transferring Amulet tokens pending on receiver acceptance.
+>
+> Signatory: (DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" transfer)), (DA.Internal.Record.getField @"sender" transfer)
+>
+> | Field        | Type                                                                                                                                       | Description                                                                   |
+> |--------------|--------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+> | lockedAmulet | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet | Locked amulet that holds the funds for executing the transfer upon acceptance |
+> | transfer     | Transfer                                                                                                                                   |                                                                               |
+>
+> - **Choice** Archive
+>
+>   Controller: (DA.Internal.Record.getField @"admin" (DA.Internal.Record.getField @"instrumentId" transfer)), (DA.Internal.Record.getField @"sender" transfer)
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Functions
+
+<div id="function-splice-amulettransferinstruction-standardtransfertotwosteptransfer-69205">
+
+standardTransferToTwoStepTransfer
+: Transfer -\> TwoStepTransfer
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer.mdx
@@ -1,0 +1,226 @@
+---
+title: "Splice.DecentralizedSynchronizer"
+description: "Documentation for Splice.DecentralizedSynchronizer"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-DecentralizedSynchronizer.rst" tag="0.6.4" hash="26258f35" */}
+
+Types and contracts for managing synchronizer fees
+
+## Templates
+
+<div id="type-splice-decentralizedsynchronizer-membertraffic-74049">
+
+**template** MemberTraffic
+
+</div>
+
+> The state of the extra synchronizer traffic purchases of a sequencer sv.
+>
+> Signatory: dso
+>
+> | Field          | Type                                                                                                                | Description                                                                                   |
+> |----------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+> | dso            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                               |
+> | memberId       | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | The id of the sequencer member (participant or mediator) for which traffic has been purchased |
+> | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | The id of the synchronizer for which this contract tracks purchased extra traffic             |
+> | migrationId    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | The migration id of the synchronizer for which this contract tracks purchased extra traffic   |
+> | totalPurchased | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | The number of bytes of extra traffic purchased                                                |
+> | numPurchases   | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | Number of times extra traffic has been purchased                                              |
+> | amuletSpent    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | Total Amulet spent on extra traffic                                                           |
+> | usdSpent       | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | Total USD spent on extra traffic                                                              |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-decentralizedsynchronizer-amuletdecentralizedsynchronizerconfig-15126">
+
+**data** AmuletDecentralizedSynchronizerConfig
+
+</div>
+
+> The configuration of the logical concept of a decentralized synchronizer, which consists over its lifetime of a series of actual synchronizers, which are introduced for handling the (rare) occasions of switching to a new synchronizer protocol version.
+>
+> <div id="constr-splice-decentralizedsynchronizer-amuletdecentralizedsynchronizerconfig-80511">
+>
+> AmuletDecentralizedSynchronizerConfig
+>
+> </div>
+>
+> > | Field                 | Type                                                                                                                                                                                                                      | Description                                                                                                                                                                      |
+> > |-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | requiredSynchronizers | Set [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The synchronizer-ids of all synchronizers that Amulet and ANS users should be connected to.                                                                                      |
+> > | activeSynchronizer    | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                              | The synchronizer-id of the synchronizer on which the SVs accepts transactions involving the AmuletRules and related contracts, which must be one of the `requiredSynchronizers`. |
+> > | fees                  | SynchronizerFeesConfig                                                                                                                                                                                                    | The fees charged for using the decentralized synchronizer. We use the same fees across all active decentralized synchronizers.                                                   |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletDecentralizedSynchronizerConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletDecentralizedSynchronizerConfig
+>
+> **instance** GetField "activeSynchronizer" AmuletDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "decentralizedSynchronizer" (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig
+>
+> **instance** GetField "fees" AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig
+>
+> **instance** GetField "requiredSynchronizers" AmuletDecentralizedSynchronizerConfig (Set [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
+>
+> **instance** SetField "activeSynchronizer" AmuletDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "decentralizedSynchronizer" (AmuletConfig unit) AmuletDecentralizedSynchronizerConfig
+>
+> **instance** SetField "fees" AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig
+>
+> **instance** SetField "requiredSynchronizers" AmuletDecentralizedSynchronizerConfig (Set [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
+>
+> **instance** Patchable AmuletDecentralizedSynchronizerConfig
+
+<div id="type-splice-decentralizedsynchronizer-baseratetrafficlimits-64372">
+
+**data** BaseRateTrafficLimits
+
+</div>
+
+> The limits defining the free base rate delivered by the synchronizer. It defines the base rate as allowing at most burstAmount of sequencing traffic within a window of burstWindow seconds.
+>
+> <div id="constr-splice-decentralizedsynchronizer-baseratetrafficlimits-1937">
+>
+> BaseRateTrafficLimits
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                   | Description                                                                         |
+> > |-------------|------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+> > | burstAmount | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)             | The total burstAmount in bytes of sequencing traffic delivered over the burstWindow |
+> > | burstWindow | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | Time window within which the burstAmount must not be exceeded                       |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) BaseRateTrafficLimits
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) BaseRateTrafficLimits
+>
+> **instance** GetField "baseRateTrafficLimits" SynchronizerFeesConfig BaseRateTrafficLimits
+>
+> **instance** GetField "burstAmount" BaseRateTrafficLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "burstWindow" BaseRateTrafficLimits [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "baseRateTrafficLimits" SynchronizerFeesConfig BaseRateTrafficLimits
+>
+> **instance** SetField "burstAmount" BaseRateTrafficLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "burstWindow" BaseRateTrafficLimits [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** Patchable BaseRateTrafficLimits
+
+<div id="type-splice-decentralizedsynchronizer-formembertraffic-62879">
+
+**data** ForMemberTraffic
+
+</div>
+
+> <div id="constr-splice-decentralizedsynchronizer-formembertraffic-24640">
+>
+> ForMemberTraffic
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                | Description |
+> > |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | dso            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | memberId       | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+> > | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+> > | migrationId    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForMemberTraffic
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForMemberTraffic
+>
+> **instance** GetField "dso" ForMemberTraffic [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "memberId" ForMemberTraffic [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "migrationId" ForMemberTraffic [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "synchronizerId" ForMemberTraffic [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "dso" ForMemberTraffic [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "memberId" ForMemberTraffic [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "migrationId" ForMemberTraffic [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "synchronizerId" ForMemberTraffic [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** HasCheckedFetch MemberTraffic ForMemberTraffic
+
+<div id="type-splice-decentralizedsynchronizer-synchronizerfeesconfig-12142">
+
+**data** SynchronizerFeesConfig
+
+</div>
+
+> Synchronizer fees related configuration to be tracked on the DsoRules contract
+>
+> <div id="constr-splice-decentralizedsynchronizer-synchronizerfeesconfig-16293">
+>
+> SynchronizerFeesConfig
+>
+> </div>
+>
+> > | Field                    | Type                                                                                                               | Description                                                                                                                                                                                                                                                                                                                                               |
+> > |--------------------------|--------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | baseRateTrafficLimits    | BaseRateTrafficLimits                                                                                              | Configuration limits for base rate traffic                                                                                                                                                                                                                                                                                                                |
+> > | extraTrafficPrice        | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | The price of extra traffic denominated in \$/MB                                                                                                                                                                                                                                                                                                           |
+> > | readVsWriteScalingFactor | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)         | How much the sending of a message to its recipient costs in terms of bytes written to the synchronizer. This factor is specified in parts per 10,000 (or per 10 mille) We charge for sending messages depending on the number of recipients, as delivering the message incurs a cost as well, albeit usually a much smaller one than the cost of a write. |
+> > | minTopupAmount           | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)         | The minimum amount of extra traffic (in bytes) that must be bought when buying extra traffic. This ensures that the SVs can amortize the cost of executing that transaction.                                                                                                                                                                              |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerFeesConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerFeesConfig
+>
+> **instance** GetField "baseRateTrafficLimits" SynchronizerFeesConfig BaseRateTrafficLimits
+>
+> **instance** GetField "extraTrafficPrice" SynchronizerFeesConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "fees" AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig
+>
+> **instance** GetField "minTopupAmount" SynchronizerFeesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "readVsWriteScalingFactor" SynchronizerFeesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "baseRateTrafficLimits" SynchronizerFeesConfig BaseRateTrafficLimits
+>
+> **instance** SetField "extraTrafficPrice" SynchronizerFeesConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "fees" AmuletDecentralizedSynchronizerConfig SynchronizerFeesConfig
+>
+> **instance** SetField "minTopupAmount" SynchronizerFeesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "readVsWriteScalingFactor" SynchronizerFeesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** Patchable SynchronizerFeesConfig
+
+## Functions
+
+<div id="function-splice-decentralizedsynchronizer-validamuletdecentralizedsynchronizerconfig-57759">
+
+validAmuletDecentralizedSynchronizerConfig
+: AmuletDecentralizedSynchronizerConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-decentralizedsynchronizer-initialmembertraffic-49736">
+
+initialMemberTraffic
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) -\> MemberTraffic
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry.mdx
@@ -1,0 +1,148 @@
+---
+title: "Splice.Expiry"
+description: "Documentation for Splice.Expiry"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Expiry.rst" tag="0.6.4" hash="c1e63c20" */}
+
+Functions for computing amulet and lock expiry times and conditions.
+
+## Data Types
+
+<div id="type-splice-expiry-boundedset-6748">
+
+**data** BoundedSet a
+
+</div>
+
+> A symbolic representation of a set of values of type `a` useful for computing upper-bounds.
+>
+> <div id="constr-splice-expiry-singleton-7610">
+>
+> Singleton a
+>
+> </div>
+>
+> > `Singleton x` represents the singleton set `{x}`
+>
+> <div id="constr-splice-expiry-aftermaxbound-46101">
+>
+> AfterMaxBound
+>
+> </div>
+>
+> > `AfterMaxBound` represents the set of all values larger than the maximal value that can be represented by type `a`
+>
+> **instance** [Functor](/appdev/reference/daml-standard-library/prelude#class-ghc-base-functor-31205) BoundedSet
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (BoundedSet a)
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (BoundedSet a)
+
+<div id="type-splice-expiry-timelock-2221">
+
+**data** TimeLock
+
+</div>
+
+> A lock held by multiple parties until its expiry.
+>
+> <div id="constr-splice-expiry-timelock-44256">
+>
+> TimeLock
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                                                                                                                        | Description                                                                                                                                                                                                                                                                       |
+> > |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | holders    | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]                                                                                                                     |                                                                                                                                                                                                                                                                                   |
+> > | expiresAt  | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                           |                                                                                                                                                                                                                                                                                   |
+> > | optContext | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Short, human-readable description of the context in which the amulet is locked. Intended for wallets to inform the user about the reason for the lock. Consider what details to share about the context, as that might be private and the string here will be public information. |
+>
+> **instance** FromAnyValue TimeLock
+>
+> **instance** ToAnyValue TimeLock
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TimeLock
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) TimeLock
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TimeLock
+>
+> **instance** GetField "expiresAt" TimeLock [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "holders" TimeLock \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]
+>
+> **instance** GetField "lock" LockedAmulet TimeLock
+>
+> **instance** GetField "lock" PreprocessedTransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
+>
+> **instance** GetField "lock" TransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
+>
+> **instance** GetField "optContext" TimeLock ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
+>
+> **instance** SetField "expiresAt" TimeLock [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "holders" TimeLock \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]
+>
+> **instance** SetField "lock" LockedAmulet TimeLock
+>
+> **instance** SetField "lock" PreprocessedTransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
+>
+> **instance** SetField "lock" TransferOutput ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TimeLock)
+>
+> **instance** SetField "optContext" TimeLock ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
+
+## Functions
+
+<div id="function-splice-expiry-maxint-28108">
+
+maxInt
+: [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+
+</div>
+
+<div id="function-splice-expiry-maxdecimaldiv10-64031">
+
+maxDecimalDiv10
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-expiry-mintime-10075">
+
+minTime
+: [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+
+The smallest time point that can be represented by the `Time` type.
+
+</div>
+
+<div id="function-splice-expiry-maxtime-17293">
+
+maxTime
+: [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+
+The largest time point that can be represented by the `Time` type.
+
+</div>
+
+<div id="function-splice-expiry-amountexpiresat-59287">
+
+amountExpiresAt
+: ExpiringAmount -\> BoundedSet Round
+
+Compute the round where the amulet expires. i.e. the amulet is fully expired.
+
+</div>
+
+<div id="function-splice-expiry-isamuletexpired-66613">
+
+isAmuletExpired
+: Round -\> ExpiringAmount -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+`isAmuletExpired openRound amuletAmount` computes whether the expiring `amuletAmount` is definitely expired in case the `openRound` is open.
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules.mdx
@@ -1,0 +1,441 @@
+---
+title: "Splice.ExternalPartyAmuletRules"
+description: "Documentation for Splice.ExternalPartyAmuletRules"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-ExternalPartyAmuletRules.rst" tag="0.6.4" hash="76e07229" */}
+
+## Templates
+
+<div id="type-splice-externalpartyamuletrules-externalpartyamuletrules-29682">
+
+**template** ExternalPartyAmuletRules
+
+</div>
+
+> Rules contract that can be used in transactions that require signatures from an external party. This is intended to get archived and recreated as rarely as possible to support long delays between preparing and signing a transaction.
+>
+> Signatory: dso
+>
+> | Field | Type                                                                                                                | Description |
+> |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommand-90877">
+>
+>   **Choice** ExternalPartyAmuletRules_CreateTransferCommand
+>
+>   </div>
+>
+>   Controller: sender
+>
+>   Returns: ExternalPartyAmuletRules_CreateTransferCommandResult
+>
+>   | Field       | Type                                                                                                                                                                                                                                               | Description |
+>   |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
+>   | receiver    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
+>   | delegate    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |             |
+>   | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                 |             |
+>   | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                  |             |
+>   | nonce       | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                         |             |
+>   | description | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | expectedDso | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocations-38439">
+>
+>   **Choice** ExternalPartyAmuletRules_ExpireAmuletAllocations
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+>
+>   | Field       | Type                                                                                                                    | Description |
+>   |-------------|-------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | expectedDso | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)     |             |
+>   | inputs      | \[ExternalPartyAmuletRules_ExpireAmuletAllocationInput\]                                                                |             |
+>   | observers   | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] |             |
+>
+> - **interface instance** AllocationFactory **for** ExternalPartyAmuletRules
+>
+> - **interface instance** TransferFactory **for** ExternalPartyAmuletRules
+
+<div id="type-splice-externalpartyamuletrules-transfercommand-52429">
+
+**template** TransferCommand
+
+</div>
+
+> Deprecated: The token standard transfer APIs now support 24h signing delays so this contract is no longer required.
+>
+> One-time delegation to execute a transfer to the given receiver for the given amount.
+>
+> Signatory: sender, dso
+>
+> | Field       | Type                                                                                                                                                                                                                                        | Description                                                                                                                                                                                         |
+> |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |                                                                                                                                                                                                     |
+> | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |                                                                                                                                                                                                     |
+> | receiver    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |                                                                                                                                                                                                     |
+> | delegate    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         | The delegate that actually executes the transfer                                                                                                                                                    |
+> | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                          |                                                                                                                                                                                                     |
+> | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                           | Expiry of the command until when TransferCommand_Send must be called                                                                                                                                |
+> | nonce       | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                  | Expected nonce value to order and deduplicate concurrent transfers. Starts at 0 and the next value to use can then be read from TransferCommandCounter and the in-flight TransferCommand contracts. |
+> | description | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |                                                                                                                                                                                                     |
+>
+> - **Choice** Archive
+>
+>   Controller: sender, dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-externalpartyamuletrules-transfercommandexpire-28516">
+>
+>   **Choice** TransferCommand_Expire
+>
+>   </div>
+>
+>   Controller: p
+>
+>   Returns: TransferCommand_ExpireResult
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | p     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-externalpartyamuletrules-transfercommandsend-32409">
+>
+>   **Choice** TransferCommand_Send
+>
+>   </div>
+>
+>   Controller: delegate
+>
+>   Returns: TransferCommand_SendResult
+>
+>   | Field                   | Type                                                                                                                                                                                                                                                                               | Description |
+>   |-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | context                 | PaymentTransferContext                                                                                                                                                                                                                                                             |             |
+>   | inputs                  | \[TransferInput\]                                                                                                                                                                                                                                                                  |             |
+>   | transferPreapprovalCidO | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval) |             |
+>   | transferCounterCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommandCounter                                                                                                                               |             |
+>
+> - <div id="type-splice-externalpartyamuletrules-transfercommandwithdraw-90837">
+>
+>   **Choice** TransferCommand_Withdraw
+>
+>   </div>
+>
+>   Controller: sender
+>
+>   Returns: TransferCommand_WithdrawResult
+>
+>   (no fields)
+
+<div id="type-splice-externalpartyamuletrules-transfercommandcounter-30214">
+
+**template** TransferCommandCounter
+
+</div>
+
+> A contract tracking the number of completed TransferCommands per sender, which is used to determine the nonces used in TransferCommands for deduplication.
+>
+> Signatory: dso
+>
+> | Field     | Type                                                                                                                | Description |
+> |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | sender    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | nextNonce | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommandresult-84908">
+
+**data** ExternalPartyAmuletRules_CreateTransferCommandResult
+
+</div>
+
+> <div id="constr-splice-externalpartyamuletrules-externalpartyamuletrulescreatetransfercommandresult-32161">
+>
+> ExternalPartyAmuletRules_CreateTransferCommandResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                          | Description |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | transferCommandCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommand |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartyAmuletRules_CreateTransferCommandResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartyAmuletRules_CreateTransferCommandResult
+>
+> **instance** GetField "transferCommandCid" ExternalPartyAmuletRules_CreateTransferCommandResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommand)
+>
+> **instance** SetField "transferCommandCid" ExternalPartyAmuletRules_CreateTransferCommandResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommand)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ExternalPartyAmuletRules ExternalPartyAmuletRules_CreateTransferCommand ExternalPartyAmuletRules_CreateTransferCommandResult
+
+<div id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationinput-45980">
+
+**data** ExternalPartyAmuletRules_ExpireAmuletAllocationInput
+
+</div>
+
+> <div id="constr-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationinput-86145">
+>
+> ExternalPartyAmuletRules_ExpireAmuletAllocationInput
+>
+> </div>
+>
+> > | Field         | Type                                                                                                                                           | Description |
+> > |---------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | allocationCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletAllocation |             |
+> > | expireLock    | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                   |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartyAmuletRules_ExpireAmuletAllocationInput
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartyAmuletRules_ExpireAmuletAllocationInput
+>
+> **instance** GetField "allocationCid" ExternalPartyAmuletRules_ExpireAmuletAllocationInput ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletAllocation)
+>
+> **instance** GetField "expireLock" ExternalPartyAmuletRules_ExpireAmuletAllocationInput [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** GetField "inputs" ExternalPartyAmuletRules_ExpireAmuletAllocations \[ExternalPartyAmuletRules_ExpireAmuletAllocationInput\]
+>
+> **instance** SetField "allocationCid" ExternalPartyAmuletRules_ExpireAmuletAllocationInput ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletAllocation)
+>
+> **instance** SetField "expireLock" ExternalPartyAmuletRules_ExpireAmuletAllocationInput [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** SetField "inputs" ExternalPartyAmuletRules_ExpireAmuletAllocations \[ExternalPartyAmuletRules_ExpireAmuletAllocationInput\]
+
+<div id="type-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationsresult-57118">
+
+**data** ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+
+</div>
+
+> <div id="constr-splice-externalpartyamuletrules-externalpartyamuletrulesexpireamuletallocationsresult-31907">
+>
+> ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+>
+> </div>
+>
+> > | Field   | Type                                 | Description |
+> > |---------|--------------------------------------|-------------|
+> > | results | \[AmuletAllocation_DsoExpireResult\] |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+>
+> **instance** GetField "results" ExternalPartyAmuletRules_ExpireAmuletAllocationsResult \[AmuletAllocation_DsoExpireResult\]
+>
+> **instance** SetField "results" ExternalPartyAmuletRules_ExpireAmuletAllocationsResult \[AmuletAllocation_DsoExpireResult\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ExternalPartyAmuletRules ExternalPartyAmuletRules_ExpireAmuletAllocations ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+
+<div id="type-splice-externalpartyamuletrules-transfercommandresult-23924">
+
+**data** TransferCommandResult
+
+</div>
+
+> <div id="constr-splice-externalpartyamuletrules-transfercommandresultfailure-75214">
+>
+> TransferCommandResultFailure
+>
+> </div>
+>
+> > | Field  | Type                  | Description |
+> > |--------|-----------------------|-------------|
+> > | reason | InvalidTransferReason |             |
+>
+> <div id="constr-splice-externalpartyamuletrules-transfercommandresultsuccess-68641">
+>
+> TransferCommandResultSuccess
+>
+> </div>
+>
+> > | Field  | Type           | Description |
+> > |--------|----------------|-------------|
+> > | result | TransferResult |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferCommandResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferCommandResult
+>
+> **instance** GetField "reason" TransferCommandResult InvalidTransferReason
+>
+> **instance** GetField "result" TransferCommandResult TransferResult
+>
+> **instance** GetField "result" TransferCommand_SendResult TransferCommandResult
+>
+> **instance** SetField "reason" TransferCommandResult InvalidTransferReason
+>
+> **instance** SetField "result" TransferCommandResult TransferResult
+>
+> **instance** SetField "result" TransferCommand_SendResult TransferCommandResult
+
+<div id="type-splice-externalpartyamuletrules-transfercommandexpireresult-5229">
+
+**data** TransferCommand_ExpireResult
+
+</div>
+
+> <div id="constr-splice-externalpartyamuletrules-transfercommandexpireresult-27948">
+>
+> TransferCommand_ExpireResult
+>
+> </div>
+>
+> > | Field  | Type                                                                                                                | Description |
+> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | sender | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | nonce  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferCommand_ExpireResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferCommand_ExpireResult
+>
+> **instance** GetField "nonce" TransferCommand_ExpireResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "sender" TransferCommand_ExpireResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "nonce" TransferCommand_ExpireResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "sender" TransferCommand_ExpireResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferCommand TransferCommand_Expire TransferCommand_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferCommand TransferCommand_Expire TransferCommand_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferCommand TransferCommand_Expire TransferCommand_ExpireResult
+
+<div id="type-splice-externalpartyamuletrules-transfercommandsendresult-21916">
+
+**data** TransferCommand_SendResult
+
+</div>
+
+> <div id="constr-splice-externalpartyamuletrules-transfercommandsendresult-15277">
+>
+> TransferCommand_SendResult
+>
+> </div>
+>
+> > | Field  | Type                                                                                                                | Description |
+> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | result | TransferCommandResult                                                                                               |             |
+> > | sender | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | nonce  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferCommand_SendResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferCommand_SendResult
+>
+> **instance** GetField "nonce" TransferCommand_SendResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "result" TransferCommand_SendResult TransferCommandResult
+>
+> **instance** GetField "sender" TransferCommand_SendResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "nonce" TransferCommand_SendResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "result" TransferCommand_SendResult TransferCommandResult
+>
+> **instance** SetField "sender" TransferCommand_SendResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferCommand TransferCommand_Send TransferCommand_SendResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferCommand TransferCommand_Send TransferCommand_SendResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferCommand TransferCommand_Send TransferCommand_SendResult
+
+<div id="type-splice-externalpartyamuletrules-transfercommandwithdrawresult-60664">
+
+**data** TransferCommand_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-externalpartyamuletrules-transfercommandwithdrawresult-93393">
+>
+> TransferCommand_WithdrawResult
+>
+> </div>
+>
+> > | Field  | Type                                                                                                                | Description |
+> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | sender | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | nonce  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferCommand_WithdrawResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferCommand_WithdrawResult
+>
+> **instance** GetField "nonce" TransferCommand_WithdrawResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "sender" TransferCommand_WithdrawResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "nonce" TransferCommand_WithdrawResult [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "sender" TransferCommand_WithdrawResult [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferCommand TransferCommand_Withdraw TransferCommand_WithdrawResult
+
+## Functions
+
+<div id="function-splice-externalpartyamuletrules-amulettransferfactorytransferimpl-9935">
+
+amulet_transferFactory_transferImpl
+: ExternalPartyAmuletRules -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) TransferInstructionResult
+
+</div>
+
+<div id="function-splice-externalpartyamuletrules-amuletallocationfactoryallocateimpl-5710">
+
+amulet_allocationFactory_allocateImpl
+: ExternalPartyAmuletRules -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) AllocationInstructionResult
+
+</div>
+
+<div id="function-splice-externalpartyamuletrules-requireexpectedadminmatch-79926">
+
+requireExpectedAdminMatch
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate.mdx
@@ -1,0 +1,38 @@
+---
+title: "Splice.ExternalPartyConfigState"
+description: "Documentation for Splice.ExternalPartyConfigState"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-ExternalPartyConfigState.rst" tag="0.6.4" hash="b2e0230d" */}
+
+## Templates
+
+<div id="type-splice-externalpartyconfigstate-externalpartyconfigstate-1378">
+
+**template** ExternalPartyConfigState
+
+</div>
+
+> `ExternalPartyConfigState` stores the configuration required for transfer, allocations, traffic purchases and taps. While it exposes a subset of the information also available on `OpenMiningRound`, `ExternalPartyConfigState` contracts are active much longer allowing for a 24 delay between preparing and executing a transaction.
+>
+> There are always two `ExternalPartyConfigState` contracts created approximately `externalPartyConfigStateTickDuration` apart from each other and each is active for `2 * externalPartyConfigStateTickDuration`.
+>
+> Signatory: dso
+>
+> | Field                      | Type                                                                                                                | Description                                                                               |
+> |----------------------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+> | dso                        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                           |
+> | holdingFeesOpenRoundNumber | Round                                                                                                               | The round number to use for charging holding fees for newly created contracts.            |
+> | amuletPrice                | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | Amulet price at the time the config state was created.                                    |
+> | transferConfig             | TransferConfigV2 USD                                                                                                | Transfer config at the time the config state was created.                                 |
+> | targetArchiveAfter         | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Lower bound on the time the contract gets archived, not enforced as a strict upper bound. |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees.mdx
@@ -1,0 +1,340 @@
+---
+title: "Splice.Fees"
+description: "Documentation for Splice.Fees"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Fees.rst" tag="0.6.4" hash="2bd77408" */}
+
+Utility functions for different kinds of fees.
+
+## Data Types
+
+<div id="type-splice-fees-expiringamount-39537">
+
+**data** ExpiringAmount
+
+</div>
+
+> <div id="constr-splice-fees-expiringamount-68564">
+>
+> ExpiringAmount
+>
+> </div>
+>
+> > | Field         | Type                                                                                                               | Description |
+> > |---------------|--------------------------------------------------------------------------------------------------------------------|-------------|
+> > | initialAmount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
+> > | createdAt     | Round                                                                                                              |             |
+> > | ratePerRound  | RatePerRound                                                                                                       |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ExpiringAmount
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) ExpiringAmount
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ExpiringAmount
+>
+> **instance** GetField "amount" Amulet ExpiringAmount
+>
+> **instance** GetField "createdAt" ExpiringAmount Round
+>
+> **instance** GetField "initialAmount" ExpiringAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "ratePerRound" ExpiringAmount RatePerRound
+>
+> **instance** SetField "amount" Amulet ExpiringAmount
+>
+> **instance** SetField "createdAt" ExpiringAmount Round
+>
+> **instance** SetField "initialAmount" ExpiringAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "ratePerRound" ExpiringAmount RatePerRound
+
+<div id="type-splice-fees-fixedfee-53985">
+
+**data** FixedFee
+
+</div>
+
+> A fixed fee independent of the action being taken. TODO(M3-90): check whether this name matches usage in financial terms, it probably isn't. Should it be 'flat-fee', 'constantfee', ... ???
+>
+> <div id="constr-splice-fees-fixedfee-53900">
+>
+> FixedFee
+>
+> </div>
+>
+> > | Field | Type                                                                                                               | Description |
+> > |-------|--------------------------------------------------------------------------------------------------------------------|-------------|
+> > | fee   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) FixedFee
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) FixedFee
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) FixedFee
+>
+> **instance** GetField "createFee" (TransferConfig unit) FixedFee
+>
+> **instance** GetField "fee" FixedFee [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "lockHolderFee" (TransferConfig unit) FixedFee
+>
+> **instance** SetField "createFee" (TransferConfig unit) FixedFee
+>
+> **instance** SetField "fee" FixedFee [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "lockHolderFee" (TransferConfig unit) FixedFee
+>
+> **instance** Patchable FixedFee
+
+<div id="type-splice-fees-rateperday-41902">
+
+**data** RatePerDay
+
+</div>
+
+> <div id="constr-splice-fees-rateperday-51003">
+>
+> RatePerDay
+>
+> </div>
+>
+> > | Field | Type                                                                                                               | Description |
+> > |-------|--------------------------------------------------------------------------------------------------------------------|-------------|
+> > | rate  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RatePerDay
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) RatePerDay
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RatePerDay
+>
+> **instance** GetField "rate" RatePerDay [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "rate" RatePerDay [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+<div id="type-splice-fees-rateperround-90570">
+
+**data** RatePerRound
+
+</div>
+
+> <div id="constr-splice-fees-rateperround-75691">
+>
+> RatePerRound
+>
+> </div>
+>
+> > | Field | Type                                                                                                               | Description |
+> > |-------|--------------------------------------------------------------------------------------------------------------------|-------------|
+> > | rate  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RatePerRound
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) RatePerRound
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RatePerRound
+>
+> **instance** GetField "holdingFee" (TransferConfig unit) RatePerRound
+>
+> **instance** GetField "holdingFee" (TransferConfigV2 unit) RatePerRound
+>
+> **instance** GetField "rate" RatePerRound [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "ratePerRound" ExpiringAmount RatePerRound
+>
+> **instance** SetField "holdingFee" (TransferConfig unit) RatePerRound
+>
+> **instance** SetField "holdingFee" (TransferConfigV2 unit) RatePerRound
+>
+> **instance** SetField "rate" RatePerRound [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "ratePerRound" ExpiringAmount RatePerRound
+>
+> **instance** Patchable RatePerRound
+
+<div id="type-splice-fees-steppedrate-36691">
+
+**data** SteppedRate
+
+</div>
+
+> A rate defined as a piecewise linear function, e.g., \`SteppedRate 0.01 \[(100.0, 0.001), (1000.0, 0.0001), (1000000, 0.00001)\] corresponds to 1% of the first 100, 0.1% between 100 and 1000, 0.01% between 1000 and 1000000 and 0.001% for everything above that.
+>
+> <div id="constr-splice-fees-steppedrate-72856">
+>
+> SteppedRate
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                                                                                                                         | Description |
+> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | initialRate | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                           |             |
+> > | steps       | \[([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\] |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SteppedRate
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) SteppedRate
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SteppedRate
+>
+> **instance** GetField "initialRate" SteppedRate [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "steps" SteppedRate \[([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\]
+>
+> **instance** GetField "transferFee" (TransferConfig unit) SteppedRate
+>
+> **instance** SetField "initialRate" SteppedRate [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "steps" SteppedRate \[([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\]
+>
+> **instance** SetField "transferFee" (TransferConfig unit) SteppedRate
+>
+> **instance** Patchable SteppedRate
+
+## Functions
+
+<div id="function-splice-fees-reltimetomicros-80866">
+
+relTimeToMicros
+: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-fees-microsperday-26445">
+
+microsPerDay
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-fees-reltimetodays-39078">
+
+relTimeToDays
+: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-fees-daystoreltime-342">
+
+daysToRelTime
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+
+</div>
+
+<div id="function-splice-fees-reltimetoseconds-31347">
+
+relTimeToSeconds
+: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-fees-chargerateperround-14136">
+
+chargeRatePerRound
+: RatePerRound -\> RelRound -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-fees-scalerateperround-96257">
+
+scaleRatePerRound
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> RatePerRound -\> RatePerRound
+
+Scale a round rate such that
+
+ALL s r dt. s \* chargeRatePerRound r dt = chargeRatePerRound (s `scaleRatePerRound` r) dt
+
+</div>
+
+<div id="function-splice-fees-positiverateperround-2835">
+
+positiveRatePerRound
+: RatePerRound -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-fees-scalefixedfee-12994">
+
+scaleFixedFee
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> FixedFee -\> FixedFee
+
+</div>
+
+<div id="function-splice-fees-positivefixedfee-97380">
+
+positiveFixedFee
+: FixedFee -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-fees-validsteppedrate-82534">
+
+validSteppedRate
+: SteppedRate -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-fees-chargesteppedrate-67705">
+
+chargeSteppedRate
+: SteppedRate -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-fees-gochargesteppedrate-62505">
+
+goChargeSteppedRate
+: ([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)) -\> \[([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\] -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-fees-scalesteppedrate-86486">
+
+scaleSteppedRate
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> SteppedRate -\> SteppedRate
+
+Scale a fixed-plus-variable rate such that
+
+ALL s r q. s \* chargeSteppedRate r (q/s) = chargeSteppedRate (s `scaleSteppedRate` r) q
+
+</div>
+
+<div id="function-splice-fees-validexpiringamount-89306">
+
+validExpiringAmount
+: ExpiringAmount -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-fees-expiringamount-85661">
+
+expiringAmount
+: RatePerRound -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Round -\> ExpiringAmount
+
+Smart constructor for an expiring amount.
+
+</div>
+
+<div id="function-splice-fees-getvalueasofround0-94025">
+
+getValueAsOfRound0
+: ExpiringAmount -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-fees-chargerateperday-61208">
+
+chargeRatePerDay
+: RatePerDay -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-fees-rateperroundtorateperday-46486">
+
+ratePerRoundToRatePerDay
+: RatePerRound -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> RatePerDay
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance.mdx
@@ -1,0 +1,288 @@
+---
+title: "Splice.Issuance"
+description: "Documentation for Splice.Issuance"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Issuance.rst" tag="0.6.4" hash="7bb0bfbc" */}
+
+Amulet rewards issuance configuration and computation.
+
+## Data Types
+
+<div id="type-splice-issuance-issuanceconfig-93012">
+
+**data** IssuanceConfig
+
+</div>
+
+> <div id="constr-splice-issuance-issuanceconfig-42917">
+>
+> IssuanceConfig
+>
+> </div>
+>
+> > | Field                        | Type                                                                                                                                                                                                                                              | Description                                                                                                                                                                |
+> > |------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | amuletToIssuePerYear         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
+> > | validatorRewardPercentage    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
+> > | appRewardPercentage          | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
+> > | validatorRewardCap           | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
+> > | featuredAppRewardCap         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
+> > | unfeaturedAppRewardCap       | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                                            |
+> > | optValidatorFaucetCap        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Maximal amount in \$ for the per-validator issuance of validator faucet coupons; Introduced as part of CIP-0003. Will default to 0.00 USD once CIP-0096 becomes effective. |
+> > | optDevelopmentFundPercentage | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Percentage of each mint emission allocated to the Development Fund under CIP-0082.                                                                                         |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) IssuanceConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) IssuanceConfig
+>
+> **instance** GetField "amuletToIssuePerYear" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "appRewardPercentage" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "featuredAppRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "issuanceConfig" OpenMiningRound IssuanceConfig
+>
+> **instance** GetField "issuanceConfig" SummarizingMiningRound IssuanceConfig
+>
+> **instance** GetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
+>
+> **instance** GetField "optDevelopmentFundPercentage" IssuanceConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** GetField "optValidatorFaucetCap" IssuanceConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** GetField "unfeaturedAppRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "validatorRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "validatorRewardPercentage" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "amuletToIssuePerYear" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "appRewardPercentage" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "featuredAppRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "issuanceConfig" OpenMiningRound IssuanceConfig
+>
+> **instance** SetField "issuanceConfig" SummarizingMiningRound IssuanceConfig
+>
+> **instance** SetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
+>
+> **instance** SetField "optDevelopmentFundPercentage" IssuanceConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** SetField "optValidatorFaucetCap" IssuanceConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** SetField "unfeaturedAppRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "validatorRewardCap" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "validatorRewardPercentage" IssuanceConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** Patchable IssuanceConfig
+
+<div id="type-splice-issuance-issuancetranche-71318">
+
+**data** IssuanceTranche
+
+</div>
+
+> <div id="constr-splice-issuance-issuancetranche-27573">
+>
+> IssuanceTranche
+>
+> </div>
+>
+> > | Field             | Type                                                                                                               | Description                                            |
+> > |-------------------|--------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+> > | rewardsToIssue    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Total amulets to issue as rewards in this tranche      |
+> > | issuancePerCoupon | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Issuence per reward coupon for this tranche            |
+> > | unclaimedRewards  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Amulets to issue in this tranche that were not claimed |
+>
+> **instance** GetField "issuancePerCoupon" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "rewardsToIssue" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "unclaimedRewards" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "issuancePerCoupon" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "rewardsToIssue" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "unclaimedRewards" IssuanceTranche [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+<div id="type-splice-issuance-issuingroundparameters-47575">
+
+**data** IssuingRoundParameters
+
+</div>
+
+> Parameters to use in a round that issues amulet as rewards for collected coupons.
+>
+> <div id="constr-splice-issuance-issuingroundparameters-60486">
+>
+> IssuingRoundParameters
+>
+> </div>
+>
+> > | Field                                | Type                                                                                                                                                                                                                                              | Description                                                                                                                                             |
+> > |--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | issuancePerValidatorRewardCoupon     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
+> > | issuancePerFeaturedAppRewardCoupon   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
+> > | issuancePerUnfeaturedAppRewardCoupon | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
+> > | issuancePerSvRewardCoupon            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
+> > | unclaimedAppRewards                  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
+> > | unclaimedValidatorRewards            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
+> > | unclaimedSvRewards                   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                | Can be non-zero due to rounding, or no SV having had the chance to claim their coupons.                                                                 |
+> > | issuancePerValidatorFaucetCoupon     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                                                         |
+> > | optAmuletsToIssueToDevelopmentFund   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Note: Made optional as the addition of this field is checked by the upgrade checker on package upload because `IssuingRoundParameters` is serializable. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) IssuingRoundParameters
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) IssuingRoundParameters
+>
+> **instance** GetField "issuancePerFeaturedAppRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "issuancePerSvRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "issuancePerUnfeaturedAppRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "issuancePerValidatorFaucetCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "issuancePerValidatorRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "optAmuletsToIssueToDevelopmentFund" IssuingRoundParameters ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** GetField "unclaimedAppRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "unclaimedSvRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "unclaimedValidatorRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "issuancePerFeaturedAppRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "issuancePerSvRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "issuancePerUnfeaturedAppRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "issuancePerValidatorFaucetCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "issuancePerValidatorRewardCoupon" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "optAmuletsToIssueToDevelopmentFund" IssuingRoundParameters ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))
+>
+> **instance** SetField "unclaimedAppRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "unclaimedSvRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "unclaimedValidatorRewards" IssuingRoundParameters [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+<div id="type-splice-issuance-openminingroundsummary-90943">
+
+**data** OpenMiningRoundSummary
+
+</div>
+
+> A summary of total reward coupons issued against a specific open mining round.
+>
+> <div id="constr-splice-issuance-openminingroundsummary-16618">
+>
+> OpenMiningRoundSummary
+>
+> </div>
+>
+> > | Field                           | Type                                                                                                                                                                                                                                      | Description                  |
+> > |---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|
+> > | totalValidatorRewardCoupons     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                        |                              |
+> > | totalFeaturedAppRewardCoupons   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                        |                              |
+> > | totalUnfeaturedAppRewardCoupons | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                        |                              |
+> > | totalSvRewardWeight             | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                |                              |
+> > | optTotalValidatorFaucetCoupons  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Introduced as part of CIP-3. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) OpenMiningRoundSummary
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) OpenMiningRoundSummary
+>
+> **instance** GetField "optTotalValidatorFaucetCoupons" OpenMiningRoundSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261))
+>
+> **instance** GetField "summary" AmuletRules_MiningRound_StartIssuing OpenMiningRoundSummary
+>
+> **instance** GetField "totalFeaturedAppRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "totalSvRewardWeight" OpenMiningRoundSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "totalUnfeaturedAppRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "totalValidatorRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "optTotalValidatorFaucetCoupons" OpenMiningRoundSummary ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261))
+>
+> **instance** SetField "summary" AmuletRules_MiningRound_StartIssuing OpenMiningRoundSummary
+>
+> **instance** SetField "totalFeaturedAppRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "totalSvRewardWeight" OpenMiningRoundSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "totalUnfeaturedAppRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "totalValidatorRewardCoupons" OpenMiningRoundSummary [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+## Functions
+
+<div id="function-splice-issuance-getvalidatorfaucetcap-50474">
+
+getValidatorFaucetCap
+: IssuanceConfig -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+Getter with the right default value for the validator faucet cap. Use this consistently instead of accessing the field directly.
+
+</div>
+
+<div id="function-splice-issuance-validissuancecurve-81463">
+
+validIssuanceCurve
+: Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-issuance-validissuanceconfig-25363">
+
+validIssuanceConfig
+: IssuanceConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-issuance-gettotalvalidatorfaucetcoupons-98130">
+
+getTotalValidatorFaucetCoupons
+: OpenMiningRoundSummary -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+
+</div>
+
+<div id="function-splice-issuance-validateopenminingroundsummary-65797">
+
+validateOpenMiningRoundSummary
+: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> OpenMiningRoundSummary -\> m ()
+
+</div>
+
+<div id="function-splice-issuance-computeissuingroundparameters-5863">
+
+computeIssuingRoundParameters
+: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> IssuanceConfig -\> OpenMiningRoundSummary -\> IssuingRoundParameters
+
+</div>
+
+<div id="function-splice-issuance-computeissuancetranche-10230">
+
+computeIssuanceTranche
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> IssuanceTranche
+
+`computeIssuanceTranche rewardsToIssue capPerCoupon totalCoupons`
+
+computes parameters that issue as many rewards per coupon as possible up to a maximum of `capPerCoupon` amulets.
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround.mdx
@@ -1,0 +1,54 @@
+---
+title: "Splice.RelRound"
+description: "Documentation for Splice.RelRound"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-RelRound.rst" tag="0.6.4" hash="e41bbbfd" */}
+
+## Data Types
+
+<div id="type-splice-relround-relround-10584">
+
+**data** RelRound
+
+</div>
+
+> The equivalent of RelTime for rounds, i.e., a delta between two rounds
+>
+> <div id="constr-splice-relround-relround-94237">
+>
+> RelRound
+>
+> </div>
+>
+> > | Field | Type                                                                                                       | Description |
+> > |-------|------------------------------------------------------------------------------------------------------------|-------------|
+> > | diff  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RelRound
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) RelRound
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RelRound
+>
+> **instance** GetField "diff" RelRound [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "diff" RelRound [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+
+## Functions
+
+<div id="function-splice-relround-addrelround-11446">
+
+addRelRound
+: Round -\> RelRound -\> Round
+
+</div>
+
+<div id="function-splice-relround-subround-39329">
+
+subRound
+: Round -\> Round -\> RelRound
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-round.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-round.mdx
@@ -1,0 +1,158 @@
+---
+title: "Splice.Round"
+description: "Documentation for Splice.Round"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Round.rst" tag="0.6.4" hash="a941ba90" */}
+
+## Templates
+
+<div id="type-splice-round-closedmininground-12506">
+
+**template** ClosedMiningRound
+
+</div>
+
+> A record that a specific mining round has been closed, which can be used to archive expired rewards.
+>
+> Signatory: dso
+>
+> | Field                                | Type                                                                                                                                                                                                                                              | Description         |
+> |--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
+> | dso                                  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                               |                     |
+> | round                                | Round                                                                                                                                                                                                                                             |                     |
+> | issuancePerValidatorRewardCoupon     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                     |
+> | issuancePerFeaturedAppRewardCoupon   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                     |
+> | issuancePerUnfeaturedAppRewardCoupon | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                     |
+> | issuancePerSvRewardCoupon            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                     |
+> | optIssuancePerValidatorFaucetCoupon  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Introduced in CIP-3 |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-round-issuingmininground-98097">
+
+**template** IssuingMiningRound
+
+</div>
+
+> A mining round for whose rewards amulets are being issued.
+>
+> Signatory: dso
+>
+> | Field                                | Type                                                                                                                                                                                                                                              | Description                                                                                                       |
+> |--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+> | dso                                  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                               |                                                                                                                   |
+> | round                                | Round                                                                                                                                                                                                                                             |                                                                                                                   |
+> | issuancePerValidatorRewardCoupon     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                   |
+> | issuancePerFeaturedAppRewardCoupon   | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                   |
+> | issuancePerUnfeaturedAppRewardCoupon | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                   |
+> | issuancePerSvRewardCoupon            | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                |                                                                                                                   |
+> | opensAt                              | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                 | Time after which rewards from this mining round can be collected                                                  |
+> | targetClosesAt                       | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                 | Time when this round is expected to close during standard DSO. The round SHOULD NOT be archived before this time. |
+> | optIssuancePerValidatorFaucetCoupon  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Introduced in CIP-3                                                                                               |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-round-openmininground-90060">
+
+**template** OpenMiningRound
+
+</div>
+
+> A mining round for which new rewards can be registered. Note that multiple mining rounds can be open at the same time to give some time for propagating a new open round, while still registering rewards against the previous open round.
+>
+> Signatory: dso
+>
+> | Field             | Type                                                                                                                   | Description                                                                                                               |
+> |-------------------|------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+> | dso               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)    |                                                                                                                           |
+> | round             | Round                                                                                                                  |                                                                                                                           |
+> | amuletPrice       | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)     |                                                                                                                           |
+> | opensAt           | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)      | Time after which transfers can use this mining round                                                                      |
+> | targetClosesAt    | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)      | Time when this round is expected to be closed as part of standard DSO. The round SHOULD NOT be archived before this time. |
+> | issuingFor        | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | Timepoint on the issuance curve that was used to determing the issuance configuration for this round.                     |
+> | transferConfigUsd | TransferConfig USD                                                                                                     | Configuration determining the fees and limits in USD for Amulet transfers                                                 |
+> | issuanceConfig    | IssuanceConfig                                                                                                         | Configuration for issuance of this round.                                                                                 |
+> | tickDuration      | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | Duration of a tick, which is the duration of half a round.                                                                |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-round-openminingroundfetch-48019">
+>
+>   **Choice** OpenMiningRound_Fetch
+>
+>   </div>
+>
+>   Controller: p
+>
+>   Returns: OpenMiningRound
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | p     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+
+<div id="type-splice-round-summarizingmininground-36579">
+
+**template** SummarizingMiningRound
+
+</div>
+
+> A mining round for which the total sum of registered rewards is being computed. Rewards can no longer be registered aginst such a round.
+>
+> Signatory: dso
+>
+> | Field          | Type                                                                                                                   | Description |
+> |----------------|------------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)    |             |
+> | round          | Round                                                                                                                  |             |
+> | amuletPrice    | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)     |             |
+> | issuanceConfig | IssuanceConfig                                                                                                         |             |
+> | tickDuration   | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Functions
+
+<div id="function-splice-round-getissuingminingroundissuancepervalidatorfaucetcoupon-99508">
+
+getIssuingMiningRoundIssuancePerValidatorFaucetCoupon
+: IssuingMiningRound -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+Accessor with defaulting for the optional issuancePerValidatorFaucetCoupon field
+
+</div>
+
+<div id="function-splice-round-getclosedminingroundissuancepervalidatorfaucetcoupon-25673">
+
+getClosedMiningRoundIssuancePerValidatorFaucetCoupon
+: ClosedMiningRound -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+Accessor with defaulting for the optional issuancePerValidatorFaucetCoupon field
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule.mdx
@@ -1,0 +1,131 @@
+---
+title: "Splice.Schedule"
+description: "Documentation for Splice.Schedule"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Schedule.rst" tag="0.6.4" hash="208c08b7" */}
+
+## Data Types
+
+<div id="type-splice-schedule-schedule-35504">
+
+**data** Schedule t a
+
+</div>
+
+> A schedule of values that change over time.
+>
+> <div id="constr-splice-schedule-schedule-12101">
+>
+> Schedule
+>
+> </div>
+>
+> > | Field        | Type       | Description                                                    |
+> > |--------------|------------|----------------------------------------------------------------|
+> > | initialValue | a          | Initial value to use until the future values come into effect. |
+> > | futureValues | \[(t, a)\] | sorted in ascending order                                      |
+>
+> **instance** [Functor](/appdev/reference/daml-standard-library/prelude#class-ghc-base-functor-31205) (Schedule t)
+>
+> **instance** ([Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a, [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) t) =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (Schedule t a)
+>
+> **instance** ([Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) t) =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (Schedule t a)
+>
+> **instance** GetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
+>
+> **instance** GetField "futureValues" (Schedule t a) \[(t, a)\]
+>
+> **instance** GetField "initialValue" (Schedule t a) a
+>
+> **instance** GetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
+>
+> **instance** SetField "configSchedule" AmuletRules (Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD))
+>
+> **instance** SetField "futureValues" (Schedule t a) \[(t, a)\]
+>
+> **instance** SetField "initialValue" (Schedule t a) a
+>
+> **instance** SetField "issuanceCurve" (AmuletConfig unit) (Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig)
+>
+> **instance** (Patchable t, Patchable a, [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t, [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a) =\> Patchable (Schedule t a)
+
+## Functions
+
+<div id="function-splice-schedule-getvalueasof-1611">
+
+getValueAsOf
+: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> t -\> Schedule t a -\> a
+
+Get the value as of a specific time
+
+</div>
+
+<div id="function-splice-schedule-getvalueasofledgertime-35649">
+
+getValueAsOfLedgerTime
+: Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) a -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) a
+
+Variant of `getValueAsOf` that communicates workflow-level bounds.
+
+</div>
+
+<div id="function-splice-schedule-validschedule-3679">
+
+validSchedule
+: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> Schedule t a -\> (a -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+Check the validity of a schedule given a function to check the validity of its values
+
+</div>
+
+<div id="function-splice-schedule-allvalues-28049">
+
+allValues
+: Schedule t a -\> \[a\]
+
+</div>
+
+<div id="function-splice-schedule-nextchangescheduledat-43849">
+
+nextChangeScheduledAt
+: Schedule t a -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) t
+
+</div>
+
+<div id="function-splice-schedule-prune-18462">
+
+prune
+: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> t -\> Schedule t a -\> Schedule t a
+
+</div>
+
+<div id="function-splice-schedule-splitattime-35540">
+
+splitAtTime
+: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> \[(t, a)\] -\> t -\> (\[(t, a)\], [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) (t, a), \[(t, a)\])
+
+</div>
+
+<div id="function-splice-schedule-insert-53714">
+
+insert
+: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> (t, a) -\> Schedule t a -\> Schedule t a
+
+</div>
+
+<div id="function-splice-schedule-remove-70441">
+
+remove
+: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> t -\> Schedule t a -\> Schedule t a
+
+</div>
+
+<div id="function-splice-schedule-update-39134">
+
+update
+: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> (t, a) -\> Schedule t a -\> Schedule t a
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-types.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-types.mdx
@@ -1,0 +1,299 @@
+---
+title: "Splice.Types"
+description: "Documentation for Splice.Types"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-Types.rst" tag="0.6.4" hash="710711fb" */}
+
+## Data Types
+
+<div id="type-splice-types-fordso-8725">
+
+**data** ForDso
+
+</div>
+
+> The group of contracts managed by the DSO party.
+>
+> Used for checked fetches.
+>
+> <div id="constr-splice-types-fordso-8586">
+>
+> ForDso
+>
+> </div>
+>
+> > | Field | Type                                                                                                                | Description |
+> > |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | dso   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForDso
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForDso
+>
+> **instance** GetField "dso" ForDso [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "dso" ForDso [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** HasCheckedFetch DevelopmentFundCoupon ForDso
+>
+> **instance** HasCheckedFetch FeaturedAppActivityMarker ForDso
+>
+> **instance** HasCheckedFetch UnclaimedDevelopmentFundCoupon ForDso
+>
+> **instance** HasCheckedFetch UnclaimedReward ForDso
+>
+> **instance** HasCheckedFetch ValidatorRewardCoupon ForDso
+>
+> **instance** HasCheckedFetch AmuletAllocation ForDso
+>
+> **instance** HasCheckedFetch AmuletRules ForDso
+>
+> **instance** HasCheckedFetch MemberTraffic ForDso
+>
+> **instance** HasCheckedFetch TransferCommand ForDso
+>
+> **instance** HasCheckedFetch ExternalPartyConfigState ForDso
+>
+> **instance** HasCheckedFetch ClosedMiningRound ForDso
+>
+> **instance** HasCheckedFetch IssuingMiningRound ForDso
+>
+> **instance** HasCheckedFetch OpenMiningRound ForDso
+>
+> **instance** HasCheckedFetch SummarizingMiningRound ForDso
+>
+> **instance** HasCheckedFetch ValidatorLicense ForDso
+>
+> **instance** HasCheckedFetch AllocationView ForDso
+>
+> **instance** HasCheckedFetch TransferInstructionView ForDso
+
+<div id="type-splice-types-forowner-62144">
+
+**data** ForOwner
+
+</div>
+
+> The group of contracts managed by the DSO party and owned by a specific party.
+>
+> Used for checked fetches.
+>
+> <div id="constr-splice-types-forowner-89915">
+>
+> ForOwner
+>
+> </div>
+>
+> > | Field | Type                                                                                                                | Description |
+> > |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | dso   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | owner | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForOwner
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForOwner
+>
+> **instance** GetField "dso" ForOwner [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "owner" ForOwner [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "dso" ForOwner [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "owner" ForOwner [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** HasCheckedFetch Amulet ForOwner
+>
+> **instance** HasCheckedFetch AppRewardCoupon ForOwner
+>
+> **instance** HasCheckedFetch DevelopmentFundCoupon ForOwner
+>
+> **instance** HasCheckedFetch FeaturedAppActivityMarker ForOwner
+>
+> **instance** HasCheckedFetch LockedAmulet ForOwner
+>
+> **instance** HasCheckedFetch SvRewardCoupon ForOwner
+>
+> **instance** HasCheckedFetch UnclaimedActivityRecord ForOwner
+>
+> **instance** HasCheckedFetch TransferPreapproval ForOwner
+>
+> **instance** HasCheckedFetch TransferCommandCounter ForOwner
+>
+> **instance** HasCheckedFetch ValidatorFaucetCoupon ForOwner
+>
+> **instance** HasCheckedFetch ValidatorLivenessActivityRecord ForOwner
+>
+> **instance** HasCheckedFetch HoldingView ForOwner
+
+<div id="type-splice-types-forround-72197">
+
+**data** ForRound
+
+</div>
+
+> The group of contracts managed by the DSO party for a specific mining round.
+>
+> Used for checked fetches.
+>
+> <div id="constr-splice-types-forround-96474">
+>
+> ForRound
+>
+> </div>
+>
+> > | Field | Type                                                                                                                | Description |
+> > |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | dso   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | round | Round                                                                                                               |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForRound
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForRound
+>
+> **instance** GetField "dso" ForRound [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "round" ForRound Round
+>
+> **instance** SetField "dso" ForRound [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "round" ForRound Round
+>
+> **instance** HasCheckedFetch ClosedMiningRound ForRound
+>
+> **instance** HasCheckedFetch IssuingMiningRound ForRound
+>
+> **instance** HasCheckedFetch OpenMiningRound ForRound
+>
+> **instance** HasCheckedFetch SummarizingMiningRound ForRound
+
+<div id="type-splice-types-round-16181">
+
+**data** Round
+
+</div>
+
+> <div id="constr-splice-types-round-29804">
+>
+> Round
+>
+> </div>
+>
+> > | Field  | Type                                                                                                       | Description |
+> > |--------|------------------------------------------------------------------------------------------------------------|-------------|
+> > | number | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Round
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) Round
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Round
+>
+> **instance** GetField "createdAt" ExpiringAmount Round
+>
+> **instance** GetField "firstReceivedFor" FaucetState Round
+>
+> **instance** GetField "holdingFeesOpenRoundNumber" ExternalPartyConfigState Round
+>
+> **instance** GetField "initialRound" AmuletRules_Bootstrap_RoundsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Round)
+>
+> **instance** GetField "issuingMiningRounds" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound))
+>
+> **instance** GetField "issuingMiningRounds" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
+>
+> **instance** GetField "issuingMiningRounds" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
+>
+> **instance** GetField "lastReceivedFor" FaucetState Round
+>
+> **instance** GetField "number" Round [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "openRoundNumber" TransferContextSummaryV2 Round
+>
+> **instance** GetField "round" (AmuletCreateSummary amuletContractId) Round
+>
+> **instance** GetField "round" AmuletExpireSummary Round
+>
+> **instance** GetField "round" AppRewardCoupon Round
+>
+> **instance** GetField "round" SvRewardCoupon Round
+>
+> **instance** GetField "round" ValidatorRewardCoupon Round
+>
+> **instance** GetField "round" AmuletRules_BuyMemberTrafficResult Round
+>
+> **instance** GetField "round" TransferResult Round
+>
+> **instance** GetField "round" ClosedMiningRound Round
+>
+> **instance** GetField "round" IssuingMiningRound Round
+>
+> **instance** GetField "round" OpenMiningRound Round
+>
+> **instance** GetField "round" SummarizingMiningRound Round
+>
+> **instance** GetField "round" ForRound Round
+>
+> **instance** GetField "round" ValidatorFaucetCoupon Round
+>
+> **instance** GetField "round" ValidatorLivenessActivityRecord Round
+>
+> **instance** SetField "createdAt" ExpiringAmount Round
+>
+> **instance** SetField "firstReceivedFor" FaucetState Round
+>
+> **instance** SetField "holdingFeesOpenRoundNumber" ExternalPartyConfigState Round
+>
+> **instance** SetField "initialRound" AmuletRules_Bootstrap_RoundsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Round)
+>
+> **instance** SetField "issuingMiningRounds" TransferContext ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound))
+>
+> **instance** SetField "issuingMiningRounds" TransferContextSummary ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
+>
+> **instance** SetField "issuingMiningRounds" TransferContextSummaryV2 ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) Round IssuingMiningRound)
+>
+> **instance** SetField "lastReceivedFor" FaucetState Round
+>
+> **instance** SetField "number" Round [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "openRoundNumber" TransferContextSummaryV2 Round
+>
+> **instance** SetField "round" (AmuletCreateSummary amuletContractId) Round
+>
+> **instance** SetField "round" AmuletExpireSummary Round
+>
+> **instance** SetField "round" AppRewardCoupon Round
+>
+> **instance** SetField "round" SvRewardCoupon Round
+>
+> **instance** SetField "round" ValidatorRewardCoupon Round
+>
+> **instance** SetField "round" AmuletRules_BuyMemberTrafficResult Round
+>
+> **instance** SetField "round" TransferResult Round
+>
+> **instance** SetField "round" ClosedMiningRound Round
+>
+> **instance** SetField "round" IssuingMiningRound Round
+>
+> **instance** SetField "round" OpenMiningRound Round
+>
+> **instance** SetField "round" SummarizingMiningRound Round
+>
+> **instance** SetField "round" ForRound Round
+>
+> **instance** SetField "round" ValidatorFaucetCoupon Round
+>
+> **instance** SetField "round" ValidatorLivenessActivityRecord Round
+
+## Functions
+
+<div id="function-splice-types-isdefinedround-76197">
+
+isDefinedRound
+: Round -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+Check if a round has a positive round number
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense.mdx
@@ -1,0 +1,513 @@
+---
+title: "Splice.ValidatorLicense"
+description: "Documentation for Splice.ValidatorLicense"
+---
+
+{/* COPIED_START source="splice:daml/splice-amulet/docs/Splice-ValidatorLicense.rst" tag="0.6.4" hash="7cb05ace" */}
+
+## Templates
+
+<div id="type-splice-validatorlicense-validatorfaucetcoupon-19254">
+
+**template** ValidatorFaucetCoupon
+
+</div>
+
+> **Deprecated**: use `ValidatorLicense_RecordValidatorLivenessActivity` instead, as that one can be expired without requiring a confirmation from the validator node.
+>
+> Signatory: dso, validator
+>
+> | Field     | Type                                                                                                                | Description |
+> |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | validator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | round     | Round                                                                                                               |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso, validator
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-validatorlicense-validatorfaucetcoupondsoexpire-65722">
+>
+>   **Choice** ValidatorFaucetCoupon_DsoExpire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: ValidatorFaucetCoupon_DsoExpireResult
+>
+>   | Field          | Type                                                                                                                                            | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
+
+<div id="type-splice-validatorlicense-validatorlicense-33456">
+
+**template** ValidatorLicense
+
+</div>
+
+> The existence of a validator license is what makes a validator an (onboarded) validator.
+>
+> Signatory: dso
+>
+> | Field        | Type                                                                                                                                                                                                                                             | Description                                                                                                       |
+> |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+> | validator    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              | The validator (party) that this license is about.                                                                 |
+> | sponsor      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              | The SV node that sponsored the onboarding.                                                                        |
+> | dso          | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              | The party representing the operations of the decentralized synchronizer.                                          |
+> | faucetState  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FaucetState                                                                                                       |                                                                                                                   |
+> | metadata     | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ValidatorLicenseMetadata                                                                                          |                                                                                                                   |
+> | lastActiveAt | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | Last time this validator was active. Tracked to get a view on the set of validator nodes that are up and running. |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-validatorlicense-validatorlicensecancel-74620">
+>
+>   **Choice** ValidatorLicense_Cancel
+>
+>   </div>
+>
+>   Controller: validator
+>
+>   Returns: ValidatorLicense_CancelResult
+>
+>   | Field  | Type                                                                                                         | Description |
+>   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> - <div id="type-splice-validatorlicense-validatorlicensereceivefaucetcoupon-91156">
+>
+>   **Choice** ValidatorLicense_ReceiveFaucetCoupon
+>
+>   </div>
+>
+>   Controller: validator
+>
+>   Returns: ValidatorLicense_ReceiveFaucetCouponResult
+>
+>   | Field        | Type                                                                                                                                          | Description |
+>   |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | openRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>
+> - <div id="type-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivity-79262">
+>
+>   **Choice** ValidatorLicense_RecordValidatorLivenessActivity
+>
+>   </div>
+>
+>   Controller: validator
+>
+>   Returns: ValidatorLicense_RecordValidatorLivenessActivityResult
+>
+>   | Field        | Type                                                                                                                                          | Description |
+>   |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | openRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound |             |
+>
+> - <div id="type-splice-validatorlicense-validatorlicensereportactive-46832">
+>
+>   **Choice** ValidatorLicense_ReportActive
+>
+>   </div>
+>
+>   Choice for validators with disabled wallets to report themselves as active. Validators that receive amulets will report through ReceiveFaucetCoupon.
+>
+>   Controller: validator
+>
+>   Returns: ValidatorLicense_ReportActiveResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-validatorlicense-validatorlicenseupdatemetadata-65458">
+>
+>   **Choice** ValidatorLicense_UpdateMetadata
+>
+>   </div>
+>
+>   Controller: validator
+>
+>   Returns: ValidatorLicense_UpdateMetadataResult
+>
+>   | Field        | Type                                                                                                         | Description |
+>   |--------------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | version      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>   | contactPoint | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> - <div id="type-splice-validatorlicense-validatorlicensewithdraw-63410">
+>
+>   **Choice** ValidatorLicense_Withdraw
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: ValidatorLicense_WithdrawResult
+>
+>   | Field  | Type                                                                                                         | Description |
+>   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+
+<div id="type-splice-validatorlicense-validatorlivenessactivityrecord-17293">
+
+**template** ValidatorLivenessActivityRecord
+
+</div>
+
+> A copy of the ValidatorFaucetCoupon template with the only difference being that the validator is an observer instead of signatory. This is to allow to expire the coupon without the validator's involvement.
+>
+> Signatory: dso
+>
+> | Field     | Type                                                                                                                | Description |
+> |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | validator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | round     | Round                                                                                                               |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-validatorlicense-validatorlivenessactivityrecorddsoexpire-78737">
+>
+>   **Choice** ValidatorLivenessActivityRecord_DsoExpire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: ValidatorLivenessActivityRecord_DsoExpireResult
+>
+>   | Field          | Type                                                                                                                                            | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | closedRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
+
+## Data Types
+
+<div id="type-splice-validatorlicense-faucetstate-67607">
+
+**data** FaucetState
+
+</div>
+
+> <div id="constr-splice-validatorlicense-faucetstate-48340">
+>
+> FaucetState
+>
+> </div>
+>
+> > | Field            | Type                                                                                                       | Description                                            |
+> > |------------------|------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+> > | firstReceivedFor | Round                                                                                                      | The first round for which a coupon was received.       |
+> > | lastReceivedFor  | Round                                                                                                      | The last round for which a coupon was received.        |
+> > | numCouponsMissed | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | The number of rounds for which no coupon was received. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) FaucetState
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) FaucetState
+>
+> **instance** GetField "faucetState" ValidatorLicense ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FaucetState)
+>
+> **instance** GetField "firstReceivedFor" FaucetState Round
+>
+> **instance** GetField "lastReceivedFor" FaucetState Round
+>
+> **instance** GetField "numCouponsMissed" FaucetState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "faucetState" ValidatorLicense ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FaucetState)
+>
+> **instance** SetField "firstReceivedFor" FaucetState Round
+>
+> **instance** SetField "lastReceivedFor" FaucetState Round
+>
+> **instance** SetField "numCouponsMissed" FaucetState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+
+<div id="type-splice-validatorlicense-validatorfaucetcoupondsoexpireresult-29807">
+
+**data** ValidatorFaucetCoupon_DsoExpireResult
+
+</div>
+
+> <div id="constr-splice-validatorlicense-validatorfaucetcoupondsoexpireresult-83728">
+>
+> ValidatorFaucetCoupon_DsoExpireResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorFaucetCoupon ValidatorFaucetCoupon_DsoExpire ValidatorFaucetCoupon_DsoExpireResult
+
+<div id="type-splice-validatorlicense-validatorlicensemetadata-6055">
+
+**data** ValidatorLicenseMetadata
+
+</div>
+
+> <div id="constr-splice-validatorlicense-validatorlicensemetadata-35622">
+>
+> ValidatorLicenseMetadata
+>
+> </div>
+>
+> > | Field         | Type                                                                                                              | Description                                                                                                                                                             |
+> > |---------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | lastUpdatedAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The last time the validator metadata was updated                                                                                                                        |
+> > | version       | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)      | The version the validator is currently on                                                                                                                               |
+> > | contactPoint  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)      | A contact point that can be used to reach the operator of the validator in case there are issues with the validator. This can be an email address or a slack user name. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ValidatorLicenseMetadata
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ValidatorLicenseMetadata
+>
+> **instance** GetField "contactPoint" ValidatorLicenseMetadata [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "lastUpdatedAt" ValidatorLicenseMetadata [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "metadata" ValidatorLicense ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ValidatorLicenseMetadata)
+>
+> **instance** GetField "version" ValidatorLicenseMetadata [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "contactPoint" ValidatorLicenseMetadata [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "lastUpdatedAt" ValidatorLicenseMetadata [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "metadata" ValidatorLicense ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ValidatorLicenseMetadata)
+>
+> **instance** SetField "version" ValidatorLicenseMetadata [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+<div id="type-splice-validatorlicense-validatorlicensecancelresult-12117">
+
+**data** ValidatorLicense_CancelResult
+
+</div>
+
+> <div id="constr-splice-validatorlicense-validatorlicensecancelresult-95954">
+>
+> ValidatorLicense_CancelResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_Cancel ValidatorLicense_CancelResult
+
+<div id="type-splice-validatorlicense-validatorlicensereceivefaucetcouponresult-11121">
+
+**data** ValidatorLicense_ReceiveFaucetCouponResult
+
+</div>
+
+> <div id="constr-splice-validatorlicense-validatorlicensereceivefaucetcouponresult-52224">
+>
+> ValidatorLicense_ReceiveFaucetCouponResult
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                                | Description |
+> > |------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | licenseCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense      |             |
+> > | couponCid  | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon |             |
+>
+> **instance** GetField "couponCid" ValidatorLicense_ReceiveFaucetCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon)
+>
+> **instance** GetField "licenseCid" ValidatorLicense_ReceiveFaucetCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** SetField "couponCid" ValidatorLicense_ReceiveFaucetCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorFaucetCoupon)
+>
+> **instance** SetField "licenseCid" ValidatorLicense_ReceiveFaucetCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_ReceiveFaucetCoupon ValidatorLicense_ReceiveFaucetCouponResult
+
+<div id="type-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivityresult-68079">
+
+**data** ValidatorLicense_RecordValidatorLivenessActivityResult
+
+</div>
+
+> <div id="constr-splice-validatorlicense-validatorlicenserecordvalidatorlivenessactivityresult-77154">
+>
+> ValidatorLicense_RecordValidatorLivenessActivityResult
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                                          | Description |
+> > |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | licenseCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense                |             |
+> > | couponCid  | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLivenessActivityRecord |             |
+>
+> **instance** GetField "couponCid" ValidatorLicense_RecordValidatorLivenessActivityResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLivenessActivityRecord)
+>
+> **instance** GetField "licenseCid" ValidatorLicense_RecordValidatorLivenessActivityResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** SetField "couponCid" ValidatorLicense_RecordValidatorLivenessActivityResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLivenessActivityRecord)
+>
+> **instance** SetField "licenseCid" ValidatorLicense_RecordValidatorLivenessActivityResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_RecordValidatorLivenessActivity ValidatorLicense_RecordValidatorLivenessActivityResult
+
+<div id="type-splice-validatorlicense-validatorlicensereportactiveresult-44973">
+
+**data** ValidatorLicense_ReportActiveResult
+
+</div>
+
+> <div id="constr-splice-validatorlicense-validatorlicensereportactiveresult-39594">
+>
+> ValidatorLicense_ReportActiveResult
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                           | Description |
+> > |------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | licenseCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense |             |
+>
+> **instance** GetField "licenseCid" ValidatorLicense_ReportActiveResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** SetField "licenseCid" ValidatorLicense_ReportActiveResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_ReportActive ValidatorLicense_ReportActiveResult
+
+<div id="type-splice-validatorlicense-validatorlicenseupdatemetadataresult-84967">
+
+**data** ValidatorLicense_UpdateMetadataResult
+
+</div>
+
+> <div id="constr-splice-validatorlicense-validatorlicenseupdatemetadataresult-7568">
+>
+> ValidatorLicense_UpdateMetadataResult
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                           | Description |
+> > |------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | licenseCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense |             |
+>
+> **instance** GetField "licenseCid" ValidatorLicense_UpdateMetadataResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** SetField "licenseCid" ValidatorLicense_UpdateMetadataResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_UpdateMetadata ValidatorLicense_UpdateMetadataResult
+
+<div id="type-splice-validatorlicense-validatorlicensewithdrawresult-32027">
+
+**data** ValidatorLicense_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-validatorlicense-validatorlicensewithdrawresult-54540">
+>
+> ValidatorLicense_WithdrawResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLicense ValidatorLicense_Withdraw ValidatorLicense_WithdrawResult
+
+<div id="type-splice-validatorlicense-validatorlivenessactivityrecorddsoexpireresult-68284">
+
+**data** ValidatorLivenessActivityRecord_DsoExpireResult
+
+</div>
+
+> <div id="constr-splice-validatorlicense-validatorlivenessactivityrecorddsoexpireresult-79751">
+>
+> ValidatorLivenessActivityRecord_DsoExpireResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorLivenessActivityRecord ValidatorLivenessActivityRecord_DsoExpire ValidatorLivenessActivityRecord_DsoExpireResult
+
+## Functions
+
+<div id="function-splice-validatorlicense-metadataupdatemininterval-59469">
+
+metadataUpdateMinInterval
+: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+
+</div>
+
+<div id="function-splice-validatorlicense-activityreportmininterval-78854">
+
+activityReportMinInterval
+: [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+
+</div>
+
+<div id="function-splice-validatorlicense-metadataupdateallowed-42050">
+
+metadataUpdateAllowed
+: [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-validatorlicense-activityreportallowed-34361">
+
+activityReportAllowed
+: [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-validatorlicense-validvalidatorlicense-11839">
+
+validValidatorLicense
+: ValidatorLicense -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-validatorlicense-maxidentifierlength-1659">
+
+maxIdentifierLength
+: [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+
+</div>
+
+<div id="function-splice-validatorlicense-validvalidatorlicensemetadata-75992">
+
+validValidatorLicenseMetadata
+: ValidatorLicenseMetadata -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1.mdx
@@ -61,7 +61,7 @@ The API for featured apps to record their activity.
 >   |---------------|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 >   | beneficiaries | \[AppRewardBeneficiary\] | The set of beneficiaries and weights that define how the rewards should be split up between the beneficiary parties. Implementations SHOULD check that the weights are positive and add up to 1.0. Implementations MAY also impose a limit on the maximum number of beneficiaries. |
 >
-> - **Method featuredAppRight_CreateActivityMarkerImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+> - **Method featuredAppRight_CreateActivityMarkerImpl :** ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult
 
 ## Data Types
 
@@ -81,26 +81,26 @@ The API for featured apps to record their activity.
 >
 > > | Field       | Type                                                                                    | Description                                                                                  |
 > > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+> > | beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | Decimal  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AppRewardBeneficiary
+> **instance** Eq AppRewardBeneficiary
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) AppRewardBeneficiary
+> **instance** Ord AppRewardBeneficiary
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AppRewardBeneficiary
+> **instance** Show AppRewardBeneficiary
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+> **instance** GetField "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "beneficiary" AppRewardBeneficiary Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** GetField "weight" AppRewardBeneficiary Decimal
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+> **instance** SetField "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "beneficiary" AppRewardBeneficiary Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** SetField "weight" AppRewardBeneficiary Decimal
 
 <div id="type-splice-api-featuredapprightv1-featuredappactivitymarkerview-84352">
 
@@ -116,34 +116,34 @@ The API for featured apps to record their activity.
 >
 > > | Field       | Type                                                                                    | Description                                                                                  |
 > > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | dso         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.                                                                               |
-> > | provider    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider.                                                                   |
-> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+> > | dso         | Party | The DSO party.                                                                               |
+> > | provider    | Party | The featured app provider.                                                                   |
+> > | beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | Decimal  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppActivityMarkerView
+> **instance** Eq FeaturedAppActivityMarkerView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppActivityMarkerView
+> **instance** Show FeaturedAppActivityMarkerView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+> **instance** HasFromAnyView FeaturedAppActivityMarker FeaturedAppActivityMarkerView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+> **instance** HasInterfaceView FeaturedAppActivityMarker FeaturedAppActivityMarkerView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "beneficiary" FeaturedAppActivityMarkerView Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "dso" FeaturedAppActivityMarkerView Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "provider" FeaturedAppActivityMarkerView Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** GetField "weight" FeaturedAppActivityMarkerView Decimal
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "beneficiary" FeaturedAppActivityMarkerView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "dso" FeaturedAppActivityMarkerView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "provider" FeaturedAppActivityMarkerView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** SetField "weight" FeaturedAppActivityMarkerView Decimal
 
 <div id="type-splice-api-featuredapprightv1-featuredapprightview-50078">
 
@@ -159,24 +159,24 @@ The API for featured apps to record their activity.
 >
 > > | Field    | Type                                                                                    | Description                |
 > > |----------|-----------------------------------------------------------------------------------------|----------------------------|
-> > | dso      | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.             |
-> > | provider | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider. |
+> > | dso      | Party | The DSO party.             |
+> > | provider | Party | The featured app provider. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppRightView
+> **instance** Eq FeaturedAppRightView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppRightView
+> **instance** Show FeaturedAppRightView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppRight FeaturedAppRightView
+> **instance** HasFromAnyView FeaturedAppRight FeaturedAppRightView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppRight FeaturedAppRightView
+> **instance** HasInterfaceView FeaturedAppRight FeaturedAppRightView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "dso" FeaturedAppRightView Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "provider" FeaturedAppRightView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "dso" FeaturedAppRightView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "provider" FeaturedAppRightView Party
 
 <div id="type-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerresult-54383">
 
@@ -194,28 +194,28 @@ The API for featured apps to record their activity.
 >
 > > | Field              | Type                                                                                                                            | Description                                        |
 > > |--------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
-> > | activityMarkerCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
+> > | activityMarkerCids | \[ContractId FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
 >
-> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult)
+> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" (ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+> **instance** GetField "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[ContractId FeaturedAppActivityMarker\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+> **instance** SetField "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[ContractId FeaturedAppActivityMarker\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** HasExercise FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** HasExerciseGuarded FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** HasFromAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** HasToAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 
 ## Functions
 
 <div id="function-splice-api-featuredapprightv1-featuredapprightcreateactivitymarkerimpl-71588">
 
 featuredAppRight_CreateActivityMarkerImpl
-: FeaturedAppRight -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+: FeaturedAppRight -\> ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2.mdx
@@ -60,9 +60,9 @@ The API for featured apps to record their activity. This package extends Feature
 >   | Field         | Type                                                                                                                                                                                      | Description                                                                                                                                                                                                                                                                                       |
 >   |---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 >   | beneficiaries | \[AppRewardBeneficiary\]                                                                                                                                                                  | The set of beneficiaries and weights that define how the rewards should be split up between the beneficiary parties. Implementations SHOULD check that the weights are positive and add up to 1.0. Implementations MAY also impose a limit on the maximum number of beneficiaries.                |
->   | weight        | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135) | A weight for the resulting markers. None defaults to a weight of 1.0. Specifying a weight of 5 for example makes the resulting markers equivalent to 5 markers of weight 1 in terms of rewards they generate. The weight must be \>= 1.0 Implementations MAY impose an upper limit on the weight. |
+>   | weight        | Optional Decimal | A weight for the resulting markers. None defaults to a weight of 1.0. Specifying a weight of 5 for example makes the resulting markers equivalent to 5 markers of weight 1 in terms of rewards they generate. The weight must be \>= 1.0 Implementations MAY impose an upper limit on the weight. |
 >
-> - **Method featuredAppRight_CreateActivityMarkerImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+> - **Method featuredAppRight_CreateActivityMarkerImpl :** ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult
 
 ## Data Types
 
@@ -82,26 +82,26 @@ The API for featured apps to record their activity. This package extends Feature
 >
 > > | Field       | Type                                                                                    | Description                                                                                  |
 > > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+> > | beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | Decimal  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AppRewardBeneficiary
+> **instance** Eq AppRewardBeneficiary
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) AppRewardBeneficiary
+> **instance** Ord AppRewardBeneficiary
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AppRewardBeneficiary
+> **instance** Show AppRewardBeneficiary
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+> **instance** GetField "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "beneficiary" AppRewardBeneficiary Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** GetField "weight" AppRewardBeneficiary Decimal
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
+> **instance** SetField "beneficiaries" FeaturedAppRight_CreateActivityMarker \[AppRewardBeneficiary\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" AppRewardBeneficiary [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "beneficiary" AppRewardBeneficiary Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" AppRewardBeneficiary [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** SetField "weight" AppRewardBeneficiary Decimal
 
 <div id="type-splice-api-featuredapprightv2-featuredappactivitymarkerview-70739">
 
@@ -117,34 +117,34 @@ The API for featured apps to record their activity. This package extends Feature
 >
 > > | Field       | Type                                                                                    | Description                                                                                  |
 > > |-------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-> > | dso         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.                                                                               |
-> > | provider    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider.                                                                   |
-> > | beneficiary | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is granted the right to mint the weighted amount of reward for this activity. |
-> > | weight      | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
+> > | dso         | Party | The DSO party.                                                                               |
+> > | provider    | Party | The featured app provider.                                                                   |
+> > | beneficiary | Party | The party that is granted the right to mint the weighted amount of reward for this activity. |
+> > | weight      | Decimal  | A weight between 0.0 and 1.0 that defines how much of the reward this beneficiary can mint.  |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppActivityMarkerView
+> **instance** Eq FeaturedAppActivityMarkerView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppActivityMarkerView
+> **instance** Show FeaturedAppActivityMarkerView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+> **instance** HasFromAnyView FeaturedAppActivityMarker FeaturedAppActivityMarkerView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppActivityMarker FeaturedAppActivityMarkerView
+> **instance** HasInterfaceView FeaturedAppActivityMarker FeaturedAppActivityMarkerView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "beneficiary" FeaturedAppActivityMarkerView Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "dso" FeaturedAppActivityMarkerView Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "provider" FeaturedAppActivityMarkerView Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** GetField "weight" FeaturedAppActivityMarkerView Decimal
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "beneficiary" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "beneficiary" FeaturedAppActivityMarkerView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "dso" FeaturedAppActivityMarkerView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppActivityMarkerView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "provider" FeaturedAppActivityMarkerView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "weight" FeaturedAppActivityMarkerView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** SetField "weight" FeaturedAppActivityMarkerView Decimal
 
 <div id="type-splice-api-featuredapprightv2-featuredapprightview-58075">
 
@@ -160,24 +160,24 @@ The API for featured apps to record their activity. This package extends Feature
 >
 > > | Field    | Type                                                                                    | Description                |
 > > |----------|-----------------------------------------------------------------------------------------|----------------------------|
-> > | dso      | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The DSO party.             |
-> > | provider | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The featured app provider. |
+> > | dso      | Party | The DSO party.             |
+> > | provider | Party | The featured app provider. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) FeaturedAppRightView
+> **instance** Eq FeaturedAppRightView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) FeaturedAppRightView
+> **instance** Show FeaturedAppRightView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) FeaturedAppRight FeaturedAppRightView
+> **instance** HasFromAnyView FeaturedAppRight FeaturedAppRightView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) FeaturedAppRight FeaturedAppRightView
+> **instance** HasInterfaceView FeaturedAppRight FeaturedAppRightView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "dso" FeaturedAppRightView Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "provider" FeaturedAppRightView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "dso" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "dso" FeaturedAppRightView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "provider" FeaturedAppRightView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "provider" FeaturedAppRightView Party
 
 <div id="type-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerresult-27928">
 
@@ -195,28 +195,28 @@ The API for featured apps to record their activity. This package extends Feature
 >
 > > | Field              | Type                                                                                                                            | Description                                        |
 > > |--------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
-> > | activityMarkerCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
+> > | activityMarkerCids | \[ContractId FeaturedAppActivityMarker\] | The set of activity markers created by the choice. |
 >
-> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult)
+> **instance** HasMethod FeaturedAppRight "featuredAppRight_CreateActivityMarkerImpl" (ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+> **instance** GetField "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[ContractId FeaturedAppActivityMarker\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppActivityMarker\]
+> **instance** SetField "activityMarkerCids" FeaturedAppRight_CreateActivityMarkerResult \[ContractId FeaturedAppActivityMarker\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** HasExercise FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** HasExerciseGuarded FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** HasFromAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
+> **instance** HasToAnyChoice FeaturedAppRight FeaturedAppRight_CreateActivityMarker FeaturedAppRight_CreateActivityMarkerResult
 
 ## Functions
 
 <div id="function-splice-api-featuredapprightv2-featuredapprightcreateactivitymarkerimpl-7767">
 
 featuredAppRight_CreateActivityMarkerImpl
-: FeaturedAppRight -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+: FeaturedAppRight -\> ContractId FeaturedAppRight -\> FeaturedAppRight_CreateActivityMarker -\> Update FeaturedAppRight_CreateActivityMarkerResult
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1.mdx
@@ -33,10 +33,10 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 >   | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 >   |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party.                                       |
+>   | expectedAdmin    | Party                       | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party.                                       |
 >   | allocation       | AllocationSpecification                                                                                       | The allocation which should be created.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
->   | requestedAt      | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                         | The time at which the allocation was requested.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
->   | inputHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that SHOULD be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger; or for registries that support automatic selection of holdings for allocations. If specified, then the successful allocation MUST archive all of these holdings, so that the execution of the allocation conflicts with any other allocations using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate allocations. |
+>   | requestedAt      | Time                         | The time at which the allocation was requested.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+>   | inputHoldingCids | \[ContractId Holding\] | The holdings that SHOULD be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger; or for registries that support automatic selection of holdings for allocations. If specified, then the successful allocation MUST archive all of these holdings, so that the execution of the allocation conflicts with any other allocations using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate allocations. |
 >   | extraArgs        | ExtraArgs                                                                                                     | Additional choice arguments.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 >
 > - <div id="type-splice-api-token-allocationinstructionv1-allocationfactorypublicfetch-20324">
@@ -51,8 +51,8 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 >   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 >   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
->   | actor         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+>   | expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | actor         | Party |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 >
 > - **Choice** Archive
 >
@@ -62,9 +62,9 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 >   (no fields)
 >
-> - **Method allocationFactory_allocateImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+> - **Method allocationFactory_allocateImpl :** ContractId AllocationFactory -\> AllocationFactory_Allocate -\> Update AllocationInstructionResult
 >
-> - **Method allocationFactory_publicFetchImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationFactoryView
+> - **Method allocationFactory_publicFetchImpl :** ContractId AllocationFactory -\> AllocationFactory_PublicFetch -\> Update AllocationFactoryView
 
 <div id="type-splice-api-token-allocationinstructionv1-allocationinstruction-29622">
 
@@ -92,7 +92,7 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 >   | Field       | Type                                                                                        | Description                                                                                                                           |
 >   |-------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
->   | extraActors | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
+>   | extraActors | \[Party\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
 >   | extraArgs   | ExtraArgs                                                                                   | Additional context required in order to exercise the choice.                                                                          |
 >
 > - <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionwithdraw-35988">
@@ -119,9 +119,9 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 >   (no fields)
 >
-> - **Method allocationInstruction_updateImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+> - **Method allocationInstruction_updateImpl :** ContractId AllocationInstruction -\> AllocationInstruction_Update -\> Update AllocationInstructionResult
 >
-> - **Method allocationInstruction_withdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+> - **Method allocationInstruction_withdrawImpl :** ContractId AllocationInstruction -\> AllocationInstruction_Withdraw -\> Update AllocationInstructionResult
 
 ## Data Types
 
@@ -141,34 +141,34 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 > > | Field | Type                                                                                    | Description                                                                                                             |
 > > |-------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this allocation factory can be used. |
+> > | admin | Party | The party representing the registry app that administers the instruments for which this allocation factory can be used. |
 > > | meta  | Metadata                                                                                | Additional metadata specific to the allocation factory, used for extensibility.                                         |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationFactoryView
+> **instance** Eq AllocationFactoryView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationFactoryView
+> **instance** Show AllocationFactoryView
 >
-> **instance** HasMethod AllocationFactory "allocationFactory_publicFetchImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationFactoryView)
+> **instance** HasMethod AllocationFactory "allocationFactory_publicFetchImpl" (ContractId AllocationFactory -\> AllocationFactory_PublicFetch -\> Update AllocationFactoryView)
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationFactory AllocationFactoryView
+> **instance** HasFromAnyView AllocationFactory AllocationFactoryView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AllocationFactory AllocationFactoryView
+> **instance** HasInterfaceView AllocationFactory AllocationFactoryView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" AllocationFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "admin" AllocationFactoryView Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationFactoryView Metadata
+> **instance** GetField "meta" AllocationFactoryView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" AllocationFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "admin" AllocationFactoryView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationFactoryView Metadata
+> **instance** SetField "meta" AllocationFactoryView Metadata
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+> **instance** HasExercise AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+> **instance** HasExerciseGuarded AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+> **instance** HasFromAnyChoice AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
+> **instance** HasToAnyChoice AllocationFactory AllocationFactory_PublicFetch AllocationFactoryView
 
 <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionresult-30943">
 
@@ -187,54 +187,54 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 > > | Field            | Type                                                                                                          | Description                                                                                                                                                                      |
 > > |------------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 > > | output           | AllocationInstructionResult_Output                                                                            | The output of the step.                                                                                                                                                          |
-> > | senderChangeCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple allocation instructions in a single Daml transaction. |
+> > | senderChangeCids | \[ContractId Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple allocation instructions in a single Daml transaction. |
 > > | meta             | Metadata                                                                                                      | Additional metadata specific to the allocation instruction, used for extensibility; e.g., fees charged.                                                                          |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationInstructionResult
+> **instance** Eq AllocationInstructionResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationInstructionResult
+> **instance** Show AllocationInstructionResult
 >
-> **instance** HasMethod AllocationFactory "allocationFactory_allocateImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult)
+> **instance** HasMethod AllocationFactory "allocationFactory_allocateImpl" (ContractId AllocationFactory -\> AllocationFactory_Allocate -\> Update AllocationInstructionResult)
 >
-> **instance** HasMethod AllocationInstruction "allocationInstruction_updateImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult)
+> **instance** HasMethod AllocationInstruction "allocationInstruction_updateImpl" (ContractId AllocationInstruction -\> AllocationInstruction_Update -\> Update AllocationInstructionResult)
 >
-> **instance** HasMethod AllocationInstruction "allocationInstruction_withdrawImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult)
+> **instance** HasMethod AllocationInstruction "allocationInstruction_withdrawImpl" (ContractId AllocationInstruction -\> AllocationInstruction_Withdraw -\> Update AllocationInstructionResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationInstructionResult Metadata
+> **instance** GetField "meta" AllocationInstructionResult Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" AllocationInstructionResult AllocationInstructionResult_Output
+> **instance** GetField "output" AllocationInstructionResult AllocationInstructionResult_Output
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderChangeCids" AllocationInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** GetField "senderChangeCids" AllocationInstructionResult \[ContractId Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationInstructionResult Metadata
+> **instance** SetField "meta" AllocationInstructionResult Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" AllocationInstructionResult AllocationInstructionResult_Output
+> **instance** SetField "output" AllocationInstructionResult AllocationInstructionResult_Output
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderChangeCids" AllocationInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** SetField "senderChangeCids" AllocationInstructionResult \[ContractId Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+> **instance** HasExercise AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+> **instance** HasExercise AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+> **instance** HasExercise AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+> **instance** HasExerciseGuarded AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+> **instance** HasExerciseGuarded AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+> **instance** HasExerciseGuarded AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+> **instance** HasFromAnyChoice AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+> **instance** HasFromAnyChoice AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+> **instance** HasFromAnyChoice AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
+> **instance** HasToAnyChoice AllocationFactory AllocationFactory_Allocate AllocationInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
+> **instance** HasToAnyChoice AllocationInstruction AllocationInstruction_Update AllocationInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
+> **instance** HasToAnyChoice AllocationInstruction AllocationInstruction_Withdraw AllocationInstructionResult
 
 <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionresultoutput-46212">
 
@@ -254,7 +254,7 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 > >
 > > | Field                    | Type                                                                                                                    | Description                                                               |
 > > |--------------------------|-------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-> > | allocationInstructionCid | [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction | Contract id of the allocation instruction representing the pending state. |
+> > | allocationInstructionCid | ContractId AllocationInstruction | Contract id of the allocation instruction representing the pending state. |
 >
 > <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultcompleted-89210">
 >
@@ -266,7 +266,7 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 > >
 > > | Field         | Type                                                                                                         | Description                   |
 > > |---------------|--------------------------------------------------------------------------------------------------------------|-------------------------------|
-> > | allocationCid | [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation | The newly created allocation. |
+> > | allocationCid | ContractId Allocation | The newly created allocation. |
 >
 > <div id="constr-splice-api-token-allocationinstructionv1-allocationinstructionresultfailed-56799">
 >
@@ -276,21 +276,21 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 > > Use this result to communicate that the creation of the allocation did not succeed and all holdings reserved for funding the allocation have been released.
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationInstructionResult_Output
+> **instance** Eq AllocationInstructionResult_Output
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationInstructionResult_Output
+> **instance** Show AllocationInstructionResult_Output
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocationCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation)
+> **instance** GetField "allocationCid" AllocationInstructionResult_Output (ContractId Allocation)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocationInstructionCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction)
+> **instance** GetField "allocationInstructionCid" AllocationInstructionResult_Output (ContractId AllocationInstruction)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" AllocationInstructionResult AllocationInstructionResult_Output
+> **instance** GetField "output" AllocationInstructionResult AllocationInstructionResult_Output
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocationCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation)
+> **instance** SetField "allocationCid" AllocationInstructionResult_Output (ContractId Allocation)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocationInstructionCid" AllocationInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction)
+> **instance** SetField "allocationInstructionCid" AllocationInstructionResult_Output (ContractId AllocationInstruction)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" AllocationInstructionResult AllocationInstructionResult_Output
+> **instance** SetField "output" AllocationInstructionResult AllocationInstructionResult_Output
 
 <div id="type-splice-api-token-allocationinstructionv1-allocationinstructionview-72001">
 
@@ -308,72 +308,72 @@ Interfaces to enable wallets to instruct the registry to create allocations.
 >
 > > | Field                  | Type                                                                                                                                                                                                                                                         | Description                                                                                                                                                                                                                                |
 > > |------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | originalInstructionCid | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction)                                 | The contract id of the original allocation instruction contract. Used by the wallet to track the lineage of allocation instructions through multiple steps. Only set if the registry evolves the allocation instruction in multiple steps. |
+> > | originalInstructionCid | Optional (ContractId AllocationInstruction)                                 | The contract id of the original allocation instruction contract. Used by the wallet to track the lineage of allocation instructions through multiple steps. Only set if the registry evolves the allocation instruction in multiple steps. |
 > > | allocation             | AllocationSpecification                                                                                                                                                                                                                                      | The allocation that this instruction should create.                                                                                                                                                                                        |
-> > | pendingActions         | [Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | The pending actions to be taken by different actors to create the allocation. ^ This field can by used to report on the progress of registry specific workflows that are required to prepare the allocation.                               |
-> > | requestedAt            | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                                                                                                                                                                        | The time at which the allocation was requested.                                                                                                                                                                                            |
-> > | inputHoldingCids       | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]                                                                                                                                                | The holdings to be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger.                                                                                                                |
+> > | pendingActions         | Map Party Text | The pending actions to be taken by different actors to create the allocation. ^ This field can by used to report on the progress of registry specific workflows that are required to prepare the allocation.                               |
+> > | requestedAt            | Time                                                                                                                                                                        | The time at which the allocation was requested.                                                                                                                                                                                            |
+> > | inputHoldingCids       | \[ContractId Holding\]                                                                                                                                                | The holdings to be used to fund the allocation. MAY be empty for registries that do not represent their holdings on-ledger.                                                                                                                |
 > > | meta                   | Metadata                                                                                                                                                                                                                                                     | Additional metadata specific to the allocation instruction, used for extensibility; e.g., more detailed status information.                                                                                                                |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationInstructionView
+> **instance** Eq AllocationInstructionView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationInstructionView
+> **instance** Show AllocationInstructionView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationInstruction AllocationInstructionView
+> **instance** HasFromAnyView AllocationInstruction AllocationInstructionView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AllocationInstruction AllocationInstructionView
+> **instance** HasInterfaceView AllocationInstruction AllocationInstructionView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocation" AllocationInstructionView AllocationSpecification
+> **instance** GetField "allocation" AllocationInstructionView AllocationSpecification
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "inputHoldingCids" AllocationInstructionView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** GetField "inputHoldingCids" AllocationInstructionView \[ContractId Holding\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationInstructionView Metadata
+> **instance** GetField "meta" AllocationInstructionView Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "originalInstructionCid" AllocationInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction))
+> **instance** GetField "originalInstructionCid" AllocationInstructionView (Optional (ContractId AllocationInstruction))
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "pendingActions" AllocationInstructionView ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** GetField "pendingActions" AllocationInstructionView (Map Party Text)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "requestedAt" AllocationInstructionView [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** GetField "requestedAt" AllocationInstructionView Time
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocation" AllocationInstructionView AllocationSpecification
+> **instance** SetField "allocation" AllocationInstructionView AllocationSpecification
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "inputHoldingCids" AllocationInstructionView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** SetField "inputHoldingCids" AllocationInstructionView \[ContractId Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationInstructionView Metadata
+> **instance** SetField "meta" AllocationInstructionView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "originalInstructionCid" AllocationInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction))
+> **instance** SetField "originalInstructionCid" AllocationInstructionView (Optional (ContractId AllocationInstruction))
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "pendingActions" AllocationInstructionView ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** SetField "pendingActions" AllocationInstructionView (Map Party Text)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "requestedAt" AllocationInstructionView [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** SetField "requestedAt" AllocationInstructionView Time
 
 ## Functions
 
 <div id="function-splice-api-token-allocationinstructionv1-allocationinstructionwithdrawimpl-26170">
 
 allocationInstruction_withdrawImpl
-: AllocationInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+: AllocationInstruction -\> ContractId AllocationInstruction -\> AllocationInstruction_Withdraw -\> Update AllocationInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-allocationinstructionv1-allocationinstructionupdateimpl-49061">
 
 allocationInstruction_updateImpl
-: AllocationInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationInstruction -\> AllocationInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+: AllocationInstruction -\> ContractId AllocationInstruction -\> AllocationInstruction_Update -\> Update AllocationInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-allocationinstructionv1-allocationfactoryallocateimpl-1231">
 
 allocationFactory_allocateImpl
-: AllocationFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_Allocate -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationInstructionResult
+: AllocationFactory -\> ContractId AllocationFactory -\> AllocationFactory_Allocate -\> Update AllocationInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-allocationinstructionv1-allocationfactorypublicfetchimpl-77778">
 
 allocationFactory_publicFetchImpl
-: AllocationFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationFactory -\> AllocationFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) AllocationFactoryView
+: AllocationFactory -\> ContractId AllocationFactory -\> AllocationFactory_PublicFetch -\> Update AllocationFactoryView
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1.mdx
@@ -37,7 +37,7 @@ This module defines the interface for an `AllocationRequest`, which is an interf
 >
 >   | Field     | Type                                                                                    | Description                                                  |
 >   |-----------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------|
->   | actor     | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party rejecting the allocation request.                  |
+>   | actor     | Party | The party rejecting the allocation request.                  |
 >   | extraArgs | ExtraArgs                                                                               | Additional context required in order to exercise the choice. |
 >
 > - <div id="type-splice-api-token-allocationrequestv1-allocationrequestwithdraw-15628">
@@ -66,9 +66,9 @@ This module defines the interface for an `AllocationRequest`, which is an interf
 >
 >   (no fields)
 >
-> - **Method allocationRequest_RejectImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+> - **Method allocationRequest_RejectImpl :** ContractId AllocationRequest -\> AllocationRequest_Reject -\> Update ChoiceExecutionMetadata
 >
-> - **Method allocationRequest_WithdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+> - **Method allocationRequest_WithdrawImpl :** ContractId AllocationRequest -\> AllocationRequest_Withdraw -\> Update ChoiceExecutionMetadata
 
 ## Data Types
 
@@ -91,42 +91,42 @@ This module defines the interface for an `AllocationRequest`, which is an interf
 > > | Field        | Type                                                                                                    | Description                                                                                                                                                                                                                                                        |
 > > |--------------|---------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 > > | settlement   | SettlementInfo                                                                                          | Settlement for which the assets are requested to be allocated.                                                                                                                                                                                                     |
-> > | transferLegs | [TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) TransferLeg | Transfer legs that are requested to be allocated for the execution of the settlement keyed by their identifier. This may or may not be a complete list of transfer legs that are part of the settlement, depending on the confidentiality requirements of the app. |
+> > | transferLegs | TextMap TransferLeg | Transfer legs that are requested to be allocated for the execution of the settlement keyed by their identifier. This may or may not be a complete list of transfer legs that are part of the settlement, depending on the confidentiality requirements of the app. |
 > > | meta         | Metadata                                                                                                | Additional metadata specific to the allocation request, used for extensibility.                                                                                                                                                                                    |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationRequestView
+> **instance** Eq AllocationRequestView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationRequestView
+> **instance** Show AllocationRequestView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AllocationRequest AllocationRequestView
+> **instance** HasFromAnyView AllocationRequest AllocationRequestView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AllocationRequest AllocationRequestView
+> **instance** HasInterfaceView AllocationRequest AllocationRequestView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationRequestView Metadata
+> **instance** GetField "meta" AllocationRequestView Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlement" AllocationRequestView SettlementInfo
+> **instance** GetField "settlement" AllocationRequestView SettlementInfo
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLegs" AllocationRequestView ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) TransferLeg)
+> **instance** GetField "transferLegs" AllocationRequestView (TextMap TransferLeg)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationRequestView Metadata
+> **instance** SetField "meta" AllocationRequestView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlement" AllocationRequestView SettlementInfo
+> **instance** SetField "settlement" AllocationRequestView SettlementInfo
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLegs" AllocationRequestView ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) TransferLeg)
+> **instance** SetField "transferLegs" AllocationRequestView (TextMap TransferLeg)
 
 ## Functions
 
 <div id="function-splice-api-token-allocationrequestv1-allocationrequestrejectimpl-48931">
 
 allocationRequest_RejectImpl
-: AllocationRequest -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+: AllocationRequest -\> ContractId AllocationRequest -\> AllocationRequest_Reject -\> Update ChoiceExecutionMetadata
 
 </div>
 
 <div id="function-splice-api-token-allocationrequestv1-allocationrequestwithdrawimpl-31866">
 
 allocationRequest_WithdrawImpl
-: AllocationRequest -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AllocationRequest -\> AllocationRequest_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) ChoiceExecutionMetadata
+: AllocationRequest -\> ContractId AllocationRequest -\> AllocationRequest_Withdraw -\> Update ChoiceExecutionMetadata
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1.mdx
@@ -79,11 +79,11 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 >   (no fields)
 >
-> - **Method allocation_cancelImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_CancelResult
+> - **Method allocation_cancelImpl :** ContractId Allocation -\> Allocation_Cancel -\> Update Allocation_CancelResult
 >
-> - **Method allocation_executeTransferImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult
+> - **Method allocation_executeTransferImpl :** ContractId Allocation -\> Allocation_ExecuteTransfer -\> Update Allocation_ExecuteTransferResult
 >
-> - **Method allocation_withdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_WithdrawResult
+> - **Method allocation_withdrawImpl :** ContractId Allocation -\> Allocation_Withdraw -\> Update Allocation_WithdrawResult
 
 ## Data Types
 
@@ -106,28 +106,28 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 > > | Field         | Type                                                                             | Description                                                        |
 > > |---------------|----------------------------------------------------------------------------------|--------------------------------------------------------------------|
 > > | settlement    | SettlementInfo                                                                   | The settlement for whose execution the assets are being allocated. |
-> > | transferLegId | [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | A unique identifer for the transfer leg within the settlement.     |
+> > | transferLegId | Text | A unique identifer for the transfer leg within the settlement.     |
 > > | transferLeg   | TransferLeg                                                                      | The transfer for which the assets are being allocated.             |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationSpecification
+> **instance** Eq AllocationSpecification
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationSpecification
+> **instance** Show AllocationSpecification
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocation" AllocationView AllocationSpecification
+> **instance** GetField "allocation" AllocationView AllocationSpecification
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlement" AllocationSpecification SettlementInfo
+> **instance** GetField "settlement" AllocationSpecification SettlementInfo
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLeg" AllocationSpecification TransferLeg
+> **instance** GetField "transferLeg" AllocationSpecification TransferLeg
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLegId" AllocationSpecification [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** GetField "transferLegId" AllocationSpecification Text
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocation" AllocationView AllocationSpecification
+> **instance** SetField "allocation" AllocationView AllocationSpecification
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlement" AllocationSpecification SettlementInfo
+> **instance** SetField "settlement" AllocationSpecification SettlementInfo
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLeg" AllocationSpecification TransferLeg
+> **instance** SetField "transferLeg" AllocationSpecification TransferLeg
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLegId" AllocationSpecification [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** SetField "transferLegId" AllocationSpecification Text
 
 <div id="type-splice-api-token-allocationv1-allocationview-9103">
 
@@ -146,28 +146,28 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 > > | Field       | Type                                                                                                          | Description                                                                                                                                                                                              |
 > > |-------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 > > | allocation  | AllocationSpecification                                                                                       | The settlement for whose execution the assets are being allocated.                                                                                                                                       |
-> > | holdingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that are backing this allocation. Provided so that that wallets can correlate the allocation with the holdings. MAY be empty for registries that do not represent their holdings on-ledger. |
+> > | holdingCids | \[ContractId Holding\] | The holdings that are backing this allocation. Provided so that that wallets can correlate the allocation with the holdings. MAY be empty for registries that do not represent their holdings on-ledger. |
 > > | meta        | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility.                                                                                                                                  |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AllocationView
+> **instance** Eq AllocationView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AllocationView
+> **instance** Show AllocationView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) Allocation AllocationView
+> **instance** HasFromAnyView Allocation AllocationView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) Allocation AllocationView
+> **instance** HasInterfaceView Allocation AllocationView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocation" AllocationView AllocationSpecification
+> **instance** GetField "allocation" AllocationView AllocationSpecification
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "holdingCids" AllocationView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** GetField "holdingCids" AllocationView \[ContractId Holding\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" AllocationView Metadata
+> **instance** GetField "meta" AllocationView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocation" AllocationView AllocationSpecification
+> **instance** SetField "allocation" AllocationView AllocationSpecification
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "holdingCids" AllocationView \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** SetField "holdingCids" AllocationView \[ContractId Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" AllocationView Metadata
+> **instance** SetField "meta" AllocationView Metadata
 
 <div id="type-splice-api-token-allocationv1-allocationcancelresult-26037">
 
@@ -185,30 +185,30 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field             | Type                                                                                                          | Description                                                             |
 > > |-------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-> > | senderHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were released back to the sender.                     |
+> > | senderHoldingCids | \[ContractId Holding\] | The holdings that were released back to the sender.                     |
 > > | meta              | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Allocation_CancelResult
+> **instance** Eq Allocation_CancelResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Allocation_CancelResult
+> **instance** Show Allocation_CancelResult
 >
-> **instance** HasMethod Allocation "allocation_cancelImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_CancelResult)
+> **instance** HasMethod Allocation "allocation_cancelImpl" (ContractId Allocation -\> Allocation_Cancel -\> Update Allocation_CancelResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Allocation_CancelResult Metadata
+> **instance** GetField "meta" Allocation_CancelResult Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_CancelResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** GetField "senderHoldingCids" Allocation_CancelResult \[ContractId Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Allocation_CancelResult Metadata
+> **instance** SetField "meta" Allocation_CancelResult Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_CancelResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** SetField "senderHoldingCids" Allocation_CancelResult \[ContractId Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_Cancel Allocation_CancelResult
+> **instance** HasExercise Allocation Allocation_Cancel Allocation_CancelResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_Cancel Allocation_CancelResult
+> **instance** HasExerciseGuarded Allocation Allocation_Cancel Allocation_CancelResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_Cancel Allocation_CancelResult
+> **instance** HasFromAnyChoice Allocation Allocation_Cancel Allocation_CancelResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_Cancel Allocation_CancelResult
+> **instance** HasToAnyChoice Allocation Allocation_Cancel Allocation_CancelResult
 
 <div id="type-splice-api-token-allocationv1-allocationexecutetransferresult-74160">
 
@@ -226,35 +226,35 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field               | Type                                                                                                          | Description                                                                                              |
 > > |---------------------|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
-> > | senderHoldingCids   | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were created for the sender. Can be used to return "change" to the sender if required. |
-> > | receiverHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were created for the receiver.                                                         |
+> > | senderHoldingCids   | \[ContractId Holding\] | The holdings that were created for the sender. Can be used to return "change" to the sender if required. |
+> > | receiverHoldingCids | \[ContractId Holding\] | The holdings that were created for the receiver.                                                         |
 > > | meta                | Metadata                                                                                                      | Additional metadata specific to the transfer instruction, used for extensibility.                        |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Allocation_ExecuteTransferResult
+> **instance** Eq Allocation_ExecuteTransferResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Allocation_ExecuteTransferResult
+> **instance** Show Allocation_ExecuteTransferResult
 >
-> **instance** HasMethod Allocation "allocation_executeTransferImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult)
+> **instance** HasMethod Allocation "allocation_executeTransferImpl" (ContractId Allocation -\> Allocation_ExecuteTransfer -\> Update Allocation_ExecuteTransferResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Allocation_ExecuteTransferResult Metadata
+> **instance** GetField "meta" Allocation_ExecuteTransferResult Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiverHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** GetField "receiverHoldingCids" Allocation_ExecuteTransferResult \[ContractId Holding\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** GetField "senderHoldingCids" Allocation_ExecuteTransferResult \[ContractId Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Allocation_ExecuteTransferResult Metadata
+> **instance** SetField "meta" Allocation_ExecuteTransferResult Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiverHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** SetField "receiverHoldingCids" Allocation_ExecuteTransferResult \[ContractId Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_ExecuteTransferResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** SetField "senderHoldingCids" Allocation_ExecuteTransferResult \[ContractId Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+> **instance** HasExercise Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+> **instance** HasExerciseGuarded Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+> **instance** HasFromAnyChoice Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
+> **instance** HasToAnyChoice Allocation Allocation_ExecuteTransfer Allocation_ExecuteTransferResult
 
 <div id="type-splice-api-token-allocationv1-allocationwithdrawresult-40879">
 
@@ -272,30 +272,30 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field             | Type                                                                                                          | Description                                                             |
 > > |-------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-> > | senderHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that were released back to the sender.                     |
+> > | senderHoldingCids | \[ContractId Holding\] | The holdings that were released back to the sender.                     |
 > > | meta              | Metadata                                                                                                      | Additional metadata specific to the allocation, used for extensibility. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Allocation_WithdrawResult
+> **instance** Eq Allocation_WithdrawResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Allocation_WithdrawResult
+> **instance** Show Allocation_WithdrawResult
 >
-> **instance** HasMethod Allocation "allocation_withdrawImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_WithdrawResult)
+> **instance** HasMethod Allocation "allocation_withdrawImpl" (ContractId Allocation -\> Allocation_Withdraw -\> Update Allocation_WithdrawResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Allocation_WithdrawResult Metadata
+> **instance** GetField "meta" Allocation_WithdrawResult Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderHoldingCids" Allocation_WithdrawResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** GetField "senderHoldingCids" Allocation_WithdrawResult \[ContractId Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Allocation_WithdrawResult Metadata
+> **instance** SetField "meta" Allocation_WithdrawResult Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderHoldingCids" Allocation_WithdrawResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** SetField "senderHoldingCids" Allocation_WithdrawResult \[ContractId Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) Allocation Allocation_Withdraw Allocation_WithdrawResult
+> **instance** HasExercise Allocation Allocation_Withdraw Allocation_WithdrawResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) Allocation Allocation_Withdraw Allocation_WithdrawResult
+> **instance** HasExerciseGuarded Allocation Allocation_Withdraw Allocation_WithdrawResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) Allocation Allocation_Withdraw Allocation_WithdrawResult
+> **instance** HasFromAnyChoice Allocation Allocation_Withdraw Allocation_WithdrawResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) Allocation Allocation_Withdraw Allocation_WithdrawResult
+> **instance** HasToAnyChoice Allocation Allocation_Withdraw Allocation_WithdrawResult
 
 <div id="type-splice-api-token-allocationv1-reference-53456">
 
@@ -313,24 +313,24 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field | Type                                                                                                             | Description                                                                                                                                                                                                                                                                |
 > > |-------|------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | id    | [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)                                 | The key that identifies the data. Can be set to the empty string if the contract-id is provided and is sufficient.                                                                                                                                                         |
-> > | cid   | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) AnyContractId | Optional contract-id to use for referring to contracts. This field is there for technical reasons, as contract-ids cannot be converted to text from within Daml, which is due to their full textual representation being only known after transactions have been prepared. |
+> > | id    | Text                                 | The key that identifies the data. Can be set to the empty string if the contract-id is provided and is sufficient.                                                                                                                                                         |
+> > | cid   | Optional AnyContractId | Optional contract-id to use for referring to contracts. This field is there for technical reasons, as contract-ids cannot be converted to text from within Daml, which is due to their full textual representation being only known after transactions have been prepared. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Reference
+> **instance** Eq Reference
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Reference
+> **instance** Show Reference
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "cid" Reference ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) AnyContractId)
+> **instance** GetField "cid" Reference (Optional AnyContractId)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "id" Reference [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** GetField "id" Reference Text
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlementRef" SettlementInfo Reference
+> **instance** GetField "settlementRef" SettlementInfo Reference
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "cid" Reference ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) AnyContractId)
+> **instance** SetField "cid" Reference (Optional AnyContractId)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "id" Reference [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** SetField "id" Reference Text
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlementRef" SettlementInfo Reference
+> **instance** SetField "settlementRef" SettlementInfo Reference
 
 <div id="type-splice-api-token-allocationv1-settlementinfo-4367">
 
@@ -348,44 +348,44 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field          | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                      |
 > > |----------------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | executor       | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party that is responsible for executing the settlement.                                                                                                                                                                                                                                                                                      |
+> > | executor       | Party | The party that is responsible for executing the settlement.                                                                                                                                                                                                                                                                                      |
 > > | settlementRef  | Reference                                                                               | Reference to the settlement that app would like to execute.                                                                                                                                                                                                                                                                                      |
-> > | requestedAt    | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)   | When the settlement was requested. Provided for display and debugging purposes, but SHOULD be in the past.                                                                                                                                                                                                                                       |
-> > | allocateBefore | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)   | Until when (exclusive) the senders are given time to allocate their assets. This field has a particular relevance with respect to instrument versioning / corporate actions, in that the settlement pertains to the instrument version resulting from the processing of all corporate actions falling strictly before the `allocateBefore` time. |
-> > | settleBefore   | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)   | Until when (exclusive) the executor is given time to execute the settlement. SHOULD be strictly after `allocateBefore`.                                                                                                                                                                                                                          |
+> > | requestedAt    | Time   | When the settlement was requested. Provided for display and debugging purposes, but SHOULD be in the past.                                                                                                                                                                                                                                       |
+> > | allocateBefore | Time   | Until when (exclusive) the senders are given time to allocate their assets. This field has a particular relevance with respect to instrument versioning / corporate actions, in that the settlement pertains to the instrument version resulting from the processing of all corporate actions falling strictly before the `allocateBefore` time. |
+> > | settleBefore   | Time   | Until when (exclusive) the executor is given time to execute the settlement. SHOULD be strictly after `allocateBefore`.                                                                                                                                                                                                                          |
 > > | meta           | Metadata                                                                                | Additional metadata about the settlement, used for extensibility.                                                                                                                                                                                                                                                                                |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) SettlementInfo
+> **instance** Eq SettlementInfo
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) SettlementInfo
+> **instance** Show SettlementInfo
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "allocateBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** GetField "allocateBefore" SettlementInfo Time
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "executor" SettlementInfo [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "executor" SettlementInfo Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" SettlementInfo Metadata
+> **instance** GetField "meta" SettlementInfo Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "requestedAt" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** GetField "requestedAt" SettlementInfo Time
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settleBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** GetField "settleBefore" SettlementInfo Time
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlement" AllocationSpecification SettlementInfo
+> **instance** GetField "settlement" AllocationSpecification SettlementInfo
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "settlementRef" SettlementInfo Reference
+> **instance** GetField "settlementRef" SettlementInfo Reference
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "allocateBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** SetField "allocateBefore" SettlementInfo Time
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "executor" SettlementInfo [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "executor" SettlementInfo Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" SettlementInfo Metadata
+> **instance** SetField "meta" SettlementInfo Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "requestedAt" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** SetField "requestedAt" SettlementInfo Time
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settleBefore" SettlementInfo [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** SetField "settleBefore" SettlementInfo Time
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlement" AllocationSpecification SettlementInfo
+> **instance** SetField "settlement" AllocationSpecification SettlementInfo
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "settlementRef" SettlementInfo Reference
+> **instance** SetField "settlementRef" SettlementInfo Reference
 
 <div id="type-splice-api-token-allocationv1-transferleg-71662">
 
@@ -403,48 +403,48 @@ Contracts implementing the `Allocation` interface represent a reservation of ass
 >
 > > | Field        | Type                                                                                    | Description                                                         |
 > > |--------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------|
-> > | sender       | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The sender of the transfer.                                         |
-> > | receiver     | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The receiver of the transfer.                                       |
-> > | amount       | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | The amount to transfer.                                             |
+> > | sender       | Party | The sender of the transfer.                                         |
+> > | receiver     | Party | The receiver of the transfer.                                       |
+> > | amount       | Decimal  | The amount to transfer.                                             |
 > > | instrumentId | InstrumentId                                                                            | The instrument identifier.                                          |
 > > | meta         | Metadata                                                                                | Additional metadata about the transfer leg, used for extensibility. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferLeg
+> **instance** Eq TransferLeg
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) TransferLeg
+> **instance** Ord TransferLeg
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferLeg
+> **instance** Show TransferLeg
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" TransferLeg [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** GetField "amount" TransferLeg Decimal
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" TransferLeg InstrumentId
+> **instance** GetField "instrumentId" TransferLeg InstrumentId
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferLeg Metadata
+> **instance** GetField "meta" TransferLeg Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiver" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "receiver" TransferLeg Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "sender" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "sender" TransferLeg Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferLeg" AllocationSpecification TransferLeg
+> **instance** GetField "transferLeg" AllocationSpecification TransferLeg
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" TransferLeg [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** SetField "amount" TransferLeg Decimal
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" TransferLeg InstrumentId
+> **instance** SetField "instrumentId" TransferLeg InstrumentId
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferLeg Metadata
+> **instance** SetField "meta" TransferLeg Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiver" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "receiver" TransferLeg Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "sender" TransferLeg [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "sender" TransferLeg Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferLeg" AllocationSpecification TransferLeg
+> **instance** SetField "transferLeg" AllocationSpecification TransferLeg
 
 ## Functions
 
 <div id="function-splice-api-token-allocationv1-allocationcontrollers-10222">
 
 allocationControllers
-: AllocationView -\> \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]
+: AllocationView -\> \[Party\]
 
 Convenience function to refer to the union of sender, receiver, and executor of the settlement, which jointly control the execution of the allocation.
 
@@ -453,21 +453,21 @@ Convenience function to refer to the union of sender, receiver, and executor of 
 <div id="function-splice-api-token-allocationv1-allocationexecutetransferimpl-90251">
 
 allocation_executeTransferImpl
-: Allocation -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_ExecuteTransfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_ExecuteTransferResult
+: Allocation -\> ContractId Allocation -\> Allocation_ExecuteTransfer -\> Update Allocation_ExecuteTransferResult
 
 </div>
 
 <div id="function-splice-api-token-allocationv1-allocationcancelimpl-12334">
 
 allocation_cancelImpl
-: Allocation -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Cancel -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_CancelResult
+: Allocation -\> ContractId Allocation -\> Allocation_Cancel -\> Update Allocation_CancelResult
 
 </div>
 
 <div id="function-splice-api-token-allocationv1-allocationwithdrawimpl-40108">
 
 allocation_withdrawImpl
-: Allocation -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Allocation -\> Allocation_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) Allocation_WithdrawResult
+: Allocation -\> ContractId Allocation -\> Allocation_Withdraw -\> Update Allocation_WithdrawResult
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1.mdx
@@ -45,11 +45,11 @@ An interface for registries to expose burn/mint operations in a generic way for 
 >
 >   | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 >   |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin    | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The expected `admin` party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | expectedAdmin    | Party                       | The expected `admin` party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
 >   | instrumentId     | InstrumentId                                                                                                  | The instrument id of the holdings. All holdings in `inputHoldingCids` as well as the resulting output holdings MUST have this instrument id.                                                                                                                                                                                                                                                                                                                                      |
->   | inputHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings that should be burnt. All holdings in `inputHoldingCids` MUST be archived by this choice. Implementations MAY enforce additional restrictions such as all `inputHoldingCids` belonging to the same owner.                                                                                                                                                                                                                                                            |
+>   | inputHoldingCids | \[ContractId Holding\] | The holdings that should be burnt. All holdings in `inputHoldingCids` MUST be archived by this choice. Implementations MAY enforce additional restrictions such as all `inputHoldingCids` belonging to the same owner.                                                                                                                                                                                                                                                            |
 >   | outputs          | \[BurnMintOutput\]                                                                                            | The holdings that should be created. The choice MUST create new holdings with the given amounts.                                                                                                                                                                                                                                                                                                                                                                                  |
->   | extraActors      | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                   | Extra actors, the full actors required are the admin + extraActors. This is often the owners of inputHoldingCids and outputs but we allow different sets of actors to support token implementations with different authorization setups.                                                                                                                                                                                                                                          |
+>   | extraActors      | \[Party\]                   | Extra actors, the full actors required are the admin + extraActors. This is often the owners of inputHoldingCids and outputs but we allow different sets of actors to support token implementations with different authorization setups.                                                                                                                                                                                                                                          |
 >   | extraArgs        | ExtraArgs                                                                                                     | Additional context. Implementations SHOULD include a `splice.lfdecentralizedtrust.org/reason` key in the metadata to provide a human readable description for explain why the `BurnMintFactory_BurnMint` choice was called, so that generic wallets can display it to the user.                                                                                                                                                                                                   |
 >
 > - <div id="type-splice-api-token-burnmintv1-burnmintfactorypublicfetch-64185">
@@ -64,12 +64,12 @@ An interface for registries to expose burn/mint operations in a generic way for 
 >
 >   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 >   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
->   | actor         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party fetching the data.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+>   | expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers should ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | actor         | Party | The party fetching the data.                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 >
-> - **Method burnMintFactory_burnMintImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult
+> - **Method burnMintFactory_burnMintImpl :** ContractId BurnMintFactory -\> BurnMintFactory_BurnMint -\> Update BurnMintFactory_BurnMintResult
 >
-> - **Method burnMintFactory_publicFetchImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactoryView
+> - **Method burnMintFactory_publicFetchImpl :** ContractId BurnMintFactory -\> BurnMintFactory_PublicFetch -\> Update BurnMintFactoryView
 
 ## Data Types
 
@@ -89,34 +89,34 @@ An interface for registries to expose burn/mint operations in a generic way for 
 >
 > > | Field | Type                                                                                    | Description                                                                                                             |
 > > |-------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
-> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this burnt-mint factory can be used. |
+> > | admin | Party | The party representing the registry app that administers the instruments for which this burnt-mint factory can be used. |
 > > | meta  | Metadata                                                                                | Additional metadata specific to the burn-mint factory, used for extensibility.                                          |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) BurnMintFactoryView
+> **instance** Eq BurnMintFactoryView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) BurnMintFactoryView
+> **instance** Show BurnMintFactoryView
 >
-> **instance** HasMethod BurnMintFactory "burnMintFactory_publicFetchImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactoryView)
+> **instance** HasMethod BurnMintFactory "burnMintFactory_publicFetchImpl" (ContractId BurnMintFactory -\> BurnMintFactory_PublicFetch -\> Update BurnMintFactoryView)
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) BurnMintFactory BurnMintFactoryView
+> **instance** HasFromAnyView BurnMintFactory BurnMintFactoryView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) BurnMintFactory BurnMintFactoryView
+> **instance** HasInterfaceView BurnMintFactory BurnMintFactoryView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" BurnMintFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "admin" BurnMintFactoryView Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" BurnMintFactoryView Metadata
+> **instance** GetField "meta" BurnMintFactoryView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" BurnMintFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "admin" BurnMintFactoryView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" BurnMintFactoryView Metadata
+> **instance** SetField "meta" BurnMintFactoryView Metadata
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+> **instance** HasExercise BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+> **instance** HasExerciseGuarded BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+> **instance** HasFromAnyChoice BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
+> **instance** HasToAnyChoice BurnMintFactory BurnMintFactory_PublicFetch BurnMintFactoryView
 
 <div id="type-splice-api-token-burnmintv1-burnmintfactoryburnmintresult-61365">
 
@@ -134,25 +134,25 @@ An interface for registries to expose burn/mint operations in a generic way for 
 >
 > > | Field      | Type                                                                                                          | Description                                                                                                              |
 > > |------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-> > | outputCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holdings created by the choice. Must contain exactly the outputs specified in the choice argument in the same order. |
+> > | outputCids | \[ContractId Holding\] | The holdings created by the choice. Must contain exactly the outputs specified in the choice argument in the same order. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) BurnMintFactory_BurnMintResult
+> **instance** Eq BurnMintFactory_BurnMintResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) BurnMintFactory_BurnMintResult
+> **instance** Show BurnMintFactory_BurnMintResult
 >
-> **instance** HasMethod BurnMintFactory "burnMintFactory_burnMintImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult)
+> **instance** HasMethod BurnMintFactory "burnMintFactory_burnMintImpl" (ContractId BurnMintFactory -\> BurnMintFactory_BurnMint -\> Update BurnMintFactory_BurnMintResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "outputCids" BurnMintFactory_BurnMintResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** GetField "outputCids" BurnMintFactory_BurnMintResult \[ContractId Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "outputCids" BurnMintFactory_BurnMintResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** SetField "outputCids" BurnMintFactory_BurnMintResult \[ContractId Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+> **instance** HasExercise BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+> **instance** HasExerciseGuarded BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+> **instance** HasFromAnyChoice BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
+> **instance** HasToAnyChoice BurnMintFactory BurnMintFactory_BurnMint BurnMintFactory_BurnMintResult
 
 <div id="type-splice-api-token-burnmintv1-burnmintoutput-36483">
 
@@ -170,43 +170,43 @@ An interface for registries to expose burn/mint operations in a generic way for 
 >
 > > | Field   | Type                                                                                    | Description                                                                                               |
 > > |---------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
-> > | owner   | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The owner of the holding to create.                                                                       |
-> > | amount  | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)  | The amount of the holding to create.                                                                      |
+> > | owner   | Party | The owner of the holding to create.                                                                       |
+> > | amount  | Decimal  | The amount of the holding to create.                                                                      |
 > > | context | ChoiceContext                                                                           | Context specific to this output which can be used to support locking or other registry-specific features. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) BurnMintOutput
+> **instance** Eq BurnMintOutput
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) BurnMintOutput
+> **instance** Show BurnMintOutput
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" BurnMintOutput [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** GetField "amount" BurnMintOutput Decimal
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" BurnMintOutput ChoiceContext
+> **instance** GetField "context" BurnMintOutput ChoiceContext
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
+> **instance** GetField "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "owner" BurnMintOutput [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "owner" BurnMintOutput Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" BurnMintOutput [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** SetField "amount" BurnMintOutput Decimal
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" BurnMintOutput ChoiceContext
+> **instance** SetField "context" BurnMintOutput ChoiceContext
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
+> **instance** SetField "outputs" BurnMintFactory_BurnMint \[BurnMintOutput\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "owner" BurnMintOutput [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "owner" BurnMintOutput Party
 
 ## Functions
 
 <div id="function-splice-api-token-burnmintv1-burnmintfactoryburnmintimpl-9738">
 
 burnMintFactory_burnMintImpl
-: BurnMintFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_BurnMint -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactory_BurnMintResult
+: BurnMintFactory -\> ContractId BurnMintFactory -\> BurnMintFactory_BurnMint -\> Update BurnMintFactory_BurnMintResult
 
 </div>
 
 <div id="function-splice-api-token-burnmintv1-burnmintfactorypublicfetchimpl-75623">
 
 burnMintFactory_publicFetchImpl
-: BurnMintFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) BurnMintFactory -\> BurnMintFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) BurnMintFactoryView
+: BurnMintFactory -\> ContractId BurnMintFactory -\> BurnMintFactory_PublicFetch -\> Update BurnMintFactoryView
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1.mdx
@@ -45,39 +45,39 @@ Types and interfaces for retrieving an investor's holdings.
 >
 > > | Field        | Type                                                                                                    | Description                                                                                                                                  |
 > > |--------------|---------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-> > | owner        | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                 | Owner of the holding.                                                                                                                        |
+> > | owner        | Party                 | Owner of the holding.                                                                                                                        |
 > > | instrumentId | InstrumentId                                                                                            | Instrument being held.                                                                                                                       |
-> > | amount       | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)                  | Size of the holding.                                                                                                                         |
-> > | lock         | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock | Lock on the holding. Registries SHOULD allow holdings with expired locks as inputs to transfers to enable a combined unlocking + use choice. |
+> > | amount       | Decimal                  | Size of the holding.                                                                                                                         |
+> > | lock         | Optional Lock | Lock on the holding. Registries SHOULD allow holdings with expired locks as inputs to transfers to enable a combined unlocking + use choice. |
 > > | meta         | Metadata                                                                                                | Metadata.                                                                                                                                    |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) HoldingView
+> **instance** Eq HoldingView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) HoldingView
+> **instance** Show HoldingView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) Holding HoldingView
+> **instance** HasFromAnyView Holding HoldingView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) Holding HoldingView
+> **instance** HasInterfaceView Holding HoldingView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" HoldingView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** GetField "amount" HoldingView Decimal
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" HoldingView InstrumentId
+> **instance** GetField "instrumentId" HoldingView InstrumentId
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+> **instance** GetField "lock" HoldingView (Optional Lock)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" HoldingView Metadata
+> **instance** GetField "meta" HoldingView Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "owner" HoldingView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "owner" HoldingView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" HoldingView [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** SetField "amount" HoldingView Decimal
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" HoldingView InstrumentId
+> **instance** SetField "instrumentId" HoldingView InstrumentId
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+> **instance** SetField "lock" HoldingView (Optional Lock)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" HoldingView Metadata
+> **instance** SetField "meta" HoldingView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "owner" HoldingView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "owner" HoldingView Party
 
 <div id="type-splice-api-token-holdingv1-instrumentid-28218">
 
@@ -95,26 +95,26 @@ Types and interfaces for retrieving an investor's holdings.
 >
 > > | Field | Type                                                                                    | Description                                                                                                                          |
 > > |-------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instrument.                                                             |
-> > | id    | [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)        | The identifier used for the instrument by the instrument admin. This identifier MUST be unique and unambiguous per instrument admin. |
+> > | admin | Party | The party representing the registry app that administers the instrument.                                                             |
+> > | id    | Text        | The identifier used for the instrument by the instrument admin. This identifier MUST be unique and unambiguous per instrument admin. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) InstrumentId
+> **instance** Eq InstrumentId
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) InstrumentId
+> **instance** Ord InstrumentId
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) InstrumentId
+> **instance** Show InstrumentId
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" InstrumentId [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "admin" InstrumentId Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "id" InstrumentId [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** GetField "id" InstrumentId Text
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" HoldingView InstrumentId
+> **instance** GetField "instrumentId" HoldingView InstrumentId
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" InstrumentId [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "admin" InstrumentId Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "id" InstrumentId [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> **instance** SetField "id" InstrumentId Text
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" HoldingView InstrumentId
+> **instance** SetField "instrumentId" HoldingView InstrumentId
 
 <div id="type-splice-api-token-holdingv1-lock-70295">
 
@@ -132,35 +132,35 @@ Types and interfaces for retrieving an investor's holdings.
 >
 > > | Field        | Type                                                                                                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                          |
 > > |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | holders      | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]                                                                                                   | Unique list of parties which are locking the contract. (Represented as a list, as that has the better JSON encoding.)                                                                                                                                                                                                                                |
-> > | expiresAt    | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)      | Absolute, inclusive deadline as of which the lock expires.                                                                                                                                                                                                                                                                                           |
-> > | expiresAfter | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082) | Duration after which the created lock expires. Measured relative to the ledger time that the locked holding contract was created. If both `expiresAt` and `expiresAfter` are set, the lock expires at the earlier of the two times.                                                                                                                  |
-> > | context      | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)           | Short, human-readable description of the context of the lock. Used by wallets to enable users to understand the reason for the lock. Note that the visibility of the content in this field might be wider than the visibility of the contracts in the context. You should thus carefully decide what information is safe to put in the lock context. |
+> > | holders      | \[Party\]                                                                                                   | Unique list of parties which are locking the contract. (Represented as a list, as that has the better JSON encoding.)                                                                                                                                                                                                                                |
+> > | expiresAt    | Optional Time      | Absolute, inclusive deadline as of which the lock expires.                                                                                                                                                                                                                                                                                           |
+> > | expiresAfter | Optional RelTime | Duration after which the created lock expires. Measured relative to the ledger time that the locked holding contract was created. If both `expiresAt` and `expiresAfter` are set, the lock expires at the earlier of the two times.                                                                                                                  |
+> > | context      | Optional Text           | Short, human-readable description of the context of the lock. Used by wallets to enable users to understand the reason for the lock. Note that the visibility of the content in this field might be wider than the visibility of the contracts in the context. You should thus carefully decide what information is safe to put in the lock context. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Lock
+> **instance** Eq Lock
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) Lock
+> **instance** Ord Lock
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Lock
+> **instance** Show Lock
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** GetField "context" Lock (Optional Text)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "expiresAfter" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082))
+> **instance** GetField "expiresAfter" Lock (Optional RelTime)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "expiresAt" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886))
+> **instance** GetField "expiresAt" Lock (Optional Time)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "holders" Lock \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]
+> **instance** GetField "holders" Lock \[Party\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+> **instance** GetField "lock" HoldingView (Optional Lock)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** SetField "context" Lock (Optional Text)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "expiresAfter" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082))
+> **instance** SetField "expiresAfter" Lock (Optional RelTime)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "expiresAt" Lock ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886))
+> **instance** SetField "expiresAt" Lock (Optional Time)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "holders" Lock \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\]
+> **instance** SetField "holders" Lock \[Party\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "lock" HoldingView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) Lock)
+> **instance** SetField "lock" HoldingView (Optional Lock)
 
 {/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1.mdx
@@ -32,7 +32,7 @@ Types and interfaces for retrieving metadata about tokens.
 <div id="type-splice-api-token-metadatav1-anycontractid-4875">
 
 **type** AnyContractId
-= [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) AnyContract
+= ContractId AnyContract
 
 A reference to some contract id. Use `coerceContractId` to convert from and to this type.
 
@@ -54,9 +54,9 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 >
 > > (no fields)
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) AnyContract AnyContractView
+> **instance** HasFromAnyView AnyContract AnyContractView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) AnyContract AnyContractView
+> **instance** HasInterfaceView AnyContract AnyContractView
 
 <div id="type-splice-api-token-metadatav1-anyvalue-34700">
 
@@ -70,49 +70,49 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 >
 > <div id="constr-splice-api-token-metadatav1-avtext-20580">
 >
-> AV_Text [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952)
+> AV_Text Text
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avint-52425">
 >
-> AV_Int [Int](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-int-37261)
+> AV_Int Int
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avdecimal-71267">
 >
-> AV_Decimal [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> AV_Decimal Decimal
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avbool-76457">
 >
-> AV_Bool [Bool](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-bool-66265)
+> AV_Bool Bool
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avdate-46205">
 >
-> AV_Date [Date](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-date-32253)
+> AV_Date Date
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avtime-30398">
 >
-> AV_Time [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> AV_Time Time
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avreltime-31008">
 >
-> AV_RelTime [RelTime](https://docs.daml.com/daml/stdlib/DA-Time.html#type-da-time-types-reltime-23082)
+> AV_RelTime RelTime
 >
 > </div>
 >
 > <div id="constr-splice-api-token-metadatav1-avparty-78344">
 >
-> AV_Party [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> AV_Party Party
 >
 > </div>
 >
@@ -130,17 +130,17 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 >
 > <div id="constr-splice-api-token-metadatav1-avmap-39932">
 >
-> AV_Map ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+> AV_Map (TextMap AnyValue)
 >
 > </div>
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) AnyValue
+> **instance** Eq AnyValue
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) AnyValue
+> **instance** Show AnyValue
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+> **instance** GetField "values" ChoiceContext (TextMap AnyValue)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+> **instance** SetField "values" ChoiceContext (TextMap AnyValue)
 
 <div id="type-splice-api-token-metadatav1-choicecontext-5566">
 
@@ -158,19 +158,19 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 >
 > > | Field  | Type                                                                                                 | Description                                                                                                                                    |
 > > |--------|------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | values | [TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue | The values passed in by the app backend to the choice. The keys are considered internal to the app and should not be read by third-party code. |
+> > | values | TextMap AnyValue | The values passed in by the app backend to the choice. The keys are considered internal to the app and should not be read by third-party code. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) ChoiceContext
+> **instance** Eq ChoiceContext
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) ChoiceContext
+> **instance** Show ChoiceContext
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" ExtraArgs ChoiceContext
+> **instance** GetField "context" ExtraArgs ChoiceContext
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+> **instance** GetField "values" ChoiceContext (TextMap AnyValue)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" ExtraArgs ChoiceContext
+> **instance** SetField "context" ExtraArgs ChoiceContext
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "values" ChoiceContext ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) AnyValue)
+> **instance** SetField "values" ChoiceContext (TextMap AnyValue)
 
 <div id="type-splice-api-token-metadatav1-choiceexecutionmetadata-98464">
 
@@ -190,13 +190,13 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 > > |-------|----------|----------------------------------------------------------------------------------------------|
 > > | meta  | Metadata | Additional metadata specific to the result of exercising the choice, used for extensibility. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) ChoiceExecutionMetadata
+> **instance** Eq ChoiceExecutionMetadata
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) ChoiceExecutionMetadata
+> **instance** Show ChoiceExecutionMetadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ChoiceExecutionMetadata Metadata
+> **instance** GetField "meta" ChoiceExecutionMetadata Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ChoiceExecutionMetadata Metadata
+> **instance** SetField "meta" ChoiceExecutionMetadata Metadata
 
 <div id="type-splice-api-token-metadatav1-extraargs-90869">
 
@@ -217,17 +217,17 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 > > | context | ChoiceContext | Extra arguments to be passed to the implementation of an interface choice. These are provided via an off-ledger API by the app implementing the interface.                                                                                                                                       |
 > > | meta    | Metadata      | Additional metadata to pass in. In contrast to the `extraArgs`, these are provided by the caller of the choice. The expectation is that the meaning of metadata fields will be agreed on in later standards, or on a case-by-case basis between the caller and the implementer of the interface. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) ExtraArgs
+> **instance** Eq ExtraArgs
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) ExtraArgs
+> **instance** Show ExtraArgs
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "context" ExtraArgs ChoiceContext
+> **instance** GetField "context" ExtraArgs ChoiceContext
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ExtraArgs Metadata
+> **instance** GetField "meta" ExtraArgs Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "context" ExtraArgs ChoiceContext
+> **instance** SetField "context" ExtraArgs ChoiceContext
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ExtraArgs Metadata
+> **instance** SetField "meta" ExtraArgs Metadata
 
 <div id="type-splice-api-token-metadatav1-metadata-21206">
 
@@ -251,25 +251,25 @@ A reference to some contract id. Use `coerceContractId` to convert from and to t
 >
 > > | Field  | Type                                                                                                                                                                         | Description                          |
 > > |--------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-> > | values | [TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | Key-value pairs of metadata entries. |
+> > | values | TextMap Text | Key-value pairs of metadata entries. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Metadata
+> **instance** Eq Metadata
 >
-> **instance** [Ord](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-ord-6395) Metadata
+> **instance** Ord Metadata
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Metadata
+> **instance** Show Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ChoiceExecutionMetadata Metadata
+> **instance** GetField "meta" ChoiceExecutionMetadata Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" ExtraArgs Metadata
+> **instance** GetField "meta" ExtraArgs Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "values" Metadata ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** GetField "values" Metadata (TextMap Text)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ChoiceExecutionMetadata Metadata
+> **instance** SetField "meta" ChoiceExecutionMetadata Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" ExtraArgs Metadata
+> **instance** SetField "meta" ExtraArgs Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "values" Metadata ([TextMap](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-textmap-11691) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** SetField "values" Metadata (TextMap Text)
 
 ## Functions
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1.mdx
@@ -41,8 +41,8 @@ Instruct transfers of holdings between parties.
 >
 >   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 >   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
->   | actor         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party fetching the contract.                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+>   | expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | actor         | Party | The party fetching the contract.                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 >
 > - <div id="type-splice-api-token-transferinstructionv1-transferfactorytransfer-25365">
 >
@@ -58,13 +58,13 @@ Instruct transfers of holdings between parties.
 >
 >   | Field         | Type                                                                                    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 >   |---------------|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
->   | expectedAdmin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
+>   | expectedAdmin | Party | The expected admin party issuing the factory. Implementations MUST validate that this matches the admin of the factory. Callers SHOULD ensure they get `expectedAdmin` from a trusted source, e.g., a read against their own participant. That way they can ensure that it is safe to exercise a choice on a factory contract acquired from an untrusted source *provided* all vetted Daml packages only contain interface implementations that check the expected admin party. |
 >   | transfer      | Transfer                                                                                | The transfer to execute.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 >   | extraArgs     | ExtraArgs                                                                               | The extra arguments to pass to the transfer implementation.                                                                                                                                                                                                                                                                                                                                                                                                                     |
 >
-> - **Method transferFactory_publicFetchImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferFactoryView
+> - **Method transferFactory_publicFetchImpl :** ContractId TransferFactory -\> TransferFactory_PublicFetch -\> Update TransferFactoryView
 >
-> - **Method transferFactory_transferImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+> - **Method transferFactory_transferImpl :** ContractId TransferFactory -\> TransferFactory_Transfer -\> Update TransferInstructionResult
 
 <div id="type-splice-api-token-transferinstructionv1-transferinstruction-69882">
 
@@ -138,7 +138,7 @@ Instruct transfers of holdings between parties.
 >
 >   | Field       | Type                                                                                        | Description                                                                                                                           |
 >   |-------------|---------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
->   | extraActors | \[[Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
+>   | extraActors | \[Party\] | Extra actors authorizing the update. Implementations MUST check that this field contains the expected actors for the specific update. |
 >   | extraArgs   | ExtraArgs                                                                                   | Additional context required in order to exercise the choice.                                                                          |
 >
 > - <div id="type-splice-api-token-transferinstructionv1-transferinstructionwithdraw-43648">
@@ -157,13 +157,13 @@ Instruct transfers of holdings between parties.
 >   |-----------|-----------|--------------------------------------------------------------|
 >   | extraArgs | ExtraArgs | Additional context required in order to exercise the choice. |
 >
-> - **Method transferInstruction_acceptImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+> - **Method transferInstruction_acceptImpl :** ContractId TransferInstruction -\> TransferInstruction_Accept -\> Update TransferInstructionResult
 >
-> - **Method transferInstruction_rejectImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+> - **Method transferInstruction_rejectImpl :** ContractId TransferInstruction -\> TransferInstruction_Reject -\> Update TransferInstructionResult
 >
-> - **Method transferInstruction_updateImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+> - **Method transferInstruction_updateImpl :** ContractId TransferInstruction -\> TransferInstruction_Update -\> Update TransferInstructionResult
 >
-> - **Method transferInstruction_withdrawImpl :** [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+> - **Method transferInstruction_withdrawImpl :** ContractId TransferInstruction -\> TransferInstruction_Withdraw -\> Update TransferInstructionResult
 
 ## Data Types
 
@@ -183,58 +183,58 @@ Instruct transfers of holdings between parties.
 >
 > > | Field            | Type                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 > > |------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | sender           | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The sender of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-> > | receiver         | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)                       | The receiver of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-> > | amount           | [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)                        | The amount to transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+> > | sender           | Party                       | The sender of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+> > | receiver         | Party                       | The receiver of the transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+> > | amount           | Decimal                        | The amount to transfer.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 > > | instrumentId     | InstrumentId                                                                                                  | The instrument identifier.                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-> > | requestedAt      | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                         | Wallet provided timestamp when the transfer was requested. MUST be in the past when instructing the transfer.                                                                                                                                                                                                                                                                                                                                                               |
-> > | executeBefore    | [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)                         | Until when (exclusive) the transfer may be executed. MUST be in the future when instructing the transfer. Registries SHOULD NOT execute the transfer instruction after this time, so that senders can retry creating a new transfer instruction after this time.                                                                                                                                                                                                            |
-> > | inputHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The holding contracts that should be used to fund the transfer. MAY be empty if the registry supports automatic selection of holdings for transfers or does not represent holdings on-ledger. If specified, then the transfer MUST archive all of these holdings, so that the execution of the transfer conflicts with any other transfers using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate transfers. |
+> > | requestedAt      | Time                         | Wallet provided timestamp when the transfer was requested. MUST be in the past when instructing the transfer.                                                                                                                                                                                                                                                                                                                                                               |
+> > | executeBefore    | Time                         | Until when (exclusive) the transfer may be executed. MUST be in the future when instructing the transfer. Registries SHOULD NOT execute the transfer instruction after this time, so that senders can retry creating a new transfer instruction after this time.                                                                                                                                                                                                            |
+> > | inputHoldingCids | \[ContractId Holding\] | The holding contracts that should be used to fund the transfer. MAY be empty if the registry supports automatic selection of holdings for transfers or does not represent holdings on-ledger. If specified, then the transfer MUST archive all of these holdings, so that the execution of the transfer conflicts with any other transfers using these holdings. Thereby allowing that the sender can use deliberate contention on holdings to prevent duplicate transfers. |
 > > | meta             | Metadata                                                                                                      | Metadata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) Transfer
+> **instance** Eq Transfer
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) Transfer
+> **instance** Show Transfer
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "amount" Transfer [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** GetField "amount" Transfer Decimal
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "executeBefore" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** GetField "executeBefore" Transfer Time
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "inputHoldingCids" Transfer \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** GetField "inputHoldingCids" Transfer \[ContractId Holding\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "instrumentId" Transfer InstrumentId
+> **instance** GetField "instrumentId" Transfer InstrumentId
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" Transfer Metadata
+> **instance** GetField "meta" Transfer Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiver" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "receiver" Transfer Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "requestedAt" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** GetField "requestedAt" Transfer Time
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "sender" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "sender" Transfer Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transfer" TransferFactory_Transfer Transfer
+> **instance** GetField "transfer" TransferFactory_Transfer Transfer
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transfer" TransferInstructionView Transfer
+> **instance** GetField "transfer" TransferInstructionView Transfer
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "amount" Transfer [Decimal](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-decimal-18135)
+> **instance** SetField "amount" Transfer Decimal
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "executeBefore" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** SetField "executeBefore" Transfer Time
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "inputHoldingCids" Transfer \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** SetField "inputHoldingCids" Transfer \[ContractId Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "instrumentId" Transfer InstrumentId
+> **instance** SetField "instrumentId" Transfer InstrumentId
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" Transfer Metadata
+> **instance** SetField "meta" Transfer Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiver" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "receiver" Transfer Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "requestedAt" Transfer [Time](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-time-63886)
+> **instance** SetField "requestedAt" Transfer Time
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "sender" Transfer [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "sender" Transfer Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transfer" TransferFactory_Transfer Transfer
+> **instance** SetField "transfer" TransferFactory_Transfer Transfer
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transfer" TransferInstructionView Transfer
+> **instance** SetField "transfer" TransferInstructionView Transfer
 
 <div id="type-splice-api-token-transferinstructionv1-transferfactoryview-36679">
 
@@ -252,34 +252,34 @@ Instruct transfers of holdings between parties.
 >
 > > | Field | Type                                                                                    | Description                                                                                                           |
 > > |-------|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-> > | admin | [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) | The party representing the registry app that administers the instruments for which this transfer factory can be used. |
+> > | admin | Party | The party representing the registry app that administers the instruments for which this transfer factory can be used. |
 > > | meta  | Metadata                                                                                | Additional metadata specific to the transfer factory, used for extensibility.                                         |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferFactoryView
+> **instance** Eq TransferFactoryView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferFactoryView
+> **instance** Show TransferFactoryView
 >
-> **instance** HasMethod TransferFactory "transferFactory_publicFetchImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferFactoryView)
+> **instance** HasMethod TransferFactory "transferFactory_publicFetchImpl" (ContractId TransferFactory -\> TransferFactory_PublicFetch -\> Update TransferFactoryView)
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) TransferFactory TransferFactoryView
+> **instance** HasFromAnyView TransferFactory TransferFactoryView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) TransferFactory TransferFactoryView
+> **instance** HasInterfaceView TransferFactory TransferFactoryView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "admin" TransferFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** GetField "admin" TransferFactoryView Party
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferFactoryView Metadata
+> **instance** GetField "meta" TransferFactoryView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "admin" TransferFactoryView [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932)
+> **instance** SetField "admin" TransferFactoryView Party
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferFactoryView Metadata
+> **instance** SetField "meta" TransferFactoryView Metadata
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+> **instance** HasExercise TransferFactory TransferFactory_PublicFetch TransferFactoryView
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+> **instance** HasExerciseGuarded TransferFactory TransferFactory_PublicFetch TransferFactoryView
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+> **instance** HasFromAnyChoice TransferFactory TransferFactory_PublicFetch TransferFactoryView
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferFactory TransferFactory_PublicFetch TransferFactoryView
+> **instance** HasToAnyChoice TransferFactory TransferFactory_PublicFetch TransferFactoryView
 
 <div id="type-splice-api-token-transferinstructionv1-transferinstructionresult-24735">
 
@@ -298,74 +298,74 @@ Instruct transfers of holdings between parties.
 > > | Field            | Type                                                                                                          | Description                                                                                                                                                                    |
 > > |------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 > > | output           | TransferInstructionResult_Output                                                                              | The output of the step.                                                                                                                                                        |
-> > | senderChangeCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple transfer instructions in a single Daml transaction. |
+> > | senderChangeCids | \[ContractId Holding\] | New holdings owned by the sender created to return "change". Can be used by callers to batch creating or updating multiple transfer instructions in a single Daml transaction. |
 > > | meta             | Metadata                                                                                                      | Additional metadata specific to the transfer instruction, used for extensibility; e.g., fees charged.                                                                          |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionResult
+> **instance** Eq TransferInstructionResult
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionResult
+> **instance** Show TransferInstructionResult
 >
-> **instance** HasMethod TransferFactory "transferFactory_transferImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+> **instance** HasMethod TransferFactory "transferFactory_transferImpl" (ContractId TransferFactory -\> TransferFactory_Transfer -\> Update TransferInstructionResult)
 >
-> **instance** HasMethod TransferInstruction "transferInstruction_acceptImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+> **instance** HasMethod TransferInstruction "transferInstruction_acceptImpl" (ContractId TransferInstruction -\> TransferInstruction_Accept -\> Update TransferInstructionResult)
 >
-> **instance** HasMethod TransferInstruction "transferInstruction_rejectImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+> **instance** HasMethod TransferInstruction "transferInstruction_rejectImpl" (ContractId TransferInstruction -\> TransferInstruction_Reject -\> Update TransferInstructionResult)
 >
-> **instance** HasMethod TransferInstruction "transferInstruction_updateImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+> **instance** HasMethod TransferInstruction "transferInstruction_updateImpl" (ContractId TransferInstruction -\> TransferInstruction_Update -\> Update TransferInstructionResult)
 >
-> **instance** HasMethod TransferInstruction "transferInstruction_withdrawImpl" ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult)
+> **instance** HasMethod TransferInstruction "transferInstruction_withdrawImpl" (ContractId TransferInstruction -\> TransferInstruction_Withdraw -\> Update TransferInstructionResult)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferInstructionResult Metadata
+> **instance** GetField "meta" TransferInstructionResult Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" TransferInstructionResult TransferInstructionResult_Output
+> **instance** GetField "output" TransferInstructionResult TransferInstructionResult_Output
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "senderChangeCids" TransferInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** GetField "senderChangeCids" TransferInstructionResult \[ContractId Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferInstructionResult Metadata
+> **instance** SetField "meta" TransferInstructionResult Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" TransferInstructionResult TransferInstructionResult_Output
+> **instance** SetField "output" TransferInstructionResult TransferInstructionResult_Output
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "senderChangeCids" TransferInstructionResult \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** SetField "senderChangeCids" TransferInstructionResult \[ContractId Holding\]
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferFactory TransferFactory_Transfer TransferInstructionResult
+> **instance** HasExercise TransferFactory TransferFactory_Transfer TransferInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+> **instance** HasExercise TransferInstruction TransferInstruction_Accept TransferInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+> **instance** HasExercise TransferInstruction TransferInstruction_Reject TransferInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Update TransferInstructionResult
+> **instance** HasExercise TransferInstruction TransferInstruction_Update TransferInstructionResult
 >
-> **instance** [HasExercise](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexercise-70422) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+> **instance** HasExercise TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferFactory TransferFactory_Transfer TransferInstructionResult
+> **instance** HasExerciseGuarded TransferFactory TransferFactory_Transfer TransferInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+> **instance** HasExerciseGuarded TransferInstruction TransferInstruction_Accept TransferInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+> **instance** HasExerciseGuarded TransferInstruction TransferInstruction_Reject TransferInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Update TransferInstructionResult
+> **instance** HasExerciseGuarded TransferInstruction TransferInstruction_Update TransferInstructionResult
 >
-> **instance** [HasExerciseGuarded](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasexerciseguarded-97843) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+> **instance** HasExerciseGuarded TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferFactory TransferFactory_Transfer TransferInstructionResult
+> **instance** HasFromAnyChoice TransferFactory TransferFactory_Transfer TransferInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+> **instance** HasFromAnyChoice TransferInstruction TransferInstruction_Accept TransferInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+> **instance** HasFromAnyChoice TransferInstruction TransferInstruction_Reject TransferInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Update TransferInstructionResult
+> **instance** HasFromAnyChoice TransferInstruction TransferInstruction_Update TransferInstructionResult
 >
-> **instance** [HasFromAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hasfromanychoice-81184) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+> **instance** HasFromAnyChoice TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferFactory TransferFactory_Transfer TransferInstructionResult
+> **instance** HasToAnyChoice TransferFactory TransferFactory_Transfer TransferInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Accept TransferInstructionResult
+> **instance** HasToAnyChoice TransferInstruction TransferInstruction_Accept TransferInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Reject TransferInstructionResult
+> **instance** HasToAnyChoice TransferInstruction TransferInstruction_Reject TransferInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Update TransferInstructionResult
+> **instance** HasToAnyChoice TransferInstruction TransferInstruction_Update TransferInstructionResult
 >
-> **instance** [HasToAnyChoice](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-template-functions-hastoanychoice-82571) TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
+> **instance** HasToAnyChoice TransferInstruction TransferInstruction_Withdraw TransferInstructionResult
 
 <div id="type-splice-api-token-transferinstructionv1-transferinstructionresultoutput-59824">
 
@@ -385,7 +385,7 @@ Instruct transfers of holdings between parties.
 > >
 > > | Field                  | Type                                                                                                                  | Description                                                             |
 > > |------------------------|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-> > | transferInstructionCid | [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction | Contract id of the transfer instruction representing the pending state. |
+> > | transferInstructionCid | ContractId TransferInstruction | Contract id of the transfer instruction representing the pending state. |
 >
 > <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresultcompleted-47798">
 >
@@ -397,7 +397,7 @@ Instruct transfers of holdings between parties.
 > >
 > > | Field               | Type                                                                                                          | Description                                                                                       |
 > > |---------------------|---------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
-> > | receiverHoldingCids | \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\] | The newly created holdings owned by the receiver as part of successfully completing the transfer. |
+> > | receiverHoldingCids | \[ContractId Holding\] | The newly created holdings owned by the receiver as part of successfully completing the transfer. |
 >
 > <div id="constr-splice-api-token-transferinstructionv1-transferinstructionresultfailed-21543">
 >
@@ -407,21 +407,21 @@ Instruct transfers of holdings between parties.
 >
 > > Use this result to communicate that the transfer did not succeed and all holdings (minus fees) have been returned to the sender.
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionResult_Output
+> **instance** Eq TransferInstructionResult_Output
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionResult_Output
+> **instance** Show TransferInstructionResult_Output
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "output" TransferInstructionResult TransferInstructionResult_Output
+> **instance** GetField "output" TransferInstructionResult TransferInstructionResult_Output
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "receiverHoldingCids" TransferInstructionResult_Output \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** GetField "receiverHoldingCids" TransferInstructionResult_Output \[ContractId Holding\]
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transferInstructionCid" TransferInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction)
+> **instance** GetField "transferInstructionCid" TransferInstructionResult_Output (ContractId TransferInstruction)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "output" TransferInstructionResult TransferInstructionResult_Output
+> **instance** SetField "output" TransferInstructionResult TransferInstructionResult_Output
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "receiverHoldingCids" TransferInstructionResult_Output \[[ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) Holding\]
+> **instance** SetField "receiverHoldingCids" TransferInstructionResult_Output \[ContractId Holding\]
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transferInstructionCid" TransferInstructionResult_Output ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction)
+> **instance** SetField "transferInstructionCid" TransferInstructionResult_Output (ContractId TransferInstruction)
 
 <div id="type-splice-api-token-transferinstructionv1-transferinstructionstatus-36298">
 
@@ -449,19 +449,19 @@ Instruct transfers of holdings between parties.
 > >
 > > | Field          | Type                                                                                                                                                                                                                                                         | Description                                                                                                                                            |
 > > |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | pendingActions | [Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952) | The actions that a party could take to advance the transfer. This field can by used to inform wallet users whether they need to take an action or not. |
+> > | pendingActions | Map Party Text | The actions that a party could take to advance the transfer. This field can by used to inform wallet users whether they need to take an action or not. |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionStatus
+> **instance** Eq TransferInstructionStatus
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionStatus
+> **instance** Show TransferInstructionStatus
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "pendingActions" TransferInstructionStatus ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** GetField "pendingActions" TransferInstructionStatus (Map Party Text)
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "status" TransferInstructionView TransferInstructionStatus
+> **instance** GetField "status" TransferInstructionView TransferInstructionStatus
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "pendingActions" TransferInstructionStatus ([Map](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-map-90052) [Party](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-party-57932) [Text](https://docs.daml.com/daml/stdlib/Prelude.html#type-ghc-types-text-51952))
+> **instance** SetField "pendingActions" TransferInstructionStatus (Map Party Text)
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "status" TransferInstructionView TransferInstructionStatus
+> **instance** SetField "status" TransferInstructionView TransferInstructionStatus
 
 <div id="type-splice-api-token-transferinstructionv1-transferinstructionview-46309">
 
@@ -479,76 +479,76 @@ Instruct transfers of holdings between parties.
 >
 > > | Field                  | Type                                                                                                                                                                                                                       | Description                                                                                                                                                                                                                          |
 > > |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-> > | originalInstructionCid | [Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction) | The contract id of the original transfer instruction contract. Used by the wallet to track the lineage of transfer instructions through multiple steps. Only set if the registry evolves the transfer instruction in multiple steps. |
+> > | originalInstructionCid | Optional (ContractId TransferInstruction) | The contract id of the original transfer instruction contract. Used by the wallet to track the lineage of transfer instructions through multiple steps. Only set if the registry evolves the transfer instruction in multiple steps. |
 > > | transfer               | Transfer                                                                                                                                                                                                                   | The transfer specified by the transfer instruction.                                                                                                                                                                                  |
 > > | status                 | TransferInstructionStatus                                                                                                                                                                                                  | The status of the transfer instruction.                                                                                                                                                                                              |
 > > | meta                   | Metadata                                                                                                                                                                                                                   | Additional metadata specific to the transfer instruction, used for extensibility; e.g., more detailed status information.                                                                                                            |
 >
-> **instance** [Eq](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-classes-eq-22713) TransferInstructionView
+> **instance** Eq TransferInstructionView
 >
-> **instance** [Show](https://docs.daml.com/daml/stdlib/Prelude.html#class-ghc-show-show-65360) TransferInstructionView
+> **instance** Show TransferInstructionView
 >
-> **instance** [HasFromAnyView](https://docs.daml.com/daml/stdlib/DA-Internal-Interface-AnyView.html#class-da-internal-interface-anyview-hasfromanyview-30108) TransferInstruction TransferInstructionView
+> **instance** HasFromAnyView TransferInstruction TransferInstructionView
 >
-> **instance** [HasInterfaceView](https://docs.daml.com/daml/stdlib/Prelude.html#class-da-internal-interface-hasinterfaceview-4492) TransferInstruction TransferInstructionView
+> **instance** HasInterfaceView TransferInstruction TransferInstructionView
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "meta" TransferInstructionView Metadata
+> **instance** GetField "meta" TransferInstructionView Metadata
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "originalInstructionCid" TransferInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction))
+> **instance** GetField "originalInstructionCid" TransferInstructionView (Optional (ContractId TransferInstruction))
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "status" TransferInstructionView TransferInstructionStatus
+> **instance** GetField "status" TransferInstructionView TransferInstructionStatus
 >
-> **instance** [GetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-getfield-53979) "transfer" TransferInstructionView Transfer
+> **instance** GetField "transfer" TransferInstructionView Transfer
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "meta" TransferInstructionView Metadata
+> **instance** SetField "meta" TransferInstructionView Metadata
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "originalInstructionCid" TransferInstructionView ([Optional](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-prelude-optional-37153) ([ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction))
+> **instance** SetField "originalInstructionCid" TransferInstructionView (Optional (ContractId TransferInstruction))
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "status" TransferInstructionView TransferInstructionStatus
+> **instance** SetField "status" TransferInstructionView TransferInstructionStatus
 >
-> **instance** [SetField](https://docs.daml.com/daml/stdlib/DA-Record.html#class-da-internal-record-setfield-4311) "transfer" TransferInstructionView Transfer
+> **instance** SetField "transfer" TransferInstructionView Transfer
 
 ## Functions
 
 <div id="function-splice-api-token-transferinstructionv1-transferinstructionacceptimpl-78274">
 
 transferInstruction_acceptImpl
-: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Accept -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+: TransferInstruction -\> ContractId TransferInstruction -\> TransferInstruction_Accept -\> Update TransferInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-transferinstructionv1-transferinstructionrejectimpl-50311">
 
 transferInstruction_rejectImpl
-: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Reject -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+: TransferInstruction -\> ContractId TransferInstruction -\> TransferInstruction_Reject -\> Update TransferInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-transferinstructionv1-transferinstructionwithdrawimpl-10586">
 
 transferInstruction_withdrawImpl
-: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Withdraw -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+: TransferInstruction -\> ContractId TransferInstruction -\> TransferInstruction_Withdraw -\> Update TransferInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-transferinstructionv1-transferinstructionupdateimpl-73329">
 
 transferInstruction_updateImpl
-: TransferInstruction -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferInstruction -\> TransferInstruction_Update -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+: TransferInstruction -\> ContractId TransferInstruction -\> TransferInstruction_Update -\> Update TransferInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-transferinstructionv1-transferfactorytransferimpl-82483">
 
 transferFactory_transferImpl
-: TransferFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_Transfer -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferInstructionResult
+: TransferFactory -\> ContractId TransferFactory -\> TransferFactory_Transfer -\> Update TransferInstructionResult
 
 </div>
 
 <div id="function-splice-api-token-transferinstructionv1-transferfactorypublicfetchimpl-930">
 
 transferFactory_publicFetchImpl
-: TransferFactory -\> [ContractId](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-contractid-95282) TransferFactory -\> TransferFactory_PublicFetch -\> [Update](https://docs.daml.com/daml/stdlib/Prelude.html#type-da-internal-lf-update-68072) TransferFactoryView
+: TransferFactory -\> ContractId TransferFactory -\> TransferFactory_PublicFetch -\> Update TransferFactoryView
 
 </div>
 

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/index.mdx
@@ -1,0 +1,16 @@
+---
+title: "splice-dso-governance docs"
+description: "Documentation for splice-dso-governance docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-dso-governance/docs/index.rst" tag="0.6.4" hash="f237c273" */}
+
+- [Splice.CometBft](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft)
+- [Splice.DSO.AmuletPrice](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice)
+- [Splice.DSO.DecentralizedSynchronizer](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer)
+- [Splice.DSO.SvState](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate)
+- [Splice.DsoBootstrap](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap)
+- [Splice.DsoRules](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules)
+- [Splice.SvOnboarding](/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft.mdx
@@ -1,0 +1,246 @@
+---
+title: "Splice.CometBft"
+description: "Documentation for Splice.CometBft"
+---
+
+{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-CometBft.rst" tag="0.6.4" hash="5c393ed3" */}
+
+## Data Types
+
+<div id="type-splice-cometbft-cometbftconfig-79018">
+
+**data** CometBftConfig
+
+</div>
+
+> Config for all CometBFT nodes and keys under the control of a single SV node operator.
+>
+> <div id="constr-splice-cometbft-cometbftconfig-91607">
+>
+> CometBftConfig
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                                                                                                                                            | Description                                          |
+> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+> > | nodes          | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) CometBftNodeConfig | A map from CometBft node-ids to their configuration. |
+> > | governanceKeys | \[GovernanceKeyConfig\]                                                                                                                                                                                                                         |                                                      |
+> > | sequencingKeys | \[SequencingKeyConfig\]                                                                                                                                                                                                                         |                                                      |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) CometBftConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) CometBftConfig
+>
+> **instance** GetField "cometBft" SynchronizerNodeConfig CometBftConfig
+>
+> **instance** GetField "governanceKeys" CometBftConfig \[GovernanceKeyConfig\]
+>
+> **instance** GetField "nodes" CometBftConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) CometBftNodeConfig)
+>
+> **instance** GetField "sequencingKeys" CometBftConfig \[SequencingKeyConfig\]
+>
+> **instance** SetField "cometBft" SynchronizerNodeConfig CometBftConfig
+>
+> **instance** SetField "governanceKeys" CometBftConfig \[GovernanceKeyConfig\]
+>
+> **instance** SetField "nodes" CometBftConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) CometBftNodeConfig)
+>
+> **instance** SetField "sequencingKeys" CometBftConfig \[SequencingKeyConfig\]
+>
+> **instance** Patchable CometBftConfig
+
+<div id="type-splice-cometbft-cometbftconfiglimits-81004">
+
+**data** CometBftConfigLimits
+
+</div>
+
+> Limits on the configurations that SV node operators can choose for their CometBFT nodes and keys.
+>
+> <div id="constr-splice-cometbft-cometbftconfiglimits-44281">
+>
+> CometBftConfigLimits
+>
+> </div>
+>
+> > | Field                | Type                                                                                                       | Description |
+> > |----------------------|------------------------------------------------------------------------------------------------------------|-------------|
+> > | maxNumCometBftNodes  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+> > | maxNumGovernanceKeys | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+> > | maxNumSequencingKeys | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+> > | maxNodeIdLength      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+> > | maxPubKeyLength      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) CometBftConfigLimits
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) CometBftConfigLimits
+>
+> **instance** GetField "cometBft" SynchronizerNodeConfigLimits CometBftConfigLimits
+>
+> **instance** GetField "maxNodeIdLength" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "maxNumCometBftNodes" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "maxNumGovernanceKeys" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "maxNumSequencingKeys" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "maxPubKeyLength" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "cometBft" SynchronizerNodeConfigLimits CometBftConfigLimits
+>
+> **instance** SetField "maxNodeIdLength" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "maxNumCometBftNodes" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "maxNumGovernanceKeys" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "maxNumSequencingKeys" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "maxPubKeyLength" CometBftConfigLimits [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** Patchable CometBftConfigLimits
+
+<div id="type-splice-cometbft-cometbftnodeconfig-40106">
+
+**data** CometBftNodeConfig
+
+</div>
+
+> Config for a single CometBFT node.
+>
+> <div id="constr-splice-cometbft-cometbftnodeconfig-66571">
+>
+> CometBftNodeConfig
+>
+> </div>
+>
+> > | Field           | Type                                                                                                         | Description |
+> > |-----------------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | validatorPubKey | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+> > | votingPower     | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)   |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) CometBftNodeConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) CometBftNodeConfig
+>
+> **instance** GetField "nodes" CometBftConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) CometBftNodeConfig)
+>
+> **instance** GetField "validatorPubKey" CometBftNodeConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "votingPower" CometBftNodeConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "nodes" CometBftConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) CometBftNodeConfig)
+>
+> **instance** SetField "validatorPubKey" CometBftNodeConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "votingPower" CometBftNodeConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** Patchable CometBftNodeConfig
+
+<div id="type-splice-cometbft-governancekeyconfig-71820">
+
+**data** GovernanceKeyConfig
+
+</div>
+
+> Config for a key used by the SvApp to create CometBFT network governance transactions.
+>
+> <div id="constr-splice-cometbft-governancekeyconfig-53123">
+>
+> GovernanceKeyConfig
+>
+> </div>
+>
+> > | Field  | Type                                                                                                         | Description |
+> > |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | pubKey | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) GovernanceKeyConfig
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) GovernanceKeyConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) GovernanceKeyConfig
+>
+> **instance** GetField "governanceKeys" CometBftConfig \[GovernanceKeyConfig\]
+>
+> **instance** GetField "pubKey" GovernanceKeyConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "governanceKeys" CometBftConfig \[GovernanceKeyConfig\]
+>
+> **instance** SetField "pubKey" GovernanceKeyConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** Patchable GovernanceKeyConfig
+
+<div id="type-splice-cometbft-sequencingkeyconfig-30402">
+
+**data** SequencingKeyConfig
+
+</div>
+
+> Config for a key used by the CometBFT Sequencer Driver to sequence messages via the CometBFT network.
+>
+> <div id="constr-splice-cometbft-sequencingkeyconfig-16921">
+>
+> SequencingKeyConfig
+>
+> </div>
+>
+> > | Field  | Type                                                                                                         | Description |
+> > |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+> > | pubKey | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SequencingKeyConfig
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) SequencingKeyConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SequencingKeyConfig
+>
+> **instance** GetField "pubKey" SequencingKeyConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "sequencingKeys" CometBftConfig \[SequencingKeyConfig\]
+>
+> **instance** SetField "pubKey" SequencingKeyConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "sequencingKeys" CometBftConfig \[SequencingKeyConfig\]
+>
+> **instance** Patchable SequencingKeyConfig
+
+## Functions
+
+<div id="function-splice-cometbft-emptycometbftconfig-94578">
+
+emptyCometBftConfig
+: CometBftConfig
+
+</div>
+
+<div id="function-splice-cometbft-defaultcometbftconfiglimits-24082">
+
+defaultCometBftConfigLimits
+: CometBftConfigLimits
+
+</div>
+
+<div id="function-splice-cometbft-validcometbftconfig-37027">
+
+validCometBftConfig
+: CometBftConfigLimits -\> CometBftConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-cometbft-validcometbftnodeconfig-27003">
+
+validCometBftNodeConfig
+: CometBftConfigLimits -\> ([Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952), CometBftNodeConfig) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-cometbft-totalvotingpower-81580">
+
+totalVotingPower
+: CometBftConfig -\> [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice.mdx
@@ -1,0 +1,59 @@
+---
+title: "Splice.DSO.AmuletPrice"
+description: "Documentation for Splice.DSO.AmuletPrice"
+---
+
+{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-DSO-AmuletPrice.rst" tag="0.6.4" hash="1c68e822" */}
+
+Templates and code for the SVs to agree on a amulet price using median-based voting.
+
+Every sv can change its desired amulet price at any time they like provided they wait at least one tick duration (2.5 minutes by default) between changes.
+
+New `OpenMiningRounds` are always openened with the median of the amulet prices voted for by the SVs.
+
+## Templates
+
+<div id="type-splice-dso-amuletprice-amuletpricevote-96658">
+
+**template** AmuletPriceVote
+
+</div>
+
+> A vote by an SV for their desired amulet price.
+>
+> Signatory: dso
+>
+> | Field         | Type                                                                                                                                                                                                                                              | Description                                                                                                  |
+> |---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+> | dso           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                               |                                                                                                              |
+> | sv            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                               |                                                                                                              |
+> | amuletPrice   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | Set to None for new svs, but defined thereafter.                                                             |
+> | lastUpdatedAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                 | The last time this price was updated. Tracked to limit svs from changing their vote more than once per tick. |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Functions
+
+<div id="function-splice-dso-amuletprice-fetchmedianamuletprice-30507">
+
+fetchMedianAmuletPrice
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] -\> \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-dso-amuletprice-median-98146">
+
+median
+: \[[Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)\] -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+See https://en.wikipedia.org/wiki/Median
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer.mdx
@@ -1,0 +1,548 @@
+---
+title: "Splice.DSO.DecentralizedSynchronizer"
+description: "Documentation for Splice.DSO.DecentralizedSynchronizer"
+---
+
+{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-DSO-DecentralizedSynchronizer.rst" tag="0.6.4" hash="90fb1057" */}
+
+Data structures and contracts related managing the decentralized synchronizer.
+
+## Data Types
+
+<div id="type-splice-dso-decentralizedsynchronizer-dsodecentralizedsynchronizerconfig-15965">
+
+**data** DsoDecentralizedSynchronizerConfig
+
+</div>
+
+> The decentralized synchronizer consists of a series of actual synchronizers. New synchronizers are created by the SVs for the rare case of needing to roll-out a BFT protocol upgrade that cannot be rolled out in a backwards compatible fashion.
+>
+> Note that synchronizers themselves are formed by a cluster of nodes run by the SVs. As can be seen form `SynchronizerNodeConfig` each sv runs multiple different kinds of physical nodes.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-dsodecentralizedsynchronizerconfig-75458">
+>
+> DsoDecentralizedSynchronizerConfig
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                                                                                                                                            | Description                                                                 |
+> > |----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+> > | synchronizers        | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerConfig | The actual synchronizers, numbered sequentially.                            |
+> > | lastSynchronizerId   | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                    | The last allocated synchronizer Id.                                         |
+> > | activeSynchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                    | The synchronizer to be used for managing standard DSO and Amulet workflows. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoDecentralizedSynchronizerConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoDecentralizedSynchronizerConfig
+>
+> **instance** GetField "activeSynchronizerId" DsoDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "decentralizedSynchronizer" DsoRulesConfig DsoDecentralizedSynchronizerConfig
+>
+> **instance** GetField "lastSynchronizerId" DsoDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "synchronizers" DsoDecentralizedSynchronizerConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerConfig)
+>
+> **instance** SetField "activeSynchronizerId" DsoDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "decentralizedSynchronizer" DsoRulesConfig DsoDecentralizedSynchronizerConfig
+>
+> **instance** SetField "lastSynchronizerId" DsoDecentralizedSynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "synchronizers" DsoDecentralizedSynchronizerConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerConfig)
+>
+> **instance** Patchable DsoDecentralizedSynchronizerConfig
+
+<div id="type-splice-dso-decentralizedsynchronizer-legacysequencerconfig-76078">
+
+**data** LegacySequencerConfig
+
+</div>
+
+> Config for a legacy sequencer, i.e., a migration id that is still up but paused. This is useful to allow validators to catch up.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-legacysequencerconfig-74515">
+>
+> LegacySequencerConfig
+>
+> </div>
+>
+> > | Field       | Type                                                                                                         | Description                                                    |
+> > |-------------|--------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
+> > | migrationId | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)   | The synchronizer migration id corresponding to this sequencer. |
+> > | sequencerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The id of the sequencer.                                       |
+> > | url         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The public accessible url of the sequencer.                    |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) LegacySequencerConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) LegacySequencerConfig
+>
+> **instance** GetField "legacySequencerConfig" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LegacySequencerConfig)
+>
+> **instance** GetField "migrationId" LegacySequencerConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "sequencerId" LegacySequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "url" LegacySequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "legacySequencerConfig" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LegacySequencerConfig)
+>
+> **instance** SetField "migrationId" LegacySequencerConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "sequencerId" LegacySequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "url" LegacySequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** Patchable LegacySequencerConfig
+
+<div id="type-splice-dso-decentralizedsynchronizer-mediatorconfig-99298">
+
+**data** MediatorConfig
+
+</div>
+
+> Config for a mediator.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-mediatorconfig-88513">
+>
+> MediatorConfig
+>
+> </div>
+>
+> > | Field      | Type                                                                                                         | Description             |
+> > |------------|--------------------------------------------------------------------------------------------------------------|-------------------------|
+> > | mediatorId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The id of the mediator. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MediatorConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MediatorConfig
+>
+> **instance** GetField "mediator" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MediatorConfig)
+>
+> **instance** GetField "mediatorId" MediatorConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "mediator" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MediatorConfig)
+>
+> **instance** SetField "mediatorId" MediatorConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** Patchable MediatorConfig
+
+<div id="type-splice-dso-decentralizedsynchronizer-physicalsynchronizernodeconfig-61630">
+
+**data** PhysicalSynchronizerNodeConfig
+
+</div>
+
+> <div id="constr-splice-dso-decentralizedsynchronizer-physicalsynchronizernodeconfig-31009">
+>
+> PhysicalSynchronizerNodeConfig
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                                     | Description                                              |
+> > |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
+> > | sequencer | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConnectionConfig | The configuration of this sv's optional local sequencer. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) PhysicalSynchronizerNodeConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) PhysicalSynchronizerNodeConfig
+>
+> **instance** GetField "sequencer" PhysicalSynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConnectionConfig)
+>
+> **instance** SetField "sequencer" PhysicalSynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConnectionConfig)
+>
+> **instance** Patchable PhysicalSynchronizerNodeConfig
+
+<div id="type-splice-dso-decentralizedsynchronizer-physicalsynchronizernodeconfigmap-79969">
+
+**type** PhysicalSynchronizerNodeConfigMap
+= [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) PhysicalSynchronizerNodeConfig
+
+A map from physical synchronizer serial to the configuration of a sv's node for that physical synchronizer.
+
+**instance** GetField "physicalSynchronizers" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) PhysicalSynchronizerNodeConfigMap)
+
+**instance** SetField "physicalSynchronizers" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) PhysicalSynchronizerNodeConfigMap)
+
+</div>
+
+<div id="type-splice-dso-decentralizedsynchronizer-scanconfig-87910">
+
+**data** ScanConfig
+
+</div>
+
+> Config for a Scan instance.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-scanconfig-27525">
+>
+> ScanConfig
+>
+> </div>
+>
+> > | Field     | Type                                                                                                         | Description                                       |
+> > |-----------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
+> > | publicUrl | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The publicly accessible URL of the Scan instance. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ScanConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ScanConfig
+>
+> **instance** GetField "publicUrl" ScanConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "scan" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ScanConfig)
+>
+> **instance** SetField "publicUrl" ScanConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "scan" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ScanConfig)
+>
+> **instance** Patchable ScanConfig
+
+<div id="type-splice-dso-decentralizedsynchronizer-sequencerconfig-38423">
+
+**data** SequencerConfig
+
+</div>
+
+> Config for a sequencer.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-sequencerconfig-73098">
+>
+> SequencerConfig
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                                                                                                                                             | Description                                                                                                       |
+> > |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+> > | migrationId    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                       | The synchronizer migration id corresponding to this sequencer.                                                    |
+> > | sequencerId    | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                     | The id of the sequencer.                                                                                          |
+> > | url            | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                     | The public accessible url of the sequencer.                                                                       |
+> > | availableAfter | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | Any participant should subscribe this sequencer after this time. ^ If not set the sequencer is not yet accessible |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SequencerConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SequencerConfig
+>
+> **instance** GetField "availableAfter" SequencerConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
+>
+> **instance** GetField "migrationId" SequencerConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "sequencer" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConfig)
+>
+> **instance** GetField "sequencerId" SequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "url" SequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "availableAfter" SequencerConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
+>
+> **instance** SetField "migrationId" SequencerConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "sequencer" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConfig)
+>
+> **instance** SetField "sequencerId" SequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "url" SequencerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** Patchable SequencerConfig
+
+<div id="type-splice-dso-decentralizedsynchronizer-sequencerconnectionconfig-44977">
+
+**data** SequencerConnectionConfig
+
+</div>
+
+> Connection config for a sequencer.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-sequencerconnectionconfig-40632">
+>
+> SequencerConnectionConfig
+>
+> </div>
+>
+> > | Field | Type                                                                                                         | Description                                 |
+> > |-------|--------------------------------------------------------------------------------------------------------------|---------------------------------------------|
+> > | url   | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | The public accessible url of the sequencer. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SequencerConnectionConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SequencerConnectionConfig
+>
+> **instance** GetField "sequencer" PhysicalSynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConnectionConfig)
+>
+> **instance** GetField "url" SequencerConnectionConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "sequencer" PhysicalSynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConnectionConfig)
+>
+> **instance** SetField "url" SequencerConnectionConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** Patchable SequencerConnectionConfig
+
+<div id="type-splice-dso-decentralizedsynchronizer-sequenceridentityconfig-4269">
+
+**data** SequencerIdentityConfig
+
+</div>
+
+> Config for a sequencer.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-sequenceridentityconfig-97016">
+>
+> SequencerIdentityConfig
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                                                                                                                                             | Description                                                                                                       |
+> > |----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|
+> > | sequencerId    | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                     | The id of the sequencer.                                                                                          |
+> > | availableAfter | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | Any participant should subscribe this sequencer after this time. ^ If not set the sequencer is not yet accessible |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SequencerIdentityConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SequencerIdentityConfig
+>
+> **instance** GetField "availableAfter" SequencerIdentityConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
+>
+> **instance** GetField "sequencerId" SequencerIdentityConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "sequencerIdentity" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerIdentityConfig)
+>
+> **instance** SetField "availableAfter" SequencerIdentityConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
+>
+> **instance** SetField "sequencerId" SequencerIdentityConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "sequencerIdentity" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerIdentityConfig)
+>
+> **instance** Patchable SequencerIdentityConfig
+
+<div id="type-splice-dso-decentralizedsynchronizer-synchronizerconfig-49093">
+
+**data** SynchronizerConfig
+
+</div>
+
+> The DSO-level configuration of a synchronizer. This contains the shared parameters of the synchronizer.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-synchronizerconfig-62326">
+>
+> SynchronizerConfig
+>
+> </div>
+>
+> > | Field                               | Type                                                                                                                                                                                                                                      | Description                                                                                                                      |
+> > |-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+> > | state                               | SynchronizerState                                                                                                                                                                                                                         | The state of this synchronizer                                                                                                   |
+> > | cometBftGenesisJson                 | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                              | The CometBftGenesis json value required for new svs to bring up their CometBft nodes for this synchronizer.                      |
+> > | acsCommitmentReconciliationInterval | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Participants connected to the decentralized synchronizer exchange ACS commitment messages every reconciliation interval seconds. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerConfig
+>
+> **instance** GetField "acsCommitmentReconciliationInterval" SynchronizerConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261))
+>
+> **instance** GetField "cometBftGenesisJson" SynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "state" SynchronizerConfig SynchronizerState
+>
+> **instance** GetField "synchronizers" DsoDecentralizedSynchronizerConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerConfig)
+>
+> **instance** SetField "acsCommitmentReconciliationInterval" SynchronizerConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261))
+>
+> **instance** SetField "cometBftGenesisJson" SynchronizerConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "state" SynchronizerConfig SynchronizerState
+>
+> **instance** SetField "synchronizers" DsoDecentralizedSynchronizerConfig ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerConfig)
+>
+> **instance** Patchable SynchronizerConfig
+
+<div id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfig-10457">
+
+**data** SynchronizerNodeConfig
+
+</div>
+
+> The configuration of a sv's node for a particular synchronizer.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-synchronizernodeconfig-64798">
+>
+> SynchronizerNodeConfig
+>
+> </div>
+>
+> > | Field                 | Type                                                                                                                                                             | Description                                                                                                                                       |
+> > |-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | cometBft              | CometBftConfig                                                                                                                                                   | The configuration of this sv's CometBFT nodes and keys.                                                                                           |
+> > | sequencer             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConfig                   | The configuration of this sv's optional local sequencer.                                                                                          |
+> > | mediator              | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MediatorConfig                    | The configuration of this sv's optional local mediator.                                                                                           |
+> > | scan                  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ScanConfig                        | The configuration of this sv's optional Scan instance.                                                                                            |
+> > | legacySequencerConfig | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LegacySequencerConfig             | The legacy sequencer config for the prior migration id that is still up. We store this so it can be published on scan and validators can catchup. |
+> > | sequencerIdentity     | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerIdentityConfig           | The configuration of this sv's optional local sequencer.                                                                                          |
+> > | physicalSynchronizers | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) PhysicalSynchronizerNodeConfigMap | The synchronizer node configs for the currently running physical synchronizers.                                                                   |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerNodeConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerNodeConfig
+>
+> **instance** GetField "cometBft" SynchronizerNodeConfig CometBftConfig
+>
+> **instance** GetField "legacySequencerConfig" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LegacySequencerConfig)
+>
+> **instance** GetField "mediator" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MediatorConfig)
+>
+> **instance** GetField "newNodeConfig" DsoRules_SetSynchronizerNodeConfig SynchronizerNodeConfig
+>
+> **instance** GetField "physicalSynchronizers" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) PhysicalSynchronizerNodeConfigMap)
+>
+> **instance** GetField "scan" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ScanConfig)
+>
+> **instance** GetField "sequencer" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConfig)
+>
+> **instance** GetField "sequencerIdentity" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerIdentityConfig)
+>
+> **instance** SetField "cometBft" SynchronizerNodeConfig CometBftConfig
+>
+> **instance** SetField "legacySequencerConfig" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LegacySequencerConfig)
+>
+> **instance** SetField "mediator" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) MediatorConfig)
+>
+> **instance** SetField "newNodeConfig" DsoRules_SetSynchronizerNodeConfig SynchronizerNodeConfig
+>
+> **instance** SetField "physicalSynchronizers" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) PhysicalSynchronizerNodeConfigMap)
+>
+> **instance** SetField "scan" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ScanConfig)
+>
+> **instance** SetField "sequencer" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerConfig)
+>
+> **instance** SetField "sequencerIdentity" SynchronizerNodeConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SequencerIdentityConfig)
+>
+> **instance** Patchable SynchronizerNodeConfig
+
+<div id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfiglimits-3659">
+
+**data** SynchronizerNodeConfigLimits
+
+</div>
+
+> <div id="constr-splice-dso-decentralizedsynchronizer-synchronizernodeconfiglimits-16072">
+>
+> SynchronizerNodeConfigLimits
+>
+> </div>
+>
+> > | Field    | Type                 | Description |
+> > |----------|----------------------|-------------|
+> > | cometBft | CometBftConfigLimits |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerNodeConfigLimits
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerNodeConfigLimits
+>
+> **instance** GetField "cometBft" SynchronizerNodeConfigLimits CometBftConfigLimits
+>
+> **instance** GetField "synchronizerNodeConfigLimits" DsoRulesConfig SynchronizerNodeConfigLimits
+>
+> **instance** SetField "cometBft" SynchronizerNodeConfigLimits CometBftConfigLimits
+>
+> **instance** SetField "synchronizerNodeConfigLimits" DsoRulesConfig SynchronizerNodeConfigLimits
+>
+> **instance** Patchable SynchronizerNodeConfigLimits
+
+<div id="type-splice-dso-decentralizedsynchronizer-synchronizernodeconfigmap-59848">
+
+**type** SynchronizerNodeConfigMap
+= [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) SynchronizerNodeConfig
+
+A map from synchronizer-ids to the configuration of a sv's node for this synchronizer.
+
+**instance** GetField "sv1SynchronizerNodes" DsoBootstrap SynchronizerNodeConfigMap
+
+**instance** GetField "synchronizerNodes" NodeState SynchronizerNodeConfigMap
+
+**instance** SetField "sv1SynchronizerNodes" DsoBootstrap SynchronizerNodeConfigMap
+
+**instance** SetField "synchronizerNodes" NodeState SynchronizerNodeConfigMap
+
+</div>
+
+<div id="type-splice-dso-decentralizedsynchronizer-synchronizerstate-25483">
+
+**data** SynchronizerState
+
+</div>
+
+> The state of a synchronizer.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-dsbootstrapping-64886">
+>
+> DS_Bootstrapping
+>
+> </div>
+>
+> > The synchronizer is still being bootstrapped, and SVs are required to provision their nodes for it.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-dsoperational-99130">
+>
+> DS_Operational
+>
+> </div>
+>
+> > The synchronizer is operational, and thus can be used as the active synchronizer.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-dsdecomissioned-12812">
+>
+> DS_Decomissioned
+>
+> </div>
+>
+> > The synchronizer has been decommissioned and svs are now allowed to shutdown their nodes for that synchronizer. We track this state explicitly instead of just deleting the synchronizer config, as decomissioning likely takes a while, and we want to avoid confusion among SV operators when they see errors raised from some of their synchronizer nodes.
+>
+> <div id="constr-splice-dso-decentralizedsynchronizer-extsynchronizerstate-26922">
+>
+> ExtSynchronizerState
+>
+> </div>
+>
+> > Extension constructor to work around the current lack of upgrading for variants in Daml 3.0. Will serve as the default value in a containing record in case of an extension.
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerState
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerState
+>
+> **instance** GetField "state" SynchronizerConfig SynchronizerState
+>
+> **instance** SetField "state" SynchronizerConfig SynchronizerState
+>
+> **instance** Patchable SynchronizerState
+
+## Functions
+
+<div id="function-splice-dso-decentralizedsynchronizer-nosynchronizernodes-89430">
+
+noSynchronizerNodes
+: SynchronizerNodeConfigMap
+
+</div>
+
+<div id="function-splice-dso-decentralizedsynchronizer-emptysynchronizernodeconfig-56591">
+
+emptySynchronizerNodeConfig
+: SynchronizerNodeConfig
+
+</div>
+
+<div id="function-splice-dso-decentralizedsynchronizer-validsynchronizernodeconfig-25090">
+
+validSynchronizerNodeConfig
+: SynchronizerNodeConfigLimits -\> SynchronizerNodeConfig -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-dso-decentralizedsynchronizer-defaultsynchronizernodeconfiglimits-67119">
+
+defaultSynchronizerNodeConfigLimits
+: SynchronizerNodeConfigLimits
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate.mdx
@@ -1,0 +1,291 @@
+---
+title: "Splice.DSO.SvState"
+description: "Documentation for Splice.DSO.SvState"
+---
+
+{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-DSO-SvState.rst" tag="0.6.4" hash="1ea16913" */}
+
+Templates to track per-sv state.
+
+## Templates
+
+<div id="type-splice-dso-svstate-svnodestate-44938">
+
+**template** SvNodeState
+
+</div>
+
+> State of a node managed by an SV operator party.
+>
+> There is exactly one such state per SV operator party. Even though every SV can operate at most one node at any one time, there can though be multiple SV node states per SV, as the state of offboarded nodes is kept around for debugging purposes.
+>
+> Signatory: dso
+>
+> | Field  | Type                                                                                                                | Description                                     |
+> |--------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
+> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                 |
+> | sv     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The SV operator party identifying the node.     |
+> | svName | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | The SV name in whose name the node is operated. |
+> | state  | NodeState                                                                                                           |                                                 |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-dso-svstate-svrewardstate-90395">
+
+**template** SvRewardState
+
+</div>
+
+> State of reward collection for a sv identified by their sv name.
+>
+> Signatory: dso
+>
+> | Field  | Type                                                                                                                | Description |
+> |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | svName | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+> | state  | RewardState                                                                                                         |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-dso-svstate-svstatusreport-18374">
+
+**template** SvStatusReport
+
+</div>
+
+> A singleton contract per SV party that is used to regularly submit status reports.
+>
+> Individual status reports serve as a heartbeat for a specific SV party and its associoated SV node ; and to distribute that SVs view on the network to all other SVs.
+>
+> Signatory: dso
+>
+> | Field  | Type                                                                                                                                    | Description                                                                      |
+> |--------|-----------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+> | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                     |                                                                                  |
+> | sv     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                     | The SV party that submitted this report.                                         |
+> | svName | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                            | The name of the SV operator whose operator party was used to submit this report. |
+> | number | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                              | The number of this report, starting from 0.                                      |
+> | status | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SvStatus | None is used when initially creating the contract upon sv addition.              |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-dso-svstate-forsv-86032">
+
+**data** ForSv
+
+</div>
+
+> <div id="constr-splice-dso-svstate-forsv-25145">
+>
+> ForSv
+>
+> </div>
+>
+> > | Field  | Type                                                                                                                | Description |
+> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | svName | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForSv
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForSv
+>
+> **instance** GetField "dso" ForSv [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "svName" ForSv [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "dso" ForSv [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "svName" ForSv [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** HasCheckedFetch SvRewardState ForSv
+
+<div id="type-splice-dso-svstate-forsvnode-12988">
+
+**data** ForSvNode
+
+</div>
+
+> <div id="constr-splice-dso-svstate-forsvnode-35713">
+>
+> ForSvNode
+>
+> </div>
+>
+> > | Field  | Type                                                                                                                | Description |
+> > |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | dso    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | sv     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | svName | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ForSvNode
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ForSvNode
+>
+> **instance** GetField "dso" ForSvNode [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "sv" ForSvNode [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "svName" ForSvNode [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "dso" ForSvNode [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "sv" ForSvNode [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "svName" ForSvNode [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** HasCheckedFetch SvNodeState ForSvNode
+>
+> **instance** HasCheckedFetch SvStatusReport ForSvNode
+
+<div id="type-splice-dso-svstate-nodestate-84781">
+
+**data** NodeState
+
+</div>
+
+> <div id="constr-splice-dso-svstate-nodestate-4328">
+>
+> NodeState
+>
+> </div>
+>
+> > | Field             | Type                      | Description                                                                                                |
+> > |-------------------|---------------------------|------------------------------------------------------------------------------------------------------------|
+> > | synchronizerNodes | SynchronizerNodeConfigMap | The config for a synchronizer's CometBFT, sequencer, mediator and scan nodes under control of an SV party. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) NodeState
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) NodeState
+>
+> **instance** GetField "state" SvNodeState NodeState
+>
+> **instance** GetField "synchronizerNodes" NodeState SynchronizerNodeConfigMap
+>
+> **instance** SetField "state" SvNodeState NodeState
+>
+> **instance** SetField "synchronizerNodes" NodeState SynchronizerNodeConfigMap
+
+<div id="type-splice-dso-svstate-rewardstate-93172">
+
+**data** RewardState
+
+</div>
+
+> Reward collection state of an SV.
+>
+> Note that we keep some extra aggregates in this state to make it easier to interpret it. In principle, these could be derived from the transaction history, but that would be much more onerous to implement.
+>
+> <div id="constr-splice-dso-svstate-rewardstate-16777">
+>
+> RewardState
+>
+> </div>
+>
+> > | Field              | Type                                                                                                       | Description                                                         |
+> > |--------------------|------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+> > | numRoundsMissed    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Number of rounds for which they missed collecting coupons.          |
+> > | numRoundsCollected | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Number of rounds for which they collected coupons.                  |
+> > | lastRoundCollected | Round                                                                                                      | Last round for which they collected reward coupons.                 |
+> > | numCouponsIssued   | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Number of SV reward coupons issued by them for their beneficiaries. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RewardState
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RewardState
+>
+> **instance** GetField "lastRoundCollected" RewardState Round
+>
+> **instance** GetField "numCouponsIssued" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "numRoundsCollected" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "numRoundsMissed" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "state" SvRewardState RewardState
+>
+> **instance** SetField "lastRoundCollected" RewardState Round
+>
+> **instance** SetField "numCouponsIssued" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "numRoundsCollected" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "numRoundsMissed" RewardState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "state" SvRewardState RewardState
+
+<div id="type-splice-dso-svstate-svstatus-81954">
+
+**data** SvStatus
+
+</div>
+
+> The status of an SV as seen from their SV node's perspective. We generally add values here that are expected to regularly increase, so that SV node operators can run alerting off of them.
+>
+> <div id="constr-splice-dso-svstate-svstatus-71949">
+>
+> SvStatus
+>
+> </div>
+>
+> > | Field                       | Type                                                                                                              | Description                                                                                                                      |
+> > |-----------------------------|-------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+> > | createdAt                   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The wall clock time of the SV node at the time when the SV node started to gather the data points in this report to submit them. |
+> > | cometBftHeight              | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)        | The height of the CometBFT chain at the time of submission                                                                       |
+> > | mediatorSynchronizerTime    | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The latest synchronizer time observed on the mediator at the time of submission                                                  |
+> > | participantSynchronizerTime | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The latest synchronizer time observed on the participant at the time of submission                                               |
+> > | latestOpenRound             | Round                                                                                                             | The maximum round number of the OpenMiningRound contracts at the time of submission                                              |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SvStatus
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SvStatus
+>
+> **instance** GetField "cometBftHeight" SvStatus [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "createdAt" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "latestOpenRound" SvStatus Round
+>
+> **instance** GetField "mediatorSynchronizerTime" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "participantSynchronizerTime" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "status" SvStatusReport ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SvStatus)
+>
+> **instance** GetField "status" DsoRules_SubmitStatusReport SvStatus
+>
+> **instance** SetField "cometBftHeight" SvStatus [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "createdAt" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "latestOpenRound" SvStatus Round
+>
+> **instance** SetField "mediatorSynchronizerTime" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "participantSynchronizerTime" SvStatus [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "status" SvStatusReport ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SvStatus)
+>
+> **instance** SetField "status" DsoRules_SubmitStatusReport SvStatus
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap.mdx
@@ -1,0 +1,77 @@
+---
+title: "Splice.DsoBootstrap"
+description: "Documentation for Splice.DsoBootstrap"
+---
+
+{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-DsoBootstrap.rst" tag="0.6.4" hash="54674734" */}
+
+## Templates
+
+<div id="type-splice-dsobootstrap-dsobootstrap-38046">
+
+**template** DsoBootstrap
+
+</div>
+
+> A template for bootstrapping DsoRules and AmuletRules.
+>
+> Signatory: dso
+>
+> | Field                | Type                                                                                                                                                                                                                                      | Description                                                          |
+> |----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+> | dso                  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                       |                                                                      |
+> | sv1Party             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                       | the SV that bootstraps the network                                   |
+> | sv1Name              | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                              | human-readable name of SV1                                           |
+> | sv1RewardWeight      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                | the weight of SV1 in the reward distribution                         |
+> | sv1ParticipantId     | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                              | the id of the participant of the SV that bootstraps the synchronizer |
+> | sv1SynchronizerNodes | SynchronizerNodeConfigMap                                                                                                                                                                                                                 | Synchronizer nodes on which this workflow runs                       |
+> | round0Duration       | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                    |                                                                      |
+> | amuletConfig         | AmuletConfig USD                                                                                                                                                                                                                          |                                                                      |
+> | amuletPrice          | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                        |                                                                      |
+> | ansRulesConfig       | AnsRulesConfig                                                                                                                                                                                                                            |                                                                      |
+> | config               | DsoRulesConfig                                                                                                                                                                                                                            |                                                                      |
+> | initialTrafficState  | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState |                                                                      |
+> | isDevNet             | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                                                                                                              |                                                                      |
+> | initialRound         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |                                                                      |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-dsobootstrap-dsobootstrapbootstrap-56803">
+>
+>   **Choice** DsoBootstrap_Bootstrap
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoBootstrap_BootstrapResult
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-dsobootstrap-dsobootstrapbootstrapresult-11174">
+
+**data** DsoBootstrap_BootstrapResult
+
+</div>
+
+> <div id="constr-splice-dsobootstrap-dsobootstrapbootstrapresult-22331">
+>
+> DsoBootstrap_BootstrapResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoBootstrap DsoBootstrap_Bootstrap DsoBootstrap_BootstrapResult
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules.mdx
@@ -1,0 +1,3615 @@
+---
+title: "Splice.DsoRules"
+description: "Documentation for Splice.DsoRules"
+---
+
+{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-DsoRules.rst" tag="0.6.4" hash="c73ff863" */}
+
+## Templates
+
+<div id="type-splice-dsorules-bootstrapexternalpartyconfigstateinstruction-72557">
+
+**template** BootstrapExternalPartyConfigStateInstruction
+
+</div>
+
+> Instruction to bootstrap the external party config state. This exists so that the `ActionRequiringConfirmation` for this is independent of the current rounds which we need so that we can do deduplication by action hash in our automation.
+>
+> Signatory: dso
+>
+> | Field | Type                                                                                                                | Description |
+> |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-dsorules-confirmation-62984">
+
+**template** Confirmation
+
+</div>
+
+> A confirmation for the SVs to take action as part of standard DSO. Used for executing automated actions in a shortened process. See the comments on `ActionRequiringConfirmation` for details.
+>
+> Signatory: dso
+>
+> | Field     | Type                                                                                                                | Description |
+> |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | confirmer | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | action    | ActionRequiringConfirmation                                                                                         |             |
+> | expiresAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-dsorules-confirmationexpire-84183">
+>
+>   **Choice** Confirmation_Expire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: Confirmation_ExpireResult
+>
+>   (no fields)
+
+<div id="type-splice-dsorules-dsorules-35440">
+
+**template** DsoRules
+
+</div>
+
+> Signatory: dso
+>
+> | Field               | Type                                                                                                                                                                                                                                                 | Description                                                                                                                       |
+> |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+> | dso                 | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                  |                                                                                                                                   |
+> | epoch               | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                           |                                                                                                                                   |
+> | svs                 | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) SvInfo           |                                                                                                                                   |
+> | offboardedSvs       | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) OffboardedSvInfo |                                                                                                                                   |
+> | dsoDelegate         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                  | **Deprecated** in favor of delegateless automation.                                                                               |
+> | config              | DsoRulesConfig                                                                                                                                                                                                                                       |                                                                                                                                   |
+> | initialTrafficState | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState            | Map from participant/mediator ID to its traffic state at the time of synchronizer bootstrapping. Used for testing, empty in prod. |
+> | isDevNet            | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                                                                                                                         |                                                                                                                                   |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-dsorules-dsorulesaddconfirmedsv-22105">
+>
+>   **Choice** DsoRules_AddConfirmedSv
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_AddConfirmedSvResult
+>
+>   | Field                    | Type                                                                                                                                                | Description |
+>   |--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | sv                       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                 |             |
+>   | svOnboardingConfirmedCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingConfirmed |             |
+>   | earliestRoundCid         | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound       |             |
+>   | middleRoundCid           | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound       |             |
+>   | latestRoundCid           | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound       |             |
+>   | amuletRulesCid           | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules           |             |
+>
+> - <div id="type-splice-dsorules-dsorulesaddsv-44293">
+>
+>   **Choice** DsoRules_AddSv
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoRules_AddSvResult
+>
+>   | Field              | Type                                                                                                                | Description |
+>   |--------------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | newSvParty         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>   | newSvName          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | newSvRewardWeight  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
+>   | newSvParticipantId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | joinedAsOfRound    | Round                                                                                                               |             |
+>
+> - <div id="type-splice-dsorules-dsorulesadvanceopenminingrounds-34192">
+>
+>   **Choice** DsoRules_AdvanceOpenMiningRounds
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_AdvanceOpenMiningRoundsResult
+>
+>   | Field               | Type                                                                                                                                                                                                                                               | Description |
+>   |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
+>   | roundToArchiveCid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                      |             |
+>   | middleRoundCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                      |             |
+>   | latestRoundCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                                      |             |
+>   | amuletPriceVoteCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote\]                                                                                                  |             |
+>   | sv                  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecord-56787">
+>
+>   **Choice** DsoRules_AllocateUnallocatedUnclaimedActivityRecord
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
+>
+>   | Field                                 | Type                                                                                                                                                             | Description                                                                                         |
+>   |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+>   | unallocatedUnclaimedActivityRecordCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnallocatedUnclaimedActivityRecord |                                                                                                     |
+>   | amuletRulesCid                        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                        |                                                                                                     |
+>   | unclaimedRewardsToBurnCids            | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward\]                | A sufficient list of `UnclaimedReward` to be archived. It must cover at least the requested amount. |
+>   | sv                                    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                              |                                                                                                     |
+>
+> - <div id="type-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkers-52437">
+>
+>   **Choice** DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
+>
+>   | Field          | Type                                                                                                                                                                                                                                               | Description |
+>   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
+>   | argument       | AmuletRules_ConvertFeaturedAppActivityMarkers                                                                                                                                                                                                      |             |
+>   | sv             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesamuletexpire-71495">
+>
+>   **Choice** DsoRules_Amulet_Expire
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_Amulet_ExpireResult
+>
+>   | Field     | Type                                                                                                                                                                                                                                               | Description |
+>   |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet                                                                                                               |             |
+>   | choiceArg | Amulet_Expire                                                                                                                                                                                                                                      |             |
+>   | sv        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesamuletexpiretransferinstructions-57305">
+>
+>   **Choice** DsoRules_Amulet_ExpireTransferInstructions
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_Amulet_ExpireTransferInstructionsResult
+>
+>   | Field          | Type                                                                                                                                      | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
+>   | transferInsts  | AmuletRules_Amulet_ExpireTransferInstructions                                                                                             |             |
+>   | sv             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                       |             |
+>
+> - <div id="type-splice-dsorules-dsorulesamuletexpirev2-61973">
+>
+>   **Choice** DsoRules_Amulet_ExpireV2
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_Amulet_ExpireV2Result
+>
+>   | Field     | Type                                                                                                                                                                                                                                               | Description |
+>   |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet                                                                                                               |             |
+>   | choiceArg | Amulet_ExpireV2                                                                                                                                                                                                                                    |             |
+>   | sv        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesarchiveoutdatedelectionrequest-55064">
+>
+>   **Choice** DsoRules_ArchiveOutdatedElectionRequest
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ArchiveOutdatedElectionRequestResult
+>
+>   | Field      | Type                                                                                                                                                                                                                                               | Description |
+>   |------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | requestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ElectionRequest                                                                                                      |             |
+>   | sv         | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesarchivesvonboardingrequest-72075">
+>
+>   **Choice** DsoRules_ArchiveSvOnboardingRequest
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ArchiveSvOnboardingRequestResult
+>
+>   | Field                  | Type                                                                                                                                                                                                                                               | Description |
+>   |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | svOnboardingRequestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingRequest                                                                                                  |             |
+>   | sv                     | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesbootstrapexternalpartyconfigstate-94209">
+>
+>   **Choice** DsoRules_BootstrapExternalPartyConfigState
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_BootstrapExternalPartyConfigStateResult
+>
+>   | Field                 | Type                                                                                                                                                                       | Description |
+>   |-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                  |             |
+>   | instructionCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BootstrapExternalPartyConfigStateInstruction |             |
+>   | openMiningRoundTriple | OpenMiningRoundTriple                                                                                                                                                      |             |
+>   | sv                    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                        |             |
+>
+> - <div id="type-splice-dsorules-dsorulescastvote-63161">
+>
+>   **Choice** DsoRules_CastVote
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"sv" vote)
+>
+>   Returns: DsoRules_CastVoteResult
+>
+>   | Field      | Type                                                                                                                                      | Description |
+>   |------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | requestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest |             |
+>   | vote       | Vote                                                                                                                                      |             |
+>
+> - <div id="type-splice-dsorules-dsorulesclaimexpiredrewards-16372">
+>
+>   **Choice** DsoRules_ClaimExpiredRewards
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ClaimExpiredRewardsResult
+>
+>   | Field          | Type                                                                                                                                                                                                                                               | Description |
+>   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
+>   | choiceArg      | AmuletRules_ClaimExpiredRewards                                                                                                                                                                                                                    |             |
+>   | sv             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesclosevoterequest-87527">
+>
+>   **Choice** DsoRules_CloseVoteRequest
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_CloseVoteRequestResult
+>
+>   | Field          | Type                                                                                                                                                                                                                                                                       | Description |
+>   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | requestCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest                                                                                                                                  |             |
+>   | amuletRulesCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules) |             |
+>   | sv             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                         |             |
+>
+> - <div id="type-splice-dsorules-dsorulescollectentryrenewalpayment-93166">
+>
+>   **Choice** DsoRules_CollectEntryRenewalPayment
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_CollectEntryRenewalPaymentResult
+>
+>   | Field              | Type                                                                                                                                                                                                                                               | Description |
+>   |--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | ansEntryContextCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext                                                                                                      |             |
+>   | choiceArg          | AnsEntryContext_CollectEntryRenewalPayment                                                                                                                                                                                                         |             |
+>   | sv                 | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesconfirmaction-67097">
+>
+>   **Choice** DsoRules_ConfirmAction
+>
+>   </div>
+>
+>   Controller: confirmer
+>
+>   Returns: DsoRules_ConfirmActionResult
+>
+>   | Field     | Type                                                                                                                | Description |
+>   |-----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | confirmer | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>   | action    | ActionRequiringConfirmation                                                                                         |             |
+>
+> - <div id="type-splice-dsorules-dsorulesconfirmsvonboarding-94029">
+>
+>   **Choice** DsoRules_ConfirmSvOnboarding
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoRules_ConfirmSvOnboardingResult
+>
+>   | Field             | Type                                                                                                                | Description |
+>   |-------------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | newSvParty        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>   | newSvName         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | newParticipantId  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | newSvRewardWeight | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
+>   | reason            | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>
+> - <div id="type-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstruction-1552">
+>
+>   **Choice** DsoRules_CreateBootstrapExternalPartyConfigStateInstruction
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-dsorules-dsorulescreateexternalpartyamuletrules-62448">
+>
+>   **Choice** DsoRules_CreateExternalPartyAmuletRules
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoRules_CreateExternalPartyAmuletRulesResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-dsorules-dsorulescreatetransfercommandcounter-44220">
+>
+>   **Choice** DsoRules_CreateTransferCommandCounter
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoRules_CreateTransferCommandCounterResult
+>
+>   | Field  | Type                                                                                                                | Description |
+>   |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | sender | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecord-78616">
+>
+>   **Choice** DsoRules_CreateUnallocatedUnclaimedActivityRecord
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
+>
+>   | Field       | Type                                                                                                                | Description |
+>   |-------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>   | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |             |
+>   | reason      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
+>
+> - <div id="type-splice-dsorules-dsoruleselectdsodelegate-82924">
+>
+>   **Choice** DsoRules_ElectDsoDelegate
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: DsoRules_ElectDsoDelegateResult
+>
+>   | Field       | Type                                                                                                                                              | Description |
+>   |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | actor       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                               |             |
+>   | requestCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ElectionRequest\] |             |
+>
+> - <div id="type-splice-dsorules-dsorulesexecuteconfirmedaction-18028">
+>
+>   **Choice** DsoRules_ExecuteConfirmedAction
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ExecuteConfirmedActionResult
+>
+>   | Field            | Type                                                                                                                                                                                                                                                                       | Description |
+>   |------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | action           | ActionRequiringConfirmation                                                                                                                                                                                                                                                |             |
+>   | amuletRulesCid   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules) |             |
+>   | confirmationCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Confirmation\]                                                                                                                             |             |
+>   | sv               | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                         |             |
+>
+> - <div id="type-splice-dsorules-dsorulesexpireamuletallocations-76865">
+>
+>   **Choice** DsoRules_ExpireAmuletAllocations
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ExpireAmuletAllocationsResult
+>
+>   | Field             | Type                                                                                                                                                   | Description |
+>   |-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | extAmuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyAmuletRules |             |
+>   | expireAllocations | ExternalPartyAmuletRules_ExpireAmuletAllocations                                                                                                       |             |
+>   | sv                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                    |             |
+>
+> - <div id="type-splice-dsorules-dsorulesexpireansentry-58167">
+>
+>   **Choice** DsoRules_ExpireAnsEntry
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ExpireAnsEntryResult
+>
+>   | Field       | Type                                                                                                                                                                                                                                               | Description |
+>   |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | ansEntryCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry                                                                                                             |             |
+>   | choiceArg   | AnsEntry_Expire                                                                                                                                                                                                                                    |             |
+>   | sv          | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesexpiredevelopmentfundcoupon-65446">
+>
+>   **Choice** DsoRules_ExpireDevelopmentFundCoupon
+>
+>   </div>
+>
+>   Expires a DevelopmentFundCoupon and produces an UnclaimedDevelopmentFundCoupon with the same amount.
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ExpireDevelopmentFundCouponResult
+>
+>   | Field                    | Type                                                                                                                                                | Description |
+>   |--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | developmentFundCouponCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DevelopmentFundCoupon |             |
+>   | sv                       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                 |             |
+>
+> - <div id="type-splice-dsorules-dsorulesexpirestaleconfirmation-23846">
+>
+>   **Choice** DsoRules_ExpireStaleConfirmation
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ExpireStaleConfirmationResult
+>
+>   | Field                | Type                                                                                                                                                                                                                                               | Description |
+>   |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | staleConfirmationCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Confirmation                                                                                                         |             |
+>   | sv                   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesexpiresubscription-15972">
+>
+>   **Choice** DsoRules_ExpireSubscription
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ExpireSubscriptionResult
+>
+>   | Field                    | Type                                                                                                                                                                                                                                               | Description |
+>   |--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | ansEntryContextCid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext                                                                                                      |             |
+>   | subscriptionIdleStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState                                                                                                |             |
+>   | choiceArg                | SubscriptionIdleState_ExpireSubscription                                                                                                                                                                                                           |             |
+>   | sv                       | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesexpiresvonboardingconfirmed-60809">
+>
+>   **Choice** DsoRules_ExpireSvOnboardingConfirmed
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ExpireSvOnboardingConfirmedResult
+>
+>   | Field | Type                                                                                                                                                                                                                                               | Description |
+>   |-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingConfirmed                                                                                                |             |
+>   | sv    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesexpiresvonboardingrequest-63611">
+>
+>   **Choice** DsoRules_ExpireSvOnboardingRequest
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ExpireSvOnboardingRequestResult
+>
+>   | Field | Type                                                                                                                                                                                                                                               | Description |
+>   |-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingRequest                                                                                                  |             |
+>   | sv    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesexpiretransferpreapproval-91729">
+>
+>   **Choice** DsoRules_ExpireTransferPreapproval
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ExpireTransferPreapprovalResult
+>
+>   | Field                  | Type                                                                                                                                                                                                                                               | Description |
+>   |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | transferPreapprovalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval                                                                                                  |             |
+>   | sv                     | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecord-90041">
+>
+>   **Choice** DsoRules_ExpireUnallocatedUnclaimedActivityRecord
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
+>
+>   | Field                                 | Type                                                                                                                                                             | Description |
+>   |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | unallocatedUnclaimedActivityRecordCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnallocatedUnclaimedActivityRecord |             |
+>   | sv                                    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                              |             |
+>
+> - <div id="type-splice-dsorules-dsorulesexpireunclaimedactivityrecord-57856">
+>
+>   **Choice** DsoRules_ExpireUnclaimedActivityRecord
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ExpireUnclaimedActivityRecordResult
+>
+>   | Field                      | Type                                                                                                                                                  | Description |
+>   |----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | unclaimedActivityRecordCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedActivityRecord |             |
+>   | sv                         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                   |             |
+>
+> - <div id="type-splice-dsorules-dsorulesgarbagecollectamuletpricevotes-77719">
+>
+>   **Choice** DsoRules_GarbageCollectAmuletPriceVotes
+>
+>   </div>
+>
+>   Garbage-collect AmuletPriceVotes from removed svs and duplicate ones that might happen due to a too quick removal and re-addition of a sv. We expect this to be run as an OnAssignedContractTrigger for the DsoRules contract.
+>
+>   Note: we do not archive the AmuletPriceVote of an SV on its removal, as that would allow that SV to block the removal via updating its AmuletPriceVote at the right time.
+>
+>   TODO(#10063): drop this code in favor of just keeping AmuletPriceVotes around.
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_GarbageCollectAmuletPriceVotesResult
+>
+>   | Field             | Type                                                                                                                                                                                                                                               | Description |
+>   |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | nonSvVoteCids     | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote\]                                                                                                  |             |
+>   | duplicateVoteCids | \[\[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote\]\]                                                                                              |             |
+>   | sv                | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesgrantfeaturedappright-79910">
+>
+>   **Choice** DsoRules_GrantFeaturedAppRight
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoRules_GrantFeaturedAppRightResult
+>
+>   | Field    | Type                                                                                                                | Description |
+>   |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsoruleslockedamuletexpireamulet-28275">
+>
+>   **Choice** DsoRules_LockedAmulet_ExpireAmulet
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_LockedAmulet_ExpireAmuletResult
+>
+>   | Field     | Type                                                                                                                                                                                                                                               | Description |
+>   |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet                                                                                                         |             |
+>   | choiceArg | LockedAmulet_ExpireAmulet                                                                                                                                                                                                                          |             |
+>   | sv        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsoruleslockedamuletexpireamuletv2-91833">
+>
+>   **Choice** DsoRules_LockedAmulet_ExpireAmuletV2
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_LockedAmulet_ExpireAmuletV2Result
+>
+>   | Field     | Type                                                                                                                                                                                                                                               | Description |
+>   |-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid       | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet                                                                                                         |             |
+>   | choiceArg | LockedAmulet_ExpireAmuletV2                                                                                                                                                                                                                        |             |
+>   | sv        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesmergemembertrafficcontracts-34275">
+>
+>   **Choice** DsoRules_MergeMemberTrafficContracts
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_MergeMemberTrafficContractsResult
+>
+>   | Field          | Type                                                                                                                                                                                                                                               | Description |
+>   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
+>   | trafficCids    | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic\]                                                                                                    |             |
+>   | sv             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesmergesvrewardstate-39851">
+>
+>   **Choice** DsoRules_MergeSvRewardState
+>
+>   </div>
+>
+>   Note this choice only exists to clean up duplicate contracts caused by the bug in \#12495. There should never be duplicates going forward.
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_MergeSvRewardStateResult
+>
+>   | Field           | Type                                                                                                                                                                                                                                               | Description |
+>   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | svName          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                       |             |
+>   | rewardStateCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState\]                                                                                                    |             |
+>   | sv              | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcoupons-23755">
+>
+>   **Choice** DsoRules_MergeUnclaimedDevelopmentFundCoupons
+>
+>   </div>
+>
+>   Batch merge of of development fund coupons.
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
+>
+>   | Field          | Type                                                                                                                                      | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
+>   | choiceArg      | AmuletRules_MergeUnclaimedDevelopmentFundCoupons                                                                                          |             |
+>   | sv             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                       |             |
+>
+> - <div id="type-splice-dsorules-dsorulesmergeunclaimedrewards-12383">
+>
+>   **Choice** DsoRules_MergeUnclaimedRewards
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_MergeUnclaimedRewardsResult
+>
+>   | Field               | Type                                                                                                                                                                                                                                               | Description |
+>   |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
+>   | unclaimedRewardCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward\]                                                                                                  |             |
+>   | sv                  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesmergevalidatorlicense-65804">
+>
+>   **Choice** DsoRules_MergeValidatorLicense
+>
+>   </div>
+>
+>   Note: removes the old duplicated licenses and creates a new one with the highest lastReceivedFor round There should never be duplicates going forward.
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_MergeValidatorLicenseResult
+>
+>   | Field                | Type                                                                                                                                                                                                                                               | Description |
+>   |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | validatorLicenseCids | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense\]                                                                                                 |             |
+>   | sv                   | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesminingroundclose-28010">
+>
+>   **Choice** DsoRules_MiningRound_Close
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_MiningRound_CloseResult
+>
+>   | Field           | Type                                                                                                                                                                                                                                               | Description |
+>   |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid  | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
+>   | issuingRoundCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) IssuingMiningRound                                                                                                   |             |
+>   | sv              | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesoffboardsv-78636">
+>
+>   **Choice** DsoRules_OffboardSv
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoRules_OffboardSvResult
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | sv    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesonboardvalidator-23909">
+>
+>   **Choice** DsoRules_OnboardValidator
+>
+>   </div>
+>
+>   Controller: sponsor
+>
+>   Returns: DsoRules_OnboardValidatorResult
+>
+>   | Field        | Type                                                                                                                                                                                                                                        | Description |
+>   |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | sponsor      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |             |
+>   | validator    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                         |             |
+>   | version      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>   | contactPoint | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> - <div id="type-splice-dsorules-dsorulespruneamuletconfigschedule-70948">
+>
+>   **Choice** DsoRules_PruneAmuletConfigSchedule
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_PruneAmuletConfigScheduleResult
+>
+>   | Field          | Type                                                                                                                                                                                                                                               | Description |
+>   |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules                                                                                                          |             |
+>   | sv             | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesreceivesvrewardcoupon-83972">
+>
+>   **Choice** DsoRules_ReceiveSvRewardCoupon
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_ReceiveSvRewardCouponResult
+>
+>   | Field          | Type                                                                                                                                                                                                                                  | Description |
+>   |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | sv             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                   |             |
+>   | openRoundCid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound                                                                                         |             |
+>   | rewardStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState                                                                                           |             |
+>   | beneficiaries  | \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261))\] |             |
+>
+> - <div id="type-splice-dsorules-dsorulesrequestelection-327">
+>
+>   **Choice** DsoRules_RequestElection
+>
+>   </div>
+>
+>   Controller: requester
+>
+>   Returns: DsoRules_RequestElectionResult
+>
+>   | Field     | Type                                                                                                                    | Description |
+>   |-----------|-------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | requester | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)     |             |
+>   | reason    | ElectionRequestReason                                                                                                   |             |
+>   | ranking   | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] |             |
+>
+> - <div id="type-splice-dsorules-dsorulesrequestvote-27270">
+>
+>   **Choice** DsoRules_RequestVote
+>
+>   </div>
+>
+>   Controller: requester
+>
+>   Returns: DsoRules_RequestVoteResult
+>
+>   | Field              | Type                                                                                                                                                                                                                                                  | Description |
+>   |--------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | requester          | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                   |             |
+>   | action             | ActionRequiringConfirmation                                                                                                                                                                                                                           |             |
+>   | reason             | Reason                                                                                                                                                                                                                                                |             |
+>   | voteRequestTimeout | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) |             |
+>   | targetEffectiveAt  | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)      |             |
+>
+> - <div id="type-splice-dsorules-dsorulesrevokefeaturedappright-46223">
+>
+>   **Choice** DsoRules_RevokeFeaturedAppRight
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoRules_RevokeFeaturedAppRightResult
+>
+>   | Field    | Type                                                                                                                                           | Description |
+>   |----------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | rightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
+>
+> - <div id="type-splice-dsorules-dsorulessetconfig-76713">
+>
+>   **Choice** DsoRules_SetConfig
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoRules_SetConfigResult
+>
+>   | Field      | Type                                                                                                                                          | Description |
+>   |------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | newConfig  | DsoRulesConfig                                                                                                                                |             |
+>   | baseConfig | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) DsoRulesConfig |             |
+>
+> - <div id="type-splice-dsorules-dsorulessetsynchronizernodeconfig-79561">
+>
+>   **Choice** DsoRules_SetSynchronizerNodeConfig
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_SetSynchronizerNodeConfigResult
+>
+>   | Field          | Type                                                                                                                                      | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | sv             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                       |             |
+>   | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                              |             |
+>   | newNodeConfig  | SynchronizerNodeConfig                                                                                                                    |             |
+>   | nodeStateCid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvNodeState |             |
+>
+> - <div id="type-splice-dsorules-dsorulesstartsvonboarding-74859">
+>
+>   **Choice** DsoRules_StartSvOnboarding
+>
+>   </div>
+>
+>   Controller: sponsor
+>
+>   Returns: DsoRules_StartSvOnboardingResult
+>
+>   | Field                  | Type                                                                                                                | Description |
+>   |------------------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | candidateName          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | candidateParty         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>   | candidateParticipantId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | token                  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | sponsor                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulessubmitstatusreport-89950">
+>
+>   **Choice** DsoRules_SubmitStatusReport
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_SubmitStatusReportResult
+>
+>   | Field             | Type                                                                                                                                         | Description |
+>   |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | sv                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                          |             |
+>   | previousReportCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvStatusReport |             |
+>   | status            | SvStatus                                                                                                                                     |             |
+>
+> - <div id="type-splice-dsorules-dsorulesterminatesubscription-67561">
+>
+>   **Choice** DsoRules_TerminateSubscription
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_TerminateSubscriptionResult
+>
+>   | Field                     | Type                                                                                                                                                                                                                                               | Description |
+>   |---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | ansEntryContextCid        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext                                                                                                      |             |
+>   | terminatedSubscriptionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription                                                                                               |             |
+>   | sv                        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-dsorules-dsorulesupdateamuletpricevote-33547">
+>
+>   **Choice** DsoRules_UpdateAmuletPriceVote
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_UpdateAmuletPriceVoteResult
+>
+>   | Field       | Type                                                                                                                                          | Description |
+>   |-------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | sv          | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                           |             |
+>   | voteCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote |             |
+>   | amuletPrice | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                            |             |
+>
+> - <div id="type-splice-dsorules-dsorulesupdateexternalpartyconfigstates-33819">
+>
+>   **Choice** DsoRules_UpdateExternalPartyConfigStates
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: DsoRules_UpdateExternalPartyConfigStatesResult
+>
+>   | Field                        | Type                                                                                                                                                   | Description |
+>   |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid               | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules              |             |
+>   | externalPartyConfigStateCid0 | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
+>   | externalPartyConfigStateCid1 | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
+>   | openMiningRoundTriple        | OpenMiningRoundTriple                                                                                                                                  |             |
+>   | sv                           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                    |             |
+>
+> - <div id="type-splice-dsorules-dsorulesupdatesvrewardweight-33689">
+>
+>   **Choice** DsoRules_UpdateSvRewardWeight
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: DsoRules_UpdateSvRewardWeightResult
+>
+>   | Field           | Type                                                                                                                | Description |
+>   |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | svParty         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>   | newRewardWeight | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |             |
+
+<div id="type-splice-dsorules-electionrequest-92680">
+
+**template** ElectionRequest
+
+</div>
+
+> **Deprecated** in favor of delegateless automation.
+>
+> A request to elect a new DSO delegate.
+>
+> Signatory: dso
+>
+> | Field     | Type                                                                                                                    | Description |
+> |-----------|-------------------------------------------------------------------------------------------------------------------------|-------------|
+> | dso       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)     |             |
+> | requester | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)     |             |
+> | epoch     | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)              |             |
+> | reason    | ElectionRequestReason                                                                                                   |             |
+> | ranking   | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] |             |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-dsorules-unallocatedunclaimedactivityrecord-15769">
+
+**template** UnallocatedUnclaimedActivityRecord
+
+</div>
+
+> A governance-approved record representing intent to reward a beneficiary. Once sufficient `UnclaimedReward` contracts are allocated and archived, this contract results in the creation of a mintable `UnclaimedActivityRecord`.
+>
+> Signatory: dso
+>
+> | Field       | Type                                                                                                                | Description                                                                       |
+> |-------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                   |
+> | beneficiary | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The owner of the `Amulet` to be minted                                            |
+> | amount      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  | The amount of `Amulet` to be minted                                               |
+> | reason      | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | A reason to mint the `Amulet`                                                     |
+> | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Selected timestamp defining the lifetime of the UnclaimedActivityRecord contract. |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-dsorules-voterequest-12683">
+
+**template** VoteRequest
+
+</div>
+
+> A request for the other svs to vote on the execution of an action requiring confirmation. We use this for implementing on-ledger governance actions triggered by SV operators in a uniform way.
+>
+> See the comments on `ActionRequiringConfirmation` for details.
+>
+> Version 3, which introduces effectivity in vote request.
+>
+> Signatory: dso
+>
+> | Field             | Type                                                                                                                                                                                                                                                                       | Description                                                                                                                                                                               |
+> |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> | dso               | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                                        |                                                                                                                                                                                           |
+> | requester         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                                               | The SV that requested to execute the action.                                                                                                                                              |
+> | action            | ActionRequiringConfirmation                                                                                                                                                                                                                                                | The action whose confirmation is required.                                                                                                                                                |
+> | reason            | Reason                                                                                                                                                                                                                                                                     | The reason for requesting the execution of the action. Typically a reference to some off-ledger justification.                                                                            |
+> | voteBefore        | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                                                                                                                                          | The time before which votes are accepted, and SHOULD be submitted.                                                                                                                        |
+> | votes             | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) Vote                                          | The votes cast by current or previous SVs. These may be previous SVs in case there was an SV change after the vote was requested.                                                         |
+> | trackingCid       | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest) | An optional tracking ContractId to be used for tracking the vote request through its updates. This is always set to the first ContractId of the original vote request (None on creation). |
+> | targetEffectiveAt | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                           | The time when the action is targeted to be made effective. If None, the action is immediately effective upon 2/3 votes in favor.                                                          |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Orphan Typeclass Instances
+
+**instance** HasCheckedFetch FeaturedAppRight ForDso
+
+## Data Types
+
+<div id="type-splice-dsorules-actionrequiringconfirmation-45397">
+
+**data** ActionRequiringConfirmation
+
+</div>
+
+> Actions that require confirmation from SV nodes before they can be executed.
+>
+> There are two processes for executing such actions:
+>
+> 1.  Any SV can request a vote to execute such an action upon which the other SV's can respond with their votes for whether they accept the execution or not. This process requires votes from 2/3 of all SVs\* for the action to be considered definitive and it can be used for all actions that require confirmation.
+> 2.  Some of the actions that require confirmations should be executed automatically once the ledger and the wall-clocks of the SV nodes are in a particular state. These actions are confirmed by each SV node automatically once the action's precondition is met. Once 2/3 of all SV's confirmations\* are visible to the DSO delegate it executes them.
+>
+> - Simplified for clarity; see `requiredNumVotes` for exact formula.
+>
+> Process 2 is an optimization of Process 1 for the case where no disagreement to the action is expected.
+>
+> We expect honest SV nodes to only create confirmations for actions whose preconditions are met. We also rely on the execution of these actions to be idempotent, as more than the required number of confirmations can be created.
+>
+> Note also that having these two processes also aids in distinguishing between manually initiated ad-hoc votes and the regular confirmations that need to happen during standard DSO.
+>
+> <div id="constr-splice-dsorules-arcdsorules-25826">
+>
+> ARC_DsoRules
+>
+> </div>
+>
+> > | Field     | Type                                 | Description |
+> > |-----------|--------------------------------------|-------------|
+> > | dsoAction | DsoRules_ActionRequiringConfirmation |             |
+>
+> <div id="constr-splice-dsorules-arcamuletrules-45909">
+>
+> ARC_AmuletRules
+>
+> </div>
+>
+> > | Field             | Type                                    | Description |
+> > |-------------------|-----------------------------------------|-------------|
+> > | amuletRulesAction | AmuletRules_ActionRequiringConfirmation |             |
+>
+> <div id="constr-splice-dsorules-arcansentrycontext-51355">
+>
+> ARC_AnsEntryContext
+>
+> </div>
+>
+> > | Field                 | Type                                                                                                                                          | Description |
+> > |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | ansEntryContextCid    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext |             |
+> > | ansEntryContextAction | AnsEntryContext_ActionRequiringConfirmation                                                                                                   |             |
+>
+> <div id="constr-splice-dsorules-extactionrequiringconformation-24220">
+>
+> ExtActionRequiringConformation
+>
+> </div>
+>
+> > | Field          | Type | Description                                                                                                                                                                            |
+> > |----------------|------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | dummyUnitField | ()   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 This on takes care of providing extensibility for the specific variants below. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ActionRequiringConfirmation
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ActionRequiringConfirmation
+>
+> **instance** GetField "action" Confirmation ActionRequiringConfirmation
+>
+> **instance** GetField "action" DsoRules_ConfirmAction ActionRequiringConfirmation
+>
+> **instance** GetField "action" DsoRules_ExecuteConfirmedAction ActionRequiringConfirmation
+>
+> **instance** GetField "action" DsoRules_RequestVote ActionRequiringConfirmation
+>
+> **instance** GetField "action" VoteRequest ActionRequiringConfirmation
+>
+> **instance** GetField "amuletRulesAction" ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation
+>
+> **instance** GetField "ansEntryContextAction" ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation
+>
+> **instance** GetField "ansEntryContextCid" ActionRequiringConfirmation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext)
+>
+> **instance** GetField "dsoAction" ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation
+>
+> **instance** GetField "dummyUnitField" ActionRequiringConfirmation ()
+>
+> **instance** SetField "action" Confirmation ActionRequiringConfirmation
+>
+> **instance** SetField "action" DsoRules_ConfirmAction ActionRequiringConfirmation
+>
+> **instance** SetField "action" DsoRules_ExecuteConfirmedAction ActionRequiringConfirmation
+>
+> **instance** SetField "action" DsoRules_RequestVote ActionRequiringConfirmation
+>
+> **instance** SetField "action" VoteRequest ActionRequiringConfirmation
+>
+> **instance** SetField "amuletRulesAction" ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation
+>
+> **instance** SetField "ansEntryContextAction" ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation
+>
+> **instance** SetField "ansEntryContextCid" ActionRequiringConfirmation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntryContext)
+>
+> **instance** SetField "dsoAction" ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation
+>
+> **instance** SetField "dummyUnitField" ActionRequiringConfirmation ()
+
+<div id="type-splice-dsorules-amuletrulesactionrequiringconfirmation-62783">
+
+**data** AmuletRules_ActionRequiringConfirmation
+
+</div>
+
+> <div id="constr-splice-dsorules-crarcminingroundstartissuing-47375">
+>
+> CRARC_MiningRound_StartIssuing AmuletRules_MiningRound_StartIssuing
+>
+> </div>
+>
+> > Automated action to start an issuing round once the summary of the reward coupons have been computed.
+>
+> <div id="constr-splice-dsorules-crarcminingroundarchive-10786">
+>
+> CRARC_MiningRound_Archive AmuletRules_MiningRound_Archive
+>
+> </div>
+>
+> > Automated action to archive a closed mining round once no expired reward coupons are left.
+>
+> <div id="constr-splice-dsorules-crarcaddfutureamuletconfigschedule-50004">
+>
+> CRARC_AddFutureAmuletConfigSchedule AmuletRules_AddFutureAmuletConfigSchedule
+>
+> </div>
+>
+> > **Deprecated, use CRARC_SetConfig instead**: Voted action to add a config schedule to the `AmuletRules`.
+>
+> <div id="constr-splice-dsorules-crarcremovefutureamuletconfigschedule-28322">
+>
+> CRARC_RemoveFutureAmuletConfigSchedule AmuletRules_RemoveFutureAmuletConfigSchedule
+>
+> </div>
+>
+> > **Deprecated, use CRARC_SetConfig instead**: Voted action to remove a config schedule from the `AmuletRules`.
+>
+> <div id="constr-splice-dsorules-crarcupdatefutureamuletconfigschedule-3041">
+>
+> CRARC_UpdateFutureAmuletConfigSchedule AmuletRules_UpdateFutureAmuletConfigSchedule
+>
+> </div>
+>
+> > **Deprecated, use CRARC_SetConfig instead**: Voted action to update a config schedule in the `AmuletRules`.
+>
+> <div id="constr-splice-dsorules-crarcsetconfig-80537">
+>
+> CRARC_SetConfig AmuletRules_SetConfig
+>
+> </div>
+>
+> > Voted action to change the `AmuletConfig`. Not idempotent.
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRules_ActionRequiringConfirmation
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRules_ActionRequiringConfirmation
+>
+> **instance** GetField "amuletRulesAction" ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation
+>
+> **instance** SetField "amuletRulesAction" ActionRequiringConfirmation AmuletRules_ActionRequiringConfirmation
+
+<div id="type-splice-dsorules-ansentrycontextactionrequiringconfirmation-11149">
+
+**data** AnsEntryContext_ActionRequiringConfirmation
+
+</div>
+
+> <div id="constr-splice-dsorules-ansrarccollectinitialentrypayment-99049">
+>
+> ANSRARC_CollectInitialEntryPayment AnsEntryContext_CollectInitialEntryPayment
+>
+> </div>
+>
+> > Automated action to collect initial payment of an ans entry.
+>
+> <div id="constr-splice-dsorules-ansrarcrejectentryinitialpayment-1047">
+>
+> ANSRARC_RejectEntryInitialPayment AnsEntryContext_RejectEntryInitialPayment
+>
+> </div>
+>
+> > Automated action to reject initial payment of an ans entry.
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AnsEntryContext_ActionRequiringConfirmation
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AnsEntryContext_ActionRequiringConfirmation
+>
+> **instance** GetField "ansEntryContextAction" ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation
+>
+> **instance** SetField "ansEntryContextAction" ActionRequiringConfirmation AnsEntryContext_ActionRequiringConfirmation
+
+<div id="type-splice-dsorules-confirmationexpireresult-10666">
+
+**data** Confirmation_ExpireResult
+
+</div>
+
+> Choice return types
+>
+> <div id="constr-splice-dsorules-confirmationexpireresult-43205">
+>
+> Confirmation_ExpireResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) Confirmation Confirmation_Expire Confirmation_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) Confirmation Confirmation_Expire Confirmation_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) Confirmation Confirmation_Expire Confirmation_ExpireResult
+
+<div id="type-splice-dsorules-dsorulesconfig-6376">
+
+**data** DsoRulesConfig
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesconfig-32625">
+>
+> DsoRulesConfig
+>
+> </div>
+>
+> > | Field                                   | Type                                                                                                                                                                                                                                                  | Description                                                                                                                                     |
+> > |-----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | numUnclaimedRewardsThreshold            | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                            | The minimum number of unclaimed rewards required for merging                                                                                    |
+> > | numMemberTrafficContractsThreshold      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                            | The minimum number of member traffic contracts required for merging                                                                             |
+> > | actionConfirmationTimeout               | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | The TTL for contracts representing a confirmation                                                                                               |
+> > | svOnboardingRequestTimeout              | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | The TTL for contracts representing an incomplete onboarding                                                                                     |
+> > | svOnboardingConfirmedTimeout            | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | The TTL for contracts representing an SV confirmation                                                                                           |
+> > | voteRequestTimeout                      | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | The TTL for a `VoteRequest` and its associated `Vote` s                                                                                         |
+> > | dsoDelegateInactiveTimeout              | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                | The amount of time given to the DSO delegate to complete an action it should take care of ^ **Deprecated** in favor of delegateless automation. |
+> > | synchronizerNodeConfigLimits            | SynchronizerNodeConfigLimits                                                                                                                                                                                                                          | Limits to enforce on the svs' `SynchronizerNodeConfig`                                                                                          |
+> > | maxTextLength                           | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                            | Generic upper limit on text fields in choices and contracts.                                                                                    |
+> > | decentralizedSynchronizer               | DsoDecentralizedSynchronizerConfig                                                                                                                                                                                                                    |                                                                                                                                                 |
+> > | nextScheduledSynchronizerUpgrade        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SynchronizerUpgradeSchedule                                                                                            |                                                                                                                                                 |
+> > | voteCooldownTime                        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | The minimum time between two votes by the same SV.                                                                                              |
+> > | nextScheduledLogicalSynchronizerUpgrade | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LogicalSynchronizerUpgradeSchedule                                                                                     |                                                                                                                                                 |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRulesConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRulesConfig
+>
+> **instance** GetField "actionConfirmationTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** GetField "baseConfig" DsoRules_SetConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) DsoRulesConfig)
+>
+> **instance** GetField "config" DsoBootstrap DsoRulesConfig
+>
+> **instance** GetField "config" DsoRules DsoRulesConfig
+>
+> **instance** GetField "decentralizedSynchronizer" DsoRulesConfig DsoDecentralizedSynchronizerConfig
+>
+> **instance** GetField "dsoDelegateInactiveTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** GetField "maxTextLength" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "newConfig" DsoRules_SetConfig DsoRulesConfig
+>
+> **instance** GetField "nextScheduledLogicalSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LogicalSynchronizerUpgradeSchedule)
+>
+> **instance** GetField "nextScheduledSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SynchronizerUpgradeSchedule)
+>
+> **instance** GetField "numMemberTrafficContractsThreshold" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "numUnclaimedRewardsThreshold" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "svOnboardingConfirmedTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** GetField "svOnboardingRequestTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** GetField "synchronizerNodeConfigLimits" DsoRulesConfig SynchronizerNodeConfigLimits
+>
+> **instance** GetField "voteCooldownTime" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082))
+>
+> **instance** GetField "voteRequestTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "actionConfirmationTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "baseConfig" DsoRules_SetConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) DsoRulesConfig)
+>
+> **instance** SetField "config" DsoBootstrap DsoRulesConfig
+>
+> **instance** SetField "config" DsoRules DsoRulesConfig
+>
+> **instance** SetField "decentralizedSynchronizer" DsoRulesConfig DsoDecentralizedSynchronizerConfig
+>
+> **instance** SetField "dsoDelegateInactiveTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "maxTextLength" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "newConfig" DsoRules_SetConfig DsoRulesConfig
+>
+> **instance** SetField "nextScheduledLogicalSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LogicalSynchronizerUpgradeSchedule)
+>
+> **instance** SetField "nextScheduledSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SynchronizerUpgradeSchedule)
+>
+> **instance** SetField "numMemberTrafficContractsThreshold" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "numUnclaimedRewardsThreshold" DsoRulesConfig [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "svOnboardingConfirmedTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "svOnboardingRequestTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "synchronizerNodeConfigLimits" DsoRulesConfig SynchronizerNodeConfigLimits
+>
+> **instance** SetField "voteCooldownTime" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082))
+>
+> **instance** SetField "voteRequestTimeout" DsoRulesConfig [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** Patchable DsoRulesConfig
+
+<div id="type-splice-dsorules-dsorulesactionrequiringconfirmation-12600">
+
+**data** DsoRules_ActionRequiringConfirmation
+
+</div>
+
+> <div id="constr-splice-dsorules-srarcaddsv-12841">
+>
+> SRARC_AddSv DsoRules_AddSv
+>
+> </div>
+>
+> > Voted action to directly add an SV
+>
+> <div id="constr-splice-dsorules-srarcoffboardsv-63692">
+>
+> SRARC_OffboardSv DsoRules_OffboardSv
+>
+> </div>
+>
+> > Voted action to remove an SV
+>
+> <div id="constr-splice-dsorules-srarcconfirmsvonboarding-51509">
+>
+> SRARC_ConfirmSvOnboarding DsoRules_ConfirmSvOnboarding
+>
+> </div>
+>
+> > Automated action to confirm that a party can become an SV.
+>
+> <div id="constr-splice-dsorules-srarcgrantfeaturedappright-84890">
+>
+> SRARC_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRight
+>
+> </div>
+>
+> > Voted action to grant a featured app right. Not idempotent.
+>
+> <div id="constr-splice-dsorules-srarcrevokefeaturedappright-73851">
+>
+> SRARC_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRight
+>
+> </div>
+>
+> > Revoke a specific featured app right.
+>
+> <div id="constr-splice-dsorules-srarcsetconfig-39305">
+>
+> SRARC_SetConfig DsoRules_SetConfig
+>
+> </div>
+>
+> > Voted action to change the `DsoRulesConfig`. Not idempotent.
+>
+> <div id="constr-splice-dsorules-srarcupdatesvrewardweight-81705">
+>
+> SRARC_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeight
+>
+> </div>
+>
+> > Voted action to update the reward weight of an SV.
+>
+> <div id="constr-splice-dsorules-srarccreateexternalpartyamuletrules-49124">
+>
+> SRARC_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRules
+>
+> </div>
+>
+> > Create ExternalPartyAmuletRules contract if it has not been created as part of network bootstrapping.
+>
+> <div id="constr-splice-dsorules-srarccreatetransfercommandcounter-88632">
+>
+> SRARC_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounter
+>
+> </div>
+>
+> > Create TransferCommandCounter contract for the given sender if it does not already exist
+>
+> <div id="constr-splice-dsorules-srarccreateunallocatedunclaimedactivityrecord-97784">
+>
+> SRARC_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecord
+>
+> </div>
+>
+> > Voted action to create an UnallocatedUnclaimedActivityRecord contract.
+>
+> <div id="constr-splice-dsorules-srarccreatebootstrapexternalpartyconfigstateinstruction-49456">
+>
+> SRARC_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstruction
+>
+> </div>
+>
+> > Create BootstrapExternalPartyConfigStateInstruction
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_ActionRequiringConfirmation
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_ActionRequiringConfirmation
+>
+> **instance** GetField "dsoAction" ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation
+>
+> **instance** SetField "dsoAction" ActionRequiringConfirmation DsoRules_ActionRequiringConfirmation
+
+<div id="type-splice-dsorules-dsorulesaddconfirmedsvresult-53040">
+
+**data** DsoRules_AddConfirmedSvResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesaddconfirmedsvresult-81391">
+>
+> DsoRules_AddConfirmedSvResult
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                   | Description |
+> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
+>
+> **instance** GetField "newDsoRules" DsoRules_AddConfirmedSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** SetField "newDsoRules" DsoRules_AddConfirmedSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_AddConfirmedSv DsoRules_AddConfirmedSvResult
+
+<div id="type-splice-dsorules-dsorulesaddsvresult-53972">
+
+**data** DsoRules_AddSvResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesaddsvresult-63557">
+>
+> DsoRules_AddSvResult
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                   | Description |
+> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
+>
+> **instance** GetField "newDsoRules" DsoRules_AddSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** SetField "newDsoRules" DsoRules_AddSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_AddSv DsoRules_AddSvResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_AddSv DsoRules_AddSvResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_AddSv DsoRules_AddSvResult
+
+<div id="type-splice-dsorules-dsorulesadvanceopenminingroundsresult-57405">
+
+**data** DsoRules_AdvanceOpenMiningRoundsResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesadvanceopenminingroundsresult-30524">
+>
+> DsoRules_AdvanceOpenMiningRoundsResult
+>
+> </div>
+>
+> > | Field            | Type                                                                                                                                                 | Description |
+> > |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | summarizingRound | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound |             |
+> > | openRound        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound        |             |
+>
+> **instance** GetField "openRound" DsoRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** GetField "summarizingRound" DsoRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound)
+>
+> **instance** SetField "openRound" DsoRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound)
+>
+> **instance** SetField "summarizingRound" DsoRules_AdvanceOpenMiningRoundsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SummarizingMiningRound)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_AdvanceOpenMiningRounds DsoRules_AdvanceOpenMiningRoundsResult
+
+<div id="type-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecordresult-87254">
+
+**data** DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesallocateunallocatedunclaimedactivityrecordresult-24573">
+>
+> DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
+>
+> </div>
+>
+> > | Field                      | Type                                                                                                                                                                                                                                                                           | Description |
+> > |----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unclaimedActivityRecordCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedActivityRecord                                                                                                                          |             |
+> > | optUnclaimedRewardCid      | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward) |             |
+>
+> **instance** GetField "optUnclaimedRewardCid" DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
+>
+> **instance** GetField "unclaimedActivityRecordCid" DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedActivityRecord)
+>
+> **instance** SetField "optUnclaimedRewardCid" DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
+>
+> **instance** SetField "unclaimedActivityRecordCid" DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedActivityRecord)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_AllocateUnallocatedUnclaimedActivityRecord DsoRules_AllocateUnallocatedUnclaimedActivityRecordResult
+
+<div id="type-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkersresult-72068">
+
+**data** DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesamuletrulesconvertfeaturedappactivitymarkersresult-81577">
+>
+> DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
+>
+> </div>
+>
+> > | Field  | Type                                                | Description |
+> > |--------|-----------------------------------------------------|-------------|
+> > | result | AmuletRules_ConvertFeaturedAppActivityMarkersResult |             |
+>
+> **instance** GetField "result" DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult AmuletRules_ConvertFeaturedAppActivityMarkersResult
+>
+> **instance** SetField "result" DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult AmuletRules_ConvertFeaturedAppActivityMarkersResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkers DsoRules_AmuletRules_ConvertFeaturedAppActivityMarkersResult
+
+<div id="type-splice-dsorules-dsorulesamuletexpireresult-67290">
+
+**data** DsoRules_Amulet_ExpireResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesamuletexpireresult-61799">
+>
+> DsoRules_Amulet_ExpireResult
+>
+> </div>
+>
+> > | Field     | Type                | Description |
+> > |-----------|---------------------|-------------|
+> > | expireSum | AmuletExpireSummary |             |
+>
+> **instance** GetField "expireSum" DsoRules_Amulet_ExpireResult AmuletExpireSummary
+>
+> **instance** SetField "expireSum" DsoRules_Amulet_ExpireResult AmuletExpireSummary
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_Amulet_Expire DsoRules_Amulet_ExpireResult
+
+<div id="type-splice-dsorules-dsorulesamuletexpiretransferinstructionsresult-29864">
+
+**data** DsoRules_Amulet_ExpireTransferInstructionsResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesamuletexpiretransferinstructionsresult-36781">
+>
+> DsoRules_Amulet_ExpireTransferInstructionsResult
+>
+> </div>
+>
+> > | Field  | Type                                                | Description |
+> > |--------|-----------------------------------------------------|-------------|
+> > | result | AmuletRules_Amulet_ExpireTransferInstructionsResult |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_Amulet_ExpireTransferInstructionsResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_Amulet_ExpireTransferInstructionsResult
+>
+> **instance** GetField "result" DsoRules_Amulet_ExpireTransferInstructionsResult AmuletRules_Amulet_ExpireTransferInstructionsResult
+>
+> **instance** SetField "result" DsoRules_Amulet_ExpireTransferInstructionsResult AmuletRules_Amulet_ExpireTransferInstructionsResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_Amulet_ExpireTransferInstructions DsoRules_Amulet_ExpireTransferInstructionsResult
+
+<div id="type-splice-dsorules-dsorulesamuletexpirev2result-94072">
+
+**data** DsoRules_Amulet_ExpireV2Result
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesamuletexpirev2result-84829">
+>
+> DsoRules_Amulet_ExpireV2Result
+>
+> </div>
+>
+> > | Field     | Type                  | Description |
+> > |-----------|-----------------------|-------------|
+> > | expireSum | AmuletExpireV2Summary |             |
+>
+> **instance** GetField "expireSum" DsoRules_Amulet_ExpireV2Result AmuletExpireV2Summary
+>
+> **instance** SetField "expireSum" DsoRules_Amulet_ExpireV2Result AmuletExpireV2Summary
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_Amulet_ExpireV2 DsoRules_Amulet_ExpireV2Result
+
+<div id="type-splice-dsorules-dsorulesarchiveoutdatedelectionrequestresult-78881">
+
+**data** DsoRules_ArchiveOutdatedElectionRequestResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesarchiveoutdatedelectionrequestresult-72534">
+>
+> DsoRules_ArchiveOutdatedElectionRequestResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ArchiveOutdatedElectionRequest DsoRules_ArchiveOutdatedElectionRequestResult
+
+<div id="type-splice-dsorules-dsorulesarchivesvonboardingrequestresult-76462">
+
+**data** DsoRules_ArchiveSvOnboardingRequestResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesarchivesvonboardingrequestresult-86253">
+>
+> DsoRules_ArchiveSvOnboardingRequestResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ArchiveSvOnboardingRequest DsoRules_ArchiveSvOnboardingRequestResult
+
+<div id="type-splice-dsorules-dsorulesbootstrapexternalpartyconfigstateresult-77872">
+
+**data** DsoRules_BootstrapExternalPartyConfigStateResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesbootstrapexternalpartyconfigstateresult-70741">
+>
+> DsoRules_BootstrapExternalPartyConfigStateResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_BootstrapExternalPartyConfigState DsoRules_BootstrapExternalPartyConfigStateResult
+
+<div id="type-splice-dsorules-dsorulescastvoteresult-84724">
+
+**data** DsoRules_CastVoteResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulescastvoteresult-18147">
+>
+> DsoRules_CastVoteResult
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                      | Description |
+> > |-------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | voteRequest | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest |             |
+>
+> **instance** GetField "voteRequest" DsoRules_CastVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest)
+>
+> **instance** SetField "voteRequest" DsoRules_CastVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CastVote DsoRules_CastVoteResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CastVote DsoRules_CastVoteResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CastVote DsoRules_CastVoteResult
+
+<div id="type-splice-dsorules-dsorulesclaimexpiredrewardsresult-70369">
+
+**data** DsoRules_ClaimExpiredRewardsResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesclaimexpiredrewardsresult-56160">
+>
+> DsoRules_ClaimExpiredRewardsResult
+>
+> </div>
+>
+> > | Field           | Type                                                                                                                                                                                                                                                                           | Description |
+> > |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unclaimedReward | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward) |             |
+>
+> **instance** GetField "unclaimedReward" DsoRules_ClaimExpiredRewardsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
+>
+> **instance** SetField "unclaimedReward" DsoRules_ClaimExpiredRewardsResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ClaimExpiredRewards DsoRules_ClaimExpiredRewardsResult
+
+<div id="type-splice-dsorules-dsorulesclosevoterequestresult-49382">
+
+**data** DsoRules_CloseVoteRequestResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesclosevoterequestresult-14349">
+>
+> DsoRules_CloseVoteRequestResult
+>
+> </div>
+>
+> > | Field            | Type                                                                                                              | Description                                                   |
+> > |------------------|-------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+> > | request          | VoteRequest                                                                                                       | The original vote request.                                    |
+> > | completedAt      | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | When the vote request was completed.                          |
+> > | offboardedVoters | \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]  | SVs that voted but were offboarded before the vote completed. |
+> > | abstainingSvs    | \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]  | SVs that did not vote.                                        |
+> > | outcome          | VoteRequestOutcome                                                                                                | The final result of the vote.                                 |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_CloseVoteRequestResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_CloseVoteRequestResult
+>
+> **instance** GetField "abstainingSvs" DsoRules_CloseVoteRequestResult \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]
+>
+> **instance** GetField "completedAt" DsoRules_CloseVoteRequestResult [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "offboardedVoters" DsoRules_CloseVoteRequestResult \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]
+>
+> **instance** GetField "outcome" DsoRules_CloseVoteRequestResult VoteRequestOutcome
+>
+> **instance** GetField "request" DsoRules_CloseVoteRequestResult VoteRequest
+>
+> **instance** SetField "abstainingSvs" DsoRules_CloseVoteRequestResult \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]
+>
+> **instance** SetField "completedAt" DsoRules_CloseVoteRequestResult [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "offboardedVoters" DsoRules_CloseVoteRequestResult \[[Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)\]
+>
+> **instance** SetField "outcome" DsoRules_CloseVoteRequestResult VoteRequestOutcome
+>
+> **instance** SetField "request" DsoRules_CloseVoteRequestResult VoteRequest
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CloseVoteRequest DsoRules_CloseVoteRequestResult
+
+<div id="type-splice-dsorules-dsorulescollectentryrenewalpaymentresult-57091">
+
+**data** DsoRules_CollectEntryRenewalPaymentResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulescollectentryrenewalpaymentresult-87832">
+>
+> DsoRules_CollectEntryRenewalPaymentResult
+>
+> </div>
+>
+> > | Field             | Type                                                                                                                                                | Description |
+> > |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | ansEntry          | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry              |             |
+> > | subscriptionState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
+>
+> **instance** GetField "ansEntry" DsoRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** GetField "subscriptionState" DsoRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** SetField "ansEntry" DsoRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AnsEntry)
+>
+> **instance** SetField "subscriptionState" DsoRules_CollectEntryRenewalPaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CollectEntryRenewalPayment DsoRules_CollectEntryRenewalPaymentResult
+
+<div id="type-splice-dsorules-dsorulesconfirmactionresult-28024">
+
+**data** DsoRules_ConfirmActionResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesconfirmactionresult-48341">
+>
+> DsoRules_ConfirmActionResult
+>
+> </div>
+>
+> > | Field        | Type                                                                                                                                       | Description |
+> > |--------------|--------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | confirmation | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Confirmation |             |
+>
+> **instance** GetField "confirmation" DsoRules_ConfirmActionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Confirmation)
+>
+> **instance** SetField "confirmation" DsoRules_ConfirmActionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Confirmation)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ConfirmAction DsoRules_ConfirmActionResult
+
+<div id="type-splice-dsorules-dsorulesconfirmsvonboardingresult-99416">
+
+**data** DsoRules_ConfirmSvOnboardingResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesconfirmsvonboardingresult-46665">
+>
+> DsoRules_ConfirmSvOnboardingResult
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                                | Description |
+> > |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | onboardingConfirmed | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingConfirmed |             |
+>
+> **instance** GetField "onboardingConfirmed" DsoRules_ConfirmSvOnboardingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingConfirmed)
+>
+> **instance** SetField "onboardingConfirmed" DsoRules_ConfirmSvOnboardingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingConfirmed)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ConfirmSvOnboarding DsoRules_ConfirmSvOnboardingResult
+
+<div id="type-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstructionresult-32985">
+
+**data** DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulescreatebootstrapexternalpartyconfigstateinstructionresult-84146">
+>
+> DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                                                                       | Description |
+> > |----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | instructionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BootstrapExternalPartyConfigStateInstruction |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
+>
+> **instance** GetField "instructionCid" DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BootstrapExternalPartyConfigStateInstruction)
+>
+> **instance** SetField "instructionCid" DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BootstrapExternalPartyConfigStateInstruction)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CreateBootstrapExternalPartyConfigStateInstruction DsoRules_CreateBootstrapExternalPartyConfigStateInstructionResult
+
+<div id="type-splice-dsorules-dsorulescreateexternalpartyamuletrulesresult-12409">
+
+**data** DsoRules_CreateExternalPartyAmuletRulesResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulescreateexternalpartyamuletrulesresult-52650">
+>
+> DsoRules_CreateExternalPartyAmuletRulesResult
+>
+> </div>
+>
+> > | Field                       | Type                                                                                                                                                   | Description |
+> > |-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | externalPartyAmuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyAmuletRules |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_CreateExternalPartyAmuletRulesResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_CreateExternalPartyAmuletRulesResult
+>
+> **instance** GetField "externalPartyAmuletRulesCid" DsoRules_CreateExternalPartyAmuletRulesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyAmuletRules)
+>
+> **instance** SetField "externalPartyAmuletRulesCid" DsoRules_CreateExternalPartyAmuletRulesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyAmuletRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CreateExternalPartyAmuletRules DsoRules_CreateExternalPartyAmuletRulesResult
+
+<div id="type-splice-dsorules-dsorulescreatetransfercommandcounterresult-97297">
+
+**data** DsoRules_CreateTransferCommandCounterResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulescreatetransfercommandcounterresult-46310">
+>
+> DsoRules_CreateTransferCommandCounterResult
+>
+> </div>
+>
+> > | Field                     | Type                                                                                                                                                 | Description |
+> > |---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | transferCommandCounterCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommandCounter |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_CreateTransferCommandCounterResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_CreateTransferCommandCounterResult
+>
+> **instance** GetField "transferCommandCounterCid" DsoRules_CreateTransferCommandCounterResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommandCounter)
+>
+> **instance** SetField "transferCommandCounterCid" DsoRules_CreateTransferCommandCounterResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferCommandCounter)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CreateTransferCommandCounter DsoRules_CreateTransferCommandCounterResult
+
+<div id="type-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecordresult-76541">
+
+**data** DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulescreateunallocatedunclaimedactivityrecordresult-18490">
+>
+> DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
+>
+> </div>
+>
+> > | Field                                 | Type                                                                                                                                                             | Description |
+> > |---------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unallocatedUnclaimedActivityRecordCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnallocatedUnclaimedActivityRecord |             |
+>
+> **instance** GetField "unallocatedUnclaimedActivityRecordCid" DsoRules_CreateUnallocatedUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnallocatedUnclaimedActivityRecord)
+>
+> **instance** SetField "unallocatedUnclaimedActivityRecordCid" DsoRules_CreateUnallocatedUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnallocatedUnclaimedActivityRecord)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_CreateUnallocatedUnclaimedActivityRecord DsoRules_CreateUnallocatedUnclaimedActivityRecordResult
+
+<div id="type-splice-dsorules-dsoruleselectdsodelegateresult-99561">
+
+**data** DsoRules_ElectDsoDelegateResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsoruleselectdsodelegateresult-71514">
+>
+> DsoRules_ElectDsoDelegateResult
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                   | Description |
+> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
+>
+> **instance** GetField "newDsoRules" DsoRules_ElectDsoDelegateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** SetField "newDsoRules" DsoRules_ElectDsoDelegateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ElectDsoDelegate DsoRules_ElectDsoDelegateResult
+
+<div id="type-splice-dsorules-dsorulesexecuteconfirmedactionresult-43893">
+
+**data** DsoRules_ExecuteConfirmedActionResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesexecuteconfirmedactionresult-89578">
+>
+> DsoRules_ExecuteConfirmedActionResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExecuteConfirmedAction DsoRules_ExecuteConfirmedActionResult
+
+<div id="type-splice-dsorules-dsorulesexpireamuletallocationsresult-27100">
+
+**data** DsoRules_ExpireAmuletAllocationsResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesexpireamuletallocationsresult-29457">
+>
+> DsoRules_ExpireAmuletAllocationsResult
+>
+> </div>
+>
+> > | Field  | Type                                                   | Description |
+> > |--------|--------------------------------------------------------|-------------|
+> > | result | ExternalPartyAmuletRules_ExpireAmuletAllocationsResult |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_ExpireAmuletAllocationsResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_ExpireAmuletAllocationsResult
+>
+> **instance** GetField "result" DsoRules_ExpireAmuletAllocationsResult ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+>
+> **instance** SetField "result" DsoRules_ExpireAmuletAllocationsResult ExternalPartyAmuletRules_ExpireAmuletAllocationsResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireAmuletAllocations DsoRules_ExpireAmuletAllocationsResult
+
+<div id="type-splice-dsorules-dsorulesexpireansentryresult-16762">
+
+**data** DsoRules_ExpireAnsEntryResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesexpireansentryresult-6565">
+>
+> DsoRules_ExpireAnsEntryResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireAnsEntry DsoRules_ExpireAnsEntryResult
+
+<div id="type-splice-dsorules-dsorulesexpiredevelopmentfundcouponresult-36543">
+
+**data** DsoRules_ExpireDevelopmentFundCouponResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesexpiredevelopmentfundcouponresult-44574">
+>
+> DsoRules_ExpireDevelopmentFundCouponResult
+>
+> </div>
+>
+> > | Field  | Type                                  | Description |
+> > |--------|---------------------------------------|-------------|
+> > | result | DevelopmentFundCoupon_DsoExpireResult |             |
+>
+> **instance** GetField "result" DsoRules_ExpireDevelopmentFundCouponResult DevelopmentFundCoupon_DsoExpireResult
+>
+> **instance** SetField "result" DsoRules_ExpireDevelopmentFundCouponResult DevelopmentFundCoupon_DsoExpireResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireDevelopmentFundCoupon DsoRules_ExpireDevelopmentFundCouponResult
+
+<div id="type-splice-dsorules-dsorulesexpirestaleconfirmationresult-27719">
+
+**data** DsoRules_ExpireStaleConfirmationResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesexpirestaleconfirmationresult-33614">
+>
+> DsoRules_ExpireStaleConfirmationResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireStaleConfirmation DsoRules_ExpireStaleConfirmationResult
+
+<div id="type-splice-dsorules-dsorulesexpiresubscriptionresult-45469">
+
+**data** DsoRules_ExpireSubscriptionResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesexpiresubscriptionresult-70870">
+>
+> DsoRules_ExpireSubscriptionResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireSubscription DsoRules_ExpireSubscriptionResult
+
+<div id="type-splice-dsorules-dsorulesexpiresvonboardingconfirmedresult-38796">
+
+**data** DsoRules_ExpireSvOnboardingConfirmedResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesexpiresvonboardingconfirmedresult-53333">
+>
+> DsoRules_ExpireSvOnboardingConfirmedResult
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                   | Description |
+> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
+>
+> **instance** GetField "newDsoRules" DsoRules_ExpireSvOnboardingConfirmedResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** SetField "newDsoRules" DsoRules_ExpireSvOnboardingConfirmedResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireSvOnboardingConfirmed DsoRules_ExpireSvOnboardingConfirmedResult
+
+<div id="type-splice-dsorules-dsorulesexpiresvonboardingrequestresult-2670">
+
+**data** DsoRules_ExpireSvOnboardingRequestResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesexpiresvonboardingrequestresult-9407">
+>
+> DsoRules_ExpireSvOnboardingRequestResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireSvOnboardingRequest DsoRules_ExpireSvOnboardingRequestResult
+
+<div id="type-splice-dsorules-dsorulesexpiretransferpreapprovalresult-76064">
+
+**data** DsoRules_ExpireTransferPreapprovalResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesexpiretransferpreapprovalresult-84197">
+>
+> DsoRules_ExpireTransferPreapprovalResult
+>
+> </div>
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_ExpireTransferPreapprovalResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_ExpireTransferPreapprovalResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireTransferPreapproval DsoRules_ExpireTransferPreapprovalResult
+
+<div id="type-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecordresult-30228">
+
+**data** DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesexpireunallocatedunclaimedactivityrecordresult-25947">
+>
+> DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireUnallocatedUnclaimedActivityRecord DsoRules_ExpireUnallocatedUnclaimedActivityRecordResult
+
+<div id="type-splice-dsorules-dsorulesexpireunclaimedactivityrecordresult-92345">
+
+**data** DsoRules_ExpireUnclaimedActivityRecordResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesexpireunclaimedactivityrecordresult-78492">
+>
+> DsoRules_ExpireUnclaimedActivityRecordResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                          | Description |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unclaimedRewardCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward |             |
+>
+> **instance** GetField "unclaimedRewardCid" DsoRules_ExpireUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
+>
+> **instance** SetField "unclaimedRewardCid" DsoRules_ExpireUnclaimedActivityRecordResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ExpireUnclaimedActivityRecord DsoRules_ExpireUnclaimedActivityRecordResult
+
+<div id="type-splice-dsorules-dsorulesgarbagecollectamuletpricevotesresult-20154">
+
+**data** DsoRules_GarbageCollectAmuletPriceVotesResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesgarbagecollectamuletpricevotesresult-33073">
+>
+> DsoRules_GarbageCollectAmuletPriceVotesResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_GarbageCollectAmuletPriceVotes DsoRules_GarbageCollectAmuletPriceVotesResult
+
+<div id="type-splice-dsorules-dsorulesgrantfeaturedapprightresult-6067">
+
+**data** DsoRules_GrantFeaturedAppRightResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesgrantfeaturedapprightresult-3282">
+>
+> DsoRules_GrantFeaturedAppRightResult
+>
+> </div>
+>
+> > | Field            | Type                                                                                                                                           | Description |
+> > |------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | featuredAppRight | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
+>
+> **instance** GetField "featuredAppRight" DsoRules_GrantFeaturedAppRightResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** SetField "featuredAppRight" DsoRules_GrantFeaturedAppRightResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_GrantFeaturedAppRight DsoRules_GrantFeaturedAppRightResult
+
+<div id="type-splice-dsorules-dsoruleslockedamuletexpireamuletresult-11398">
+
+**data** DsoRules_LockedAmulet_ExpireAmuletResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsoruleslockedamuletexpireamuletresult-46735">
+>
+> DsoRules_LockedAmulet_ExpireAmuletResult
+>
+> </div>
+>
+> > | Field     | Type                | Description |
+> > |-----------|---------------------|-------------|
+> > | expireSum | AmuletExpireSummary |             |
+>
+> **instance** GetField "expireSum" DsoRules_LockedAmulet_ExpireAmuletResult AmuletExpireSummary
+>
+> **instance** SetField "expireSum" DsoRules_LockedAmulet_ExpireAmuletResult AmuletExpireSummary
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_LockedAmulet_ExpireAmulet DsoRules_LockedAmulet_ExpireAmuletResult
+
+<div id="type-splice-dsorules-dsoruleslockedamuletexpireamuletv2result-75516">
+
+**data** DsoRules_LockedAmulet_ExpireAmuletV2Result
+
+</div>
+
+> <div id="constr-splice-dsorules-dsoruleslockedamuletexpireamuletv2result-22605">
+>
+> DsoRules_LockedAmulet_ExpireAmuletV2Result
+>
+> </div>
+>
+> > | Field     | Type                  | Description |
+> > |-----------|-----------------------|-------------|
+> > | expireSum | AmuletExpireV2Summary |             |
+>
+> **instance** GetField "expireSum" DsoRules_LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
+>
+> **instance** SetField "expireSum" DsoRules_LockedAmulet_ExpireAmuletV2Result AmuletExpireV2Summary
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_LockedAmulet_ExpireAmuletV2 DsoRules_LockedAmulet_ExpireAmuletV2Result
+
+<div id="type-splice-dsorules-dsorulesmergemembertrafficcontractsresult-1402">
+
+**data** DsoRules_MergeMemberTrafficContractsResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesmergemembertrafficcontractsresult-22987">
+>
+> DsoRules_MergeMemberTrafficContractsResult
+>
+> </div>
+>
+> > | Field         | Type                                                                                                                                        | Description |
+> > |---------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | memberTraffic | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic |             |
+>
+> **instance** GetField "memberTraffic" DsoRules_MergeMemberTrafficContractsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
+>
+> **instance** SetField "memberTraffic" DsoRules_MergeMemberTrafficContractsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MergeMemberTrafficContracts DsoRules_MergeMemberTrafficContractsResult
+
+<div id="type-splice-dsorules-dsorulesmergesvrewardstateresult-26494">
+
+**data** DsoRules_MergeSvRewardStateResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesmergesvrewardstateresult-58441">
+>
+> DsoRules_MergeSvRewardStateResult
+>
+> </div>
+>
+> > | Field         | Type                                                                                                                                        | Description |
+> > |---------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | svRewardState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState |             |
+>
+> **instance** GetField "svRewardState" DsoRules_MergeSvRewardStateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState)
+>
+> **instance** SetField "svRewardState" DsoRules_MergeSvRewardStateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MergeSvRewardState DsoRules_MergeSvRewardStateResult
+
+<div id="type-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcouponsresult-91402">
+
+**data** DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesmergeunclaimeddevelopmentfundcouponsresult-95789">
+>
+> DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
+>
+> </div>
+>
+> > | Field  | Type                                                   | Description |
+> > |--------|--------------------------------------------------------|-------------|
+> > | result | AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult |             |
+>
+> **instance** GetField "result" DsoRules_MergeUnclaimedDevelopmentFundCouponsResult AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
+>
+> **instance** SetField "result" DsoRules_MergeUnclaimedDevelopmentFundCouponsResult AmuletRules_MergeUnclaimedDevelopmentFundCouponsResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MergeUnclaimedDevelopmentFundCoupons DsoRules_MergeUnclaimedDevelopmentFundCouponsResult
+
+<div id="type-splice-dsorules-dsorulesmergeunclaimedrewardsresult-75266">
+
+**data** DsoRules_MergeUnclaimedRewardsResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesmergeunclaimedrewardsresult-90979">
+>
+> DsoRules_MergeUnclaimedRewardsResult
+>
+> </div>
+>
+> > | Field           | Type                                                                                                                                          | Description |
+> > |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | unclaimedReward | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward |             |
+>
+> **instance** GetField "unclaimedReward" DsoRules_MergeUnclaimedRewardsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
+>
+> **instance** SetField "unclaimedReward" DsoRules_MergeUnclaimedRewardsResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UnclaimedReward)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MergeUnclaimedRewards DsoRules_MergeUnclaimedRewardsResult
+
+<div id="type-splice-dsorules-dsorulesmergevalidatorlicenseresult-11621">
+
+**data** DsoRules_MergeValidatorLicenseResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesmergevalidatorlicenseresult-87256">
+>
+> DsoRules_MergeValidatorLicenseResult
+>
+> </div>
+>
+> > | Field            | Type                                                                                                                                           | Description |
+> > |------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | validatorLicense | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense |             |
+>
+> **instance** GetField "validatorLicense" DsoRules_MergeValidatorLicenseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** SetField "validatorLicense" DsoRules_MergeValidatorLicenseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MergeValidatorLicense DsoRules_MergeValidatorLicenseResult
+
+<div id="type-splice-dsorules-dsorulesminingroundcloseresult-29143">
+
+**data** DsoRules_MiningRound_CloseResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesminingroundcloseresult-49506">
+>
+> DsoRules_MiningRound_CloseResult
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                            | Description |
+> > |-------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | closedRound | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound |             |
+>
+> **instance** GetField "closedRound" DsoRules_MiningRound_CloseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound)
+>
+> **instance** SetField "closedRound" DsoRules_MiningRound_CloseResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ClosedMiningRound)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_MiningRound_Close DsoRules_MiningRound_CloseResult
+
+<div id="type-splice-dsorules-dsorulesoffboardsvresult-15733">
+
+**data** DsoRules_OffboardSvResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesoffboardsvresult-15494">
+>
+> DsoRules_OffboardSvResult
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                   | Description |
+> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
+>
+> **instance** GetField "newDsoRules" DsoRules_OffboardSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** SetField "newDsoRules" DsoRules_OffboardSvResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_OffboardSv DsoRules_OffboardSvResult
+
+<div id="type-splice-dsorules-dsorulesonboardvalidatorresult-97208">
+
+**data** DsoRules_OnboardValidatorResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesonboardvalidatorresult-75375">
+>
+> DsoRules_OnboardValidatorResult
+>
+> </div>
+>
+> > | Field            | Type                                                                                                                                           | Description |
+> > |------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | validatorLicense | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense |             |
+>
+> **instance** GetField "validatorLicense" DsoRules_OnboardValidatorResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** SetField "validatorLicense" DsoRules_OnboardValidatorResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorLicense)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_OnboardValidator DsoRules_OnboardValidatorResult
+
+<div id="type-splice-dsorules-dsorulespruneamuletconfigscheduleresult-66013">
+
+**data** DsoRules_PruneAmuletConfigScheduleResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulespruneamuletconfigscheduleresult-2640">
+>
+> DsoRules_PruneAmuletConfigScheduleResult
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                                      | Description |
+> > |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
+>
+> **instance** GetField "amuletRulesCid" DsoRules_PruneAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** SetField "amuletRulesCid" DsoRules_PruneAmuletConfigScheduleResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_PruneAmuletConfigSchedule DsoRules_PruneAmuletConfigScheduleResult
+
+<div id="type-splice-dsorules-dsorulesreceivesvrewardcouponresult-91325">
+
+**data** DsoRules_ReceiveSvRewardCouponResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesreceivesvrewardcouponresult-74804">
+>
+> DsoRules_ReceiveSvRewardCouponResult
+>
+> </div>
+>
+> > | Field           | Type                                                                                                                                             | Description |
+> > |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | svRewardState   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState      |             |
+> > | svRewardCoupons | \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardCoupon\] |             |
+>
+> **instance** GetField "svRewardCoupons" DsoRules_ReceiveSvRewardCouponResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardCoupon\]
+>
+> **instance** GetField "svRewardState" DsoRules_ReceiveSvRewardCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState)
+>
+> **instance** SetField "svRewardCoupons" DsoRules_ReceiveSvRewardCouponResult \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardCoupon\]
+>
+> **instance** SetField "svRewardState" DsoRules_ReceiveSvRewardCouponResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvRewardState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_ReceiveSvRewardCoupon DsoRules_ReceiveSvRewardCouponResult
+
+<div id="type-splice-dsorules-dsorulesrequestelectionresult-48590">
+
+**data** DsoRules_RequestElectionResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesrequestelectionresult-48843">
+>
+> DsoRules_RequestElectionResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                          | Description |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | electionRequestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ElectionRequest |             |
+>
+> **instance** GetField "electionRequestCid" DsoRules_RequestElectionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ElectionRequest)
+>
+> **instance** SetField "electionRequestCid" DsoRules_RequestElectionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ElectionRequest)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_RequestElection DsoRules_RequestElectionResult
+
+<div id="type-splice-dsorules-dsorulesrequestvoteresult-78559">
+
+**data** DsoRules_RequestVoteResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesrequestvoteresult-22502">
+>
+> DsoRules_RequestVoteResult
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                      | Description |
+> > |-------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | voteRequest | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest |             |
+>
+> **instance** GetField "voteRequest" DsoRules_RequestVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest)
+>
+> **instance** SetField "voteRequest" DsoRules_RequestVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) VoteRequest)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_RequestVote DsoRules_RequestVoteResult
+
+<div id="type-splice-dsorules-dsorulesrevokefeaturedapprightresult-31874">
+
+**data** DsoRules_RevokeFeaturedAppRightResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesrevokefeaturedapprightresult-56949">
+>
+> DsoRules_RevokeFeaturedAppRightResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_RevokeFeaturedAppRight DsoRules_RevokeFeaturedAppRightResult
+
+<div id="type-splice-dsorules-dsorulessetconfigresult-20888">
+
+**data** DsoRules_SetConfigResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulessetconfigresult-7861">
+>
+> DsoRules_SetConfigResult
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                   | Description |
+> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
+>
+> **instance** GetField "newDsoRules" DsoRules_SetConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** SetField "newDsoRules" DsoRules_SetConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_SetConfig DsoRules_SetConfigResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_SetConfig DsoRules_SetConfigResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_SetConfig DsoRules_SetConfigResult
+
+<div id="type-splice-dsorules-dsorulessetsynchronizernodeconfigresult-80120">
+
+**data** DsoRules_SetSynchronizerNodeConfigResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulessetsynchronizernodeconfigresult-93925">
+>
+> DsoRules_SetSynchronizerNodeConfigResult
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                      | Description |
+> > |-------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | svNodeState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvNodeState |             |
+>
+> **instance** GetField "svNodeState" DsoRules_SetSynchronizerNodeConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvNodeState)
+>
+> **instance** SetField "svNodeState" DsoRules_SetSynchronizerNodeConfigResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvNodeState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_SetSynchronizerNodeConfig DsoRules_SetSynchronizerNodeConfigResult
+
+<div id="type-splice-dsorules-dsorulesstartsvonboardingresult-18158">
+
+**data** DsoRules_StartSvOnboardingResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesstartsvonboardingresult-27583">
+>
+> DsoRules_StartSvOnboardingResult
+>
+> </div>
+>
+> > | Field             | Type                                                                                                                                              | Description |
+> > |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | onboardingRequest | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingRequest |             |
+>
+> **instance** GetField "onboardingRequest" DsoRules_StartSvOnboardingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingRequest)
+>
+> **instance** SetField "onboardingRequest" DsoRules_StartSvOnboardingResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvOnboardingRequest)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_StartSvOnboarding DsoRules_StartSvOnboardingResult
+
+<div id="type-splice-dsorules-dsorulessubmitstatusreportresult-52083">
+
+**data** DsoRules_SubmitStatusReportResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulessubmitstatusreportresult-24832">
+>
+> DsoRules_SubmitStatusReportResult
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                         | Description |
+> > |-----------|----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newReport | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvStatusReport |             |
+>
+> **instance** GetField "newReport" DsoRules_SubmitStatusReportResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvStatusReport)
+>
+> **instance** SetField "newReport" DsoRules_SubmitStatusReportResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SvStatusReport)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_SubmitStatusReport DsoRules_SubmitStatusReportResult
+
+<div id="type-splice-dsorules-dsorulesterminatesubscriptionresult-840">
+
+**data** DsoRules_TerminateSubscriptionResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesterminatesubscriptionresult-26229">
+>
+> DsoRules_TerminateSubscriptionResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_TerminateSubscription DsoRules_TerminateSubscriptionResult
+
+<div id="type-splice-dsorules-dsorulesupdateamuletpricevoteresult-31774">
+
+**data** DsoRules_UpdateAmuletPriceVoteResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesupdateamuletpricevoteresult-27803">
+>
+> DsoRules_UpdateAmuletPriceVoteResult
+>
+> </div>
+>
+> > | Field           | Type                                                                                                                                          | Description |
+> > |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletPriceVote | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote |             |
+>
+> **instance** GetField "amuletPriceVote" DsoRules_UpdateAmuletPriceVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote)
+>
+> **instance** SetField "amuletPriceVote" DsoRules_UpdateAmuletPriceVoteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletPriceVote)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_UpdateAmuletPriceVote DsoRules_UpdateAmuletPriceVoteResult
+
+<div id="type-splice-dsorules-dsorulesupdateexternalpartyconfigstatesresult-26858">
+
+**data** DsoRules_UpdateExternalPartyConfigStatesResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesupdateexternalpartyconfigstatesresult-3139">
+>
+> DsoRules_UpdateExternalPartyConfigStatesResult
+>
+> </div>
+>
+> > | Field                          | Type                                                                                                                                                   | Description |
+> > |--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newExternalPartyConfigStateCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoRules_UpdateExternalPartyConfigStatesResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoRules_UpdateExternalPartyConfigStatesResult
+>
+> **instance** GetField "newExternalPartyConfigStateCid" DsoRules_UpdateExternalPartyConfigStatesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
+>
+> **instance** SetField "newExternalPartyConfigStateCid" DsoRules_UpdateExternalPartyConfigStatesResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartyConfigState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_UpdateExternalPartyConfigStates DsoRules_UpdateExternalPartyConfigStatesResult
+
+<div id="type-splice-dsorules-dsorulesupdatesvrewardweightresult-38140">
+
+**data** DsoRules_UpdateSvRewardWeightResult
+
+</div>
+
+> <div id="constr-splice-dsorules-dsorulesupdatesvrewardweightresult-2499">
+>
+> DsoRules_UpdateSvRewardWeightResult
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                   | Description |
+> > |-------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | newDsoRules | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules |             |
+>
+> **instance** GetField "newDsoRules" DsoRules_UpdateSvRewardWeightResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** SetField "newDsoRules" DsoRules_UpdateSvRewardWeightResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DsoRules DsoRules_UpdateSvRewardWeight DsoRules_UpdateSvRewardWeightResult
+
+<div id="type-splice-dsorules-dsosummary-18963">
+
+**data** DsoSummary
+
+</div>
+
+> <div id="constr-splice-dsorules-dsosummary-70086">
+>
+> DsoSummary
+>
+> </div>
+>
+> > | Field            | Type                                                                                                                | Description                                                                          |
+> > |------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+> > | dsoDelegate      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | **Deprecated** in favor of delegateless automation.                                  |
+> > | numSvs           | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |                                                                                      |
+> > | requiredNumVotes | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | The number of votes required for considering a confirmation, or a request for a vote |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) DsoSummary
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) DsoSummary
+>
+> **instance** GetField "dsoDelegate" DsoSummary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "numSvs" DsoSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "requiredNumVotes" DsoSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "dsoDelegate" DsoSummary [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "numSvs" DsoSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "requiredNumVotes" DsoSummary [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+
+<div id="type-splice-dsorules-electionrequestreason-11906">
+
+**data** ElectionRequestReason
+
+</div>
+
+> **Deprecated** in favor of delegateless automation.
+>
+> <div id="constr-splice-dsorules-errdsodelegateunavailable-67703">
+>
+> ERR_DsoDelegateUnavailable
+>
+> </div>
+>
+> <div id="constr-splice-dsorules-errotherreason-56585">
+>
+> ERR_OtherReason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> </div>
+>
+> <div id="constr-splice-dsorules-extelectionrequestreason-65169">
+>
+> ExtElectionRequestReason
+>
+> </div>
+>
+> > | Field          | Type | Description                                                                                             |
+> > |----------------|------|---------------------------------------------------------------------------------------------------------|
+> > | dummyUnitField | ()   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ElectionRequestReason
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) ElectionRequestReason
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ElectionRequestReason
+>
+> **instance** GetField "dummyUnitField" ElectionRequestReason ()
+>
+> **instance** GetField "reason" DsoRules_RequestElection ElectionRequestReason
+>
+> **instance** GetField "reason" ElectionRequest ElectionRequestReason
+>
+> **instance** SetField "dummyUnitField" ElectionRequestReason ()
+>
+> **instance** SetField "reason" DsoRules_RequestElection ElectionRequestReason
+>
+> **instance** SetField "reason" ElectionRequest ElectionRequestReason
+
+<div id="type-splice-dsorules-logicalsynchronizerupgradeschedule-67809">
+
+**data** LogicalSynchronizerUpgradeSchedule
+
+</div>
+
+> <div id="constr-splice-dsorules-logicalsynchronizerupgradeschedule-50336">
+>
+> LogicalSynchronizerUpgradeSchedule
+>
+> </div>
+>
+> > | Field                                  | Type                                                                                                              | Description                                                                                                                                                                                                                         |
+> > |----------------------------------------|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> > | topologyFreezeTime                     | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The time at which topology transactions will be frozen. Note that this time is used by the automation to initiate the topology transactions for freezing. The actual freeze time is the effective time of the topology transaction. |
+> > | upgradeTime                            | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The time at which the upgrade to the new physical synchronizer will happen.                                                                                                                                                         |
+> > | newPhysicalSynchronizerSerial          | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)        | The serial of the new physical synchronizer. Usually just the serial of the old physical synchronizer + 1.                                                                                                                          |
+> > | newPhysicalSynchronizerProtocolVersion | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)      | The protocol version of the new physical synchronizer                                                                                                                                                                               |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) LogicalSynchronizerUpgradeSchedule
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) LogicalSynchronizerUpgradeSchedule
+>
+> **instance** GetField "newPhysicalSynchronizerProtocolVersion" LogicalSynchronizerUpgradeSchedule [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "newPhysicalSynchronizerSerial" LogicalSynchronizerUpgradeSchedule [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "nextScheduledLogicalSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LogicalSynchronizerUpgradeSchedule)
+>
+> **instance** GetField "topologyFreezeTime" LogicalSynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "upgradeTime" LogicalSynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "newPhysicalSynchronizerProtocolVersion" LogicalSynchronizerUpgradeSchedule [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "newPhysicalSynchronizerSerial" LogicalSynchronizerUpgradeSchedule [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "nextScheduledLogicalSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) LogicalSynchronizerUpgradeSchedule)
+>
+> **instance** SetField "topologyFreezeTime" LogicalSynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "upgradeTime" LogicalSynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** Patchable LogicalSynchronizerUpgradeSchedule
+
+<div id="type-splice-dsorules-offboardedsvinfo-61414">
+
+**data** OffboardedSvInfo
+
+</div>
+
+> Information about offboarded svs
+>
+> <div id="constr-splice-dsorules-offboardedsvinfo-34519">
+>
+> OffboardedSvInfo
+>
+> </div>
+>
+> > | Field         | Type                                                                                                         | Description                          |
+> > |---------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------|
+> > | name          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Human-readable name; must be unique. |
+> > | participantId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Participant ID of the offboarded SV. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) OffboardedSvInfo
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) OffboardedSvInfo
+>
+> **instance** GetField "name" OffboardedSvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "offboardedSvs" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) OffboardedSvInfo)
+>
+> **instance** GetField "participantId" OffboardedSvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "name" OffboardedSvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "offboardedSvs" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) OffboardedSvInfo)
+>
+> **instance** SetField "participantId" OffboardedSvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+<div id="type-splice-dsorules-reason-36941">
+
+**data** Reason
+
+</div>
+
+> <div id="constr-splice-dsorules-reason-51132">
+>
+> Reason
+>
+> </div>
+>
+> > | Field | Type                                                                                                         | Description                                                                                            |
+> > |-------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
+> > | url   | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Url pointing to additional background on the reason, e.g., using a https://w3c-ccg.github.io/hashlink/ |
+> > | body  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Freeform text intended for human consumption.                                                          |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Reason
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Reason
+>
+> **instance** GetField "body" Reason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "reason" DsoRules_RequestVote Reason
+>
+> **instance** GetField "reason" Vote Reason
+>
+> **instance** GetField "reason" VoteRequest Reason
+>
+> **instance** GetField "url" Reason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "body" Reason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "reason" DsoRules_RequestVote Reason
+>
+> **instance** SetField "reason" Vote Reason
+>
+> **instance** SetField "reason" VoteRequest Reason
+>
+> **instance** SetField "url" Reason [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+
+<div id="type-splice-dsorules-svinfo-76274">
+
+**data** SvInfo
+
+</div>
+
+> Information about SVs relevant to DSO governance.
+>
+> <div id="constr-splice-dsorules-svinfo-69131">
+>
+> SvInfo
+>
+> </div>
+>
+> > | Field           | Type                                                                                                         | Description                                                                                                                                   |
+> > |-----------------|--------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+> > | name            | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Human-readable name; must be unique.                                                                                                          |
+> > | joinedAsOfRound | Round                                                                                                        | Round in which the SV joined                                                                                                                  |
+> > | svRewardWeight  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)   | Weight of the SV in the SV reward distribution.                                                                                               |
+> > | participantId   | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Participant ID of the SV, stored here as PartyToParticipant mappings are tracked via state on the DsoRules + SvOnboardingConfirmed contracts. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SvInfo
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SvInfo
+>
+> **instance** GetField "joinedAsOfRound" SvInfo Round
+>
+> **instance** GetField "name" SvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "participantId" SvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "svRewardWeight" SvInfo [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "svs" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) SvInfo)
+>
+> **instance** SetField "joinedAsOfRound" SvInfo Round
+>
+> **instance** SetField "name" SvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "participantId" SvInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "svRewardWeight" SvInfo [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "svs" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) SvInfo)
+
+<div id="type-splice-dsorules-synchronizerupgradeschedule-64447">
+
+**data** SynchronizerUpgradeSchedule
+
+</div>
+
+> <div id="constr-splice-dsorules-synchronizerupgradeschedule-53308">
+>
+> SynchronizerUpgradeSchedule
+>
+> </div>
+>
+> > | Field       | Type                                                                                                              | Description                                            |
+> > |-------------|-------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+> > | time        | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The time at which the migration is scheduled to start. |
+> > | migrationId | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)        | The incremental integer ID of the migration.           |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SynchronizerUpgradeSchedule
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SynchronizerUpgradeSchedule
+>
+> **instance** GetField "migrationId" SynchronizerUpgradeSchedule [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "nextScheduledSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SynchronizerUpgradeSchedule)
+>
+> **instance** GetField "time" SynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "migrationId" SynchronizerUpgradeSchedule [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "nextScheduledSynchronizerUpgrade" DsoRulesConfig ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) SynchronizerUpgradeSchedule)
+>
+> **instance** SetField "time" SynchronizerUpgradeSchedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** Patchable SynchronizerUpgradeSchedule
+
+<div id="type-splice-dsorules-trafficstate-38069">
+
+**data** TrafficState
+
+</div>
+
+> <div id="constr-splice-dsorules-trafficstate-23304">
+>
+> TrafficState
+>
+> </div>
+>
+> > | Field           | Type                                                                                                       | Description                                                                             |
+> > |-----------------|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+> > | consumedTraffic | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) | Bytes of extra traffic consumed before the decentralized synchronizer was bootstrapped. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TrafficState
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TrafficState
+>
+> **instance** GetField "consumedTraffic" TrafficState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "initialTrafficState" DsoBootstrap ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState)
+>
+> **instance** GetField "initialTrafficState" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState)
+>
+> **instance** SetField "consumedTraffic" TrafficState [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "initialTrafficState" DsoBootstrap ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState)
+>
+> **instance** SetField "initialTrafficState" DsoRules ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) TrafficState)
+
+<div id="type-splice-dsorules-vote-50851">
+
+**data** Vote
+
+</div>
+
+> A vote cast by an SV.
+>
+> <div id="constr-splice-dsorules-vote-51690">
+>
+> Vote
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                                                                                                                             | Description                                                               |
+> > |-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+> > | sv        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                              | The SV party used to submit the vote.                                     |
+> > | accept    | [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)                                                                                                                                     | Whether the responder accepted the request to execute the action or not.  |
+> > | reason    | Reason                                                                                                                                                                                                                                           | The reason for voting this way.                                           |
+> > | optCastAt | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | The time when the vote was cast. Used to rate-limit the casting of votes. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Vote
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Vote
+>
+> **instance** GetField "accept" Vote [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** GetField "optCastAt" Vote ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
+>
+> **instance** GetField "reason" Vote Reason
+>
+> **instance** GetField "sv" Vote [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "vote" DsoRules_CastVote Vote
+>
+> **instance** GetField "votes" VoteRequest ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) Vote)
+>
+> **instance** SetField "accept" Vote [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+>
+> **instance** SetField "optCastAt" Vote ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886))
+>
+> **instance** SetField "reason" Vote Reason
+>
+> **instance** SetField "sv" Vote [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "vote" DsoRules_CastVote Vote
+>
+> **instance** SetField "votes" VoteRequest ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) Vote)
+
+<div id="type-splice-dsorules-voterequestoutcome-63724">
+
+**data** VoteRequestOutcome
+
+</div>
+
+> <div id="constr-splice-dsorules-vroacceptedbutactionfailed-51100">
+>
+> VRO_AcceptedButActionFailed
+>
+> </div>
+>
+> > | Field       | Type                                                                                                         | Description                 |
+> > |-------------|--------------------------------------------------------------------------------------------------------------|-----------------------------|
+> > | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) | Description of the failure. |
+>
+> <div id="constr-splice-dsorules-vroaccepted-67803">
+>
+> VRO_Accepted
+>
+> </div>
+>
+> > | Field       | Type                                                                                                              | Description                             |
+> > |-------------|-------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+> > | effectiveAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) | Time when the action will be effective. |
+>
+> <div id="constr-splice-dsorules-vrorejected-43182">
+>
+> VRO_Rejected
+>
+> </div>
+>
+> <div id="constr-splice-dsorules-vroexpired-35522">
+>
+> VRO_Expired
+>
+> </div>
+>
+> <div id="constr-splice-dsorules-extvoterequestoutcome-76073">
+>
+> ExtVoteRequestOutcome
+>
+> </div>
+>
+> > | Field          | Type | Description |
+> > |----------------|------|-------------|
+> > | dummyUnitField | ()   |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) VoteRequestOutcome
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) VoteRequestOutcome
+>
+> **instance** GetField "description" VoteRequestOutcome [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "dummyUnitField" VoteRequestOutcome ()
+>
+> **instance** GetField "effectiveAt" VoteRequestOutcome [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "outcome" DsoRules_CloseVoteRequestResult VoteRequestOutcome
+>
+> **instance** SetField "description" VoteRequestOutcome [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "dummyUnitField" VoteRequestOutcome ()
+>
+> **instance** SetField "effectiveAt" VoteRequestOutcome [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "outcome" DsoRules_CloseVoteRequestResult VoteRequestOutcome
+
+<div id="type-splice-dsorules-votingstate-60200">
+
+**data** VotingState a
+
+</div>
+
+> **Deprecated** in favor of delegateless automation. Functions implementing instant-runoff voting
+>
+> <div id="constr-splice-dsorules-votingstate-26047">
+>
+> VotingState
+>
+> </div>
+>
+> > | Field    | Type                                                                                                                        | Description                                                                                                                                   |
+> > |----------|-----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+> > | rankings | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) a \[\[a\]\] | Candidate and the remaining rankings in case that candidate is eliminated.                                                                    |
+> > | loosers  | Set a              | Loosers are tracked explicitly and removed lazily to avoid the cubic runtime that would result from filtering the remaining rankings eagerly. |
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) a =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (VotingState a)
+>
+> **instance** ([Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a, [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) a) =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (VotingState a)
+>
+> **instance** GetField "loosers" (VotingState a) (Set a)
+>
+> **instance** GetField "rankings" (VotingState a) ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) a \[\[a\]\])
+>
+> **instance** SetField "loosers" (VotingState a) (Set a)
+>
+> **instance** SetField "rankings" (VotingState a) ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) a \[\[a\]\])
+
+## Functions
+
+<div id="function-splice-dsorules-getvotecooldowntime-44916">
+
+getVoteCooldownTime
+: DsoRulesConfig -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+
+Read the `voteCooldownTime` from the `DsoRulesConfig` with a default value of 1 minute.
+
+</div>
+
+<div id="function-splice-dsorules-pruneatleastone-36934">
+
+pruneAtLeastOne
+: [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) t =\> t -\> Schedule t a -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) (Schedule t a)
+
+</div>
+
+<div id="function-splice-dsorules-summarizedso-49860">
+
+summarizeDso
+: DsoRules -\> DsoSummary
+
+</div>
+
+<div id="function-splice-dsorules-executeactionrequiringconfirmation-87907">
+
+executeActionRequiringConfirmation
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules) -\> ActionRequiringConfirmation -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+Execute an action which requires certain number of confirmations from SVs. Each confirmed action can at most be executed once.
+
+</div>
+
+<div id="function-splice-dsorules-requirewellformedreason-26428">
+
+requireWellformedReason
+: DsoRulesConfig -\> Reason -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-dsorules-requirewellformedvote-94014">
+
+requireWellformedVote
+: DsoRulesConfig -\> Vote -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-dsorules-ensurenotexpired-58839">
+
+ensureNotExpired
+: [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-dsorules-actionrequiringconfirmationeffectiveat-38122">
+
+actionRequiringConfirmationEffectiveAt
+: ActionRequiringConfirmation -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+
+Get the future-dated effectiveAt of an action requiring confirmation.
+
+</div>
+
+<div id="function-splice-dsorules-getsvinfo-85569">
+
+getSvInfo
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> DsoRules -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) SvInfo
+
+</div>
+
+<div id="function-splice-dsorules-lookupsvinfobyname-29850">
+
+lookupSvInfoByName
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> DsoRules -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), SvInfo)
+
+</div>
+
+<div id="function-splice-dsorules-svhasbeenonboardedbefore-57101">
+
+svHasBeenOnboardedBefore
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> DsoRules -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+Returns True if an SV with that name is either currently onboarded or an SV with that name has been onboarded before and is now in offboardedSvs.
+
+</div>
+
+<div id="function-splice-dsorules-ensureneveroperatednode-60956">
+
+ensureNeverOperatedNode
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> DsoRules -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-dsorules-dsorulesaddsv-73633">
+
+dsoRules_addSv
+: DsoRules -\> DsoRules_AddSv -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) DsoRules)
+
+</div>
+
+<div id="function-splice-dsorules-createpersvcontracts-25068">
+
+createPerSvContracts
+: DsoRules -\> DsoRules_AddSv -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-dsorules-createpersvpartycontracts-3309">
+
+createPerSvPartyContracts
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> SynchronizerNodeConfigMap -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-dsorules-getandvalidatesvparty-72916">
+
+getAndValidateSvParty
+: DsoRules -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+</div>
+
+<div id="function-splice-dsorules-enforcecooldown-11925">
+
+enforceCooldown
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+Enforce that an action is not performed again before a cooldown period has passed.
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding.mdx
@@ -1,0 +1,130 @@
+---
+title: "Splice.SvOnboarding"
+description: "Documentation for Splice.SvOnboarding"
+---
+
+{/* COPIED_START source="splice:daml/splice-dso-governance/docs/Splice-SvOnboarding.rst" tag="0.6.4" hash="f6ca8a1c" */}
+
+## Templates
+
+<div id="type-splice-svonboarding-svonboardingconfirmed-6814">
+
+**template** SvOnboardingConfirmed
+
+</div>
+
+> A confirmation for approval of a candidate SV.
+>
+> Once this contract is created, the workflows to onboard that SVs node starts.
+>
+> Signatory: dso
+>
+> | Field           | Type                                                                                                                | Description                         |
+> |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------|
+> | svParty         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                     |
+> | svName          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |                                     |
+> | svRewardWeight  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |                                     |
+> | svParticipantId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |                                     |
+> | reason          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |                                     |
+> | dso             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                     |
+> | expiresAt       | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | When this contract can be archived. |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-svonboarding-svonboardingconfirmedexpire-37945">
+>
+>   **Choice** SvOnboardingConfirmed_Expire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: SvOnboardingConfirmed_ExpireResult
+>
+>   (no fields)
+
+<div id="type-splice-svonboarding-svonboardingrequest-71856">
+
+**template** SvOnboardingRequest
+
+</div>
+
+> Template used by the SVs to collect confirmations for the onboarding of an SV candidate. The existence of this contract triggers SV automation that creates confirmation contracts for the candidate if the token is a valid `SvOnboardingToken` and matches an `ApprovedSvIdentity`.
+>
+> Signatory: dso
+>
+> | Field                  | Type                                                                                                                | Description                                                                          |
+> |------------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+> | candidateName          | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | Human-readable name of the SV candidate. Must match the one in `ApprovedSvIdentity`! |
+> | candidateParty         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | PartyId of the candidate SV party.                                                   |
+> | candidateParticipantId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | ParticipantId of the candidate SV.                                                   |
+> | token                  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | An encoded and signed `SvOnboardingToken` that confirms the candidate's identity.    |
+> | sponsor                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The established SV node that created this contract.                                  |
+> | dso                    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                      |
+> | expiresAt              | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | When this contract can be archived even if the onboarding did not succeed.           |
+>
+> - **Choice** Archive
+>
+>   Controller: dso
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-svonboarding-svonboardingrequestexpire-23755">
+>
+>   **Choice** SvOnboardingRequest_Expire
+>
+>   </div>
+>
+>   Controller: dso
+>
+>   Returns: SvOnboardingRequest_ExpireResult
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-svonboarding-svonboardingconfirmedexpireresult-89548">
+
+**data** SvOnboardingConfirmed_ExpireResult
+
+</div>
+
+> <div id="constr-splice-svonboarding-svonboardingconfirmedexpireresult-55325">
+>
+> SvOnboardingConfirmed_ExpireResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SvOnboardingConfirmed SvOnboardingConfirmed_Expire SvOnboardingConfirmed_ExpireResult
+
+<div id="type-splice-svonboarding-svonboardingrequestexpireresult-6542">
+
+**data** SvOnboardingRequest_ExpireResult
+
+</div>
+
+> <div id="constr-splice-svonboarding-svonboardingrequestexpireresult-87875">
+>
+> SvOnboardingRequest_ExpireResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SvOnboardingRequest SvOnboardingRequest_Expire SvOnboardingRequest_ExpireResult
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/index.mdx
@@ -1,0 +1,25 @@
+---
+title: "splice-token-standard-test docs"
+description: "Documentation for splice-token-standard-test docs"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-token-standard-test/docs/index.rst" tag="0.6.4" hash="d5eda1f9" */}
+
+Copy the code of this package from [https://github.com/canton-network/splice](https://github.com/canton-network/splice) to gain access to test infrastructure for:
+
+- building apps that use the token standard
+- implementing a token standard compliant registry
+
+Note that a **copy of the source code is required**, as at the time of writing Daml Script code cannot be shared across SDK's in compiled form.
+
+See the module docs below for an overview of the functionality provided by this package.
+
+- [Splice.Testing.Registries.AmuletRegistry](/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry)
+- [Splice.Testing.Registries.AmuletRegistry.Parameters](/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry-parameters)
+- [Splice.Testing.TokenStandard.RegistryApi](/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-registryapi)
+- [Splice.Testing.TokenStandard.WalletClient](/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-walletclient)
+- [Splice.Testing.Utils](/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-utils)
+- [Splice.Tests.TestAmuletTokenDvP](/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokendvp)
+- [Splice.Tests.TestAmuletTokenTransfer](/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokentransfer)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry-parameters.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry-parameters.mdx
@@ -1,0 +1,113 @@
+---
+title: "Splice.Testing.Registries.AmuletRegistry.Parameters"
+description: "Documentation for Splice.Testing.Registries.AmuletRegistry.Parameters"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-token-standard-test/docs/Splice-Testing-Registries-AmuletRegistry-Parameters.rst" tag="0.6.4" hash="ef57e92d" */}
+
+Default configuration paramaters for the amulet registry used for testing.
+
+## Functions
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-defaulttransferconfig-26619">
+
+defaultTransferConfig
+: TransferConfig USD
+
+Somewhat realistic fees to be used in test-code.
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-defaultamuletdecentralizedsynchronizerconfig-11431">
+
+defaultAmuletDecentralizedSynchronizerConfig
+: AmuletDecentralizedSynchronizerConfig
+
+Decentralized synchronizer config to use for testing.
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-defaultfeaturedappactivitymarkeramount-91429">
+
+defaultFeaturedAppActivityMarkerAmount
+: [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-defaultamuletconfig-4026">
+
+defaultAmuletConfig
+: AmuletConfig USD
+
+Default proposal for issuance curve and tickDuration
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-defaultamuletconfigschedule-68093">
+
+defaultAmuletConfigSchedule
+: Schedule [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) (AmuletConfig USD)
+
+Default configuration schedule with single current amulet config
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-issuanceconfig00p5-46562">
+
+issuanceConfig_0_0p5
+: IssuanceConfig
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-issuanceconfig0p51p5-32608">
+
+issuanceConfig_0p5_1p5
+: IssuanceConfig
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-issuanceconfig1p55-41998">
+
+issuanceConfig_1p5_5
+: IssuanceConfig
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-issuanceconfig510-86316">
+
+issuanceConfig_5_10
+: IssuanceConfig
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-issuanceconfig10plus-48446">
+
+issuanceConfig_10plus
+: IssuanceConfig
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-defaultissuancecurve-61043">
+
+defaultIssuanceCurve
+: Schedule [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) IssuanceConfig
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-defaultbaseratetrafficlimits-50057">
+
+defaultBaseRateTrafficLimits
+: BaseRateTrafficLimits
+
+Default synchronizer fees configuration
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-parameters-defaultsynchronizerfeesconfig-31989">
+
+defaultSynchronizerFeesConfig
+: SynchronizerFeesConfig
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry.mdx
@@ -1,0 +1,200 @@
+---
+title: "Splice.Testing.Registries.AmuletRegistry"
+description: "Documentation for Splice.Testing.Registries.AmuletRegistry"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-token-standard-test/docs/Splice-Testing-Registries-AmuletRegistry.rst" tag="0.6.4" hash="761611ed" */}
+
+Daml script functions for initializing and using an amulet registry via the token standard and the amulet specific functions.
+
+## Data Types
+
+<div id="type-splice-testing-registries-amuletregistry-amuletregistry-76694">
+
+**data** AmuletRegistry
+
+</div>
+
+> A reference to a mock amulet registry. Use it via the the token standard functions provided by the "Splice.Testing.RegistryApi" module and type-class; or via the amulet specific functions exported from this module.
+>
+> <div id="constr-splice-testing-registries-amuletregistry-amuletregistry-65341">
+>
+> AmuletRegistry
+>
+> </div>
+>
+> > | Field        | Type                                                                                                                | Description |
+> > |--------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | dso          | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | instrumentId | InstrumentId                                                                                                        |             |
+>
+> **instance** RegistryApi AmuletRegistry
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRegistry
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) AmuletRegistry
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRegistry
+>
+> **instance** GetField "dso" AmuletRegistry [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "instrumentId" AmuletRegistry InstrumentId
+>
+> **instance** GetField "registry" AllocatedOTCTrade AmuletRegistry
+>
+> **instance** GetField "registry" TestSetup AmuletRegistry
+>
+> **instance** SetField "dso" AmuletRegistry [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "instrumentId" AmuletRegistry InstrumentId
+>
+> **instance** SetField "registry" AllocatedOTCTrade AmuletRegistry
+>
+> **instance** SetField "registry" TestSetup AmuletRegistry
+
+<div id="type-splice-testing-registries-amuletregistry-amuletregistryconfig-57082">
+
+**data** AmuletRegistryConfig
+
+</div>
+
+> <div id="constr-splice-testing-registries-amuletregistry-amuletregistryconfig-72661">
+>
+> AmuletRegistryConfig
+>
+> </div>
+>
+> > | Field              | Type                                                                                                               | Description |
+> > |--------------------|--------------------------------------------------------------------------------------------------------------------|-------------|
+> > | initialAmuletPrice | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
+> > | demoTime           | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)  |             |
+> > | dsoPartyName       | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)       |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletRegistryConfig
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletRegistryConfig
+>
+> **instance** GetField "demoTime" AmuletRegistryConfig [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "dsoPartyName" AmuletRegistryConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "initialAmuletPrice" AmuletRegistryConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "demoTime" AmuletRegistryConfig [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "dsoPartyName" AmuletRegistryConfig [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "initialAmuletPrice" AmuletRegistryConfig [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+## Functions
+
+<div id="function-splice-testing-registries-amuletregistry-defaultamuletregistryconfig-89742">
+
+defaultAmuletRegistryConfig
+: AmuletRegistryConfig
+
+Recommended default configuration for setting up the mock amulet registry.
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-initialize-82895">
+
+initialize
+: AmuletRegistryConfig -\> Script AmuletRegistry
+
+Initialize the mock amulet registry.
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-tapfaucet-5281">
+
+tapFaucet
+: AmuletRegistry -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Script ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding)
+
+Tap the faucet on DevNet to get a specified amount of Amulet.
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-createlockedamulet-2941">
+
+createLockedAmulet
+: AmuletRegistry -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> TimeLock -\> Script ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding)
+
+Direct-create locked amulet -- used for testing purposes only.
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-createtransferpreapproval-18003">
+
+createTransferPreapproval
+: AmuletRegistry -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> Script ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+
+Simulate that a validator operator created a transfer pre-approval for a party for the purpose of that party being able to receive Amulet from any other party.
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-featureapp-19022">
+
+featureApp
+: AmuletRegistry -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Script ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+
+Mark a particular registry provider part as featured.
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-beneficiariestometadata-71079">
+
+beneficiariesToMetadata
+: \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\] -\> Metadata
+
+Encode a list of beneficiaries as metadata to pass in via token standard choices. Currently only supported for allocation execution.
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-expirelockasowner-96835">
+
+expireLockAsOwner
+: AmuletRegistry -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding -\> Script ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding)
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-taplockedandunlockedfunds-93647">
+
+tapLockedAndUnlockedFunds
+: AmuletRegistry -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Script \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
+
+Get funds in equal splits as locked and unlocked holdings to test using expired locked holdings as transfer inputs.
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-advancetonextroundchange-68961">
+
+advanceToNextRoundChange
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Script ()
+
+Advance time to next round change
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-getactiveopenroundssorted-97680">
+
+getActiveOpenRoundsSorted
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Script \[([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OpenMiningRound, OpenMiningRound)\]
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-convertallfeaturedappactivitymarkers-52068">
+
+convertAllFeaturedAppActivityMarkers
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Script ()
+
+</div>
+
+<div id="function-splice-testing-registries-amuletregistry-runnextissuance-50793">
+
+runNextIssuance
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Script ()
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-registryapi.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-registryapi.mdx
@@ -1,0 +1,82 @@
+---
+title: "Splice.Testing.TokenStandard.RegistryApi"
+description: "Documentation for Splice.Testing.TokenStandard.RegistryApi"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-token-standard-test/docs/Splice-Testing-TokenStandard-RegistryApi.rst" tag="0.6.4" hash="d9cca672" */}
+
+Support for using a token compliant registry API in tests.
+
+These simulate the OpenAPI endpoints that would be served by the backend of the registry implementation.
+
+## Typeclasses
+
+<div id="class-splice-testing-tokenstandard-registryapi-registryapi-36771">
+
+**class** RegistryApi app **where**
+
+</div>
+
+> Type-class for simulating calls to the off-ledger API of a registry.
+>
+> The function names match the names of the handlers defined in the OpenAPI specification.
+>
+> <div id="function-splice-testing-tokenstandard-registryapi-gettransferfactory-16733">
+>
+> getTransferFactory
+> : app -\> TransferFactory_Transfer -\> Script (EnrichedFactoryChoice TransferFactory TransferFactory_Transfer)
+>
+> </div>
+>
+> <div id="function-splice-testing-tokenstandard-registryapi-getallocationfactory-44546">
+>
+> getAllocationFactory
+> : app -\> AllocationFactory_Allocate -\> Script (EnrichedFactoryChoice AllocationFactory AllocationFactory_Allocate)
+>
+> </div>
+>
+> <div id="function-splice-testing-tokenstandard-registryapi-getallocationtransfercontext-86176">
+>
+> getAllocation_TransferContext
+> : app -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Metadata -\> Script OpenApiChoiceContext
+>
+> </div>
+>
+> <div id="function-splice-testing-tokenstandard-registryapi-getallocationwithdrawcontext-92853">
+>
+> getAllocation_WithdrawContext
+> : app -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Metadata -\> Script OpenApiChoiceContext
+>
+> </div>
+>
+> <div id="function-splice-testing-tokenstandard-registryapi-getallocationcancelcontext-26663">
+>
+> getAllocation_CancelContext
+> : app -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation -\> Metadata -\> Script OpenApiChoiceContext
+>
+> </div>
+>
+> <div id="function-splice-testing-tokenstandard-registryapi-gettransferinstructionacceptcontext-72301">
+>
+> getTransferInstruction_AcceptContext
+> : app -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> Metadata -\> Script OpenApiChoiceContext
+>
+> </div>
+>
+> <div id="function-splice-testing-tokenstandard-registryapi-gettransferinstructionrejectcontext-89866">
+>
+> getTransferInstruction_RejectContext
+> : app -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> Metadata -\> Script OpenApiChoiceContext
+>
+> </div>
+>
+> <div id="function-splice-testing-tokenstandard-registryapi-gettransferinstructionwithdrawcontext-233">
+>
+> getTransferInstruction_WithdrawContext
+> : app -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction -\> Metadata -\> Script OpenApiChoiceContext
+>
+> </div>
+>
+> **instance** RegistryApi AmuletRegistry
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-walletclient.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-walletclient.mdx
@@ -1,0 +1,120 @@
+---
+title: "Splice.Testing.TokenStandard.WalletClient"
+description: "Documentation for Splice.Testing.TokenStandard.WalletClient"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-token-standard-test/docs/Splice-Testing-TokenStandard-WalletClient.rst" tag="0.6.4" hash="6e90be3c" */}
+
+Daml script test utilities for simulating the actions of wallet client based on the token standard.
+
+NOTE: there are likely more functions that could/should be added to this module. PRs welcome.
+
+## Functions
+
+<div id="function-splice-testing-tokenstandard-walletclient-listholdings-798">
+
+listHoldings
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> InstrumentId -\> Script \[([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding, HoldingView)\]
+
+List the hodlings of a party of a specific instrument.
+
+</div>
+
+<div id="function-splice-testing-tokenstandard-walletclient-listlockedholdings-45902">
+
+listLockedHoldings
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> InstrumentId -\> Script \[([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding, HoldingView)\]
+
+</div>
+
+<div id="function-splice-testing-tokenstandard-walletclient-listholdingcids-24613">
+
+listHoldingCids
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> InstrumentId -\> Script \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
+
+List the cids of the hodlings of a party of a specific instrument.
+
+</div>
+
+<div id="function-splice-testing-tokenstandard-walletclient-checkholdingwithamountexists-67059">
+
+checkHoldingWithAmountExists
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> InstrumentId -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Script ()
+
+Check that a holding with a specific amount exists for the given owner.
+
+</div>
+
+<div id="function-splice-testing-tokenstandard-walletclient-checkbalancebounds-93015">
+
+checkBalanceBounds
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> InstrumentId -\> ([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)) -\> Script ()
+
+Check the bounds on a party's total balance of all holdings of the given instrument.
+
+</div>
+
+<div id="function-splice-testing-tokenstandard-walletclient-checkholding-92171">
+
+checkHolding
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Script ()
+
+Check the exact value of on an individual holding's amount.
+
+</div>
+
+<div id="function-splice-testing-tokenstandard-walletclient-checkholdingbounds-16142">
+
+checkHoldingBounds
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding -\> ([Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)) -\> Script ()
+
+Check the bounds on an individual holding's amount.
+
+</div>
+
+<div id="function-splice-testing-tokenstandard-walletclient-checkbalanceapprox-77056">
+
+checkBalanceApprox
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> InstrumentId -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Script ()
+
+Check the approximate value (+/- 1.0) a party's total balance of all holdings of the given instrument.
+
+</div>
+
+<div id="function-splice-testing-tokenstandard-walletclient-checkholdingapprox-49413">
+
+checkHoldingApprox
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Script ()
+
+Check the approximate (+/- 1.0) amount of an individual holding.
+
+</div>
+
+<div id="function-splice-testing-tokenstandard-walletclient-checkbalance-47862">
+
+checkBalance
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> InstrumentId -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> Script ()
+
+Check the exact value a party's total balance of all holdings of the given instrument.
+
+</div>
+
+<div id="function-splice-testing-tokenstandard-walletclient-listtransferoffers-42592">
+
+listTransferOffers
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> InstrumentId -\> Script \[([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction, TransferInstructionView)\]
+
+List pending transfer offers (as sender or receiver)
+
+</div>
+
+<div id="function-splice-testing-tokenstandard-walletclient-listrequestedallocations-63651">
+
+listRequestedAllocations
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> InstrumentId -\> Script \[AllocationSpecification\]
+
+List all allocations requested from the owner for a specific instrument.
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-utils.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-utils.mdx
@@ -1,0 +1,231 @@
+---
+title: "Splice.Testing.Utils"
+description: "Documentation for Splice.Testing.Utils"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-token-standard-test/docs/Splice-Testing-Utils.rst" tag="0.6.4" hash="463393d8" */}
+
+Testing utilities to simplify testing token standard usage and implementation.
+
+## Data Types
+
+<div id="type-splice-testing-utils-disclosurestick-7569">
+
+**data** Disclosures'
+
+</div>
+
+> A set of disclosures. Used to work around the fact that duplicate disclosures for the same contract are not allowed.
+>
+> <div id="constr-splice-testing-utils-disclosurestick-34366">
+>
+> Disclosures'
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                                     | Description |
+> > |-------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | disclosures | [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) AnyContractId Disclosure |             |
+>
+> **instance** [Monoid](/appdev/reference/daml-standard-library/prelude#class-da-internal-prelude-monoid-6742) Disclosures'
+>
+> **instance** [Semigroup](/appdev/reference/daml-standard-library/prelude#class-da-internal-prelude-semigroup-78998) Disclosures'
+>
+> **instance** GetField "disclosures" Disclosures' ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) AnyContractId Disclosure)
+>
+> **instance** GetField "disclosures" (EnrichedFactoryChoice t ch) Disclosures'
+>
+> **instance** GetField "disclosures" OpenApiChoiceContext Disclosures'
+>
+> **instance** SetField "disclosures" Disclosures' ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) AnyContractId Disclosure)
+>
+> **instance** SetField "disclosures" (EnrichedFactoryChoice t ch) Disclosures'
+>
+> **instance** SetField "disclosures" OpenApiChoiceContext Disclosures'
+
+<div id="type-splice-testing-utils-enrichedfactorychoice-76896">
+
+**data** EnrichedFactoryChoice t ch
+
+</div>
+
+> A choice on a factory contract enriched with an appropriate choice-context and disclosures.
+>
+> <div id="constr-splice-testing-utils-enrichedfactorychoice-82153">
+>
+> EnrichedFactoryChoice
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                            | Description |
+> > |-------------|---------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | factoryCid  | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t |             |
+> > | arg         | ch                                                                                                                              |             |
+> > | disclosures | Disclosures'                                                                                                                    |             |
+>
+> **instance** GetField "arg" (EnrichedFactoryChoice t ch) ch
+>
+> **instance** GetField "disclosures" (EnrichedFactoryChoice t ch) Disclosures'
+>
+> **instance** GetField "factoryCid" (EnrichedFactoryChoice t ch) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t)
+>
+> **instance** SetField "arg" (EnrichedFactoryChoice t ch) ch
+>
+> **instance** SetField "disclosures" (EnrichedFactoryChoice t ch) Disclosures'
+>
+> **instance** SetField "factoryCid" (EnrichedFactoryChoice t ch) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t)
+
+<div id="type-splice-testing-utils-failurestatuscheck-2574">
+
+**data** FailureStatusCheck
+
+</div>
+
+> <div id="constr-splice-testing-utils-failurestatuscheck-17729">
+>
+> FailureStatusCheck
+>
+> </div>
+>
+> > | Field | Type                                                                                                                                                                                                                                                                                                                                                                                        | Description |
+> > |-------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | check | FailureStatus -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> **instance** [Semigroup](/appdev/reference/daml-standard-library/prelude#class-da-internal-prelude-semigroup-78998) FailureStatusCheck
+>
+> **instance** GetField "check" FailureStatusCheck (FailureStatus -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
+>
+> **instance** SetField "check" FailureStatusCheck (FailureStatus -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
+
+<div id="type-splice-testing-utils-openapichoicecontext-5726">
+
+**data** OpenApiChoiceContext
+
+</div>
+
+> A representation of a ChoiceContext and disclosed contracts as they would be returned by the an OpenAPI endpoint of the token standard.
+>
+> <div id="constr-splice-testing-utils-openapichoicecontext-58633">
+>
+> OpenApiChoiceContext
+>
+> </div>
+>
+> > | Field         | Type          | Description |
+> > |---------------|---------------|-------------|
+> > | choiceContext | ChoiceContext |             |
+> > | disclosures   | Disclosures'  |             |
+>
+> **instance** [Semigroup](/appdev/reference/daml-standard-library/prelude#class-da-internal-prelude-semigroup-78998) OpenApiChoiceContext
+>
+> **instance** GetField "choiceContext" OpenApiChoiceContext ChoiceContext
+>
+> **instance** GetField "disclosures" OpenApiChoiceContext Disclosures'
+>
+> **instance** SetField "choiceContext" OpenApiChoiceContext ChoiceContext
+>
+> **instance** SetField "disclosures" OpenApiChoiceContext Disclosures'
+
+## Functions
+
+<div id="function-splice-testing-utils-emptyextraargs-23102">
+
+emptyExtraArgs
+: ExtraArgs
+
+Use this to construct an empty 'ExtraArgs' record.
+
+</div>
+
+<div id="function-splice-testing-utils-withextradisclosures-38780">
+
+withExtraDisclosures
+: Disclosures' -\> OpenApiChoiceContext -\> OpenApiChoiceContext
+
+Add extra disclosures to an 'OpenApiChoiceContext'.
+
+</div>
+
+<div id="function-splice-testing-utils-querydisclosuretick-36762">
+
+queryDisclosure'
+: [Template](/appdev/reference/daml-standard-library/prelude#type-da-internal-template-functions-template-31804) t =\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> Script Disclosures'
+
+Retrieve a disclosed contract by its contract-id from a specific party's ACS.
+
+</div>
+
+<div id="function-splice-testing-utils-submitwithdisclosurestick-2335">
+
+submitWithDisclosures'
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Disclosures' -\> Commands a -\> Script a
+
+Version of 'submitWithDisclosures' that works with the simplified `Disclosures'` type.
+
+</div>
+
+<div id="function-splice-testing-utils-submitwithdisclosuresmustfailtick-79338">
+
+submitWithDisclosuresMustFail'
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Disclosures' -\> Commands a -\> Script ()
+
+Version of 'submitWithDisclosuresMustFail' that works with the simplified `Disclosures'` type.
+
+</div>
+
+<div id="function-splice-testing-utils-allocatepartyexact-97926">
+
+allocatePartyExact
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> Script [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+Allocate party with a specific name.
+
+</div>
+
+<div id="function-splice-testing-utils-submitwithdisclosuresmustfailticktick-58494">
+
+submitWithDisclosuresMustFail''
+: [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a =\> FailureStatusCheck -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Disclosures' -\> Commands a -\> Script ()
+
+Use this to check that commands fail with the expected 'FailureStatus'.
+
+</div>
+
+<div id="function-splice-testing-utils-submitmultimustfailticktick-78157">
+
+submitMultiMustFail''
+: [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a =\> FailureStatusCheck -\> \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] -\> \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] -\> Commands a -\> Script ()
+
+Use this to check that multi-party submission fails with the expected 'FailureStatus'.
+
+</div>
+
+<div id="function-splice-testing-utils-expecterrorid-70623">
+
+expectErrorId
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> FailureStatusCheck
+
+</div>
+
+<div id="function-splice-testing-utils-expectmessagecontains-36340">
+
+expectMessageContains
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> FailureStatusCheck
+
+</div>
+
+<div id="function-splice-testing-utils-expectunmetrequirement-1831">
+
+expectUnmetRequirement
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> FailureStatusCheck
+
+</div>
+
+<div id="function-splice-testing-utils-expectfailurestatus-34748">
+
+expectFailureStatus
+: (FailureStatus -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)) -\> FailureStatusCheck
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokendvp.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokendvp.mdx
@@ -1,0 +1,119 @@
+---
+title: "Splice.Tests.TestAmuletTokenDvP"
+description: "Documentation for Splice.Tests.TestAmuletTokenDvP"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-token-standard-test/docs/Splice-Tests-TestAmuletTokenDvP.rst" tag="0.6.4" hash="92304d93" */}
+
+Daml script tests showing that the token standard can be used to execute DvP settlements of Amulet tokens; and how to do so.
+
+See this test and the 'Splice.Testing.TradingApp' module for an example of how to integrate with the allocation APIs of the token standard to execute DvP settlements.
+
+Note also that the delivery part of a DvP settelement can be both another token implementing the standard, as well as the creation of on-ledger state specific to your registry; e.g., a license contract.
+
+## Data Types
+
+<div id="type-splice-tests-testamulettokendvp-allocatedotctrade-90362">
+
+**data** AllocatedOTCTrade
+
+</div>
+
+> <div id="constr-splice-tests-testamulettokendvp-allocatedotctrade-19245">
+>
+> AllocatedOTCTrade
+>
+> </div>
+>
+> > | Field                 | Type                                                                                                                                                                                                                                          | Description |
+> > |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | alice                 | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                           |             |
+> > | bob                   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                           |             |
+> > | provider              | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                           |             |
+> > | providerBeneficiary1  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                           |             |
+> > | providerBeneficiary2  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                           |             |
+> > | providerBeneficiaries | \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\] |             |
+> > | registry              | AmuletRegistry                                                                                                                                                                                                                                |             |
+> > | otcTradeCid           | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTrade                                                                                                        |             |
+> > | otcTrade              | OTCTrade                                                                                                                                                                                                                                      |             |
+> > | amuletId              | InstrumentId                                                                                                                                                                                                                                  |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AllocatedOTCTrade
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AllocatedOTCTrade
+>
+> **instance** GetField "alice" AllocatedOTCTrade [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "amuletId" AllocatedOTCTrade InstrumentId
+>
+> **instance** GetField "bob" AllocatedOTCTrade [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "otcTrade" AllocatedOTCTrade OTCTrade
+>
+> **instance** GetField "otcTradeCid" AllocatedOTCTrade ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTrade)
+>
+> **instance** GetField "provider" AllocatedOTCTrade [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "providerBeneficiaries" AllocatedOTCTrade \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\]
+>
+> **instance** GetField "providerBeneficiary1" AllocatedOTCTrade [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "providerBeneficiary2" AllocatedOTCTrade [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "registry" AllocatedOTCTrade AmuletRegistry
+>
+> **instance** SetField "alice" AllocatedOTCTrade [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "amuletId" AllocatedOTCTrade InstrumentId
+>
+> **instance** SetField "bob" AllocatedOTCTrade [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "otcTrade" AllocatedOTCTrade OTCTrade
+>
+> **instance** SetField "otcTradeCid" AllocatedOTCTrade ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTrade)
+>
+> **instance** SetField "provider" AllocatedOTCTrade [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "providerBeneficiaries" AllocatedOTCTrade \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135))\]
+>
+> **instance** SetField "providerBeneficiary1" AllocatedOTCTrade [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "providerBeneficiary2" AllocatedOTCTrade [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "registry" AllocatedOTCTrade AmuletRegistry
+
+## Functions
+
+<div id="function-splice-tests-testamulettokendvp-setupotctrade-96214">
+
+setupOtcTrade
+: Script AllocatedOTCTrade
+
+</div>
+
+<div id="function-splice-tests-testamulettokendvp-testdvp-18055">
+
+testDvP
+: Script ()
+
+Test that a DvP settlement of an OTC trade works when using Amulet via the token standard.
+
+</div>
+
+<div id="function-splice-tests-testamulettokendvp-appbackendlistallocations-88475">
+
+appBackendListAllocations
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> Reference -\> Script ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation, AllocationView))
+
+List all allocations matching a particular settlement reference, sorted by their tradeLeg id. This function would be run on the trading app provider's backend as part of an automation loop.
+
+</div>
+
+<div id="function-splice-tests-testamulettokendvp-expectnoburn-66061">
+
+expectNoBurn
+: Metadata -\> Script ()
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokentransfer.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokentransfer.mdx
@@ -1,0 +1,164 @@
+---
+title: "Splice.Tests.TestAmuletTokenTransfer"
+description: "Documentation for Splice.Tests.TestAmuletTokenTransfer"
+---
+
+{/* COPIED_START source="splice:token-standard/splice-token-standard-test/docs/Splice-Tests-TestAmuletTokenTransfer.rst" tag="0.6.4" hash="4139d045" */}
+
+Daml script tests showing that the token standard can be used to execute free-of-payment transfers of Amulet tokens; and how to do so.
+
+## Data Types
+
+<div id="type-splice-tests-testamulettokentransfer-testsetup-23760">
+
+**data** TestSetup
+
+</div>
+
+> <div id="constr-splice-tests-testamulettokentransfer-testsetup-65645">
+>
+> TestSetup
+>
+> </div>
+>
+> > | Field           | Type                                                                                                                | Description |
+> > |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | registry        | AmuletRegistry                                                                                                      |             |
+> > | alice           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | aliceValidator  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | bob             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | now             | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
+> > | defaultTransfer | Transfer                                                                                                            |             |
+>
+> **instance** GetField "alice" TestSetup [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "aliceValidator" TestSetup [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "bob" TestSetup [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "defaultTransfer" TestSetup Transfer
+>
+> **instance** GetField "now" TestSetup [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "registry" TestSetup AmuletRegistry
+>
+> **instance** SetField "alice" TestSetup [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "aliceValidator" TestSetup [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "bob" TestSetup [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "defaultTransfer" TestSetup Transfer
+>
+> **instance** SetField "now" TestSetup [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "registry" TestSetup AmuletRegistry
+
+## Functions
+
+<div id="function-splice-tests-testamulettokentransfer-setuptest-24792">
+
+setupTest
+: Script TestSetup
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-setuptwosteptransfer-95496">
+
+setupTwoStepTransfer
+: Script (TestSetup, [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction)
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-assertnofeaturedrewards-59478">
+
+assertNoFeaturedRewards
+: \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] -\> Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-expectnoburn-5077">
+
+expectNoBurn
+: Metadata -\> Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-testhappypathself-81760">
+
+test_happy_path_self
+: Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-testhappypathdirect-60815">
+
+test_happy_path_direct
+: Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-testtwostepsuccess-72631">
+
+test_two_step_success
+: Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-testtwostepwithdraw-23771">
+
+test_two_step_withdraw
+: Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-testtwostepwithdrawlockedamuletgone-99068">
+
+test_two_step_withdraw_locked_amulet_gone
+: Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-testtwostepreject-58318">
+
+test_two_step_reject
+: Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-testtwosteprejectlockedamuletgone-59771">
+
+test_two_step_reject_locked_amulet_gone
+: Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-testnoholdings-86337">
+
+test_no_holdings
+: Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-testexpired-89770">
+
+test_expired
+: Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-testwrongadmin-22190">
+
+test_wrong_admin
+: Script ()
+
+</div>
+
+<div id="function-splice-tests-testamulettokentransfer-testfactorypublicfetch-19587">
+
+test_factory_PublicFetch
+: Script ()
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/index.mdx
@@ -1,0 +1,14 @@
+---
+title: "splice-test-trading-app docs"
+description: "Documentation for splice-test-trading-app docs"
+---
+
+{/* COPIED_START source="splice:token-standard/examples/splice-token-test-trading-app/docs/index.rst" tag="0.6.4" hash="ec7fa10a" */}
+
+A trading app example built on top of the allocation APIs of the Canton Network Token Standard.
+
+Serves both as an example as well as a test suite for the token standard APIs. See `splice-token-standard-test-docs` for the test harness that uses this trading app example for testing allocation usage and implementations.
+
+- [Splice.Testing.Apps.TradingApp](/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp.mdx
@@ -1,0 +1,181 @@
+---
+title: "Splice.Testing.Apps.TradingApp"
+description: "Documentation for Splice.Testing.Apps.TradingApp"
+---
+
+{/* COPIED_START source="splice:token-standard/examples/splice-token-test-trading-app/docs/Splice-Testing-Apps-TradingApp.rst" tag="0.6.4" hash="c0da3034" */}
+
+An example of how to build an OTC trading app for multi-leg standard token trades.
+
+Used as part of the testing infrastructure to test the DvP workflows based on the token standard.
+
+## Templates
+
+<div id="type-splice-testing-apps-tradingapp-otctrade-80775">
+
+**template** OTCTrade
+
+</div>
+
+> Signatory: venue, tradingParties transferLegs
+>
+> | Field        | Type                                                                                                                                           | Description |
+> |--------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> | venue        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                            |             |
+> | transferLegs | [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) TransferLeg            |             |
+> | tradeCid     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTradeProposal |             |
+> | createdAt    | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                              |             |
+> | prepareUntil | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                              |             |
+> | settleBefore | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                              |             |
+>
+> - **Choice** Archive
+>
+>   Controller: venue, tradingParties transferLegs
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-testing-apps-tradingapp-otctradecancel-34465">
+>
+>   **Choice** OTCTrade_Cancel
+>
+>   </div>
+>
+>   Controller: venue
+>
+>   Returns: [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) Allocation_CancelResult)
+>
+>   | Field                  | Type                                                                                                                                                                                                                                                                          | Description |
+>   |------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | allocationsWithContext | [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation, ExtraArgs) |             |
+>
+> - <div id="type-splice-testing-apps-tradingapp-otctradesettle-9210">
+>
+>   **Choice** OTCTrade_Settle
+>
+>   </div>
+>
+>   Controller: venue
+>
+>   Returns: [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) Allocation_ExecuteTransferResult
+>
+>   | Field                  | Type                                                                                                                                                                                                                                                                          | Description |
+>   |------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | allocationsWithContext | [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation, ExtraArgs) |             |
+>
+> - **interface instance** AllocationRequest **for** OTCTrade
+
+<div id="type-splice-testing-apps-tradingapp-otctradeproposal-78093">
+
+**template** OTCTradeProposal
+
+</div>
+
+> Signatory: approvers
+>
+> | Field        | Type                                                                                                                                                                                                                                                                            | Description                             |
+> |--------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+> | venue        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                                             |                                         |
+> | tradeCid     | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTradeProposal) |                                         |
+> | transferLegs | [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) TransferLeg                                                                                                                                             |                                         |
+> | approvers    | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]                                                                                                                                                         | Parties that have approved the proposal |
+>
+> - **Choice** Archive
+>
+>   Controller: approvers
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-testing-apps-tradingapp-otctradeproposalaccept-97549">
+>
+>   **Choice** OTCTradeProposal_Accept
+>
+>   </div>
+>
+>   Controller: approver
+>
+>   Returns: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTradeProposal
+>
+>   | Field    | Type                                                                                                                | Description |
+>   |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | approver | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-testing-apps-tradingapp-otctradeproposalinitiatesettlement-54617">
+>
+>   **Choice** OTCTradeProposal_InitiateSettlement
+>
+>   </div>
+>
+>   Controller: venue
+>
+>   Returns: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTrade
+>
+>   | Field        | Type                                                                                                              | Description |
+>   |--------------|-------------------------------------------------------------------------------------------------------------------|-------------|
+>   | prepareUntil | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) |             |
+>   | settleBefore | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) |             |
+>
+> - <div id="type-splice-testing-apps-tradingapp-otctradeproposalreject-13148">
+>
+>   **Choice** OTCTradeProposal_Reject
+>
+>   </div>
+>
+>   Controller: trader
+>
+>   Returns: ()
+>
+>   | Field  | Type                                                                                                                | Description |
+>   |--------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | trader | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+
+## Functions
+
+<div id="function-splice-testing-apps-tradingapp-tradeallocations-16894">
+
+tradeAllocations
+: SettlementInfo -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) TransferLeg -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) AllocationSpecification
+
+</div>
+
+<div id="function-splice-testing-apps-tradingapp-tradingparties-11886">
+
+tradingParties
+: [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) TransferLeg -\> Set [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+</div>
+
+<div id="function-splice-testing-apps-tradingapp-require-88127">
+
+require
+: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+
+Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+
+</div>
+
+<div id="function-splice-testing-apps-tradingapp-maketraderef-67526">
+
+makeTradeRef
+: [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) OTCTradeProposal -\> Reference
+
+</div>
+
+<div id="function-splice-testing-apps-tradingapp-ziptextmaps-57279">
+
+zipTextMaps
+: [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) a -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) b -\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a, [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) b)
+
+</div>
+
+<div id="function-splice-testing-apps-tradingapp-fortextmapwithkey-78275">
+
+forTextMapWithKey
+: [Applicative](/appdev/reference/daml-standard-library/prelude#class-da-internal-prelude-applicative-9257) f =\> [TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) a -\> ([Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> a -\> f b) -\> f ([TextMap](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-textmap-11691) b)
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "splice-util-batched-markers docs"
+description: "Documentation for splice-util-batched-markers docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-util-batched-markers/docs/index.rst" tag="0.6.4" hash="1636b7a2" */}
+
+This package provides the `BatchedMarkersProxy` contract which can be used to create a batch of `FeaturedAppActivityMarkers` in a transaction with a single view which is more efficient to process. To use it first create one long-lived `BatchedMarkersProxy` contract and then use `BatchedMarkersProxy_CreateMarkers` to create the actual markers. Note that for this to work all beneficiaries and the provider must have vetted the DAR.
+
+- [Splice.Util.FeaturedApp.BatchedMarkersProxy](/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy.mdx
@@ -1,0 +1,194 @@
+---
+title: "Splice.Util.FeaturedApp.BatchedMarkersProxy"
+description: "Documentation for Splice.Util.FeaturedApp.BatchedMarkersProxy"
+---
+
+{/* COPIED_START source="splice:daml/splice-util-batched-markers/docs/Splice-Util-FeaturedApp-BatchedMarkersProxy.rst" tag="0.6.4" hash="224dec62" */}
+
+This module provides a BatchedMarkersProxy that can be used to create multiple markers in one view.
+
+## Templates
+
+<div id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxy-55016">
+
+**template** BatchedMarkersProxy
+
+</div>
+
+> Signatory: provider
+>
+> | Field    | Type                                                                                                                | Description |
+> |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | dso      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: provider
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkers-27654">
+>
+>   **Choice** BatchedMarkersProxy_CreateMarkers
+>
+>   </div>
+>
+>   Controller: provider
+>
+>   Returns: BatchedMarkersProxy_CreateMarkersResult
+>
+>   | Field               | Type                                                                                                                                           | Description |
+>   |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
+>   | batches             | \[RewardBatch\]                                                                                                                                |             |
+>
+> - <div id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersv2-19116">
+>
+>   **Choice** BatchedMarkersProxy_CreateMarkersV2
+>
+>   </div>
+>
+>   Controller: provider
+>
+>   Returns: BatchedMarkersProxy_CreateMarkersV2Result
+>
+>   | Field               | Type                                                                                                                                           | Description |
+>   |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
+>   | batches             | \[RewardBatchV2\]                                                                                                                              |             |
+
+## Data Types
+
+<div id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersresult-99671">
+
+**data** BatchedMarkersProxy_CreateMarkersResult
+
+</div>
+
+> <div id="constr-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersresult-77896">
+>
+> BatchedMarkersProxy_CreateMarkersResult
+>
+> </div>
+>
+> > | Field   | Type                                                | Description |
+> > |---------|-----------------------------------------------------|-------------|
+> > | results | \[\[FeaturedAppRight_CreateActivityMarkerResult\]\] |             |
+>
+> **instance** GetField "results" BatchedMarkersProxy_CreateMarkersResult \[\[FeaturedAppRight_CreateActivityMarkerResult\]\]
+>
+> **instance** SetField "results" BatchedMarkersProxy_CreateMarkersResult \[\[FeaturedAppRight_CreateActivityMarkerResult\]\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkers BatchedMarkersProxy_CreateMarkersResult
+
+<div id="type-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersv2result-28373">
+
+**data** BatchedMarkersProxy_CreateMarkersV2Result
+
+</div>
+
+> <div id="constr-splice-util-featuredapp-batchedmarkersproxy-batchedmarkersproxycreatemarkersv2result-1154">
+>
+> BatchedMarkersProxy_CreateMarkersV2Result
+>
+> </div>
+>
+> > | Field   | Type                                            | Description |
+> > |---------|-------------------------------------------------|-------------|
+> > | results | \[FeaturedAppRight_CreateActivityMarkerResult\] |             |
+>
+> **instance** GetField "results" BatchedMarkersProxy_CreateMarkersV2Result \[FeaturedAppRight_CreateActivityMarkerResult\]
+>
+> **instance** SetField "results" BatchedMarkersProxy_CreateMarkersV2Result \[FeaturedAppRight_CreateActivityMarkerResult\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkersV2 BatchedMarkersProxy_CreateMarkersV2Result
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkersV2 BatchedMarkersProxy_CreateMarkersV2Result
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) BatchedMarkersProxy BatchedMarkersProxy_CreateMarkersV2 BatchedMarkersProxy_CreateMarkersV2Result
+
+<div id="type-splice-util-featuredapp-batchedmarkersproxy-rewardbatch-19803">
+
+**data** RewardBatch
+
+</div>
+
+> <div id="constr-splice-util-featuredapp-batchedmarkersproxy-rewardbatch-87344">
+>
+> RewardBatch
+>
+> </div>
+>
+> > | Field         | Type                                                                                                       | Description |
+> > |---------------|------------------------------------------------------------------------------------------------------------|-------------|
+> > | beneficiaries | \[AppRewardBeneficiary\]                                                                                   |             |
+> > | numMarkers    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RewardBatch
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RewardBatch
+>
+> **instance** GetField "batches" BatchedMarkersProxy_CreateMarkers \[RewardBatch\]
+>
+> **instance** GetField "beneficiaries" RewardBatch \[AppRewardBeneficiary\]
+>
+> **instance** GetField "numMarkers" RewardBatch [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "batches" BatchedMarkersProxy_CreateMarkers \[RewardBatch\]
+>
+> **instance** SetField "beneficiaries" RewardBatch \[AppRewardBeneficiary\]
+>
+> **instance** SetField "numMarkers" RewardBatch [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+
+<div id="type-splice-util-featuredapp-batchedmarkersproxy-rewardbatchv2-80405">
+
+**data** RewardBatchV2
+
+</div>
+
+> <div id="constr-splice-util-featuredapp-batchedmarkersproxy-rewardbatchv2-45814">
+>
+> RewardBatchV2
+>
+> </div>
+>
+> > | Field         | Type                                                                                                               | Description                                             |
+> > |---------------|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+> > | beneficiaries | \[AppRewardBeneficiary\]                                                                                           |                                                         |
+> > | markerWeight  | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) | The total weight of the markers that should be created. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) RewardBatchV2
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) RewardBatchV2
+>
+> **instance** GetField "batches" BatchedMarkersProxy_CreateMarkersV2 \[RewardBatchV2\]
+>
+> **instance** GetField "beneficiaries" RewardBatchV2 \[AppRewardBeneficiary\]
+>
+> **instance** GetField "markerWeight" RewardBatchV2 [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "batches" BatchedMarkersProxy_CreateMarkersV2 \[RewardBatchV2\]
+>
+> **instance** SetField "beneficiaries" RewardBatchV2 \[AppRewardBeneficiary\]
+>
+> **instance** SetField "markerWeight" RewardBatchV2 [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+## Functions
+
+<div id="function-splice-util-featuredapp-batchedmarkersproxy-require-64969">
+
+require
+: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+
+Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "splice-util-featured-app-proxies docs"
+description: "Documentation for splice-util-featured-app-proxies docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-util-featured-app-proxies/docs/index.rst" tag="0.6.4" hash="21d081ce" */}
+
+Optional package simplifying the integration of featured apps with the token standard. Not uploaded by default to a validator node.
+
+- [Splice.Util.FeaturedApp.DelegateProxy](/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy)
+- [Splice.Util.FeaturedApp.WalletUserProxy](/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy.mdx
@@ -1,0 +1,276 @@
+---
+title: "Splice.Util.FeaturedApp.DelegateProxy"
+description: "Documentation for Splice.Util.FeaturedApp.DelegateProxy"
+---
+
+{/* COPIED_START source="splice:daml/splice-util-featured-app-proxies/docs/Splice-Util-FeaturedApp-DelegateProxy.rst" tag="0.6.4" hash="1b1ebdb6" */}
+
+Utility template for proxying token standard choices so that featured app markers are created when using extra parties for operating an app.
+
+You can either use this template directly, or copy the code under a **different package name** and a **different module name**.
+
+Note: use the `WalletUserProxy` if you are building a wallet app and want your users to create featured app markers for you.
+
+## Templates
+
+<div id="type-splice-util-featuredapp-delegateproxy-delegateproxy-71400">
+
+**template** DelegateProxy
+
+</div>
+
+> A proxy for a delegate to create featured app markers jointly with using token standard workflows. The delegate is given full control over the creation of the markers.
+>
+> This is for example useful when using one or more parties for app operation purposes. Using this proxy allows the operational parties to properly attribute their activity to the featured app, which is represented by the app provider party.
+>
+> Signatory: provider
+>
+> | Field    | Type                                                                                                                | Description                                               |
+> |----------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+> | provider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The app provider whose featured app right should be used  |
+> | delegate | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The delegate interacting with the token standard workflow |
+>
+> - **Choice** Archive
+>
+>   Controller: provider
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxyallocationfactoryallocate-41540">
+>
+>   **Choice** DelegateProxy_AllocationFactory_Allocate
+>
+>   </div>
+>
+>   Controller: delegate
+>
+>   Returns: ProxyResult AllocationInstructionResult
+>
+>   | Field    | Type                                                                                                                                            | Description |
+>   |----------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory |             |
+>   | proxyArg | ProxyArg AllocationFactory_Allocate                                                                                                             |             |
+>
+> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxyallocationwithdraw-47558">
+>
+>   **Choice** DelegateProxy_Allocation_Withdraw
+>
+>   </div>
+>
+>   Controller: delegate
+>
+>   Returns: ProxyResult Allocation_WithdrawResult
+>
+>   | Field    | Type                                                                                                                                     | Description |
+>   |----------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation |             |
+>   | proxyArg | ProxyArg Allocation_Withdraw                                                                                                             |             |
+>
+> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferfactorytransfer-85873">
+>
+>   **Choice** DelegateProxy_TransferFactory_Transfer
+>
+>   </div>
+>
+>   Controller: delegate
+>
+>   Returns: ProxyResult TransferInstructionResult
+>
+>   | Field    | Type                                                                                                                                          | Description |
+>   |----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory |             |
+>   | proxyArg | ProxyArg TransferFactory_Transfer                                                                                                             |             |
+>
+> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionaccept-5120">
+>
+>   **Choice** DelegateProxy_TransferInstruction_Accept
+>
+>   </div>
+>
+>   Controller: delegate
+>
+>   Returns: ProxyResult TransferInstructionResult
+>
+>   | Field    | Type                                                                                                                                              | Description |
+>   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
+>   | proxyArg | ProxyArg TransferInstruction_Accept                                                                                                               |             |
+>
+> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionreject-73393">
+>
+>   **Choice** DelegateProxy_TransferInstruction_Reject
+>
+>   </div>
+>
+>   Controller: delegate
+>
+>   Returns: ProxyResult TransferInstructionResult
+>
+>   | Field    | Type                                                                                                                                              | Description |
+>   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
+>   | proxyArg | ProxyArg TransferInstruction_Reject                                                                                                               |             |
+>
+> - <div id="type-splice-util-featuredapp-delegateproxy-delegateproxytransferinstructionwithdraw-896">
+>
+>   **Choice** DelegateProxy_TransferInstruction_Withdraw
+>
+>   </div>
+>
+>   Controller: delegate
+>
+>   Returns: ProxyResult TransferInstructionResult
+>
+>   | Field    | Type                                                                                                                                              | Description |
+>   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
+>   | proxyArg | ProxyArg TransferInstruction_Withdraw                                                                                                             |             |
+
+## Data Types
+
+<div id="type-splice-util-featuredapp-delegateproxy-proxyarg-10352">
+
+**data** ProxyArg arg
+
+</div>
+
+> Generic argument to the proxy choices.
+>
+> <div id="constr-splice-util-featuredapp-delegateproxy-proxyarg-5545">
+>
+> ProxyArg
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                           | Description                                                 |
+> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+> > | choiceArg           | arg                                                                                                                                            | The argument to the choice that the delegate is exercising. |
+> > | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight | The featured app right contract of the provider.            |
+> > | beneficiaries       | \[AppRewardBeneficiary\]                                                                                                                       | The beneficiaries for the activity marker.                  |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) arg =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (ProxyArg arg)
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) arg =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (ProxyArg arg)
+>
+> **instance** GetField "beneficiaries" (ProxyArg arg) \[AppRewardBeneficiary\]
+>
+> **instance** GetField "choiceArg" (ProxyArg arg) arg
+>
+> **instance** GetField "featuredAppRightCid" (ProxyArg arg) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** GetField "proxyArg" DelegateProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)
+>
+> **instance** GetField "proxyArg" DelegateProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)
+>
+> **instance** GetField "proxyArg" DelegateProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)
+>
+> **instance** GetField "proxyArg" DelegateProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)
+>
+> **instance** GetField "proxyArg" DelegateProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)
+>
+> **instance** GetField "proxyArg" DelegateProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)
+>
+> **instance** SetField "beneficiaries" (ProxyArg arg) \[AppRewardBeneficiary\]
+>
+> **instance** SetField "choiceArg" (ProxyArg arg) arg
+>
+> **instance** SetField "featuredAppRightCid" (ProxyArg arg) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** SetField "proxyArg" DelegateProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)
+>
+> **instance** SetField "proxyArg" DelegateProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)
+>
+> **instance** SetField "proxyArg" DelegateProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)
+>
+> **instance** SetField "proxyArg" DelegateProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)
+>
+> **instance** SetField "proxyArg" DelegateProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)
+>
+> **instance** SetField "proxyArg" DelegateProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)
+
+<div id="type-splice-util-featuredapp-delegateproxy-proxyresult-3914">
+
+**data** ProxyResult r
+
+</div>
+
+> Generic result of the proxy choices.
+>
+> <div id="constr-splice-util-featuredapp-delegateproxy-proxyresult-43225">
+>
+> ProxyResult
+>
+> </div>
+>
+> > | Field        | Type                                        | Description |
+> > |--------------|---------------------------------------------|-------------|
+> > | markerResult | FeaturedAppRight_CreateActivityMarkerResult |             |
+> > | choiceResult | r                                           |             |
+>
+> **instance** GetField "choiceResult" (ProxyResult r) r
+>
+> **instance** GetField "markerResult" (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult
+>
+> **instance** SetField "choiceResult" (ProxyResult r) r
+>
+> **instance** SetField "markerResult" (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) DelegateProxy DelegateProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
+
+## Functions
+
+<div id="function-splice-util-featuredapp-delegateproxy-exerciseproxychoice-9818">
+
+exerciseProxyChoice
+: [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) t ch r =\> DelegateProxy -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> ProxyArg ch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (ProxyResult r)
+
+Shared code to execute the proxied choice.
+
+</div>
+
+<div id="function-splice-util-featuredapp-delegateproxy-require-76960">
+
+require
+: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+
+Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy.mdx
@@ -1,0 +1,460 @@
+---
+title: "Splice.Util.FeaturedApp.WalletUserProxy"
+description: "Documentation for Splice.Util.FeaturedApp.WalletUserProxy"
+---
+
+{/* COPIED_START source="splice:daml/splice-util-featured-app-proxies/docs/Splice-Util-FeaturedApp-WalletUserProxy.rst" tag="0.6.4" hash="18b18cc4" */}
+
+Utility template for proxying token standard choices so that featured app markers are created for a wallet app provider by their users when they are using token standard workflows.
+
+You can either use this template directly, or copy the code under a **different package name** and a **different module name**.
+
+Note: use the `DelegateProxy` if you are building an app that uses multiple parties for its own operations.
+
+## Templates
+
+<div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxy-95528">
+
+**template** WalletUserProxy
+
+</div>
+
+> A proxy to attribute the activity of a wallet user to the wallet app provider.
+>
+> The intended usage is for the wallet app provider to
+>
+> 1.  create a `WalletUserProxy` contract with the `provider` set to the app provider's party
+> 2.  setup their wallet frontend such that users call the proxy's choices instead of the original token standard choices.
+>
+> Note that the weights are specified on the proxy contract, so that they are under the providers control. If they were specified on the choices, then the user could in principle change them, and grant themselves a higher reward than intended.
+>
+> Note also that the batch transfer support can be used without having a featured app right.
+>
+> Signatory: provider
+>
+> | Field              | Type                                                                                                                                                                                                                                                   | Description                                                                    |
+> |--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
+> | provider           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                    | The app provider whose featured app right should be triggered                  |
+> | providerWeight     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                     | Reward weight for the provider                                                 |
+> | userWeight         | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                     | Reward weight for the user, set to 0.0 if the user should not receive a reward |
+> | extraBeneficiaries | \[AppRewardBeneficiary\]                                                                                                                                                                                                                               | Extra beneficiaries to add                                                     |
+> | optAllowList       | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] | An optional allow list of parties that can use the proxy                       |
+>
+> - **Choice** Archive
+>
+>   Controller: provider
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxyallocationfactoryallocate-70856">
+>
+>   **Choice** WalletUserProxy_AllocationFactory_Allocate
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"user" proxyArg)
+>
+>   Returns: ProxyResult AllocationInstructionResult
+>
+>   | Field    | Type                                                                                                                                            | Description |
+>   |----------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory |             |
+>   | proxyArg | ProxyArg AllocationFactory_Allocate                                                                                                             |             |
+>
+> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxyallocationwithdraw-8358">
+>
+>   **Choice** WalletUserProxy_Allocation_Withdraw
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"user" proxyArg)
+>
+>   Returns: ProxyResult Allocation_WithdrawResult
+>
+>   | Field    | Type                                                                                                                                     | Description |
+>   |----------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation |             |
+>   | proxyArg | ProxyArg Allocation_Withdraw                                                                                                             |             |
+>
+> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransfer-93002">
+>
+>   **Choice** WalletUserProxy_BatchTransfer
+>
+>   </div>
+>
+>   Controller: getFirstSender transferCalls
+>
+>   Returns: WalletUserProxy_BatchTransferResult
+>
+>   | Field                  | Type                                                                                                                                                                                                                                                                            | Description                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+>   |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+>   | transferCalls          | \[TransferFactoryCall\]                                                                                                                                                                                                                                                         | Transfers to execute via their respective transfer factories. Input holdings are properly threaded through for all instrument-ids. The sender change is always added back as an additional input to follow-up transfers for the same instrument-ids. Note that we accept fully specified calls to factories for maximum flexibility. Some token admins may actually use different factories for different recipients, e.g., to implement preapprovals. |
+>   | optFeaturedAppRightCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight) | The featured app right contract of the provider to use on every transfer. Optional so the batched choice can be used without a featured app right.                                                                                                                                                                                                                                                                                                     |
+>
+> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxypublicfetch-18804">
+>
+>   **Choice** WalletUserProxy_PublicFetch
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: WalletUserProxy
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | actor | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferfactorytransfer-32457">
+>
+>   **Choice** WalletUserProxy_TransferFactory_Transfer
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"user" proxyArg)
+>
+>   Returns: ProxyResult TransferInstructionResult
+>
+>   | Field    | Type                                                                                                                                          | Description |
+>   |----------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory |             |
+>   | proxyArg | ProxyArg TransferFactory_Transfer                                                                                                             |             |
+>
+> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionaccept-38416">
+>
+>   **Choice** WalletUserProxy_TransferInstruction_Accept
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"user" proxyArg)
+>
+>   Returns: ProxyResult TransferInstructionResult
+>
+>   | Field    | Type                                                                                                                                              | Description |
+>   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
+>   | proxyArg | ProxyArg TransferInstruction_Accept                                                                                                               |             |
+>
+> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionreject-59713">
+>
+>   **Choice** WalletUserProxy_TransferInstruction_Reject
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"user" proxyArg)
+>
+>   Returns: ProxyResult TransferInstructionResult
+>
+>   | Field    | Type                                                                                                                                              | Description |
+>   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
+>   | proxyArg | ProxyArg TransferInstruction_Reject                                                                                                               |             |
+>
+> - <div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxytransferinstructionwithdraw-40772">
+>
+>   **Choice** WalletUserProxy_TransferInstruction_Withdraw
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"user" proxyArg)
+>
+>   Returns: ProxyResult TransferInstructionResult
+>
+>   | Field    | Type                                                                                                                                              | Description |
+>   |----------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
+>   | proxyArg | ProxyArg TransferInstruction_Withdraw                                                                                                             |             |
+
+## Data Types
+
+<div id="type-splice-util-featuredapp-walletuserproxy-instrumentholdingmap-68187">
+
+**type** InstrumentHoldingMap
+= [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) InstrumentId \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
+
+**instance** GetField "senderChangeMap" WalletUserProxy_BatchTransferResult InstrumentHoldingMap
+
+**instance** SetField "senderChangeMap" WalletUserProxy_BatchTransferResult InstrumentHoldingMap
+
+</div>
+
+<div id="type-splice-util-featuredapp-walletuserproxy-proxyarg-78125">
+
+**data** ProxyArg arg
+
+</div>
+
+> Generic argument to the proxy choices.
+>
+> <div id="constr-splice-util-featuredapp-walletuserproxy-proxyarg-32408">
+>
+> ProxyArg
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                           | Description                                                    |
+> > |---------------------|------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
+> > | user                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                            | The wallet user that is using the wallet to exercise a choice. |
+> > | choiceArg           | arg                                                                                                                                            | The argument to the choice that the user is exercising.        |
+> > | featuredAppRightCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight | The featured app right contract of the provider.               |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) arg =\> [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) (ProxyArg arg)
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) arg =\> [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) (ProxyArg arg)
+>
+> **instance** GetField "choiceArg" (ProxyArg arg) arg
+>
+> **instance** GetField "featuredAppRightCid" (ProxyArg arg) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** GetField "proxyArg" WalletUserProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)
+>
+> **instance** GetField "proxyArg" WalletUserProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)
+>
+> **instance** GetField "proxyArg" WalletUserProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)
+>
+> **instance** GetField "proxyArg" WalletUserProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)
+>
+> **instance** GetField "proxyArg" WalletUserProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)
+>
+> **instance** GetField "proxyArg" WalletUserProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)
+>
+> **instance** GetField "user" (ProxyArg arg) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "choiceArg" (ProxyArg arg) arg
+>
+> **instance** SetField "featuredAppRightCid" (ProxyArg arg) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** SetField "proxyArg" WalletUserProxy_AllocationFactory_Allocate (ProxyArg AllocationFactory_Allocate)
+>
+> **instance** SetField "proxyArg" WalletUserProxy_Allocation_Withdraw (ProxyArg Allocation_Withdraw)
+>
+> **instance** SetField "proxyArg" WalletUserProxy_TransferFactory_Transfer (ProxyArg TransferFactory_Transfer)
+>
+> **instance** SetField "proxyArg" WalletUserProxy_TransferInstruction_Accept (ProxyArg TransferInstruction_Accept)
+>
+> **instance** SetField "proxyArg" WalletUserProxy_TransferInstruction_Reject (ProxyArg TransferInstruction_Reject)
+>
+> **instance** SetField "proxyArg" WalletUserProxy_TransferInstruction_Withdraw (ProxyArg TransferInstruction_Withdraw)
+>
+> **instance** SetField "user" (ProxyArg arg) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+<div id="type-splice-util-featuredapp-walletuserproxy-proxyresult-11789">
+
+**data** ProxyResult r
+
+</div>
+
+> Generic result of the proxy choices.
+>
+> <div id="constr-splice-util-featuredapp-walletuserproxy-proxyresult-146">
+>
+> ProxyResult
+>
+> </div>
+>
+> > | Field        | Type                                        | Description |
+> > |--------------|---------------------------------------------|-------------|
+> > | markerResult | FeaturedAppRight_CreateActivityMarkerResult |             |
+> > | choiceResult | r                                           |             |
+>
+> **instance** GetField "choiceResult" (ProxyResult r) r
+>
+> **instance** GetField "markerResult" (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult
+>
+> **instance** SetField "choiceResult" (ProxyResult r) r
+>
+> **instance** SetField "markerResult" (ProxyResult r) FeaturedAppRight_CreateActivityMarkerResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_AllocationFactory_Allocate (ProxyResult AllocationInstructionResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_Allocation_Withdraw (ProxyResult Allocation_WithdrawResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_TransferFactory_Transfer (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_TransferInstruction_Accept (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_TransferInstruction_Reject (ProxyResult TransferInstructionResult)
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_TransferInstruction_Withdraw (ProxyResult TransferInstructionResult)
+
+<div id="type-splice-util-featuredapp-walletuserproxy-transferfactorycall-48419">
+
+**data** TransferFactoryCall
+
+</div>
+
+> A call to the token standard factory to initiate a token standard transfer. Specialized because it is used in the batch transfer choice below.
+>
+> <div id="constr-splice-util-featuredapp-walletuserproxy-transferfactorycall-65712">
+>
+> TransferFactoryCall
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                          | Description |
+> > |------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | factoryCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory |             |
+> > | choiceArg  | TransferFactory_Transfer                                                                                                                      |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferFactoryCall
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferFactoryCall
+>
+> **instance** GetField "choiceArg" TransferFactoryCall TransferFactory_Transfer
+>
+> **instance** GetField "factoryCid" TransferFactoryCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory)
+>
+> **instance** GetField "transferCalls" WalletUserProxy_BatchTransfer \[TransferFactoryCall\]
+>
+> **instance** SetField "choiceArg" TransferFactoryCall TransferFactory_Transfer
+>
+> **instance** SetField "factoryCid" TransferFactoryCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory)
+>
+> **instance** SetField "transferCalls" WalletUserProxy_BatchTransfer \[TransferFactoryCall\]
+
+<div id="type-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransferresult-21051">
+
+**data** WalletUserProxy_BatchTransferResult
+
+</div>
+
+> <div id="constr-splice-util-featuredapp-walletuserproxy-walletuserproxybatchtransferresult-77048">
+>
+> WalletUserProxy_BatchTransferResult
+>
+> </div>
+>
+> > | Field           | Type                          | Description |
+> > |-----------------|-------------------------------|-------------|
+> > | transferResults | \[TransferInstructionResult\] |             |
+> > | senderChangeMap | InstrumentHoldingMap          |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) WalletUserProxy_BatchTransferResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) WalletUserProxy_BatchTransferResult
+>
+> **instance** GetField "senderChangeMap" WalletUserProxy_BatchTransferResult InstrumentHoldingMap
+>
+> **instance** GetField "transferResults" WalletUserProxy_BatchTransferResult \[TransferInstructionResult\]
+>
+> **instance** SetField "senderChangeMap" WalletUserProxy_BatchTransferResult InstrumentHoldingMap
+>
+> **instance** SetField "transferResults" WalletUserProxy_BatchTransferResult \[TransferInstructionResult\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletUserProxy WalletUserProxy_BatchTransfer WalletUserProxy_BatchTransferResult
+
+## Functions
+
+<div id="function-splice-util-featuredapp-walletuserproxy-getfirstsender-96870">
+
+getFirstSender
+: \[TransferFactoryCall\] -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+Determine the sender of the transfer in the first call.
+
+</div>
+
+<div id="function-splice-util-featuredapp-walletuserproxy-runbatch-13560">
+
+runBatch
+: WalletUserProxy -\> WalletUserProxy_BatchTransfer -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) WalletUserProxy_BatchTransferResult
+
+Validate the batch call and run it
+
+</div>
+
+<div id="function-splice-util-featuredapp-walletuserproxy-executetransfercalls-34186">
+
+executeTransferCalls
+: WalletUserProxy -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight) -\> \[TransferFactoryCall\] -\> InstrumentHoldingMap -\> \[TransferInstructionResult\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) WalletUserProxy_BatchTransferResult
+
+Run the individual transfer calls in the batch with proper threading of input holdings.
+
+</div>
+
+<div id="function-splice-util-featuredapp-walletuserproxy-exerciseproxychoice-45581">
+
+exerciseProxyChoice
+: [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) t ch r =\> WalletUserProxy -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> ProxyArg ch -\> ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) (ProxyResult r)
+
+Shared code to execute the proxied choice.
+
+</div>
+
+<div id="function-splice-util-featuredapp-walletuserproxy-validateappright-75174">
+
+validateAppRight
+: WalletUserProxy -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-util-featuredapp-walletuserproxy-checkallowlist-76724">
+
+checkAllowList
+: [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\] -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-util-featuredapp-walletuserproxy-createappmarker-13733">
+
+createAppMarker
+: WalletUserProxy -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) FeaturedAppRight_CreateActivityMarkerResult
+
+</div>
+
+<div id="function-splice-util-featuredapp-walletuserproxy-proxybeneficiaries-11168">
+
+proxyBeneficiaries
+: WalletUserProxy -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> \[AppRewardBeneficiary\]
+
+Get the list of beneficiaries for the featured app marker.
+
+</div>
+
+<div id="function-splice-util-featuredapp-walletuserproxy-validproxy-47629">
+
+validProxy
+: WalletUserProxy -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-util-featuredapp-walletuserproxy-require-57479">
+
+require
+: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+
+Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/index.mdx
@@ -1,0 +1,14 @@
+---
+title: "splice-util-token-standard-wallet docs"
+description: "Documentation for splice-util-token-standard-wallet docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-util-token-standard-wallet/docs/index.rst" tag="0.6.4" hash="1c1fbd22" */}
+
+Optional package implementing common workflows of wallets using the Token Standard. Not uploaded by default to a validator node.
+
+- [Splice.Util.Token.Wallet.MergeDelegation](/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation)
+
+See also the `module-splice-util-featuredapp-walletuserproxy-40223` for code that simplifies integrating wallets with featured app rewards.
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation.mdx
@@ -1,0 +1,561 @@
+---
+title: "Splice.Util.Token.Wallet.MergeDelegation"
+description: "Documentation for Splice.Util.Token.Wallet.MergeDelegation"
+---
+
+{/* COPIED_START source="splice:daml/splice-util-token-standard-wallet/docs/Splice-Util-Token-Wallet-MergeDelegation.rst" tag="0.6.4" hash="0129edf8" */}
+
+Delegation from users to wallet operators allowing them to merge their token standard holdings; and optionally transfer tokens from the operator to the user as part of the merge operation, e.g., for efficiently implementing extraTransfers.
+
+The main reasons for using this merge delegation infrastructure are:
+
+- keeping the number of holdings low to reduce storage and compute cost on the validator node hosting them
+- batching operations to execute them more efficiently both in terms of traffic spend and throughput
+
+## Templates
+
+<div id="type-splice-util-token-wallet-mergedelegation-batchmergeutility-64168">
+
+**template** BatchMergeUtility
+
+</div>
+
+> Utility contract for a operator to execute a batch of merge calls with proper threading of the operator's change holdings between the calls that involve extra transfers.
+>
+> Signatory: operator
+>
+> | Field    | Type                                                                                                                | Description |
+> |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | operator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: operator
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmerge-8070">
+>
+>   **Choice** BatchMergeUtility_BatchMerge
+>
+>   </div>
+>
+>   Controller: operator
+>
+>   Returns: BatchMergeUtility_BatchMergeResult
+>
+>   | Field      | Type                    | Description |
+>   |------------|-------------------------|-------------|
+>   | mergeCalls | \[MergeDelegationCall\] |             |
+
+<div id="type-splice-util-token-wallet-mergedelegation-mergedelegation-14952">
+
+**template** MergeDelegation
+
+</div>
+
+> The right for a operator like the wallet app operator to merge token standard holdings on behalf of a token owner.
+>
+> Signatory: owner, operator
+>
+> | Field    | Type                                                                                                                | Description                                            |
+> |----------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+> | operator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | Operator allowed to merge holdings.                    |
+> | owner    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | Owner delegating their right.                          |
+> | meta     | Metadata                                                                                                            | Metadata about the delegation, used for extensibility. |
+>
+> - **Choice** Archive
+>
+>   Controller: owner, operator
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationmerge-40083">
+>
+>   **Choice** MergeDelegation_Merge
+>
+>   </div>
+>
+>   Controller: operator
+>
+>   Returns: MergeDelegation_MergeResult
+>
+>   | Field               | Type                                                                                                                                                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+>   |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+>   | optMergeTransfer    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall         | The self-transfer to merge holdings for the owner. Optional to allow for an extra transfer to be executed when the owner does not yet have any holdings. At least one of optMergeTransfer or optExtraTransfer must be provided.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+>   | optExtraTransfer    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall         | An optional extra transfer from the operator to the user to execute as part of the merge operation. The amount of the self-transfer will be increased by the amount of the extra transfer, and the new input holdings from the extra transfer will be added to the self-transfer's input holdings. These extra transfers can for example be used to efficiently implement extraTransfers or reward distributions as part of the merge operation. Note that extra transfers only work for users that have preapproved incoming transfers from the operator. Therefore there is no additional restriction on the merge delegation to let users decide whether to allow or disallow those transfers as it is already controlled through the preapproval. |
+>   | optFeaturedAppRight | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FeaturedAppRightCall | The featured app right to use to feature the operator's merging activity.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+>
+> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationreject-58487">
+>
+>   **Choice** MergeDelegation_Reject
+>
+>   </div>
+>
+>   Controller: operator
+>
+>   Returns: MergeDelegation_RejectResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationwithdraw-32286">
+>
+>   **Choice** MergeDelegation_Withdraw
+>
+>   </div>
+>
+>   Controller: owner
+>
+>   Returns: MergeDelegation_WithdrawResult
+>
+>   (no fields)
+
+<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposal-17546">
+
+**template** MergeDelegationProposal
+
+</div>
+
+> Proposal by the user to setup a merge delegation.
+>
+> Signatory: (DA.Internal.Record.getField @"owner" delegation)
+>
+> | Field      | Type            | Description                               |
+> |------------|-----------------|-------------------------------------------|
+> | delegation | MergeDelegation | The delegation to be created if accepted. |
+>
+> - **Choice** Archive
+>
+>   Controller: (DA.Internal.Record.getField @"owner" delegation)
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalaccept-29492">
+>
+>   **Choice** MergeDelegationProposal_Accept
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"operator" delegation)
+>
+>   Returns: MergeDelegationProposal_AcceptResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalreject-90901">
+>
+>   **Choice** MergeDelegationProposal_Reject
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"operator" delegation)
+>
+>   Returns: MergeDelegationProposal_RejectResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdraw-80248">
+>
+>   **Choice** MergeDelegationProposal_Withdraw
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"owner" delegation)
+>
+>   Returns: MergeDelegationProposal_WithdrawResult
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmergeresult-21039">
+
+**data** BatchMergeUtility_BatchMergeResult
+
+</div>
+
+> <div id="constr-splice-util-token-wallet-mergedelegation-batchmergeutilitybatchmergeresult-14556">
+>
+> BatchMergeUtility_BatchMergeResult
+>
+> </div>
+>
+> > | Field             | Type                            | Description                                                       |
+> > |-------------------|---------------------------------|-------------------------------------------------------------------|
+> > | results           | \[MergeDelegation_MergeResult\] | Results of each individual merge delegation call.                 |
+> > | operatorChangeMap | InstrumentHoldingMap            | Change holdings for the operator after executing extra transfers. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) BatchMergeUtility_BatchMergeResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) BatchMergeUtility_BatchMergeResult
+>
+> **instance** GetField "operatorChangeMap" BatchMergeUtility_BatchMergeResult InstrumentHoldingMap
+>
+> **instance** GetField "results" BatchMergeUtility_BatchMergeResult \[MergeDelegation_MergeResult\]
+>
+> **instance** SetField "operatorChangeMap" BatchMergeUtility_BatchMergeResult InstrumentHoldingMap
+>
+> **instance** SetField "results" BatchMergeUtility_BatchMergeResult \[MergeDelegation_MergeResult\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) BatchMergeUtility BatchMergeUtility_BatchMerge BatchMergeUtility_BatchMergeResult
+
+<div id="type-splice-util-token-wallet-mergedelegation-featuredapprightcall-44578">
+
+**data** FeaturedAppRightCall
+
+</div>
+
+> A call to create featured app markers using a featured app right.
+>
+> <div id="constr-splice-util-token-wallet-mergedelegation-featuredapprightcall-28365">
+>
+> FeaturedAppRightCall
+>
+> </div>
+>
+> > | Field         | Type                                                                                                                                           | Description |
+> > |---------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | appRightCid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
+> > | beneficiaries | \[AppRewardBeneficiary\]                                                                                                                       |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) FeaturedAppRightCall
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) FeaturedAppRightCall
+>
+> **instance** GetField "appRightCid" FeaturedAppRightCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** GetField "beneficiaries" FeaturedAppRightCall \[AppRewardBeneficiary\]
+>
+> **instance** GetField "optFeaturedAppRight" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FeaturedAppRightCall)
+>
+> **instance** SetField "appRightCid" FeaturedAppRightCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** SetField "beneficiaries" FeaturedAppRightCall \[AppRewardBeneficiary\]
+>
+> **instance** SetField "optFeaturedAppRight" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) FeaturedAppRightCall)
+
+<div id="type-splice-util-token-wallet-mergedelegation-instrumentholdingmap-42719">
+
+**type** InstrumentHoldingMap
+= [Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) InstrumentId \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Holding\]
+
+**instance** GetField "operatorChangeMap" BatchMergeUtility_BatchMergeResult InstrumentHoldingMap
+
+**instance** SetField "operatorChangeMap" BatchMergeUtility_BatchMergeResult InstrumentHoldingMap
+
+</div>
+
+<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationcall-90300">
+
+**data** MergeDelegationCall
+
+</div>
+
+> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationcall-66961">
+>
+> MergeDelegationCall
+>
+> </div>
+>
+> > | Field         | Type                                                                                                                                          | Description |
+> > |---------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | delegationCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation |             |
+> > | choiceArg     | MergeDelegation_Merge                                                                                                                         |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegationCall
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegationCall
+>
+> **instance** GetField "choiceArg" MergeDelegationCall MergeDelegation_Merge
+>
+> **instance** GetField "delegationCid" MergeDelegationCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation)
+>
+> **instance** GetField "mergeCalls" BatchMergeUtility_BatchMerge \[MergeDelegationCall\]
+>
+> **instance** SetField "choiceArg" MergeDelegationCall MergeDelegation_Merge
+>
+> **instance** SetField "delegationCid" MergeDelegationCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation)
+>
+> **instance** SetField "mergeCalls" BatchMergeUtility_BatchMerge \[MergeDelegationCall\]
+
+<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalacceptresult-63821">
+
+**data** MergeDelegationProposal_AcceptResult
+
+</div>
+
+> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalacceptresult-91086">
+>
+> MergeDelegationProposal_AcceptResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                          | Description |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | mergeDelegationCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegationProposal_AcceptResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegationProposal_AcceptResult
+>
+> **instance** GetField "mergeDelegationCid" MergeDelegationProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation)
+>
+> **instance** SetField "mergeDelegationCid" MergeDelegationProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MergeDelegation)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegationProposal MergeDelegationProposal_Accept MergeDelegationProposal_AcceptResult
+
+<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalrejectresult-81380">
+
+**data** MergeDelegationProposal_RejectResult
+
+</div>
+
+> Dedicated record type to simplify upgrading
+>
+> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalrejectresult-11455">
+>
+> MergeDelegationProposal_RejectResult
+>
+> </div>
+>
+> > | Field  | Type | Description |
+> > |--------|------|-------------|
+> > | result | ()   |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegationProposal_RejectResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegationProposal_RejectResult
+>
+> **instance** GetField "result" MergeDelegationProposal_RejectResult ()
+>
+> **instance** SetField "result" MergeDelegationProposal_RejectResult ()
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegationProposal MergeDelegationProposal_Reject MergeDelegationProposal_RejectResult
+
+<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdrawresult-14389">
+
+**data** MergeDelegationProposal_WithdrawResult
+
+</div>
+
+> Dedicated record type to simplify upgrading
+>
+> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationproposalwithdrawresult-8570">
+>
+> MergeDelegationProposal_WithdrawResult
+>
+> </div>
+>
+> > | Field  | Type | Description |
+> > |--------|------|-------------|
+> > | result | ()   |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegationProposal_WithdrawResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegationProposal_WithdrawResult
+>
+> **instance** GetField "result" MergeDelegationProposal_WithdrawResult ()
+>
+> **instance** SetField "result" MergeDelegationProposal_WithdrawResult ()
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegationProposal MergeDelegationProposal_Withdraw MergeDelegationProposal_WithdrawResult
+
+<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationmergeresult-93186">
+
+**data** MergeDelegation_MergeResult
+
+</div>
+
+> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationmergeresult-31679">
+>
+> MergeDelegation_MergeResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                     | Description |
+> > |------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | optMergeTransferResult | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult |             |
+> > | optExtraTransferResult | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegation_MergeResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegation_MergeResult
+>
+> **instance** GetField "optExtraTransferResult" MergeDelegation_MergeResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult)
+>
+> **instance** GetField "optMergeTransferResult" MergeDelegation_MergeResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult)
+>
+> **instance** GetField "results" BatchMergeUtility_BatchMergeResult \[MergeDelegation_MergeResult\]
+>
+> **instance** SetField "optExtraTransferResult" MergeDelegation_MergeResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult)
+>
+> **instance** SetField "optMergeTransferResult" MergeDelegation_MergeResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferInstructionResult)
+>
+> **instance** SetField "results" BatchMergeUtility_BatchMergeResult \[MergeDelegation_MergeResult\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegation MergeDelegation_Merge MergeDelegation_MergeResult
+
+<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationrejectresult-25578">
+
+**data** MergeDelegation_RejectResult
+
+</div>
+
+> Dedicated record type to simplify upgrading
+>
+> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationrejectresult-53673">
+>
+> MergeDelegation_RejectResult
+>
+> </div>
+>
+> > | Field  | Type | Description |
+> > |--------|------|-------------|
+> > | result | ()   |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegation_RejectResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegation_RejectResult
+>
+> **instance** GetField "result" MergeDelegation_RejectResult ()
+>
+> **instance** SetField "result" MergeDelegation_RejectResult ()
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegation MergeDelegation_Reject MergeDelegation_RejectResult
+
+<div id="type-splice-util-token-wallet-mergedelegation-mergedelegationwithdrawresult-70671">
+
+**data** MergeDelegation_WithdrawResult
+
+</div>
+
+> Dedicated record type to simplify upgrading
+>
+> <div id="constr-splice-util-token-wallet-mergedelegation-mergedelegationwithdrawresult-6896">
+>
+> MergeDelegation_WithdrawResult
+>
+> </div>
+>
+> > | Field  | Type | Description |
+> > |--------|------|-------------|
+> > | result | ()   |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MergeDelegation_WithdrawResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MergeDelegation_WithdrawResult
+>
+> **instance** GetField "result" MergeDelegation_WithdrawResult ()
+>
+> **instance** SetField "result" MergeDelegation_WithdrawResult ()
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MergeDelegation MergeDelegation_Withdraw MergeDelegation_WithdrawResult
+
+<div id="type-splice-util-token-wallet-mergedelegation-transfercall-7536">
+
+**data** TransferCall
+
+</div>
+
+> A call to perform a transfer using a transfer factory.
+>
+> <div id="constr-splice-util-token-wallet-mergedelegation-transfercall-34031">
+>
+> TransferCall
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                          | Description |
+> > |------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | factoryCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory |             |
+> > | choiceArg  | TransferFactory_Transfer                                                                                                                      |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferCall
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferCall
+>
+> **instance** GetField "choiceArg" TransferCall TransferFactory_Transfer
+>
+> **instance** GetField "factoryCid" TransferCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory)
+>
+> **instance** GetField "optExtraTransfer" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall)
+>
+> **instance** GetField "optMergeTransfer" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall)
+>
+> **instance** SetField "choiceArg" TransferCall TransferFactory_Transfer
+>
+> **instance** SetField "factoryCid" TransferCall ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory)
+>
+> **instance** SetField "optExtraTransfer" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall)
+>
+> **instance** SetField "optMergeTransfer" MergeDelegation_Merge ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) TransferCall)
+
+## Functions
+
+<div id="function-splice-util-token-wallet-mergedelegation-runbatch-68276">
+
+runBatch
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> \[MergeDelegationCall\] -\> InstrumentHoldingMap -\> \[MergeDelegation_MergeResult\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) BatchMergeUtility_BatchMergeResult
+
+Run a batch of token standard transfers.
+
+</div>
+
+<div id="function-splice-util-token-wallet-mergedelegation-createactivitymarkerforprovider-74667">
+
+createActivityMarkerForProvider
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> FeaturedAppRightCall -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-util-token-wallet-mergedelegation-checkexpected-33668">
+
+checkExpected
+: ([Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) a) =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> a -\> a -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+</div>
+
+<div id="function-splice-util-token-wallet-mergedelegation-require-88931">
+
+require
+: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+
+Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util/index.mdx
@@ -1,0 +1,10 @@
+---
+title: "splice-util docs"
+description: "Documentation for splice-util docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-util/docs/index.rst" tag="0.6.4" hash="169b4e1f" */}
+
+- [Splice.Util](/sdks-tools/api-reference/splice-daml/splice-util/splice-util)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-util/splice-util.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-util/splice-util.mdx
@@ -1,0 +1,222 @@
+---
+title: "Splice.Util"
+description: "Documentation for Splice.Util"
+---
+
+{/* COPIED_START source="splice:daml/splice-util/docs/Splice-Util.rst" tag="0.6.4" hash="ad0bba02" */}
+
+Utility functions shared across all splice apps.
+
+## Typeclasses
+
+<div id="class-splice-util-hascheckedfetch-36555">
+
+**class** ([Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) t, [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) cgid, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) cgid) =\> HasCheckedFetch t cgid **where**
+
+</div>
+
+> Contracts typically come in groups. For example, all contracts managed by a specific DSO party.
+>
+> We aim to always fetch with a specific contract group identifier to ensure that we do not mixup contracts from different groups.
+>
+> Note that we are not requiring `HasFetch` here, so that we can use this typeclass also for contract groups that are not templates, e.g., interface views.
+>
+> <div id="function-splice-util-contractgroupid-63283">
+>
+> contractGroupId
+> : t -\> cgid
+>
+> </div>
+
+<div id="class-splice-util-patchable-41062">
+
+**class** Patchable a **where**
+
+</div>
+
+> A type class for patching values. Used in particular for changing only a subset of fields in a config value.
+>
+> <div id="function-splice-util-patch-72775">
+>
+> patch
+> : a -\> a -\> a -\> a
+>
+> For records, `patch new base current` should set all fields in `current` to their value in `new` iff their value was changed in `new` compared to `base`. For other kinds of values that have field-like values (e.g. Maps with keys) the implementation should match the one for records by analogy.
+>
+> </div>
+>
+> **instance** Patchable [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** Patchable [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** Patchable [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** ([Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) k, Patchable v) =\> Patchable ([Map](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-map-90052) k v)
+>
+> **instance** Patchable [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** Patchable [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** Patchable a =\> Patchable ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) a)
+>
+> **instance** (Patchable a, [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) a) =\> Patchable (Set a)
+>
+> **instance** Patchable [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+
+## Functions
+
+<div id="function-splice-util-requirematchingcontract-54053">
+
+requireMatchingContract
+: ([Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) t, [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) t, [HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t) =\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+Require that a contract-id refers to a specific contract.
+
+</div>
+
+<div id="function-splice-util-require-11486">
+
+require
+: [CanAssert](/appdev/reference/daml-standard-library/prelude#class-da-internal-assert-canassert-67323) m =\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265) -\> m ()
+
+Check whether a required condition is true. If it's not, abort the transaction with a message saying that the requirement was not met.
+
+</div>
+
+<div id="function-splice-util-fetchchecked-58913">
+
+fetchChecked
+: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t, HasCheckedFetch t cgid) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+
+Fetch a contract that is part of a specific contract group.
+
+The group is typically chosen by the caller to match its own group, or a more specific group.
+
+</div>
+
+<div id="function-splice-util-fetchcheckedinterface-8937">
+
+fetchCheckedInterface
+: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) i, [HasInterfaceView](/appdev/reference/daml-standard-library/prelude#class-da-internal-interface-hasinterfaceview-4492) i v, HasCheckedFetch v cgid) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) i -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) i
+
+Fetch a contract that is part of a specific contract group defined by its interface view.
+
+The group is typically chosen by the caller to match its own group, or a more specific group.
+
+</div>
+
+<div id="function-splice-util-fetchandarchive-96960">
+
+fetchAndArchive
+: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t, HasCheckedFetch t cgid, [HasArchive](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasarchive-7071) t) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+
+Fetch and archive a contract in one go.
+
+Use this when implementing choices that mutate another contract by fetching, archiving, and then creating the updated contract.
+
+</div>
+
+<div id="function-splice-util-fetchreferencedata-72475">
+
+fetchReferenceData
+: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t, HasCheckedFetch t cgid) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+
+Fetch a contract that serves as reference data.
+
+Use this whenever you need to fetch a contract that you do not intend to mutate.
+
+</div>
+
+<div id="function-splice-util-fetchbutarchivelater-86159">
+
+fetchButArchiveLater
+: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t, HasCheckedFetch t cgid) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+
+Fetch a contract that is not reference data, and should be archived later in some cases.
+
+Prefer `fetchAndArchive` over this function, as it avoids forgetting to archive the contract.
+
+</div>
+
+<div id="function-splice-util-fetchpublicreferencedata-76996">
+
+fetchPublicReferenceData
+: (HasCheckedFetch t cgid, [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) t ch t) =\> cgid -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> ch -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+
+Fetch a contract that offers a choice anybody to be read as reference data.
+
+</div>
+
+<div id="function-splice-util-fetchuncheckedandarchive-65397">
+
+fetchUncheckedAndArchive
+: ([HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) b, [HasArchive](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasarchive-7071) b) =\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) b -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) b
+
+Fetch and archive a contract in one go.
+
+Use this when implementing choices that mutate another contract by fetching, archiving, and then creating the updated contract.
+
+</div>
+
+<div id="function-splice-util-fetchuncheckedreferencedata-5520">
+
+fetchUncheckedReferenceData
+: [HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t =\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+
+Fetch a contract that serves as reference data.
+
+Use this whenever you need to fetch a contract that you do not intend to mutate.
+
+</div>
+
+<div id="function-splice-util-fetchuncheckedbutarchivelater-82900">
+
+fetchUncheckedButArchiveLater
+: [HasFetch](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfetch-52387) t =\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) t
+
+Fetch a contract that is not reference data, and should be archived later in some cases.
+
+Prefer `fetchAndArchive` over this function, as it avoids forgetting to archive the contract.
+
+</div>
+
+<div id="function-splice-util-potentiallyunsafearchive-47027">
+
+potentiallyUnsafeArchive
+: [HasArchive](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasarchive-7071) t =\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) t -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ()
+
+A more appropriately named version of `archive`.
+
+Please justify all its uses, and where possible prefer `fetchAndArchive` so that the contract group identifier is surely performed.
+
+</div>
+
+<div id="function-splice-util-patchscalar-11117">
+
+patchScalar
+: [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a =\> a -\> a -\> a -\> a
+
+</div>
+
+<div id="function-splice-util-patchlistasscalar-47719">
+
+patchListAsScalar
+: [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) a =\> \[a\] -\> \[a\] -\> \[a\] -\> \[a\]
+
+</div>
+
+<div id="function-splice-util-patchlistasset-9274">
+
+patchListAsSet
+: (Patchable a, [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) a) =\> \[a\] -\> \[a\] -\> \[a\] -\> \[a\]
+
+</div>
+
+<div id="function-splice-util-deprecatedchoice-19928">
+
+deprecatedChoice
+: [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) a
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/index.mdx
@@ -1,0 +1,10 @@
+---
+title: "splice-validator-life-cycle docs"
+description: "Documentation for splice-validator-life-cycle docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-validator-lifecycle/docs/index.rst" tag="0.6.4" hash="ac41f15d" */}
+
+- [Splice.ValidatorOnboarding](/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding.mdx
@@ -1,0 +1,131 @@
+---
+title: "Splice.ValidatorOnboarding"
+description: "Documentation for Splice.ValidatorOnboarding"
+---
+
+{/* COPIED_START source="splice:daml/splice-validator-lifecycle/docs/Splice-ValidatorOnboarding.rst" tag="0.6.4" hash="eec20687" */}
+
+## Templates
+
+<div id="type-splice-validatoronboarding-usedsecret-49603">
+
+**template** UsedSecret
+
+</div>
+
+> Template used by a sponsoring SV node for enforcing that an onboarding secret is used only once.
+>
+> Signatory: sv
+>
+> | Field     | Type                                                                                                                | Description                                    |
+> |-----------|---------------------------------------------------------------------------------------------------------------------|------------------------------------------------|
+> | sv        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The SV node that sponsored the onboarding.     |
+> | secret    | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | An onboarding secret.                          |
+> | validator | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The validator that onboarded using the secret. |
+>
+> - **Choice** Archive
+>
+>   Controller: sv
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-validatoronboarding-validatoronboarding-92198">
+
+**template** ValidatorOnboarding
+
+</div>
+
+> Template used by a sponsoring SV node to keep track of the onboarding of a validator candidate. We use a secret for authenticating the candidate once he has set up his participant. The secret should be unique, contain at least 256-bits of entropy, and be communicated to the candidate via a secure off-ledger channel. Once the candidate has set up his participants, he contacts the SV node via an API call and presents his secret, which triggers the SV node to add him as a validator (as a separate on-ledger action for reducing coupling with the DSO governance contracts).
+>
+> Signatory: sv
+>
+> | Field           | Type                                                                                                                | Description                                        |
+> |-----------------|---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
+> | sv              | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The SV node sponsoring this onboarding.            |
+> | candidateSecret | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | The unique secret given to the candidate.          |
+> | expiresAt       | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Can be used by the SV for time-bounding the offer. |
+>
+> - **Choice** Archive
+>
+>   Controller: sv
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-validatoronboarding-validatoronboardingexpire-7877">
+>
+>   **Choice** ValidatorOnboarding_Expire
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: ValidatorOnboarding_ExpireResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-validatoronboarding-validatoronboardingmatch-2118">
+>
+>   **Choice** ValidatorOnboarding_Match
+>
+>   </div>
+>
+>   Controller: sv
+>
+>   Returns: ValidatorOnboarding_MatchResult
+>
+>   | Field          | Type                                                                                                                | Description |
+>   |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | providedSecret | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | validator      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+
+## Data Types
+
+<div id="type-splice-validatoronboarding-validatoronboardingexpireresult-28676">
+
+**data** ValidatorOnboarding_ExpireResult
+
+</div>
+
+> <div id="constr-splice-validatoronboarding-validatoronboardingexpireresult-66123">
+>
+> ValidatorOnboarding_ExpireResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorOnboarding ValidatorOnboarding_Expire ValidatorOnboarding_ExpireResult
+
+<div id="type-splice-validatoronboarding-validatoronboardingmatchresult-68567">
+
+**data** ValidatorOnboarding_MatchResult
+
+</div>
+
+> <div id="constr-splice-validatoronboarding-validatoronboardingmatchresult-91618">
+>
+> ValidatorOnboarding_MatchResult
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                                     | Description |
+> > |------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | usedSecret | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UsedSecret |             |
+>
+> **instance** GetField "usedSecret" ValidatorOnboarding_MatchResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UsedSecret)
+>
+> **instance** SetField "usedSecret" ValidatorOnboarding_MatchResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) UsedSecret)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) ValidatorOnboarding ValidatorOnboarding_Match ValidatorOnboarding_MatchResult
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/index.mdx
@@ -1,0 +1,21 @@
+---
+title: "splice-wallet-payments docs"
+description: "Documentation for splice-wallet-payments docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-wallet-payments/docs/index.rst" tag="0.6.4" hash="cb7aa487" */}
+
+<Note>
+**Deprecated** (since splice-0.4.10): the modules below and their workflows are deprecated and should not be used in new applications.
+
+To implement a Canton Coin payment, use the Token Standard allocation workflow instead. Note that this immediately makes your application compatible with all Token Standard assets, and allows all of them to be used as payment methods in your application, if desired.
+
+If you need to implement a subscription-like payment, then we recommend doing so via regular renewals on top of token standard allocations in your application. See the `License_Renew` choice and its [tests](https://github.com/digital-asset/cn-quickstart/blob/8b15f38d157d1f88e8da4345f477fffc0cfc4b8f/quickstart/daml/licensing-tests/daml/Licensing/Scripts/TestLicense.daml#L207-L221) in the Canton Network QuickStart repo for an [example of how to do this](https://github.com/digital-asset/cn-quickstart/blob/8b15f38d157d1f88e8da4345f477fffc0cfc4b8f/quickstart/daml/licensing/daml/Licensing/License.daml#L44).
+
+The workflows in the modules below are not compatible with the token standard, and will not be supported in the future.
+</Note>
+
+- [Splice.Wallet.Payment](/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment)
+- [Splice.Wallet.Subscriptions](/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment.mdx
@@ -1,0 +1,582 @@
+---
+title: "Splice.Wallet.Payment"
+description: "Documentation for Splice.Wallet.Payment"
+---
+
+{/* COPIED_START source="splice:daml/splice-wallet-payments/docs/Splice-Wallet-Payment.rst" tag="0.6.4" hash="6c338ed0" */}
+
+## Templates
+
+<div id="type-splice-wallet-payment-acceptedapppayment-18193">
+
+**template** AcceptedAppPayment
+
+</div>
+
+> Signatory: sender, provider, map (\\ r -\> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts
+>
+> | Field                 | Type                                                                                                                                            | Description                                                                                                         |
+> |-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+> | sender                | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                             |                                                                                                                     |
+> | amuletReceiverAmounts | \[ReceiverAmuletAmount\]                                                                                                                        |                                                                                                                     |
+> | provider              | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                             |                                                                                                                     |
+> | dso                   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                             |                                                                                                                     |
+> | lockedAmulet          | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet      |                                                                                                                     |
+> | round                 | Round                                                                                                                                           | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets. |
+> | reference             | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppPaymentRequest | The contract id of the original payment request to correlate it. Note that the contract will no longer be active.   |
+>
+> - <div id="type-splice-wallet-payment-acceptedapppaymentcollect-62282">
+>
+>   **Choice** AcceptedAppPayment_Collect
+>
+>   </div>
+>
+>   Controller: signatory this
+>
+>   Returns: AcceptedAppPayment_CollectResult
+>
+>   | Field   | Type               | Description |
+>   |---------|--------------------|-------------|
+>   | context | AppTransferContext |             |
+>
+> - <div id="type-splice-wallet-payment-acceptedapppaymentexpire-51092">
+>
+>   **Choice** AcceptedAppPayment_Expire
+>
+>   </div>
+>
+>   Controller: sender
+>
+>   Returns: AcceptedAppPayment_ExpireResult
+>
+>   | Field   | Type               | Description |
+>   |---------|--------------------|-------------|
+>   | context | AppTransferContext |             |
+>
+> - <div id="type-splice-wallet-payment-acceptedapppaymentreject-83760">
+>
+>   **Choice** AcceptedAppPayment_Reject
+>
+>   </div>
+>
+>   Controller: map (\\ r -\> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts
+>
+>   Returns: AcceptedAppPayment_RejectResult
+>
+>   | Field   | Type               | Description |
+>   |---------|--------------------|-------------|
+>   | context | AppTransferContext |             |
+>
+> - **Choice** Archive
+>
+>   Controller: sender, provider, map (\\ r -\> (DA.Internal.Record.getField @"receiver" r)) amuletReceiverAmounts
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-wallet-payment-apppaymentrequest-31524">
+
+**template** AppPaymentRequest
+
+</div>
+
+> Signatory: sender, appPaymentRequest_receivers this, provider
+>
+> | Field           | Type                                                                                                                | Description                                                                         |
+> |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+> | sender          | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that should pay.                                                          |
+> | receiverAmounts | \[ReceiverAmount\]                                                                                                  | Pairs of (party, amount) requesting to be paid.                                     |
+> | provider        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The app provider; receives usage rewards.                                           |
+> | dso             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The DSO party of the amulet that should be used to make the payment.                |
+> | expiresAt       | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | When the payment request expires.                                                   |
+> | description     | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | Human readable description of the reason / good for which the payment is requested. |
+>
+> - <div id="type-splice-wallet-payment-apppaymentrequestaccept-83530">
+>
+>   **Choice** AppPaymentRequest_Accept
+>
+>   </div>
+>
+>   Controller: sender, walletProvider
+>
+>   Returns: AppPaymentRequest_AcceptResult
+>
+>   | Field          | Type                                                                                                                | Description |
+>   |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | inputs         | \[TransferInput\]                                                                                                   |             |
+>   | context        | PaymentTransferContext                                                                                              |             |
+>   | walletProvider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-wallet-payment-apppaymentrequestexpire-10515">
+>
+>   **Choice** AppPaymentRequest_Expire
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: AppPaymentRequest_ExpireResult
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | actor | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-wallet-payment-apppaymentrequestreject-66391">
+>
+>   **Choice** AppPaymentRequest_Reject
+>
+>   </div>
+>
+>   Controller: sender
+>
+>   Returns: AppPaymentRequest_RejectResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-payment-apppaymentrequestwithdraw-31618">
+>
+>   **Choice** AppPaymentRequest_Withdraw
+>
+>   </div>
+>
+>   Controller: appPaymentRequest_receivers this
+>
+>   Returns: AppPaymentRequest_WithdrawResult
+>
+>   (no fields)
+>
+> - **Choice** Archive
+>
+>   Controller: sender, appPaymentRequest_receivers this, provider
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-wallet-payment-terminatedapppayment-49143">
+
+**template** TerminatedAppPayment
+
+</div>
+
+> Instead of just archiving payments (e.g. when the request is accepted) we create an TerminatedAppPayment contract. This allows the coordinating workflow to archive its own contracts once the app-payment workflow terminated.
+>
+> Signatory: sender, provider, receivers
+>
+> | Field     | Type                                                                                                                                            | Description |
+> |-----------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> | sender    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                             |             |
+> | provider  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                             |             |
+> | receivers | \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]                         |             |
+> | reference | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppPaymentRequest |             |
+>
+> - **Choice** Archive
+>
+>   Controller: sender, provider, receivers
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-wallet-payment-acceptedapppaymentcollectresult-5751">
+
+**data** AcceptedAppPayment_CollectResult
+
+</div>
+
+> <div id="constr-splice-wallet-payment-acceptedapppaymentcollectresult-53822">
+>
+> AcceptedAppPayment_CollectResult
+>
+> </div>
+>
+> > | Field           | Type                                                                                                                                                                                                                                                            | Description |
+> > |-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | receiverAmulets | \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)\] |             |
+>
+> **instance** GetField "receiverAmulets" AcceptedAppPayment_CollectResult \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)\]
+>
+> **instance** SetField "receiverAmulets" AcceptedAppPayment_CollectResult \[([Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932), [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AcceptedAppPayment AcceptedAppPayment_Collect AcceptedAppPayment_CollectResult
+
+<div id="type-splice-wallet-payment-acceptedapppaymentexpireresult-93793">
+
+**data** AcceptedAppPayment_ExpireResult
+
+</div>
+
+> <div id="constr-splice-wallet-payment-acceptedapppaymentexpireresult-95234">
+>
+> AcceptedAppPayment_ExpireResult
+>
+> </div>
+>
+> > | Field  | Type                                                                                                                                                       | Description |
+> > |--------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amulet | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "amulet" AcceptedAppPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "amulet" AcceptedAppPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AcceptedAppPayment AcceptedAppPayment_Expire AcceptedAppPayment_ExpireResult
+
+<div id="type-splice-wallet-payment-acceptedapppaymentrejectresult-56853">
+
+**data** AcceptedAppPayment_RejectResult
+
+</div>
+
+> <div id="constr-splice-wallet-payment-acceptedapppaymentrejectresult-75142">
+>
+> AcceptedAppPayment_RejectResult
+>
+> </div>
+>
+> > | Field  | Type                                                                                                                                                       | Description |
+> > |--------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amulet | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "amulet" AcceptedAppPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "amulet" AcceptedAppPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AcceptedAppPayment AcceptedAppPayment_Reject AcceptedAppPayment_RejectResult
+
+<div id="type-splice-wallet-payment-apppaymentrequestacceptresult-82387">
+
+**data** AppPaymentRequest_AcceptResult
+
+</div>
+
+> <div id="constr-splice-wallet-payment-apppaymentrequestacceptresult-79598">
+>
+> AppPaymentRequest_AcceptResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                                                                                                                                                  | Description |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | acceptedPayment    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedAppPayment                                                                                                                      |             |
+> > | senderChangeAmulet | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "acceptedPayment" AppPaymentRequest_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedAppPayment)
+>
+> **instance** GetField "senderChangeAmulet" AppPaymentRequest_AcceptResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "acceptedPayment" AppPaymentRequest_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedAppPayment)
+>
+> **instance** SetField "senderChangeAmulet" AppPaymentRequest_AcceptResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AppPaymentRequest AppPaymentRequest_Accept AppPaymentRequest_AcceptResult
+
+<div id="type-splice-wallet-payment-apppaymentrequestexpireresult-63922">
+
+**data** AppPaymentRequest_ExpireResult
+
+</div>
+
+> <div id="constr-splice-wallet-payment-apppaymentrequestexpireresult-76475">
+>
+> AppPaymentRequest_ExpireResult
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                                               | Description |
+> > |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedAppPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment |             |
+>
+> **instance** GetField "terminatedAppPayment" AppPaymentRequest_ExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
+>
+> **instance** SetField "terminatedAppPayment" AppPaymentRequest_ExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AppPaymentRequest AppPaymentRequest_Expire AppPaymentRequest_ExpireResult
+
+<div id="type-splice-wallet-payment-apppaymentrequestrejectresult-75838">
+
+**data** AppPaymentRequest_RejectResult
+
+</div>
+
+> <div id="constr-splice-wallet-payment-apppaymentrequestrejectresult-65943">
+>
+> AppPaymentRequest_RejectResult
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                                               | Description |
+> > |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedAppPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment |             |
+>
+> **instance** GetField "terminatedAppPayment" AppPaymentRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
+>
+> **instance** SetField "terminatedAppPayment" AppPaymentRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AppPaymentRequest AppPaymentRequest_Reject AppPaymentRequest_RejectResult
+
+<div id="type-splice-wallet-payment-apppaymentrequestwithdrawresult-19567">
+
+**data** AppPaymentRequest_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-wallet-payment-apppaymentrequestwithdrawresult-24638">
+>
+> AppPaymentRequest_WithdrawResult
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                                               | Description |
+> > |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedAppPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment |             |
+>
+> **instance** GetField "terminatedAppPayment" AppPaymentRequest_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
+>
+> **instance** SetField "terminatedAppPayment" AppPaymentRequest_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AppPaymentRequest AppPaymentRequest_Withdraw AppPaymentRequest_WithdrawResult
+
+<div id="type-splice-wallet-payment-paymentamount-12698">
+
+**data** PaymentAmount
+
+</div>
+
+> <div id="constr-splice-wallet-payment-paymentamount-44729">
+>
+> PaymentAmount
+>
+> </div>
+>
+> > | Field  | Type                                                                                                               | Description |
+> > |--------|--------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
+> > | unit   | Unit                                                                                                               |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) PaymentAmount
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) PaymentAmount
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) PaymentAmount
+>
+> **instance** GetField "amount" PaymentAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "amount" ReceiverAmount PaymentAmount
+>
+> **instance** GetField "paymentAmount" SubscriptionPayData PaymentAmount
+>
+> **instance** GetField "unit" PaymentAmount Unit
+>
+> **instance** SetField "amount" PaymentAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "amount" ReceiverAmount PaymentAmount
+>
+> **instance** SetField "paymentAmount" SubscriptionPayData PaymentAmount
+>
+> **instance** SetField "unit" PaymentAmount Unit
+
+<div id="type-splice-wallet-payment-receiveramount-43100">
+
+**data** ReceiverAmount
+
+</div>
+
+> <div id="constr-splice-wallet-payment-receiveramount-91649">
+>
+> ReceiverAmount
+>
+> </div>
+>
+> > | Field    | Type                                                                                                                | Description |
+> > |----------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | receiver | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | amount   | PaymentAmount                                                                                                       |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ReceiverAmount
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) ReceiverAmount
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ReceiverAmount
+>
+> **instance** GetField "amount" ReceiverAmount PaymentAmount
+>
+> **instance** GetField "receiver" ReceiverAmount [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "receiverAmounts" AppPaymentRequest \[ReceiverAmount\]
+>
+> **instance** SetField "amount" ReceiverAmount PaymentAmount
+>
+> **instance** SetField "receiver" ReceiverAmount [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "receiverAmounts" AppPaymentRequest \[ReceiverAmount\]
+
+<div id="type-splice-wallet-payment-receiveramulet-61330">
+
+**data** ReceiverAmulet
+
+</div>
+
+> <div id="constr-splice-wallet-payment-receiveramulet-72427">
+>
+> ReceiverAmulet
+>
+> </div>
+>
+> > | Field        | Type                                                                                                                                       | Description |
+> > |--------------|--------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | receiver     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                        |             |
+> > | lockedAmulet | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ReceiverAmulet
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ReceiverAmulet
+>
+> **instance** GetField "lockedAmulet" ReceiverAmulet ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet)
+>
+> **instance** GetField "receiver" ReceiverAmulet [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "lockedAmulet" ReceiverAmulet ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet)
+>
+> **instance** SetField "receiver" ReceiverAmulet [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+<div id="type-splice-wallet-payment-receiveramuletamount-72096">
+
+**data** ReceiverAmuletAmount
+
+</div>
+
+> <div id="constr-splice-wallet-payment-receiveramuletamount-97653">
+>
+> ReceiverAmuletAmount
+>
+> </div>
+>
+> > | Field        | Type                                                                                                                | Description |
+> > |--------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | receiver     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | amuletAmount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)  |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) ReceiverAmuletAmount
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) ReceiverAmuletAmount
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) ReceiverAmuletAmount
+>
+> **instance** GetField "amuletAmount" ReceiverAmuletAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "amuletReceiverAmounts" AcceptedAppPayment \[ReceiverAmuletAmount\]
+>
+> **instance** GetField "receiver" ReceiverAmuletAmount [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "amuletAmount" ReceiverAmuletAmount [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "amuletReceiverAmounts" AcceptedAppPayment \[ReceiverAmuletAmount\]
+>
+> **instance** SetField "receiver" ReceiverAmuletAmount [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+<div id="type-splice-wallet-payment-unit-67175">
+
+**data** Unit
+
+</div>
+
+> <div id="constr-splice-wallet-payment-usdunit-55511">
+>
+> USDUnit
+>
+> </div>
+>
+> <div id="constr-splice-wallet-payment-amuletunit-84830">
+>
+> AmuletUnit
+>
+> </div>
+>
+> <div id="constr-splice-wallet-payment-extunit-45462">
+>
+> ExtUnit
+>
+> </div>
+>
+> > Extension constructor to work around the current lack of upgrading for variants in Daml 3.0. Will serve as the default value in a containing record in case of an extension.
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) Unit
+>
+> **instance** [Ord](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-ord-6395) Unit
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) Unit
+>
+> **instance** GetField "unit" PaymentAmount Unit
+>
+> **instance** SetField "unit" PaymentAmount Unit
+
+## Functions
+
+<div id="function-splice-wallet-payment-paymentamounttoamulet-10099">
+
+paymentAmountToAmulet
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> OpenMiningRound -\> PaymentAmount -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+
+</div>
+
+<div id="function-splice-wallet-payment-receiveramounttoamuletreceiveramount-72316">
+
+receiverAmountToAmuletReceiverAmount
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> OpenMiningRound -\> ReceiverAmount -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ReceiverAmuletAmount
+
+</div>
+
+<div id="function-splice-wallet-payment-apppaymentrequestreceivers-97989">
+
+appPaymentRequest_receivers
+: AppPaymentRequest -\> \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]
+
+</div>
+
+<div id="function-splice-wallet-payment-unzipreceiveramulets-38827">
+
+unzipReceiverAmulets
+: \[ReceiverAmulet\] -\> (\[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\], \[[ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet\])
+
+</div>
+
+<div id="function-splice-wallet-payment-mkreceiveroutput-26465">
+
+mkReceiverOutput
+: ReceiverAmuletAmount -\> TransferOutput
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions.mdx
@@ -1,0 +1,873 @@
+---
+title: "Splice.Wallet.Subscriptions"
+description: "Documentation for Splice.Wallet.Subscriptions"
+---
+
+{/* COPIED_START source="splice:daml/splice-wallet-payments/docs/Splice-Wallet-Subscriptions.rst" tag="0.6.4" hash="abf6a5bb" */}
+
+## Templates
+
+<div id="type-splice-wallet-subscriptions-subscription-33404">
+
+**template** Subscription
+
+</div>
+
+> Main subscription object.
+>
+> Signatory: subscriptionSignatories subscriptionData
+>
+> | Field            | Type                                                                                                                                              | Description                                                                                                                |
+> |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+> | subscriptionData | SubscriptionData                                                                                                                                  |                                                                                                                            |
+> | reference        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest | Reference to the subscription request, note that the contract will no longer be active so this just acts as a tracking id. |
+>
+> - **Choice** Archive
+>
+>   Controller: subscriptionSignatories subscriptionData
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptionarchive-38051">
+>
+>   **Choice** Subscription_Archive
+>
+>   </div>
+>
+>   Controller: signatory this
+>
+>   Returns: Subscription_ArchiveResult
+>
+>   (no fields)
+
+<div id="type-splice-wallet-subscriptions-subscriptionidlestate-59870">
+
+**template** SubscriptionIdleState
+
+</div>
+
+> The base state in our subscription flow. Here, we are typically waiting for the time for the next payment to arrive. If that time has passed, we are waiting for someone to expire the subscription.
+>
+> Signatory: subscriptionSignatories subscriptionData
+>
+> | Field            | Type                                                                                                                                              | Description                                                       |
+> |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+> | subscription     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Subscription        | The subscription this belongs to.                                 |
+> | subscriptionData | SubscriptionData                                                                                                                                  | Copy of the subscription contract for easier access to its field. |
+> | payData          | SubscriptionPayData                                                                                                                               | Payment-related properties.                                       |
+> | nextPaymentDueAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                 | After which time the next payment can and should be paid.         |
+> | reference        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest |                                                                   |
+>
+> - **Choice** Archive
+>
+>   Controller: subscriptionSignatories subscriptionData
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptionidlestatecancelsubscription-25061">
+>
+>   **Choice** SubscriptionIdleState_CancelSubscription
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"sender" subscriptionData)
+>
+>   Returns: SubscriptionIdleState_CancelSubscriptionResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptionidlestateexpiresubscription-50078">
+>
+>   **Choice** SubscriptionIdleState_ExpireSubscription
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: SubscriptionIdleState_ExpireSubscriptionResult
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | actor | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptionidlestatemakepayment-62467">
+>
+>   **Choice** SubscriptionIdleState_MakePayment
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"sender" subscriptionData), walletProvider
+>
+>   Returns: SubscriptionIdleState_MakePaymentResult
+>
+>   | Field          | Type                                                                                                                | Description |
+>   |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | inputs         | \[TransferInput\]                                                                                                   |             |
+>   | context        | PaymentTransferContext                                                                                              |             |
+>   | walletProvider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+
+<div id="type-splice-wallet-subscriptions-subscriptioninitialpayment-79960">
+
+**template** SubscriptionInitialPayment
+
+</div>
+
+> The initial payment on a subscription. Implicitly, this is also the "accept" of the preceding `SubscriptionRequest`. Collecting this payments creates the subscription and thereby enables all follow-up payments.
+>
+> Signatory: subscriptionSignatories subscriptionData
+>
+> | Field            | Type                                                                                                                                              | Description                                                                                                                |
+> |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+> | subscriptionData | SubscriptionData                                                                                                                                  |                                                                                                                            |
+> | payData          | SubscriptionPayData                                                                                                                               |                                                                                                                            |
+> | targetAmount     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                | Exact amount in Amulet that the receiver will get.                                                                         |
+> | lockedAmulet     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet        |                                                                                                                            |
+> | round            | Round                                                                                                                                             | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets.        |
+> | reference        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest | Reference to the subscription request, note that the contract will no longer be active so this just acts as a tracking id. |
+>
+> - **Choice** Archive
+>
+>   Controller: subscriptionSignatories subscriptionData
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentcollect-92147">
+>
+>   **Choice** SubscriptionInitialPayment_Collect
+>
+>   </div>
+>
+>   Controller: signatory this
+>
+>   Returns: SubscriptionInitialPayment_CollectResult
+>
+>   | Field           | Type               | Description |
+>   |-----------------|--------------------|-------------|
+>   | transferContext | AppTransferContext |             |
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentexpire-95363">
+>
+>   **Choice** SubscriptionInitialPayment_Expire
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: SubscriptionInitialPayment_ExpireResult
+>
+>   | Field           | Type                                                                                                                | Description |
+>   |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | actor           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>   | transferContext | AppTransferContext                                                                                                  |             |
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentreject-61119">
+>
+>   **Choice** SubscriptionInitialPayment_Reject
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"receiver" subscriptionData)
+>
+>   Returns: SubscriptionInitialPayment_RejectResult
+>
+>   | Field           | Type               | Description |
+>   |-----------------|--------------------|-------------|
+>   | transferContext | AppTransferContext |             |
+
+<div id="type-splice-wallet-subscriptions-subscriptionpayment-4463">
+
+**template** SubscriptionPayment
+
+</div>
+
+> An in-flight (yet to be collected) payment on an existing subscription. Doubles as a "payment in progress" state.
+>
+> Signatory: subscriptionSignatories subscriptionData
+>
+> | Field            | Type                                                                                                                                              | Description                                                                                                         |
+> |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+> | subscription     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Subscription        | The subscription this belongs to.                                                                                   |
+> | subscriptionData | SubscriptionData                                                                                                                                  | Copy of the base subscription properties; for convenience.                                                          |
+> | payData          | SubscriptionPayData                                                                                                                               | Payment-related properties.                                                                                         |
+> | thisPaymentDueAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                 | After which time the next payment can and should be paid.                                                           |
+> | targetAmount     | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                |                                                                                                                     |
+> | lockedAmulet     | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet        |                                                                                                                     |
+> | round            | Round                                                                                                                                             | The round in which the locked amulet was created, added as an extra field so we can avoid ingesting locked amulets. |
+> | reference        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest |                                                                                                                     |
+>
+> - **Choice** Archive
+>
+>   Controller: subscriptionSignatories subscriptionData
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptionpaymentcollect-45604">
+>
+>   **Choice** SubscriptionPayment_Collect
+>
+>   </div>
+>
+>   Controller: signatory this
+>
+>   Returns: SubscriptionPayment_CollectResult
+>
+>   | Field           | Type               | Description |
+>   |-----------------|--------------------|-------------|
+>   | transferContext | AppTransferContext |             |
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptionpaymentexpire-61162">
+>
+>   **Choice** SubscriptionPayment_Expire
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: SubscriptionPayment_ExpireResult
+>
+>   | Field           | Type                                                                                                                | Description |
+>   |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | actor           | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>   | transferContext | AppTransferContext                                                                                                  |             |
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptionpaymentreject-72046">
+>
+>   **Choice** SubscriptionPayment_Reject
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"receiver" subscriptionData)
+>
+>   Returns: SubscriptionPayment_RejectResult
+>
+>   | Field           | Type               | Description |
+>   |-----------------|--------------------|-------------|
+>   | transferContext | AppTransferContext |             |
+
+<div id="type-splice-wallet-subscriptions-subscriptionrequest-40942">
+
+**template** SubscriptionRequest
+
+</div>
+
+> A request for establishing a subscription.
+>
+> Signatory: subscriptionSignatories subscriptionData
+>
+> | Field            | Type                | Description |
+> |------------------|---------------------|-------------|
+> | subscriptionData | SubscriptionData    |             |
+> | payData          | SubscriptionPayData |             |
+>
+> - **Choice** Archive
+>
+>   Controller: subscriptionSignatories subscriptionData
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptionrequestacceptandmakepayment-96423">
+>
+>   **Choice** SubscriptionRequest_AcceptAndMakePayment
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"sender" subscriptionData), walletProvider
+>
+>   Returns: SubscriptionRequest_AcceptAndMakePaymentResult
+>
+>   | Field          | Type                                                                                                                | Description |
+>   |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | inputs         | \[TransferInput\]                                                                                                   |             |
+>   | context        | PaymentTransferContext                                                                                              |             |
+>   | walletProvider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptionrequestreject-95001">
+>
+>   **Choice** SubscriptionRequest_Reject
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"sender" subscriptionData)
+>
+>   Returns: SubscriptionRequest_RejectResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-subscriptions-subscriptionrequestwithdraw-88172">
+>
+>   **Choice** SubscriptionRequest_Withdraw
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"receiver" subscriptionData)
+>
+>   Returns: SubscriptionRequest_WithdrawResult
+>
+>   (no fields)
+
+<div id="type-splice-wallet-subscriptions-terminatedsubscription-20905">
+
+**template** TerminatedSubscription
+
+</div>
+
+> An aborted subscription. Subscriptions should usually be archived together with the context contract of the app that makes the subscription, e.g., AnsEntryContext. To achieve that, we don't archive subscriptions directly but instead create TerminatedSubscription contracts that are then archived as part of the surrounding workflows.
+>
+> Signatory: subscriptionSignatories subscriptionData
+>
+> | Field            | Type                                                                                                                                              | Description |
+> |------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> | subscriptionData | SubscriptionData                                                                                                                                  |             |
+> | reference        | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest |             |
+>
+> - **Choice** Archive
+>
+>   Controller: subscriptionSignatories subscriptionData
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-wallet-subscriptions-subscriptiondata-61040">
+
+**data** SubscriptionData
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptiondata-87477">
+>
+> SubscriptionData
+>
+> </div>
+>
+> > | Field       | Type                                                                                                                | Description                      |
+> > |-------------|---------------------------------------------------------------------------------------------------------------------|----------------------------------|
+> > | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that pays.             |
+> > | receiver    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party that receives payment. |
+> > | provider    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The app provider.                |
+> > | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                  |
+> > | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |                                  |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SubscriptionData
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SubscriptionData
+>
+> **instance** GetField "description" SubscriptionData [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "dso" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "provider" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "receiver" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "sender" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "subscriptionData" Subscription SubscriptionData
+>
+> **instance** GetField "subscriptionData" SubscriptionIdleState SubscriptionData
+>
+> **instance** GetField "subscriptionData" SubscriptionInitialPayment SubscriptionData
+>
+> **instance** GetField "subscriptionData" SubscriptionPayment SubscriptionData
+>
+> **instance** GetField "subscriptionData" SubscriptionRequest SubscriptionData
+>
+> **instance** GetField "subscriptionData" TerminatedSubscription SubscriptionData
+>
+> **instance** SetField "description" SubscriptionData [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "dso" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "provider" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "receiver" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "sender" SubscriptionData [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "subscriptionData" Subscription SubscriptionData
+>
+> **instance** SetField "subscriptionData" SubscriptionIdleState SubscriptionData
+>
+> **instance** SetField "subscriptionData" SubscriptionInitialPayment SubscriptionData
+>
+> **instance** SetField "subscriptionData" SubscriptionPayment SubscriptionData
+>
+> **instance** SetField "subscriptionData" SubscriptionRequest SubscriptionData
+>
+> **instance** SetField "subscriptionData" TerminatedSubscription SubscriptionData
+
+<div id="type-splice-wallet-subscriptions-subscriptionidlestatecancelsubscriptionresult-53096">
+
+**data** SubscriptionIdleState_CancelSubscriptionResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptionidlestatecancelsubscriptionresult-80217">
+>
+> SubscriptionIdleState_CancelSubscriptionResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                 | Description |
+> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
+>
+> **instance** GetField "terminatedSubscription" SubscriptionIdleState_CancelSubscriptionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** SetField "terminatedSubscription" SubscriptionIdleState_CancelSubscriptionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionIdleState SubscriptionIdleState_CancelSubscription SubscriptionIdleState_CancelSubscriptionResult
+
+<div id="type-splice-wallet-subscriptions-subscriptionidlestateexpiresubscriptionresult-84335">
+
+**data** SubscriptionIdleState_ExpireSubscriptionResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptionidlestateexpiresubscriptionresult-85758">
+>
+> SubscriptionIdleState_ExpireSubscriptionResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                 | Description |
+> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
+>
+> **instance** GetField "terminatedSubscription" SubscriptionIdleState_ExpireSubscriptionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** SetField "terminatedSubscription" SubscriptionIdleState_ExpireSubscriptionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionIdleState SubscriptionIdleState_ExpireSubscription SubscriptionIdleState_ExpireSubscriptionResult
+
+<div id="type-splice-wallet-subscriptions-subscriptionidlestatemakepaymentresult-27466">
+
+**data** SubscriptionIdleState_MakePaymentResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptionidlestatemakepaymentresult-79353">
+>
+> SubscriptionIdleState_MakePaymentResult
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                                                                                                                                                  | Description |
+> > |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | subscriptionPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment                                                                                                                     |             |
+> > | senderChange        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "senderChange" SubscriptionIdleState_MakePaymentResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "subscriptionPayment" SubscriptionIdleState_MakePaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment)
+>
+> **instance** SetField "senderChange" SubscriptionIdleState_MakePaymentResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "subscriptionPayment" SubscriptionIdleState_MakePaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionIdleState SubscriptionIdleState_MakePayment SubscriptionIdleState_MakePaymentResult
+
+<div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentcollectresult-97286">
+
+**data** SubscriptionInitialPayment_CollectResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentcollectresult-66575">
+>
+> SubscriptionInitialPayment_CollectResult
+>
+> </div>
+>
+> > | Field             | Type                                                                                                                                                | Description |
+> > |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | subscription      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Subscription          |             |
+> > | subscriptionState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
+> > | amulet            | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet                |             |
+>
+> **instance** GetField "amulet" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+>
+> **instance** GetField "subscription" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Subscription)
+>
+> **instance** GetField "subscriptionState" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** SetField "amulet" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+>
+> **instance** SetField "subscription" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Subscription)
+>
+> **instance** SetField "subscriptionState" SubscriptionInitialPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionInitialPayment SubscriptionInitialPayment_Collect SubscriptionInitialPayment_CollectResult
+
+<div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentexpireresult-71466">
+
+**data** SubscriptionInitialPayment_ExpireResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentexpireresult-14633">
+>
+> SubscriptionInitialPayment_ExpireResult
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                                       | Description |
+> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "amuletSum" SubscriptionInitialPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "amuletSum" SubscriptionInitialPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionInitialPayment SubscriptionInitialPayment_Expire SubscriptionInitialPayment_ExpireResult
+
+<div id="type-splice-wallet-subscriptions-subscriptioninitialpaymentrejectresult-97550">
+
+**data** SubscriptionInitialPayment_RejectResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptioninitialpaymentrejectresult-64365">
+>
+> SubscriptionInitialPayment_RejectResult
+>
+> </div>
+>
+> > | Field     | Type                                                                                                                                                       | Description |
+> > |-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | amuletSum | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "amuletSum" SubscriptionInitialPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "amuletSum" SubscriptionInitialPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionInitialPayment SubscriptionInitialPayment_Reject SubscriptionInitialPayment_RejectResult
+
+<div id="type-splice-wallet-subscriptions-subscriptionpaydata-96623">
+
+**data** SubscriptionPayData
+
+</div>
+
+> Payment-related properties. Expected to be mutated rarely.
+>
+> <div id="constr-splice-wallet-subscriptions-subscriptionpaydata-90180">
+>
+> SubscriptionPayData
+>
+> </div>
+>
+> > | Field           | Type                                                                                                                   | Description                                                                                                                             |
+> > |-----------------|------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+> > | paymentAmount   | PaymentAmount                                                                                                          | What amount of amulet is due on each interval.                                                                                          |
+> > | paymentInterval | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | At which intervals payments should be made.                                                                                             |
+> > | paymentDuration | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082) | The time available to the sender to initiate a payment; they can initiate the payment this much before the end of the current interval. |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) SubscriptionPayData
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) SubscriptionPayData
+>
+> **instance** GetField "payData" SubscriptionIdleState SubscriptionPayData
+>
+> **instance** GetField "payData" SubscriptionInitialPayment SubscriptionPayData
+>
+> **instance** GetField "payData" SubscriptionPayment SubscriptionPayData
+>
+> **instance** GetField "payData" SubscriptionRequest SubscriptionPayData
+>
+> **instance** GetField "paymentAmount" SubscriptionPayData PaymentAmount
+>
+> **instance** GetField "paymentDuration" SubscriptionPayData [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** GetField "paymentInterval" SubscriptionPayData [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "payData" SubscriptionIdleState SubscriptionPayData
+>
+> **instance** SetField "payData" SubscriptionInitialPayment SubscriptionPayData
+>
+> **instance** SetField "payData" SubscriptionPayment SubscriptionPayData
+>
+> **instance** SetField "payData" SubscriptionRequest SubscriptionPayData
+>
+> **instance** SetField "paymentAmount" SubscriptionPayData PaymentAmount
+>
+> **instance** SetField "paymentDuration" SubscriptionPayData [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "paymentInterval" SubscriptionPayData [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+
+<div id="type-splice-wallet-subscriptions-subscriptionpaymentcollectresult-94269">
+
+**data** SubscriptionPayment_CollectResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptionpaymentcollectresult-9234">
+>
+> SubscriptionPayment_CollectResult
+>
+> </div>
+>
+> > | Field             | Type                                                                                                                                                | Description |
+> > |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | subscriptionState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
+> > | amulet            | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet                |             |
+>
+> **instance** GetField "amulet" SubscriptionPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+>
+> **instance** GetField "subscriptionState" SubscriptionPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** SetField "amulet" SubscriptionPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+>
+> **instance** SetField "subscriptionState" SubscriptionPayment_CollectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionPayment SubscriptionPayment_Collect SubscriptionPayment_CollectResult
+
+<div id="type-splice-wallet-subscriptions-subscriptionpaymentexpireresult-84183">
+
+**data** SubscriptionPayment_ExpireResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptionpaymentexpireresult-46758">
+>
+> SubscriptionPayment_ExpireResult
+>
+> </div>
+>
+> > | Field             | Type                                                                                                                                                       | Description |
+> > |-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | subscriptionState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState        |             |
+> > | amuletSum         | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "amuletSum" SubscriptionPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "subscriptionState" SubscriptionPayment_ExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** SetField "amuletSum" SubscriptionPayment_ExpireResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "subscriptionState" SubscriptionPayment_ExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionPayment SubscriptionPayment_Expire SubscriptionPayment_ExpireResult
+
+<div id="type-splice-wallet-subscriptions-subscriptionpaymentrejectresult-80731">
+
+**data** SubscriptionPayment_RejectResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptionpaymentrejectresult-20586">
+>
+> SubscriptionPayment_RejectResult
+>
+> </div>
+>
+> > | Field             | Type                                                                                                                                                       | Description |
+> > |-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | subscriptionState | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState        |             |
+> > | amuletSum         | AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "amuletSum" SubscriptionPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "subscriptionState" SubscriptionPayment_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** SetField "amuletSum" SubscriptionPayment_RejectResult (AmuletCreateSummary ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "subscriptionState" SubscriptionPayment_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionPayment SubscriptionPayment_Reject SubscriptionPayment_RejectResult
+
+<div id="type-splice-wallet-subscriptions-subscriptionrequestacceptandmakepaymentresult-1166">
+
+**data** SubscriptionRequest_AcceptAndMakePaymentResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptionrequestacceptandmakepaymentresult-32571">
+>
+> SubscriptionRequest_AcceptAndMakePaymentResult
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                                                                                                                                                  | Description |
+> > |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | subscriptionPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment                                                                                                              |             |
+> > | senderChange        | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "senderChange" SubscriptionRequest_AcceptAndMakePaymentResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "subscriptionPayment" SubscriptionRequest_AcceptAndMakePaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment)
+>
+> **instance** SetField "senderChange" SubscriptionRequest_AcceptAndMakePaymentResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "subscriptionPayment" SubscriptionRequest_AcceptAndMakePaymentResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionRequest SubscriptionRequest_AcceptAndMakePayment SubscriptionRequest_AcceptAndMakePaymentResult
+
+<div id="type-splice-wallet-subscriptions-subscriptionrequestrejectresult-11624">
+
+**data** SubscriptionRequest_RejectResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptionrequestrejectresult-75381">
+>
+> SubscriptionRequest_RejectResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                 | Description |
+> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
+>
+> **instance** GetField "terminatedSubscription" SubscriptionRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** SetField "terminatedSubscription" SubscriptionRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionRequest SubscriptionRequest_Reject SubscriptionRequest_RejectResult
+
+<div id="type-splice-wallet-subscriptions-subscriptionrequestwithdrawresult-7225">
+
+**data** SubscriptionRequest_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptionrequestwithdrawresult-40204">
+>
+> SubscriptionRequest_WithdrawResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                 | Description |
+> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
+>
+> **instance** GetField "terminatedSubscription" SubscriptionRequest_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** SetField "terminatedSubscription" SubscriptionRequest_WithdrawResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) SubscriptionRequest SubscriptionRequest_Withdraw SubscriptionRequest_WithdrawResult
+
+<div id="type-splice-wallet-subscriptions-subscriptionarchiveresult-60922">
+
+**data** Subscription_ArchiveResult
+
+</div>
+
+> <div id="constr-splice-wallet-subscriptions-subscriptionarchiveresult-91207">
+>
+> Subscription_ArchiveResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                 | Description |
+> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
+>
+> **instance** GetField "terminatedSubscription" Subscription_ArchiveResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** SetField "terminatedSubscription" Subscription_ArchiveResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) Subscription Subscription_Archive Subscription_ArchiveResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) Subscription Subscription_Archive Subscription_ArchiveResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) Subscription Subscription_Archive Subscription_ArchiveResult
+
+## Functions
+
+<div id="function-splice-wallet-subscriptions-subscriptionsignatories-98765">
+
+subscriptionSignatories
+: SubscriptionData -\> \[[Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)\]
+
+</div>
+
+<div id="function-splice-wallet-subscriptions-paydataisvalid-4217">
+
+payDataIsValid
+: SubscriptionPayData -\> [Bool](/appdev/reference/daml-standard-library/prelude#type-ghc-types-bool-66265)
+
+</div>
+
+<div id="function-splice-wallet-subscriptions-lockandmakechange-61624">
+
+lockAndMakeChange
+: PaymentTransferContext -\> SubscriptionData -\> SubscriptionPayData -\> \[TransferInput\] -\> [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet, [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet), [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135), Round)
+
+</div>
+
+<div id="function-splice-wallet-subscriptions-unlockandtransfer-4476">
+
+unlockAndTransfer
+: AppTransferContext -\> SubscriptionData -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) LockedAmulet -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+
+</div>
+
+<div id="function-splice-wallet-subscriptions-mktransferoutput-31673">
+
+mkTransferOutput
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) -\> TransferOutput
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/index.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/index.mdx
@@ -1,0 +1,19 @@
+---
+title: "splice-wallet docs"
+description: "Documentation for splice-wallet docs"
+---
+
+{/* COPIED_START source="splice:daml/splice-wallet/docs/index.rst" tag="0.6.4" hash="a8830322" */}
+
+Note that these are internal modules to implement the Canton Coin specific wallet funcationality in the Splice Wallet served by a Validator Node. Avoid referencing these models in your own Daml code, as no guarantees are made about their stability and upgrade cadence.
+
+For implementing a wallet of your own, compose with the interfaces defined as part of the Canton Network Token Standard.
+
+- [Splice.Wallet.BuyTrafficRequest](/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-buytrafficrequest)
+- [Splice.Wallet.Install](/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-install)
+- [Splice.Wallet.MintingDelegation](/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-mintingdelegation)
+- [Splice.Wallet.TopUpState](/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-topupstate)
+- [Splice.Wallet.TransferOffer](/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferoffer)
+- [Splice.Wallet.TransferPreapproval](/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferpreapproval)
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-buytrafficrequest.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-buytrafficrequest.mdx
@@ -1,0 +1,220 @@
+---
+title: "Splice.Wallet.BuyTrafficRequest"
+description: "Documentation for Splice.Wallet.BuyTrafficRequest"
+---
+
+{/* COPIED_START source="splice:daml/splice-wallet/docs/Splice-Wallet-BuyTrafficRequest.rst" tag="0.6.4" hash="b27f069d" */}
+
+## Templates
+
+<div id="type-splice-wallet-buytrafficrequest-buytrafficrequest-65116">
+
+**template** BuyTrafficRequest
+
+</div>
+
+> A request by an end-user to the wallet's automation to buy traffic for a sequencer member
+>
+> Signatory: endUserParty
+>
+> | Field          | Type                                                                                                                | Description                       |
+> |----------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------|
+> | dso            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                   |
+> | endUserParty   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                   |
+> | expiresAt      | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Buy the traffic before this time. |
+> | trackingId     | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | Used to deduplicate requests      |
+> | trafficAmount  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |                                   |
+> | memberId       | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |                                   |
+> | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |                                   |
+> | migrationId    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          |                                   |
+>
+> - **Choice** Archive
+>
+>   Controller: endUserParty
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-buytrafficrequest-buytrafficrequestcancel-52564">
+>
+>   **Choice** BuyTrafficRequest_Cancel
+>
+>   </div>
+>
+>   Controller: endUserParty
+>
+>   Returns: BuyTrafficRequest_CancelResult
+>
+>   | Field  | Type                                                                                                         | Description |
+>   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> - <div id="type-splice-wallet-buytrafficrequest-buytrafficrequestcomplete-61949">
+>
+>   **Choice** BuyTrafficRequest_Complete
+>
+>   </div>
+>
+>   Controller: endUserParty, walletProvider
+>
+>   Returns: BuyTrafficRequest_CompleteResult
+>
+>   | Field          | Type                                                                                                                | Description |
+>   |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | inputs         | \[TransferInput\]                                                                                                   |             |
+>   | context        | PaymentTransferContext                                                                                              |             |
+>   | walletProvider | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-wallet-buytrafficrequest-buytrafficrequestexpire-77595">
+>
+>   **Choice** BuyTrafficRequest_Expire
+>
+>   </div>
+>
+>   Controller: endUserParty
+>
+>   Returns: BuyTrafficRequest_ExpireResult
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-wallet-buytrafficrequest-buytrafficrequesttrackinginfo-63943">
+
+**data** BuyTrafficRequestTrackingInfo
+
+</div>
+
+> <div id="constr-splice-wallet-buytrafficrequest-buytrafficrequesttrackinginfo-4476">
+>
+> BuyTrafficRequestTrackingInfo
+>
+> </div>
+>
+> > | Field        | Type                                                                                                                | Description                                           |
+> > |--------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+> > | trackingId   | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | used to deduplicate requests and query for the status |
+> > | endUserParty | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | used in UserWalletTxLogParser's filterByParty         |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) BuyTrafficRequestTrackingInfo
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) BuyTrafficRequestTrackingInfo
+>
+> **instance** GetField "endUserParty" BuyTrafficRequestTrackingInfo [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "trackingId" BuyTrafficRequestTrackingInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "trackingInfo" BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo
+>
+> **instance** GetField "trackingInfo" BuyTrafficRequest_CompleteResult BuyTrafficRequestTrackingInfo
+>
+> **instance** GetField "trackingInfo" BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo
+>
+> **instance** SetField "endUserParty" BuyTrafficRequestTrackingInfo [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "trackingId" BuyTrafficRequestTrackingInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "trackingInfo" BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo
+>
+> **instance** SetField "trackingInfo" BuyTrafficRequest_CompleteResult BuyTrafficRequestTrackingInfo
+>
+> **instance** SetField "trackingInfo" BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo
+
+<div id="type-splice-wallet-buytrafficrequest-buytrafficrequestcancelresult-81241">
+
+**data** BuyTrafficRequest_CancelResult
+
+</div>
+
+> <div id="constr-splice-wallet-buytrafficrequest-buytrafficrequestcancelresult-28380">
+>
+> BuyTrafficRequest_CancelResult
+>
+> </div>
+>
+> > | Field        | Type                          | Description |
+> > |--------------|-------------------------------|-------------|
+> > | trackingInfo | BuyTrafficRequestTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo
+>
+> **instance** SetField "trackingInfo" BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) BuyTrafficRequest BuyTrafficRequest_Cancel BuyTrafficRequest_CancelResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) BuyTrafficRequest BuyTrafficRequest_Cancel BuyTrafficRequest_CancelResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) BuyTrafficRequest BuyTrafficRequest_Cancel BuyTrafficRequest_CancelResult
+
+<div id="type-splice-wallet-buytrafficrequest-buytrafficrequestcompleteresult-44764">
+
+**data** BuyTrafficRequest_CompleteResult
+
+</div>
+
+> <div id="constr-splice-wallet-buytrafficrequest-buytrafficrequestcompleteresult-27129">
+>
+> BuyTrafficRequest_CompleteResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                                                                                                                                                  | Description |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | purchasedTraffic   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic                                                                                                                           |             |
+> > | trackingInfo       | BuyTrafficRequestTrackingInfo                                                                                                                                                                                                                                         |             |
+> > | senderChangeAmulet | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "purchasedTraffic" BuyTrafficRequest_CompleteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
+>
+> **instance** GetField "senderChangeAmulet" BuyTrafficRequest_CompleteResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "trackingInfo" BuyTrafficRequest_CompleteResult BuyTrafficRequestTrackingInfo
+>
+> **instance** SetField "purchasedTraffic" BuyTrafficRequest_CompleteResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
+>
+> **instance** SetField "senderChangeAmulet" BuyTrafficRequest_CompleteResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "trackingInfo" BuyTrafficRequest_CompleteResult BuyTrafficRequestTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) BuyTrafficRequest BuyTrafficRequest_Complete BuyTrafficRequest_CompleteResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) BuyTrafficRequest BuyTrafficRequest_Complete BuyTrafficRequest_CompleteResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) BuyTrafficRequest BuyTrafficRequest_Complete BuyTrafficRequest_CompleteResult
+
+<div id="type-splice-wallet-buytrafficrequest-buytrafficrequestexpireresult-25706">
+
+**data** BuyTrafficRequest_ExpireResult
+
+</div>
+
+> <div id="constr-splice-wallet-buytrafficrequest-buytrafficrequestexpireresult-5207">
+>
+> BuyTrafficRequest_ExpireResult
+>
+> </div>
+>
+> > | Field        | Type                          | Description |
+> > |--------------|-------------------------------|-------------|
+> > | trackingInfo | BuyTrafficRequestTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo
+>
+> **instance** SetField "trackingInfo" BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) BuyTrafficRequest BuyTrafficRequest_Expire BuyTrafficRequest_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) BuyTrafficRequest BuyTrafficRequest_Expire BuyTrafficRequest_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) BuyTrafficRequest BuyTrafficRequest_Expire BuyTrafficRequest_ExpireResult
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-install.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-install.mdx
@@ -1,0 +1,1261 @@
+---
+title: "Splice.Wallet.Install"
+description: "Documentation for Splice.Wallet.Install"
+---
+
+{/* COPIED_START source="splice:daml/splice-wallet/docs/Splice-Wallet-Install.rst" tag="0.6.4" hash="b86c403d" */}
+
+## Templates
+
+<div id="type-splice-wallet-install-walletappinstall-78445">
+
+**template** WalletAppInstall
+
+</div>
+
+> Signatory: endUserParty, validatorParty
+>
+> | Field          | Type                                                                                                                | Description |
+> |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | dsoParty       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | validatorParty | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | endUserName    | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+> | endUserParty   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: endUserParty, validatorParty
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-install-walletappinstallacceptedtransferofferabort-68763">
+>
+>   **Choice** WalletAppInstall_AcceptedTransferOffer_Abort
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_AcceptedTransferOffer_AbortResult
+>
+>   | Field  | Type                                                                                                                                                | Description |
+>   |--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedTransferOffer |             |
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                        |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallacceptedtransferofferexpire-57521">
+>
+>   **Choice** WalletAppInstall_AcceptedTransferOffer_Expire
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_AcceptedTransferOffer_ExpireResult
+>
+>   | Field | Type                                                                                                                                                | Description |
+>   |-------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedTransferOffer |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallacceptedtransferofferwithdraw-52092">
+>
+>   **Choice** WalletAppInstall_AcceptedTransferOffer_Withdraw
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_AcceptedTransferOffer_WithdrawResult
+>
+>   | Field  | Type                                                                                                                                                | Description |
+>   |--------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedTransferOffer |             |
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                        |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallallocationfactoryallocate-87859">
+>
+>   **Choice** WalletAppInstall_AllocationFactory_Allocate
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: AllocationInstructionResult
+>
+>   | Field             | Type                                                                                                                                            | Description |
+>   |-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | allocationFactory | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AllocationFactory |             |
+>   | allocateArg       | AllocationFactory_Allocate                                                                                                                      |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallallocationwithdraw-36167">
+>
+>   **Choice** WalletAppInstall_Allocation_Withdraw
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: Allocation_WithdrawResult
+>
+>   | Field         | Type                                                                                                                                     | Description |
+>   |---------------|------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | allocationCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Allocation |             |
+>   | withdrawArg   | Allocation_Withdraw                                                                                                                      |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallapppaymentrequestexpire-63657">
+>
+>   **Choice** WalletAppInstall_AppPaymentRequest_Expire
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_AppPaymentRequest_ExpireResult
+>
+>   | Field | Type                                                                                                                                            | Description |
+>   |-------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppPaymentRequest |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallapppaymentrequestreject-30597">
+>
+>   **Choice** WalletAppInstall_AppPaymentRequest_Reject
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_AppPaymentRequest_RejectResult
+>
+>   | Field | Type                                                                                                                                            | Description |
+>   |-------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppPaymentRequest |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallbuytrafficrequestcancel-57332">
+>
+>   **Choice** WalletAppInstall_BuyTrafficRequest_Cancel
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_BuyTrafficRequest_CancelResult
+>
+>   | Field      | Type                                                                                                                                            | Description |
+>   |------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | requestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BuyTrafficRequest |             |
+>   | reason     | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                    |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallbuytrafficrequestexpire-56287">
+>
+>   **Choice** WalletAppInstall_BuyTrafficRequest_Expire
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_BuyTrafficRequest_ExpireResult
+>
+>   | Field      | Type                                                                                                                                            | Description |
+>   |------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | requestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BuyTrafficRequest |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallcreatebuytrafficrequest-33718">
+>
+>   **Choice** WalletAppInstall_CreateBuyTrafficRequest
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_CreateBuyTrafficRequestResult
+>
+>   | Field          | Type                                                                                                              | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------|-------------|
+>   | memberId       | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)      |             |
+>   | synchronizerId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)      |             |
+>   | migrationId    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)        |             |
+>   | trafficAmount  | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)        |             |
+>   | expiresAt      | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) |             |
+>   | trackingId     | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)      |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallcreatetransferoffer-6821">
+>
+>   **Choice** WalletAppInstall_CreateTransferOffer
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_CreateTransferOfferResult
+>
+>   | Field       | Type                                                                                                                | Description |
+>   |-------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | receiver    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>   | amount      | PaymentAmount                                                                                                       |             |
+>   | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>   | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
+>   | trackingId  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallexecutebatch-90628">
+>
+>   **Choice** WalletAppInstall_ExecuteBatch
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_ExecuteBatchResult
+>
+>   | Field      | Type                   | Description |
+>   |------------|------------------------|-------------|
+>   | context    | PaymentTransferContext |             |
+>   | inputs     | \[TransferInput\]      |             |
+>   | operations | \[AmuletOperation\]    |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallfeaturedapprightscancel-92504">
+>
+>   **Choice** WalletAppInstall_FeaturedAppRights_Cancel
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_FeaturedAppRights_CancelResult
+>
+>   | Field | Type                                                                                                                                           | Description |
+>   |-------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallfeaturedapprightsselfgrant-7751">
+>
+>   **Choice** WalletAppInstall_FeaturedAppRights_SelfGrant
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_FeaturedAppRights_SelfGrantResult
+>
+>   | Field          | Type                                                                                                                                      | Description |
+>   |----------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | amuletRulesCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AmuletRules |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallsubscriptionidlestatecancelsubscription-97037">
+>
+>   **Choice** WalletAppInstall_SubscriptionIdleState_CancelSubscription
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult
+>
+>   | Field | Type                                                                                                                                                | Description |
+>   |-------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstallsubscriptionrequestreject-94073">
+>
+>   **Choice** WalletAppInstall_SubscriptionRequest_Reject
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_SubscriptionRequest_RejectResult
+>
+>   | Field | Type                                                                                                                                              | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstalltransferfactorytransfer-23966">
+>
+>   **Choice** WalletAppInstall_TransferFactory_Transfer
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: TransferInstructionResult
+>
+>   | Field              | Type                                                                                                                                          | Description |
+>   |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | transferFactoryCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferFactory |             |
+>   | transferArg        | TransferFactory_Transfer                                                                                                                      |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstalltransferinstructionaccept-23051">
+>
+>   **Choice** WalletAppInstall_TransferInstruction_Accept
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: TransferInstructionResult
+>
+>   | Field                  | Type                                                                                                                                              | Description |
+>   |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | transferInstructionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
+>   | acceptArg              | TransferInstruction_Accept                                                                                                                        |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstalltransferinstructionreject-1446">
+>
+>   **Choice** WalletAppInstall_TransferInstruction_Reject
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: TransferInstructionResult
+>
+>   | Field                  | Type                                                                                                                                              | Description |
+>   |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | transferInstructionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
+>   | rejectArg              | TransferInstruction_Reject                                                                                                                        |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstalltransferinstructionwithdraw-1151">
+>
+>   **Choice** WalletAppInstall_TransferInstruction_Withdraw
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: TransferInstructionResult
+>
+>   | Field                  | Type                                                                                                                                              | Description |
+>   |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | transferInstructionCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferInstruction |             |
+>   | withdrawArg            | TransferInstruction_Withdraw                                                                                                                      |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstalltransferofferaccept-7295">
+>
+>   **Choice** WalletAppInstall_TransferOffer_Accept
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_TransferOffer_AcceptResult
+>
+>   | Field | Type                                                                                                                                        | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferOffer |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstalltransferofferexpire-5606">
+>
+>   **Choice** WalletAppInstall_TransferOffer_Expire
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_TransferOffer_ExpireResult
+>
+>   | Field | Type                                                                                                                                        | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferOffer |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstalltransferofferreject-96746">
+>
+>   **Choice** WalletAppInstall_TransferOffer_Reject
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_TransferOffer_RejectResult
+>
+>   | Field | Type                                                                                                                                        | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid   | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferOffer |             |
+>
+> - <div id="type-splice-wallet-install-walletappinstalltransferofferwithdraw-19519">
+>
+>   **Choice** WalletAppInstall_TransferOffer_Withdraw
+>
+>   </div>
+>
+>   Controller: validatorParty
+>
+>   Returns: WalletAppInstall_TransferOffer_WithdrawResult
+>
+>   | Field  | Type                                                                                                                                        | Description |
+>   |--------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+>   | cid    | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferOffer |             |
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                |             |
+
+## Data Types
+
+<div id="type-splice-wallet-install-amuletoperation-34848">
+
+**data** AmuletOperation
+
+</div>
+
+> <div id="constr-splice-wallet-install-coapppayment-62800">
+>
+> CO_AppPayment ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AppPaymentRequest)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-cocompleteacceptedtransfer-10636">
+>
+> CO_CompleteAcceptedTransfer ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedTransferOffer)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-cosubscriptionacceptandmakeinitialpayment-39374">
+>
+> CO_SubscriptionAcceptAndMakeInitialPayment ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionRequest)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-cosubscriptionmakepayment-67209">
+>
+> CO_SubscriptionMakePayment ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionIdleState)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-comergetransferinputs-20390">
+>
+> CO_MergeTransferInputs
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-cobuymembertraffic-66746">
+>
+> CO_BuyMemberTraffic
+>
+> </div>
+>
+> > | Field            | Type                                                                                                                                                                                                                                                                               | Description |
+> > |------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | trafficAmount    | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                                                         |             |
+> > | memberId         | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                                                       |             |
+> > | synchronizerId   | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                                                       |             |
+> > | migrationId      | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)                                                                                                                                                                         |             |
+> > | minTopupInterval | [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)                                                                                                                                                             |             |
+> > | topupStateCid    | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorTopUpState) |             |
+>
+> <div id="constr-splice-wallet-install-cocompletebuytrafficrequest-39331">
+>
+> CO_CompleteBuyTrafficRequest
+>
+> </div>
+>
+> > | Field             | Type                                                                                                                                            | Description |
+> > |-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | trafficRequestCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BuyTrafficRequest |             |
+>
+> <div id="constr-splice-wallet-install-cotap-54191">
+>
+> CO_Tap
+>
+> </div>
+>
+> > | Field     | Type                                                                                                               | Description |
+> > |-----------|--------------------------------------------------------------------------------------------------------------------|-------------|
+> > | tapAmount | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135) |             |
+>
+> <div id="constr-splice-wallet-install-extamuletoperation-64373">
+>
+> ExtAmuletOperation
+>
+> </div>
+>
+> > | Field          | Type | Description                                                                                             |
+> > |----------------|------|---------------------------------------------------------------------------------------------------------|
+> > | dummyUnitField | ()   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+>
+> <div id="constr-splice-wallet-install-cocreateexternalpartysetupproposal-60911">
+>
+> CO_CreateExternalPartySetupProposal
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                | Description |
+> > |----------------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | externalParty        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | preapprovalExpiresAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
+>
+> <div id="constr-splice-wallet-install-coaccepttransferpreapprovalproposal-59253">
+>
+> CO_AcceptTransferPreapprovalProposal
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                      | Description |
+> > |------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | preapprovalProposalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapprovalProposal |             |
+> > | expiresAt              | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                         |             |
+>
+> <div id="constr-splice-wallet-install-corenewtransferpreapproval-62183">
+>
+> CO_RenewTransferPreapproval
+>
+> </div>
+>
+> > | Field               | Type                                                                                                                                              | Description |
+> > |---------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | previousApprovalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval |             |
+> > | newExpiresAt        | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)                                 |             |
+>
+> <div id="constr-splice-wallet-install-cotransferpreapprovalsend-6635">
+>
+> CO_TransferPreapprovalSend
+>
+> </div>
+>
+> > | Field                       | Type                                                                                                                                                                                                                                                                            | Description |
+> > |-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | transferPreapprovalCid      | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval                                                                                                                               |             |
+> > | providerFeaturedAppRightCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight) |             |
+> > | amount                      | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                                                                                                                                              |             |
+> > | description                 | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                     |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletOperation
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletOperation
+>
+> **instance** GetField "amount" AmuletOperation [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "description" AmuletOperation ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
+>
+> **instance** GetField "dummyUnitField" AmuletOperation ()
+>
+> **instance** GetField "expiresAt" AmuletOperation [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "externalParty" AmuletOperation [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "memberId" AmuletOperation [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "migrationId" AmuletOperation [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "minTopupInterval" AmuletOperation [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** GetField "newExpiresAt" AmuletOperation [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "operations" WalletAppInstall_ExecuteBatch \[AmuletOperation\]
+>
+> **instance** GetField "preapprovalExpiresAt" AmuletOperation [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** GetField "preapprovalProposalCid" AmuletOperation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapprovalProposal)
+>
+> **instance** GetField "previousApprovalCid" AmuletOperation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> **instance** GetField "providerFeaturedAppRightCid" AmuletOperation ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
+>
+> **instance** GetField "synchronizerId" AmuletOperation [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "tapAmount" AmuletOperation [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "topupStateCid" AmuletOperation ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorTopUpState))
+>
+> **instance** GetField "trafficAmount" AmuletOperation [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** GetField "trafficRequestCid" AmuletOperation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BuyTrafficRequest)
+>
+> **instance** GetField "transferPreapprovalCid" AmuletOperation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> **instance** SetField "amount" AmuletOperation [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "description" AmuletOperation ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952))
+>
+> **instance** SetField "dummyUnitField" AmuletOperation ()
+>
+> **instance** SetField "expiresAt" AmuletOperation [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "externalParty" AmuletOperation [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "memberId" AmuletOperation [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "migrationId" AmuletOperation [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "minTopupInterval" AmuletOperation [RelTime](/appdev/reference/daml-standard-library/da-time#type-da-time-types-reltime-23082)
+>
+> **instance** SetField "newExpiresAt" AmuletOperation [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "operations" WalletAppInstall_ExecuteBatch \[AmuletOperation\]
+>
+> **instance** SetField "preapprovalExpiresAt" AmuletOperation [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)
+>
+> **instance** SetField "preapprovalProposalCid" AmuletOperation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapprovalProposal)
+>
+> **instance** SetField "previousApprovalCid" AmuletOperation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> **instance** SetField "providerFeaturedAppRightCid" AmuletOperation ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight))
+>
+> **instance** SetField "synchronizerId" AmuletOperation [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "tapAmount" AmuletOperation [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "topupStateCid" AmuletOperation ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ValidatorTopUpState))
+>
+> **instance** SetField "trafficAmount" AmuletOperation [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)
+>
+> **instance** SetField "trafficRequestCid" AmuletOperation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BuyTrafficRequest)
+>
+> **instance** SetField "transferPreapprovalCid" AmuletOperation ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+
+<div id="type-splice-wallet-install-amuletoperationoutcome-52121">
+
+**data** AmuletOperationOutcome
+
+</div>
+
+> <div id="constr-splice-wallet-install-cooacceptedapppayment-45545">
+>
+> COO_AcceptedAppPayment ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedAppPayment)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-coocompleteacceptedtransfer-44398">
+>
+> COO_CompleteAcceptedTransfer (TransferResult, TransferOfferTrackingInfo)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-coosubscriptioninitialpayment-16470">
+>
+> COO_SubscriptionInitialPayment ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionInitialPayment)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-coosubscriptionpayment-22077">
+>
+> COO_SubscriptionPayment ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) SubscriptionPayment)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-coomergetransferinputs-47604">
+>
+> COO_MergeTransferInputs ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-coobuymembertraffic-30084">
+>
+> COO_BuyMemberTraffic ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-coocompletebuytrafficrequest-58397">
+>
+> COO_CompleteBuyTrafficRequest ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MemberTraffic, BuyTrafficRequestTrackingInfo)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-cootap-14325">
+>
+> COO_Tap ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-cooerror-5538">
+>
+> COO_Error InvalidTransferReason
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-extamuletoperationoutcome-44318">
+>
+> ExtAmuletOperationOutcome
+>
+> </div>
+>
+> > | Field          | Type | Description                                                                                             |
+> > |----------------|------|---------------------------------------------------------------------------------------------------------|
+> > | dummyUnitField | ()   | Extension constructor (and field) to work around the current lack of upgrading for variants in Daml 3.0 |
+>
+> <div id="constr-splice-wallet-install-coocreateexternalpartysetupproposal-75945">
+>
+> COO_CreateExternalPartySetupProposal ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) ExternalPartySetupProposal)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-cooaccepttransferpreapprovalproposal-26799">
+>
+> COO_AcceptTransferPreapprovalProposal ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-coorenewtransferpreapproval-16241">
+>
+> COO_RenewTransferPreapproval ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> </div>
+>
+> <div id="constr-splice-wallet-install-cootransferpreapprovalsend-96669">
+>
+> COO_TransferPreapprovalSend ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> </div>
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) AmuletOperationOutcome
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) AmuletOperationOutcome
+>
+> **instance** GetField "dummyUnitField" AmuletOperationOutcome ()
+>
+> **instance** GetField "outcomes" WalletAppInstall_ExecuteBatchResult \[AmuletOperationOutcome\]
+>
+> **instance** SetField "dummyUnitField" AmuletOperationOutcome ()
+>
+> **instance** SetField "outcomes" WalletAppInstall_ExecuteBatchResult \[AmuletOperationOutcome\]
+
+<div id="type-splice-wallet-install-executioncontext-4075">
+
+**data** ExecutionContext
+
+</div>
+
+> <div id="constr-splice-wallet-install-executioncontext-25706">
+>
+> ExecutionContext
+>
+> </div>
+>
+> > | Field          | Type                                                                                                                | Description |
+> > |----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | dso            | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | endUser        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | validator      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | paymentContext | PaymentTransferContext                                                                                              |             |
+>
+> **instance** GetField "dso" ExecutionContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "endUser" ExecutionContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "paymentContext" ExecutionContext PaymentTransferContext
+>
+> **instance** GetField "validator" ExecutionContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "dso" ExecutionContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "endUser" ExecutionContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "paymentContext" ExecutionContext PaymentTransferContext
+>
+> **instance** SetField "validator" ExecutionContext [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+
+<div id="type-splice-wallet-install-walletappinstallacceptedtransferofferabortresult-76594">
+
+**data** WalletAppInstall_AcceptedTransferOffer_AbortResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallacceptedtransferofferabortresult-71839">
+>
+> WalletAppInstall_AcceptedTransferOffer_AbortResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Abort WalletAppInstall_AcceptedTransferOffer_AbortResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Abort WalletAppInstall_AcceptedTransferOffer_AbortResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Abort WalletAppInstall_AcceptedTransferOffer_AbortResult
+
+<div id="type-splice-wallet-install-walletappinstallacceptedtransferofferexpireresult-73364">
+
+**data** WalletAppInstall_AcceptedTransferOffer_ExpireResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallacceptedtransferofferexpireresult-63931">
+>
+> WalletAppInstall_AcceptedTransferOffer_ExpireResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Expire WalletAppInstall_AcceptedTransferOffer_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Expire WalletAppInstall_AcceptedTransferOffer_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Expire WalletAppInstall_AcceptedTransferOffer_ExpireResult
+
+<div id="type-splice-wallet-install-walletappinstallacceptedtransferofferwithdrawresult-30981">
+
+**data** WalletAppInstall_AcceptedTransferOffer_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallacceptedtransferofferwithdrawresult-50854">
+>
+> WalletAppInstall_AcceptedTransferOffer_WithdrawResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Withdraw WalletAppInstall_AcceptedTransferOffer_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Withdraw WalletAppInstall_AcceptedTransferOffer_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_AcceptedTransferOffer_Withdraw WalletAppInstall_AcceptedTransferOffer_WithdrawResult
+
+<div id="type-splice-wallet-install-walletappinstallapppaymentrequestexpireresult-40772">
+
+**data** WalletAppInstall_AppPaymentRequest_ExpireResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallapppaymentrequestexpireresult-9239">
+>
+> WalletAppInstall_AppPaymentRequest_ExpireResult
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                                               | Description |
+> > |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedAppPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment |             |
+>
+> **instance** GetField "terminatedAppPayment" WalletAppInstall_AppPaymentRequest_ExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
+>
+> **instance** SetField "terminatedAppPayment" WalletAppInstall_AppPaymentRequest_ExpireResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_AppPaymentRequest_Expire WalletAppInstall_AppPaymentRequest_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_AppPaymentRequest_Expire WalletAppInstall_AppPaymentRequest_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_AppPaymentRequest_Expire WalletAppInstall_AppPaymentRequest_ExpireResult
+
+<div id="type-splice-wallet-install-walletappinstallapppaymentrequestrejectresult-13912">
+
+**data** WalletAppInstall_AppPaymentRequest_RejectResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallapppaymentrequestrejectresult-2323">
+>
+> WalletAppInstall_AppPaymentRequest_RejectResult
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                                               | Description |
+> > |----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedAppPayment | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment |             |
+>
+> **instance** GetField "terminatedAppPayment" WalletAppInstall_AppPaymentRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
+>
+> **instance** SetField "terminatedAppPayment" WalletAppInstall_AppPaymentRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedAppPayment)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_AppPaymentRequest_Reject WalletAppInstall_AppPaymentRequest_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_AppPaymentRequest_Reject WalletAppInstall_AppPaymentRequest_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_AppPaymentRequest_Reject WalletAppInstall_AppPaymentRequest_RejectResult
+
+<div id="type-splice-wallet-install-walletappinstallbuytrafficrequestcancelresult-7425">
+
+**data** WalletAppInstall_BuyTrafficRequest_CancelResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallbuytrafficrequestcancelresult-5910">
+>
+> WalletAppInstall_BuyTrafficRequest_CancelResult
+>
+> </div>
+>
+> > | Field        | Type                          | Description |
+> > |--------------|-------------------------------|-------------|
+> > | trackingInfo | BuyTrafficRequestTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_BuyTrafficRequest_CancelResult BuyTrafficRequestTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_BuyTrafficRequest_Cancel WalletAppInstall_BuyTrafficRequest_CancelResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_BuyTrafficRequest_Cancel WalletAppInstall_BuyTrafficRequest_CancelResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_BuyTrafficRequest_Cancel WalletAppInstall_BuyTrafficRequest_CancelResult
+
+<div id="type-splice-wallet-install-walletappinstallbuytrafficrequestexpireresult-53806">
+
+**data** WalletAppInstall_BuyTrafficRequest_ExpireResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallbuytrafficrequestexpireresult-73389">
+>
+> WalletAppInstall_BuyTrafficRequest_ExpireResult
+>
+> </div>
+>
+> > | Field        | Type                          | Description |
+> > |--------------|-------------------------------|-------------|
+> > | trackingInfo | BuyTrafficRequestTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_BuyTrafficRequest_ExpireResult BuyTrafficRequestTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_BuyTrafficRequest_Expire WalletAppInstall_BuyTrafficRequest_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_BuyTrafficRequest_Expire WalletAppInstall_BuyTrafficRequest_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_BuyTrafficRequest_Expire WalletAppInstall_BuyTrafficRequest_ExpireResult
+
+<div id="type-splice-wallet-install-walletappinstallcreatebuytrafficrequestresult-63991">
+
+**data** WalletAppInstall_CreateBuyTrafficRequestResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallcreatebuytrafficrequestresult-84558">
+>
+> WalletAppInstall_CreateBuyTrafficRequestResult
+>
+> </div>
+>
+> > | Field             | Type                                                                                                                                            | Description |
+> > |-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | buyTrafficRequest | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BuyTrafficRequest |             |
+>
+> **instance** GetField "buyTrafficRequest" WalletAppInstall_CreateBuyTrafficRequestResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BuyTrafficRequest)
+>
+> **instance** SetField "buyTrafficRequest" WalletAppInstall_CreateBuyTrafficRequestResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) BuyTrafficRequest)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_CreateBuyTrafficRequest WalletAppInstall_CreateBuyTrafficRequestResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_CreateBuyTrafficRequest WalletAppInstall_CreateBuyTrafficRequestResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_CreateBuyTrafficRequest WalletAppInstall_CreateBuyTrafficRequestResult
+
+<div id="type-splice-wallet-install-walletappinstallcreatetransferofferresult-68160">
+
+**data** WalletAppInstall_CreateTransferOfferResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallcreatetransferofferresult-22589">
+>
+> WalletAppInstall_CreateTransferOfferResult
+>
+> </div>
+>
+> > | Field         | Type                                                                                                                                        | Description |
+> > |---------------|---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | transferOffer | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferOffer |             |
+>
+> **instance** GetField "transferOffer" WalletAppInstall_CreateTransferOfferResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferOffer)
+>
+> **instance** SetField "transferOffer" WalletAppInstall_CreateTransferOfferResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferOffer)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_CreateTransferOffer WalletAppInstall_CreateTransferOfferResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_CreateTransferOffer WalletAppInstall_CreateTransferOfferResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_CreateTransferOffer WalletAppInstall_CreateTransferOfferResult
+
+<div id="type-splice-wallet-install-walletappinstallexecutebatchresult-15097">
+
+**data** WalletAppInstall_ExecuteBatchResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallexecutebatchresult-44858">
+>
+> WalletAppInstall_ExecuteBatchResult
+>
+> </div>
+>
+> > | Field           | Type                                                                                                                                                                                                                                               | Description |
+> > |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | endUserName     | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)                                                                                                                                       |             |
+> > | outcomes        | \[AmuletOperationOutcome\]                                                                                                                                                                                                                         |             |
+> > | optEndUserParty | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) WalletAppInstall_ExecuteBatchResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) WalletAppInstall_ExecuteBatchResult
+>
+> **instance** GetField "endUserName" WalletAppInstall_ExecuteBatchResult [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "optEndUserParty" WalletAppInstall_ExecuteBatchResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
+>
+> **instance** GetField "outcomes" WalletAppInstall_ExecuteBatchResult \[AmuletOperationOutcome\]
+>
+> **instance** SetField "endUserName" WalletAppInstall_ExecuteBatchResult [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "optEndUserParty" WalletAppInstall_ExecuteBatchResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932))
+>
+> **instance** SetField "outcomes" WalletAppInstall_ExecuteBatchResult \[AmuletOperationOutcome\]
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_ExecuteBatch WalletAppInstall_ExecuteBatchResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_ExecuteBatch WalletAppInstall_ExecuteBatchResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_ExecuteBatch WalletAppInstall_ExecuteBatchResult
+
+<div id="type-splice-wallet-install-walletappinstallfeaturedapprightscancelresult-9581">
+
+**data** WalletAppInstall_FeaturedAppRights_CancelResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallfeaturedapprightscancelresult-72714">
+>
+> WalletAppInstall_FeaturedAppRights_CancelResult
+>
+> </div>
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_FeaturedAppRights_Cancel WalletAppInstall_FeaturedAppRights_CancelResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_FeaturedAppRights_Cancel WalletAppInstall_FeaturedAppRights_CancelResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_FeaturedAppRights_Cancel WalletAppInstall_FeaturedAppRights_CancelResult
+
+<div id="type-splice-wallet-install-walletappinstallfeaturedapprightsselfgrantresult-93142">
+
+**data** WalletAppInstall_FeaturedAppRights_SelfGrantResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallfeaturedapprightsselfgrantresult-62683">
+>
+> WalletAppInstall_FeaturedAppRights_SelfGrantResult
+>
+> </div>
+>
+> > | Field            | Type                                                                                                                                           | Description |
+> > |------------------|------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | featuredAppRight | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight |             |
+>
+> **instance** GetField "featuredAppRight" WalletAppInstall_FeaturedAppRights_SelfGrantResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** SetField "featuredAppRight" WalletAppInstall_FeaturedAppRights_SelfGrantResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) FeaturedAppRight)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_FeaturedAppRights_SelfGrant WalletAppInstall_FeaturedAppRights_SelfGrantResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_FeaturedAppRights_SelfGrant WalletAppInstall_FeaturedAppRights_SelfGrantResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_FeaturedAppRights_SelfGrant WalletAppInstall_FeaturedAppRights_SelfGrantResult
+
+<div id="type-splice-wallet-install-walletappinstallsubscriptionidlestatecancelsubscriptionresult-84496">
+
+**data** WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallsubscriptionidlestatecancelsubscriptionresult-61435">
+>
+> WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                 | Description |
+> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
+>
+> **instance** GetField "terminatedSubscription" WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** SetField "terminatedSubscription" WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_SubscriptionIdleState_CancelSubscription WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_SubscriptionIdleState_CancelSubscription WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_SubscriptionIdleState_CancelSubscription WalletAppInstall_SubscriptionIdleState_CancelSubscriptionResult
+
+<div id="type-splice-wallet-install-walletappinstallsubscriptionrequestrejectresult-88896">
+
+**data** WalletAppInstall_SubscriptionRequest_RejectResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstallsubscriptionrequestrejectresult-60059">
+>
+> WalletAppInstall_SubscriptionRequest_RejectResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                 | Description |
+> > |------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | terminatedSubscription | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription |             |
+>
+> **instance** GetField "terminatedSubscription" WalletAppInstall_SubscriptionRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** SetField "terminatedSubscription" WalletAppInstall_SubscriptionRequest_RejectResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TerminatedSubscription)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_SubscriptionRequest_Reject WalletAppInstall_SubscriptionRequest_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_SubscriptionRequest_Reject WalletAppInstall_SubscriptionRequest_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_SubscriptionRequest_Reject WalletAppInstall_SubscriptionRequest_RejectResult
+
+<div id="type-splice-wallet-install-walletappinstalltransferofferacceptresult-54230">
+
+**data** WalletAppInstall_TransferOffer_AcceptResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstalltransferofferacceptresult-12149">
+>
+> WalletAppInstall_TransferOffer_AcceptResult
+>
+> </div>
+>
+> > | Field                 | Type                                                                                                                                                | Description |
+> > |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | acceptedTransferOffer | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedTransferOffer |             |
+>
+> **instance** GetField "acceptedTransferOffer" WalletAppInstall_TransferOffer_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedTransferOffer)
+>
+> **instance** SetField "acceptedTransferOffer" WalletAppInstall_TransferOffer_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedTransferOffer)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_TransferOffer_Accept WalletAppInstall_TransferOffer_AcceptResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_TransferOffer_Accept WalletAppInstall_TransferOffer_AcceptResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_TransferOffer_Accept WalletAppInstall_TransferOffer_AcceptResult
+
+<div id="type-splice-wallet-install-walletappinstalltransferofferexpireresult-53807">
+
+**data** WalletAppInstall_TransferOffer_ExpireResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstalltransferofferexpireresult-15612">
+>
+> WalletAppInstall_TransferOffer_ExpireResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_TransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_TransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_TransferOffer_Expire WalletAppInstall_TransferOffer_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_TransferOffer_Expire WalletAppInstall_TransferOffer_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_TransferOffer_Expire WalletAppInstall_TransferOffer_ExpireResult
+
+<div id="type-splice-wallet-install-walletappinstalltransferofferrejectresult-95787">
+
+**data** WalletAppInstall_TransferOffer_RejectResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstalltransferofferrejectresult-23888">
+>
+> WalletAppInstall_TransferOffer_RejectResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_TransferOffer_RejectResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_TransferOffer_RejectResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_TransferOffer_Reject WalletAppInstall_TransferOffer_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_TransferOffer_Reject WalletAppInstall_TransferOffer_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_TransferOffer_Reject WalletAppInstall_TransferOffer_RejectResult
+
+<div id="type-splice-wallet-install-walletappinstalltransferofferwithdrawresult-71362">
+
+**data** WalletAppInstall_TransferOffer_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstalltransferofferwithdrawresult-55293">
+>
+> WalletAppInstall_TransferOffer_WithdrawResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_TransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_TransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) WalletAppInstall WalletAppInstall_TransferOffer_Withdraw WalletAppInstall_TransferOffer_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) WalletAppInstall WalletAppInstall_TransferOffer_Withdraw WalletAppInstall_TransferOffer_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) WalletAppInstall WalletAppInstall_TransferOffer_Withdraw WalletAppInstall_TransferOffer_WithdrawResult
+
+<div id="type-splice-wallet-install-walletappinstalltransferpreapprovalproposalcreateresult-12514">
+
+**data** WalletAppInstall_TransferPreapprovalProposal_CreateResult
+
+</div>
+
+> <div id="constr-splice-wallet-install-walletappinstalltransferpreapprovalproposalcreateresult-3417">
+>
+> WalletAppInstall_TransferPreapprovalProposal_CreateResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                                      | Description |
+> > |------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | preapprovalProposalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapprovalProposal |             |
+>
+> **instance** GetField "preapprovalProposalCid" WalletAppInstall_TransferPreapprovalProposal_CreateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapprovalProposal)
+>
+> **instance** SetField "preapprovalProposalCid" WalletAppInstall_TransferPreapprovalProposal_CreateResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapprovalProposal)
+
+## Functions
+
+<div id="function-splice-wallet-install-executeamuletoperationrec-79799">
+
+executeAmuletOperationRec
+: ExecutionContext -\> \[TransferInput\] -\> \[AmuletOperationOutcome\] -\> \[AmuletOperation\] -\> [Update](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-update-68072) \[AmuletOperationOutcome\]
+
+</div>
+
+<div id="function-splice-wallet-install-mkmergeamuletandrewardstransfer-3655">
+
+mkMergeAmuletAndRewardsTransfer
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> \[TransferInput\] -\> Transfer
+
+</div>
+
+<div id="function-splice-wallet-install-unpackcid-65301">
+
+unpackCid
+: AnyValue -\> AnyContractId
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-mintingdelegation.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-mintingdelegation.mdx
@@ -1,0 +1,293 @@
+---
+title: "Splice.Wallet.MintingDelegation"
+description: "Documentation for Splice.Wallet.MintingDelegation"
+---
+
+{/* COPIED_START source="splice:daml/splice-wallet/docs/Splice-Wallet-MintingDelegation.rst" tag="0.6.4" hash="cd95567c" */}
+
+## Templates
+
+<div id="type-splice-wallet-mintingdelegation-mintingdelegation-65428">
+
+**template** MintingDelegation
+
+</div>
+
+> The right allowing the delegate to mint rewards on behalf of the beneficiary.
+>
+> Signatory: beneficiary, delegate
+>
+> | Field            | Type                                                                                                                | Description                                                                                                                                                                                                        |
+> |------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> | beneficiary      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party on whose behalf minting is performed.                                                                                                                                                                    |
+> | delegate         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The party authorized to perform minting operations.                                                                                                                                                                |
+> | dso              | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | Expected DSO party.                                                                                                                                                                                                |
+> | expiresAt        | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | The time after which this delegation is no longer valid.                                                                                                                                                           |
+> | amuletMergeLimit | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | The number of amulet contracts to keep after auto-merging; i.e., auto-merge contracts once there are strictly more than this number of contracts. This is a suggestion to the delegate and is not enforced in daml |
+>
+> - **Choice** Archive
+>
+>   Controller: beneficiary, delegate
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-mintingdelegation-mintingdelegationmint-91388">
+>
+>   **Choice** MintingDelegation_Mint
+>
+>   </div>
+>
+>   Controller: delegate
+>
+>   Returns: MintingDelegation_MintResult
+>
+>   | Field   | Type                   | Description                                                                                        |
+>   |---------|------------------------|----------------------------------------------------------------------------------------------------|
+>   | inputs  | \[TransferInput\]      | The inputs to the transfer, like the validator liveness activity records owned by the beneficiary. |
+>   | context | PaymentTransferContext | The transfer context including amulet rules.                                                       |
+>
+> - <div id="type-splice-wallet-mintingdelegation-mintingdelegationreject-13031">
+>
+>   **Choice** MintingDelegation_Reject
+>
+>   </div>
+>
+>   Controller: delegate
+>
+>   Returns: MintingDelegation_RejectResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-mintingdelegation-mintingdelegationwithdraw-75826">
+>
+>   **Choice** MintingDelegation_Withdraw
+>
+>   </div>
+>
+>   Controller: beneficiary
+>
+>   Returns: MintingDelegation_WithdrawResult
+>
+>   (no fields)
+
+<div id="type-splice-wallet-mintingdelegation-mintingdelegationproposal-50922">
+
+**template** MintingDelegationProposal
+
+</div>
+
+> Proposal by the user to setup a minting delegation.
+>
+> Signatory: (DA.Internal.Record.getField @"beneficiary" delegation)
+>
+> | Field      | Type              | Description                               |
+> |------------|-------------------|-------------------------------------------|
+> | delegation | MintingDelegation | The delegation to be created if accepted. |
+>
+> - **Choice** Archive
+>
+>   Controller: (DA.Internal.Record.getField @"beneficiary" delegation)
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-mintingdelegation-mintingdelegationproposalaccept-24656">
+>
+>   **Choice** MintingDelegationProposal_Accept
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"delegate" delegation)
+>
+>   Returns: MintingDelegationProposal_AcceptResult
+>
+>   | Field                 | Type                                                                                                                                                                                                                                                                             | Description                                                                                                               |
+>   |-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+>   | existingDelegationCid | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MintingDelegation) | Optional existing delegation to archive while creating the new one. Useful for changing the parameters of the delegation. |
+>
+> - <div id="type-splice-wallet-mintingdelegation-mintingdelegationproposalreject-13601">
+>
+>   **Choice** MintingDelegationProposal_Reject
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"delegate" delegation)
+>
+>   Returns: MintingDelegationProposal_RejectResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-mintingdelegation-mintingdelegationproposalwithdraw-3376">
+>
+>   **Choice** MintingDelegationProposal_Withdraw
+>
+>   </div>
+>
+>   Controller: (DA.Internal.Record.getField @"beneficiary" delegation)
+>
+>   Returns: MintingDelegationProposal_WithdrawResult
+>
+>   (no fields)
+
+## Data Types
+
+<div id="type-splice-wallet-mintingdelegation-mintingdelegationproposalacceptresult-95133">
+
+**data** MintingDelegationProposal_AcceptResult
+
+</div>
+
+> <div id="constr-splice-wallet-mintingdelegation-mintingdelegationproposalacceptresult-35064">
+>
+> MintingDelegationProposal_AcceptResult
+>
+> </div>
+>
+> > | Field                | Type                                                                                                                                            | Description |
+> > |----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | mintingDelegationCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MintingDelegation |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MintingDelegationProposal_AcceptResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MintingDelegationProposal_AcceptResult
+>
+> **instance** GetField "mintingDelegationCid" MintingDelegationProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MintingDelegation)
+>
+> **instance** SetField "mintingDelegationCid" MintingDelegationProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) MintingDelegation)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MintingDelegationProposal MintingDelegationProposal_Accept MintingDelegationProposal_AcceptResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MintingDelegationProposal MintingDelegationProposal_Accept MintingDelegationProposal_AcceptResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MintingDelegationProposal MintingDelegationProposal_Accept MintingDelegationProposal_AcceptResult
+
+<div id="type-splice-wallet-mintingdelegation-mintingdelegationproposalrejectresult-38748">
+
+**data** MintingDelegationProposal_RejectResult
+
+</div>
+
+> <div id="constr-splice-wallet-mintingdelegation-mintingdelegationproposalrejectresult-9461">
+>
+> MintingDelegationProposal_RejectResult
+>
+> </div>
+>
+> > (no fields)
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MintingDelegationProposal_RejectResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MintingDelegationProposal_RejectResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MintingDelegationProposal MintingDelegationProposal_Reject MintingDelegationProposal_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MintingDelegationProposal MintingDelegationProposal_Reject MintingDelegationProposal_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MintingDelegationProposal MintingDelegationProposal_Reject MintingDelegationProposal_RejectResult
+
+<div id="type-splice-wallet-mintingdelegation-mintingdelegationproposalwithdrawresult-74809">
+
+**data** MintingDelegationProposal_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-wallet-mintingdelegation-mintingdelegationproposalwithdrawresult-928">
+>
+> MintingDelegationProposal_WithdrawResult
+>
+> </div>
+>
+> > (no fields)
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MintingDelegationProposal_WithdrawResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MintingDelegationProposal_WithdrawResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MintingDelegationProposal MintingDelegationProposal_Withdraw MintingDelegationProposal_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MintingDelegationProposal MintingDelegationProposal_Withdraw MintingDelegationProposal_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MintingDelegationProposal MintingDelegationProposal_Withdraw MintingDelegationProposal_WithdrawResult
+
+<div id="type-splice-wallet-mintingdelegation-mintingdelegationmintresult-4933">
+
+**data** MintingDelegation_MintResult
+
+</div>
+
+> <div id="constr-splice-wallet-mintingdelegation-mintingdelegationmintresult-18172">
+>
+> MintingDelegation_MintResult
+>
+> </div>
+>
+> > | Field          | Type           | Description |
+> > |----------------|----------------|-------------|
+> > | transferResult | TransferResult |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MintingDelegation_MintResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MintingDelegation_MintResult
+>
+> **instance** GetField "transferResult" MintingDelegation_MintResult TransferResult
+>
+> **instance** SetField "transferResult" MintingDelegation_MintResult TransferResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MintingDelegation MintingDelegation_Mint MintingDelegation_MintResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MintingDelegation MintingDelegation_Mint MintingDelegation_MintResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MintingDelegation MintingDelegation_Mint MintingDelegation_MintResult
+
+<div id="type-splice-wallet-mintingdelegation-mintingdelegationrejectresult-12270">
+
+**data** MintingDelegation_RejectResult
+
+</div>
+
+> <div id="constr-splice-wallet-mintingdelegation-mintingdelegationrejectresult-24691">
+>
+> MintingDelegation_RejectResult
+>
+> </div>
+>
+> > (no fields)
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MintingDelegation_RejectResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MintingDelegation_RejectResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MintingDelegation MintingDelegation_Reject MintingDelegation_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MintingDelegation MintingDelegation_Reject MintingDelegation_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MintingDelegation MintingDelegation_Reject MintingDelegation_RejectResult
+
+<div id="type-splice-wallet-mintingdelegation-mintingdelegationwithdrawresult-83199">
+
+**data** MintingDelegation_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-wallet-mintingdelegation-mintingdelegationwithdrawresult-61082">
+>
+> MintingDelegation_WithdrawResult
+>
+> </div>
+>
+> > (no fields)
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) MintingDelegation_WithdrawResult
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) MintingDelegation_WithdrawResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) MintingDelegation MintingDelegation_Withdraw MintingDelegation_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) MintingDelegation MintingDelegation_Withdraw MintingDelegation_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) MintingDelegation MintingDelegation_Withdraw MintingDelegation_WithdrawResult
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-topupstate.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-topupstate.mdx
@@ -1,0 +1,51 @@
+---
+title: "Splice.Wallet.TopUpState"
+description: "Documentation for Splice.Wallet.TopUpState"
+---
+
+{/* COPIED_START source="splice:daml/splice-wallet/docs/Splice-Wallet-TopUpState.rst" tag="0.6.4" hash="d6502930" */}
+
+## Templates
+
+<div id="type-splice-wallet-topupstate-validatortopupstate-56541">
+
+**template** ValidatorTopUpState
+
+</div>
+
+> The state of a given top-up loop.
+>
+> Records the last time when this validator purchased traffic for this sequencer member in order to:
+>
+> 1.  allow for crash fault tolerant deduplication of traffic purchases
+> 2.  allow enforcing a rate limit to prevent the validator from spending too much on traffic purchases.
+>
+> Signatory: validator
+>
+> | Field           | Type                                                                                                                | Description                                                                                   |
+> |-----------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+> | dso             | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |                                                                                               |
+> | validator       | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The validator operator purchasing traffic for the given sequencer member                      |
+> | memberId        | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | The id of the sequencer member (participant or mediator) for which traffic has been purchased |
+> | synchronizerId  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        | The id of the synchronizer for which this contract tracks purchased extra traffic             |
+> | migrationId     | [Int](/appdev/reference/daml-standard-library/prelude#type-ghc-types-int-37261)          | The migration id of the synchronizer for which this contract tracks purchased extra traffic   |
+> | lastPurchasedAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   | Time when the traffic was last purchased by the validator for the given sequencer member      |
+>
+> - **Choice** Archive
+>
+>   Controller: validator
+>
+>   Returns: ()
+>
+>   (no fields)
+
+## Functions
+
+<div id="function-splice-wallet-topupstate-initialvalidatortopupstate-90212">
+
+initialValidatorTopUpState
+: [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) -\> ValidatorTopUpState
+
+</div>
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferoffer.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferoffer.mdx
@@ -1,0 +1,477 @@
+---
+title: "Splice.Wallet.TransferOffer"
+description: "Documentation for Splice.Wallet.TransferOffer"
+---
+
+{/* COPIED_START source="splice:daml/splice-wallet/docs/Splice-Wallet-TransferOffer.rst" tag="0.6.4" hash="f1fa6e04" */}
+
+## Templates
+
+<div id="type-splice-wallet-transferoffer-acceptedtransferoffer-37657">
+
+**template** AcceptedTransferOffer
+
+</div>
+
+> Signatory: sender, receiver
+>
+> | Field      | Type                                                                                                                | Description |
+> |------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | sender     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | receiver   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | dso        | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | amount     | PaymentAmount                                                                                                       |             |
+> | expiresAt  | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
+> | trackingId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>
+> - <div id="type-splice-wallet-transferoffer-acceptedtransferofferabort-66868">
+>
+>   **Choice** AcceptedTransferOffer_Abort
+>
+>   </div>
+>
+>   Controller: sender
+>
+>   Returns: AcceptedTransferOffer_AbortResult
+>
+>   | Field  | Type                                                                                                         | Description |
+>   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> - <div id="type-splice-wallet-transferoffer-acceptedtransferoffercomplete-88466">
+>
+>   **Choice** AcceptedTransferOffer_Complete
+>
+>   </div>
+>
+>   Controller: sender, walletProvider
+>
+>   Returns: AcceptedTransferOffer_CompleteResult
+>
+>   | Field           | Type                                                                                                                | Description |
+>   |-----------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | inputs          | \[TransferInput\]                                                                                                   |             |
+>   | transferContext | PaymentTransferContext                                                                                              |             |
+>   | walletProvider  | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-wallet-transferoffer-acceptedtransferofferexpire-98344">
+>
+>   **Choice** AcceptedTransferOffer_Expire
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: AcceptedTransferOffer_ExpireResult
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | actor | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-wallet-transferoffer-acceptedtransferofferwithdraw-26317">
+>
+>   **Choice** AcceptedTransferOffer_Withdraw
+>
+>   </div>
+>
+>   Controller: receiver
+>
+>   Returns: AcceptedTransferOffer_WithdrawResult
+>
+>   | Field  | Type                                                                                                         | Description |
+>   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+>
+> - **Choice** Archive
+>
+>   Controller: sender, receiver
+>
+>   Returns: ()
+>
+>   (no fields)
+
+<div id="type-splice-wallet-transferoffer-transferoffer-51604">
+
+**template** TransferOffer
+
+</div>
+
+> Signatory: sender
+>
+> | Field       | Type                                                                                                                | Description |
+> |-------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> | sender      | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | receiver    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | dso         | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> | amount      | PaymentAmount                                                                                                       |             |
+> | description | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+> | expiresAt   | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886)   |             |
+> | trackingId  | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+>
+> - **Choice** Archive
+>
+>   Controller: sender
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-transferoffer-transferofferaccept-78794">
+>
+>   **Choice** TransferOffer_Accept
+>
+>   </div>
+>
+>   Controller: receiver
+>
+>   Returns: TransferOffer_AcceptResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-transferoffer-transferofferexpire-75051">
+>
+>   **Choice** TransferOffer_Expire
+>
+>   </div>
+>
+>   Controller: actor
+>
+>   Returns: TransferOffer_ExpireResult
+>
+>   | Field | Type                                                                                                                | Description |
+>   |-------|---------------------------------------------------------------------------------------------------------------------|-------------|
+>   | actor | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> - <div id="type-splice-wallet-transferoffer-transferofferreject-41375">
+>
+>   **Choice** TransferOffer_Reject
+>
+>   </div>
+>
+>   Controller: receiver
+>
+>   Returns: TransferOffer_RejectResult
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-transferoffer-transferofferwithdraw-41986">
+>
+>   **Choice** TransferOffer_Withdraw
+>
+>   </div>
+>
+>   Controller: sender
+>
+>   Returns: TransferOffer_WithdrawResult
+>
+>   | Field  | Type                                                                                                         | Description |
+>   |--------|--------------------------------------------------------------------------------------------------------------|-------------|
+>   | reason | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952) |             |
+
+## Data Types
+
+<div id="type-splice-wallet-transferoffer-acceptedtransferofferabortresult-19853">
+
+**data** AcceptedTransferOffer_AbortResult
+
+</div>
+
+> <div id="constr-splice-wallet-transferoffer-acceptedtransferofferabortresult-99882">
+>
+> AcceptedTransferOffer_AbortResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AcceptedTransferOffer AcceptedTransferOffer_Abort AcceptedTransferOffer_AbortResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AcceptedTransferOffer AcceptedTransferOffer_Abort AcceptedTransferOffer_AbortResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AcceptedTransferOffer AcceptedTransferOffer_Abort AcceptedTransferOffer_AbortResult
+
+<div id="type-splice-wallet-transferoffer-acceptedtransferoffercompleteresult-69887">
+
+**data** AcceptedTransferOffer_CompleteResult
+
+</div>
+
+> <div id="constr-splice-wallet-transferoffer-acceptedtransferoffercompleteresult-43306">
+>
+> AcceptedTransferOffer_CompleteResult
+>
+> </div>
+>
+> > | Field              | Type                                                                                                                                                                                                                                                                  | Description |
+> > |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | transferResult     | TransferResult                                                                                                                                                                                                                                                        |             |
+> > | trackingInfo       | TransferOfferTrackingInfo                                                                                                                                                                                                                                             |             |
+> > | senderChangeAmulet | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet) |             |
+>
+> **instance** GetField "senderChangeAmulet" AcceptedTransferOffer_CompleteResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** GetField "trackingInfo" AcceptedTransferOffer_CompleteResult TransferOfferTrackingInfo
+>
+> **instance** GetField "transferResult" AcceptedTransferOffer_CompleteResult TransferResult
+>
+> **instance** SetField "senderChangeAmulet" AcceptedTransferOffer_CompleteResult ([Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) Amulet))
+>
+> **instance** SetField "trackingInfo" AcceptedTransferOffer_CompleteResult TransferOfferTrackingInfo
+>
+> **instance** SetField "transferResult" AcceptedTransferOffer_CompleteResult TransferResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AcceptedTransferOffer AcceptedTransferOffer_Complete AcceptedTransferOffer_CompleteResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AcceptedTransferOffer AcceptedTransferOffer_Complete AcceptedTransferOffer_CompleteResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AcceptedTransferOffer AcceptedTransferOffer_Complete AcceptedTransferOffer_CompleteResult
+
+<div id="type-splice-wallet-transferoffer-acceptedtransferofferexpireresult-60205">
+
+**data** AcceptedTransferOffer_ExpireResult
+
+</div>
+
+> <div id="constr-splice-wallet-transferoffer-acceptedtransferofferexpireresult-67584">
+>
+> AcceptedTransferOffer_ExpireResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AcceptedTransferOffer AcceptedTransferOffer_Expire AcceptedTransferOffer_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AcceptedTransferOffer AcceptedTransferOffer_Expire AcceptedTransferOffer_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AcceptedTransferOffer AcceptedTransferOffer_Expire AcceptedTransferOffer_ExpireResult
+
+<div id="type-splice-wallet-transferoffer-acceptedtransferofferwithdrawresult-79292">
+
+**data** AcceptedTransferOffer_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-wallet-transferoffer-acceptedtransferofferwithdrawresult-34065">
+>
+> AcceptedTransferOffer_WithdrawResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) AcceptedTransferOffer AcceptedTransferOffer_Withdraw AcceptedTransferOffer_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) AcceptedTransferOffer AcceptedTransferOffer_Withdraw AcceptedTransferOffer_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) AcceptedTransferOffer AcceptedTransferOffer_Withdraw AcceptedTransferOffer_WithdrawResult
+
+<div id="type-splice-wallet-transferoffer-transferoffertrackinginfo-52959">
+
+**data** TransferOfferTrackingInfo
+
+</div>
+
+> <div id="constr-splice-wallet-transferoffer-transferoffertrackinginfo-29420">
+>
+> TransferOfferTrackingInfo
+>
+> </div>
+>
+> > | Field      | Type                                                                                                                | Description |
+> > |------------|---------------------------------------------------------------------------------------------------------------------|-------------|
+> > | trackingId | [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)        |             |
+> > | sender     | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+> > | receiver   | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) |             |
+>
+> **instance** [Eq](/appdev/reference/daml-standard-library/prelude#class-ghc-classes-eq-22713) TransferOfferTrackingInfo
+>
+> **instance** [Show](/appdev/reference/daml-standard-library/prelude#class-ghc-show-show-65360) TransferOfferTrackingInfo
+>
+> **instance** GetField "receiver" TransferOfferTrackingInfo [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "sender" TransferOfferTrackingInfo [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** GetField "trackingId" TransferOfferTrackingInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_TransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_TransferOffer_RejectResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" WalletAppInstall_TransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" AcceptedTransferOffer_CompleteResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" TransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" TransferOffer_RejectResult TransferOfferTrackingInfo
+>
+> **instance** GetField "trackingInfo" TransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** SetField "receiver" TransferOfferTrackingInfo [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "sender" TransferOfferTrackingInfo [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)
+>
+> **instance** SetField "trackingId" TransferOfferTrackingInfo [Text](/appdev/reference/daml-standard-library/prelude#type-ghc-types-text-51952)
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_TransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_TransferOffer_RejectResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" WalletAppInstall_TransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" AcceptedTransferOffer_AbortResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" AcceptedTransferOffer_CompleteResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" AcceptedTransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" AcceptedTransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" TransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" TransferOffer_RejectResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" TransferOffer_WithdrawResult TransferOfferTrackingInfo
+
+<div id="type-splice-wallet-transferoffer-transferofferacceptresult-62459">
+
+**data** TransferOffer_AcceptResult
+
+</div>
+
+> <div id="constr-splice-wallet-transferoffer-transferofferacceptresult-68938">
+>
+> TransferOffer_AcceptResult
+>
+> </div>
+>
+> > | Field                 | Type                                                                                                                                                | Description |
+> > |-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | acceptedTransferOffer | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedTransferOffer |             |
+>
+> **instance** GetField "acceptedTransferOffer" TransferOffer_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedTransferOffer)
+>
+> **instance** SetField "acceptedTransferOffer" TransferOffer_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) AcceptedTransferOffer)
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferOffer TransferOffer_Accept TransferOffer_AcceptResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferOffer TransferOffer_Accept TransferOffer_AcceptResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferOffer TransferOffer_Accept TransferOffer_AcceptResult
+
+<div id="type-splice-wallet-transferoffer-transferofferexpireresult-84418">
+
+**data** TransferOffer_ExpireResult
+
+</div>
+
+> <div id="constr-splice-wallet-transferoffer-transferofferexpireresult-36631">
+>
+> TransferOffer_ExpireResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" TransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" TransferOffer_ExpireResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferOffer TransferOffer_Expire TransferOffer_ExpireResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferOffer TransferOffer_Expire TransferOffer_ExpireResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferOffer TransferOffer_Expire TransferOffer_ExpireResult
+
+<div id="type-splice-wallet-transferoffer-transferofferrejectresult-40046">
+
+**data** TransferOffer_RejectResult
+
+</div>
+
+> <div id="constr-splice-wallet-transferoffer-transferofferrejectresult-28795">
+>
+> TransferOffer_RejectResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" TransferOffer_RejectResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" TransferOffer_RejectResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferOffer TransferOffer_Reject TransferOffer_RejectResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferOffer TransferOffer_Reject TransferOffer_RejectResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferOffer TransferOffer_Reject TransferOffer_RejectResult
+
+<div id="type-splice-wallet-transferoffer-transferofferwithdrawresult-27711">
+
+**data** TransferOffer_WithdrawResult
+
+</div>
+
+> <div id="constr-splice-wallet-transferoffer-transferofferwithdrawresult-1170">
+>
+> TransferOffer_WithdrawResult
+>
+> </div>
+>
+> > | Field        | Type                      | Description |
+> > |--------------|---------------------------|-------------|
+> > | trackingInfo | TransferOfferTrackingInfo |             |
+>
+> **instance** GetField "trackingInfo" TransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** SetField "trackingInfo" TransferOffer_WithdrawResult TransferOfferTrackingInfo
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferOffer TransferOffer_Withdraw TransferOffer_WithdrawResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferOffer TransferOffer_Withdraw TransferOffer_WithdrawResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferOffer TransferOffer_Withdraw TransferOffer_WithdrawResult
+
+{/* COPIED_END */}

--- a/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferpreapproval.mdx
+++ b/docs-main/sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferpreapproval.mdx
@@ -1,0 +1,86 @@
+---
+title: "Splice.Wallet.TransferPreapproval"
+description: "Documentation for Splice.Wallet.TransferPreapproval"
+---
+
+{/* COPIED_START source="splice:daml/splice-wallet/docs/Splice-Wallet-TransferPreapproval.rst" tag="0.6.4" hash="dcf90dc1" */}
+
+## Templates
+
+<div id="type-splice-wallet-transferpreapproval-transferpreapprovalproposal-39002">
+
+**template** TransferPreapprovalProposal
+
+</div>
+
+> Signatory: receiver
+>
+> | Field       | Type                                                                                                                                                                                                                                               | Description                                                                                                                                                                   |
+> |-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+> | receiver    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |                                                                                                                                                                               |
+> | provider    | [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932)                                                                                                                                |                                                                                                                                                                               |
+> | expectedDso | [Optional](/appdev/reference/daml-standard-library/prelude#type-da-internal-prelude-optional-37153) [Party](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-party-57932) | The DSO party that the receiver expects to bet set on the transfer preapproval. Must be set. It is only optional due to being introduced as part of a smart-contract upgrade. |
+>
+> - **Choice** Archive
+>
+>   Controller: receiver
+>
+>   Returns: ()
+>
+>   (no fields)
+>
+> - <div id="type-splice-wallet-transferpreapproval-transferpreapprovalproposalaccept-6548">
+>
+>   **Choice** TransferPreapprovalProposal_Accept
+>
+>   </div>
+>
+>   Controller: provider
+>
+>   Returns: TransferPreapprovalProposal_AcceptResult
+>
+>   | Field     | Type                                                                                                              | Description |
+>   |-----------|-------------------------------------------------------------------------------------------------------------------|-------------|
+>   | context   | PaymentTransferContext                                                                                            |             |
+>   | inputs    | \[TransferInput\]                                                                                                 |             |
+>   | expiresAt | [Time](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-time-63886) |             |
+
+## Data Types
+
+<div id="type-splice-wallet-transferpreapproval-transferpreapprovalproposalacceptresult-56845">
+
+**data** TransferPreapprovalProposal_AcceptResult
+
+</div>
+
+> <div id="constr-splice-wallet-transferpreapproval-transferpreapprovalproposalacceptresult-12116">
+>
+> TransferPreapprovalProposal_AcceptResult
+>
+> </div>
+>
+> > | Field                  | Type                                                                                                                                              | Description |
+> > |------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+> > | transferPreapprovalCid | [ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval |             |
+> > | transferResult         | TransferResult                                                                                                                                    |             |
+> > | amuletPaid             | [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)                                |             |
+>
+> **instance** GetField "amuletPaid" TransferPreapprovalProposal_AcceptResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** GetField "transferPreapprovalCid" TransferPreapprovalProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> **instance** GetField "transferResult" TransferPreapprovalProposal_AcceptResult TransferResult
+>
+> **instance** SetField "amuletPaid" TransferPreapprovalProposal_AcceptResult [Decimal](/appdev/reference/daml-standard-library/prelude#type-ghc-types-decimal-18135)
+>
+> **instance** SetField "transferPreapprovalCid" TransferPreapprovalProposal_AcceptResult ([ContractId](/appdev/reference/daml-standard-library/prelude#type-da-internal-lf-contractid-95282) TransferPreapproval)
+>
+> **instance** SetField "transferResult" TransferPreapprovalProposal_AcceptResult TransferResult
+>
+> **instance** [HasExercise](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasexercise-70422) TransferPreapprovalProposal TransferPreapprovalProposal_Accept TransferPreapprovalProposal_AcceptResult
+>
+> **instance** [HasFromAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hasfromanychoice-81184) TransferPreapprovalProposal TransferPreapprovalProposal_Accept TransferPreapprovalProposal_AcceptResult
+>
+> **instance** [HasToAnyChoice](/appdev/reference/daml-standard-library/prelude#class-da-internal-template-functions-hastoanychoice-82571) TransferPreapprovalProposal TransferPreapprovalProposal_Accept TransferPreapprovalProposal_AcceptResult
+
+{/* COPIED_END */}


### PR DESCRIPTION
## Summary

Addresses the compiled-package portion of tracking issue #539.

PR #540 ported the 9 **archived** Splice Daml packages (where pre-rendered RST is checked into the splice repo). This PR completes the picture by codegenning the 12 **compiled** packages — the ones the splice repo regenerates from `.daml` source at every release — and importing them under the same nav structure.

## Packages added (12)

| Package | Source path in splice 0.6.4 | Module pages |
|---|---|---|
| `splice-amulet` | `daml/splice-amulet` | 18 |
| `splice-amulet-name-service` | `daml/splice-amulet-name-service` | 2 |
| `splice-dso-governance` | `daml/splice-dso-governance` | 7 |
| `splice-util` | `daml/splice-util` | 1 |
| `splice-util-batched-markers` | `daml/splice-util-batched-markers` | 1 |
| `splice-util-featured-app-proxies` | `daml/splice-util-featured-app-proxies` | 2 |
| `splice-util-token-standard-wallet` | `daml/splice-util-token-standard-wallet` | 1 |
| `splice-validator-lifecycle` | `daml/splice-validator-lifecycle` | 1 |
| `splice-wallet` | `daml/splice-wallet` | 6 |
| `splice-wallet-payments` | `daml/splice-wallet-payments` | 2 |
| `splice-token-standard-test` | `token-standard/splice-token-standard-test` | 7 |
| `splice-token-test-trading-app` | `token-standard/examples/splice-token-test-trading-app` | 1 |

## Follow-up

Pinned to splice `0.6.4`. When splice releases a new version with API changes, this content has to be regenerated. The exact recipe is in the merge commit message and can be turned into a `scripts/generate_splice_daml_reference.py` (sibling to `generate_daml_standard_library_reference.py`) in a future PR if this becomes a recurring task. The build-and-docgen step took ~3-5 minutes total across all 12 packages.