### PR TITLE
Rename Wallet Kernel SDK to Wallet SDK

### DIFF
--- a/docs-main/integrations/wallet/sdk-download.mdx
+++ b/docs-main/integrations/wallet/sdk-download.mdx
@@ -7,9 +7,9 @@ description: "Download and install the Canton Network Wallet SDK for building wa
 import CantonIntegrationsWalletSdkDownloadL20 from "/snippets/canton-docs/integrations_wallet_sdk-download_L20.mdx";
 import CantonIntegrationsWalletSdkDownloadL14 from "/snippets/canton-docs/integrations_wallet_sdk-download_L14.mdx";
 
-The Splice Wallet SDK provides TypeScript/JavaScript libraries for interacting with Canton Coin and the Canton Network Token Standard. Use it to build wallet applications, integrate Canton Coin payments into your dApp, or manage external party signing workflows.
+The Wallet SDK provides TypeScript/JavaScript libraries for interacting with Canton Coin and the Canton Network Token Standard. Use it to build wallet applications, integrate Canton Coin payments into your dApp, or manage external party signing workflows.
 
-The SDK is published as the [`@canton-network/wallet-sdk`](https://www.npmjs.com/package/@canton-network/wallet-sdk) npm package. Source code and the OpenRPC specification for the dApp API are available in the [splice-wallet-kernel repository](https://github.com/canton-network/wallet-gateway).
+The SDK is published as the [`@canton-network/wallet-sdk`](https://www.npmjs.com/package/@canton-network/wallet-sdk) npm package. Source code and the OpenRPC specification for the dApp API are available in the [wallet-gateway repository](https://github.com/canton-network/wallet-gateway).
 
 ## Installation
 

--- a/docs-main/sdks-tools/overview.mdx
+++ b/docs-main/sdks-tools/overview.mdx
@@ -11,7 +11,7 @@ Canton provides a set of SDKs, CLI tools, and development environments for build
 flowchart TB
     subgraph SDKs[SDKs]
         DAMLSDK[Daml SDK<br>Compiler, Script, Sandbox]
-        EXCHSDK[Wallet Kernel SDKs<br>e.g., dApp, wallet, exchange]
+        WALLETSDK[Wallet SDK<br>+ dApp SDK]
     end
 
     subgraph CLI[CLI Tools]
@@ -44,8 +44,8 @@ flowchart TB
 
 The **Daml SDK** is the primary development kit. It includes the Daml compiler, Daml Script runner, PQS, the Canton Sandbox, and many other components. You install and manage it through `dpm install`.
 
-The **[Splice Wallet Kernel](https://github.com/canton-network/wallet-gateway) SDK** provides a set of TypeScript libraries for dApp, wallet, and exchange libraries for integrating with the Canton Network.
-It is covered in the [Integrations](/integrations/overview) section.
+The **[Wallet SDK](https://github.com/canton-network/wallet-gateway/tree/main/sdk/wallet-sdk)** is a TypeScript library that wallet providers (including exchanges) use to integrate with the Canton Network. A separate **dApp SDK** provides the browser-side counterpart that frontends use to connect to a Wallet Gateway.
+Both are covered in the [Integrations](/integrations/overview) section.
 
 ## CLI Tools
 

--- a/docs-main/sdks-tools/sdks/wallet-sdk.mdx
+++ b/docs-main/sdks-tools/sdks/wallet-sdk.mdx
@@ -1,6 +1,6 @@
 ---
-title: Wallet Kernel SDK
-description: Reference for the Splice Wallet SDK, a TypeScript library for programmatic wallet operations on Canton Network.
+title: Wallet SDK
+description: Reference for the Wallet SDK, a TypeScript library for programmatic wallet operations on Canton Network.
 ---
 
 import DamlDocsSdksToolsSdksWalletSdkL69 from "/snippets/daml-docs/sdks-tools_sdks_wallet-sdk_L69.mdx";
@@ -14,11 +14,9 @@ import CantonIntegrationsWalletSdkDownloadL14 from "/snippets/canton-docs/integr
 import CantonIntegrationsWalletSdkDownloadL20 from "/snippets/canton-docs/integrations_wallet_sdk-download_L20.mdx";
 
 
-The [Splice Wallet SDK](https://github.com/canton-network/wallet-gateway/tree/main/sdk/wallet-sdk) is a TypeScript library that enables programmatic wallet operations on Canton Network. It provides APIs for party management, token transfers, UTXO queries, transaction signing, and integration with third-party dApps.
+The [Wallet SDK](https://github.com/canton-network/wallet-gateway/tree/main/sdk/wallet-sdk) is a TypeScript library that enables programmatic wallet operations on Canton Network. It provides APIs for party management, token transfers, UTXO queries, transaction signing, and integration with third-party dApps.
 
 The SDK is designed for wallet providers, exchanges, and application developers who need to interact with Canton Network tokens and manage external party wallets.
-
-A smaller variant, the dApp SDK, is also available for browser-based applications providing transaction signing and submission capabilities.
 
 ## Prerequisites
 
@@ -45,27 +43,7 @@ Install the full Wallet SDK from the NPM registry:
   </Tab>
 </Tabs>
 
-For dApp development only, you can install the smaller dApp SDK, which is optimized for browser usage:
-
-<Tabs>
-  <Tab title="npm">
-  ```shell
-  npm install @canton-network/dapp-sdk
-  ```
-  </Tab>
-  <Tab title="yarn">
-  ```shell
-  yarn add @canton-network/dapp-sdk
-  ```
-  </Tab>
-  <Tab title="pnpm">
-  ```shell
-  pnpm add @canton-network/dapp-sdk
-  ```
-  </Tab>
-</Tabs>
-
-Both SDKs share the same underlying core packages. Where only partial functionality is needed (for example, transaction visualization or hash verification), those packages can be used independently.
+Where only partial functionality is needed (for example, transaction visualization or hash verification), the underlying core packages can be used independently.
 
 {/* COPIED_END */}
 
@@ -180,7 +158,7 @@ The SDK can decode prepared transactions into human-readable JSON for display to
 
 ## Further resources
 
-- [Splice Wallet Kernel GitHub repository](https://github.com/canton-network/wallet-gateway) -- source code, API specs, and example scripts
+- [Wallet Gateway GitHub repository](https://github.com/canton-network/wallet-gateway) -- contains the Wallet SDK source, API specs, and example scripts
 - [Token standard documentation](/appdev/deep-dives/token-standard) -- full token standard reference
 - [CIP-0056](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0056/cip-0056.md) -- Canton Network token standard specification
 - [External party signing tutorial](/appdev/deep-dives/external-signing-onboarding) -- step-by-step external signing walkthrough


### PR DESCRIPTION
## Summary

Closes #571.

Applies the renames requested in the issue body, plus the related corrections from @mjuchli-da on adjacent issues confirming that the SDK lineup is **Wallet SDK + dApp SDK only** — there is no Wallet Kernel SDK and no Exchange SDK.

### `/sdks-tools/sdks/wallet-sdk`
- Title and frontmatter description switched to **Wallet SDK**
- "Splice Wallet SDK" → "Wallet SDK" in the lede
- Removed the dapp-sdk install Tabs block
- Removed "A smaller variant, the dApp SDK, is also available..."
- Removed "Both SDKs share the same underlying core packages."
- Repo link relabeled from "Splice Wallet Kernel GitHub repository" to "Wallet Gateway GitHub repository"

### `/sdks-tools/overview` (SDKs and Tools landing)
- Mermaid SDKs node: `Wallet Kernel SDKs / e.g., dApp, wallet, exchange` → `Wallet SDK + dApp SDK`
- Prose paragraph replaced to introduce Wallet SDK + dApp SDK without the Wallet Kernel / exchange misnomer

### `/integrations/wallet/sdk-download`
- "Splice Wallet SDK" → "Wallet SDK"
- "splice-wallet-kernel repository" → "wallet-gateway repository"