### PR TITLE
Update footer GitHub link to canton-network org

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -2463,7 +2463,7 @@
   "footer": {
     "socials": {
       "x": "https://x.com/CantonNetwork",
-      "github": "https://github.com/digital-asset",
+      "github": "https://github.com/canton-network",
       "linkedin": "https://www.linkedin.com/company/canton-network/",
       "discord": "https://discord.gg/canton",
       "telegram": "https://t.me/CantonNetwork1"


### PR DESCRIPTION
## Summary

The footer GitHub social link previously pointed to `https://github.com/digital-asset`. Repointed to `https://github.com/canton-network` to reflect the current home of the Canton Network repos.