### PR TITLE
Fix empty DPM link & remove Assistant link in JSON API quickstart prerequisites

### DIFF
--- a/docs-main/appdev/quickstart/json-api.mdx
+++ b/docs-main/appdev/quickstart/json-api.mdx
@@ -81,7 +81,7 @@ You are ready to extend the CN Quickstart to interact directly with your LocalNe
 
 ## Prerequisites
 
-This guide requires the Digital Asset Package Manager. Follow installation instructions at [DPM](). (Exception: if you're running Daml 3.3, then use the Daml [Assistant]().)
+This guide requires the Digital Asset Package Manager. Follow installation instructions at [DPM](/sdks-tools/cli-tools/dpm).
 
 You should have also finished the Quickstart installation and Explore the demo tutorial. We also recommend reading the developer journey lifecycle to better understand how Quickstart bootstraps your Canton Network development by providing the tooling you will need for any CN app.
 


### PR DESCRIPTION
## Summary

Closes #501.

The Prerequisites section of `appdev/quickstart/json-api` had two empty markdown links: `[DPM]()` and `[Assistant]()`. The DPM link is repointed to the internal DPM reference page; the Daml 3.3 Assistant aside is removed since it pointed at an empty link.

Before:

> This guide requires the Digital Asset Package Manager. Follow installation instructions at [DPM](). (Exception: if you're running Daml 3.3, then use the Daml [Assistant]().)

After:

> This guide requires the Digital Asset Package Manager. Follow installation instructions at [DPM](/sdks-tools/cli-tools/dpm).