### PR TITLE
Remove inline TOC with broken URLs from observability page (#508)

### DIFF
--- a/docs-main/appdev/quickstart/observability-and-tracing.mdx
+++ b/docs-main/appdev/quickstart/observability-and-tracing.mdx
@@ -18,30 +18,6 @@ import ExternalCnQuickstartMainCnQuickstartRstCodeSdkDocsSharableSdkQuickstartOb
 The screenshots in this guide are taken from multiple sessions and are inconsistent with each other. This will be rectified once some of the updates are committed.
 </Note>
 
-**Contents**
-
-Overview of [observability]()
-
-> The LocalNet [configuration]()
->
-> Observability [overview]()
->
-> Daml [Shell]()
->
-> [Grafana](#grafana)
->
-> Direct Postgres [access]()
->
-> Interactive [debugger]()
-
-Observability and [tracing]()
-
-> Correlation [identifiers]()
->
-> Direct Ledger inspection using correlation [identifiers]()
->
-> Correlated Logs and traces using correlation [identifiers]()
-
 It's assumed that you have read the quickstart getting started guide and explore the demo. If you haven't, we strongly encourage those documents to establish a baseline understanding of observability.
 
 ## Overview of observability


### PR DESCRIPTION
## Summary

Closes #508.

The "Canton Network Quickstart observability & troubleshooting overview" page (`appdev/quickstart/observability-and-tracing`) had a 23-line "Contents" inline TOC at the top — a leftover from the upstream RST's `contents::` directive that didn't survive the RST→MDX conversion cleanly. After conversion, 11 of its 12 entries rendered as broken `[text]()` links pointing nowhere; only the `[Grafana](#grafana)` anchor was correct.