### PR TITLE
Update Wallet SDK release notes from upstream (#570)

### DIFF
--- a/docs-main/integrations/release-notes/wallet-sdk.mdx
+++ b/docs-main/integrations/release-notes/wallet-sdk.mdx
@@ -3,9 +3,215 @@ title: "Wallet SDK"
 description: "Release notes for the Canton Network Wallet SDK"
 ---
 
-{/* COPIED_START source="splice-wallet-kernel:docs/wallet-integration-guide/src/release-notes/index.rst" hash="7fa6307c" */}
+{/* COPIED_START source="wallet-gateway:docs/wallet-integration-guide/src/release-notes/index.rst@82ec39c9" hash="5dbcea2b" */}
 
 Below are the release notes for the Wallet SDK versions, detailing new features, improvements, and bug fixes in each version.
+
+## 1.1.0
+
+**Released on April 28th, 2026**
+
+- Added support for Canton 3.5.X & Splice 0.6.X
+- Backwards compatibility with Canton 3.4X and Splice 0.5.X
+- Allow offline SDK signing without ledger access
+- Few improvments to the amulet fetch status to handle easier expectations like (expect cancelled or expired)
+
+## 1.0.0
+
+**Released on April 17th, 2026**
+
+Wallet SDK v1 is the new long-term API shape for application development. Rather than being an additive patch to v0, v1 introduces a cleaner and more explicit model focused on composability, multi-party flows, and transport flexibility.
+
+**Why move to v1**
+
+- Stateless and safer by default: v1 removes global SDK/controller party state and requires explicit `partyId` at call time, which improves
+  thread safety and makes concurrent multi-party operations much easier to reason about.
+
+- Clearer transaction lifecycle: flows are modeled as explicit `prepare -> sign -> execute` steps, improving observability and reducing hidden behavior.
+
+- Better API organization: v0 controllers are replaced by namespaces (`ledger`, `party`, `token`, `amulet`, `user`, `asset`, `events`)
+  with clearer boundaries and easier discoverability.
+
+- More flexible integration model: v1 supports static configuration and provider-based initialization, making it easier to integrate with browser,
+  dApp, remote wallet, and alternative transport setups.
+
+- Improved extension model: optional functionality can be enabled via `extend()` which keeps base initialization small and purpose-driven.
+
+This release note intentionally avoids listing every single method-level change. For full migration details and examples, use the migration guide:
+
+- [Wallet SDK v1 Migration Guide](https://github.com/canton-network/wallet-gateway/blob/82ec39c9/docs/wallet-integration-guide/src/wallet-sdk-v1-migration-guide/index.rst)
+- [v1 Ledger Migration](https://github.com/canton-network/wallet-gateway/blob/82ec39c9/docs/wallet-integration-guide/src/wallet-sdk-v1-migration-guide/ledger.rst)
+- [v1 Token Migration](https://github.com/canton-network/wallet-gateway/blob/82ec39c9/docs/wallet-integration-guide/src/wallet-sdk-v1-migration-guide/token.rst)
+- [v1 Party Migration](https://github.com/canton-network/wallet-gateway/blob/82ec39c9/docs/wallet-integration-guide/src/wallet-sdk-v1-migration-guide/party.rst)
+- [v1 User Migration](https://github.com/canton-network/wallet-gateway/blob/82ec39c9/docs/wallet-integration-guide/src/wallet-sdk-v1-migration-guide/user.rst)
+
+## 0.21.1
+
+**Released on February 20th, 2026**
+
+- fix fetching active contracts in loop mode
+
+*a bug was identified where fetching active contracts in loop mode (`continueUntilCompletion`) would not correctly handle pagination, resulting in incomplete results being returned. This has now been fixed ensuring all contracts are reliably returned.*
+
+## 0.21.0
+
+**Released on February 6th, 2026**
+
+- pagination support for listing UTXOs
+
+*previously `listHoldingsUtxo` was limited to the ledger API upper bound of 200 items per request. For parties with a large number of holdings this meant not all UTXOs would be returned. A new optional `continueUntilCompletion` parameter has been added that when set to true will automatically page through all results, making it possible to reliably work with parties that hold more than 200 UTXOs.*
+
+``` javascript
+// fetch only the first page (default behaviour, up to 200 items)
+const utxos = await sdk.tokenStandard?.listHoldingsUtxo()
+
+// fetch ALL utxos regardless of how many there are
+const allUtxos = await sdk.tokenStandard?.listHoldingsUtxo(
+    true,  // include locked
+    undefined, // offset
+    undefined, // limit
+    true   // continueUntilCompletion
+)
+```
+
+- cost estimation now returned when using Canton 3.4
+
+*when calling `prepareSubmission` against a Canton 3.4 participant the `costEstimation` field was previously dropped from the response. The response type has been corrected and the cost estimation is now correctly surfaced.*
+
+``` javascript
+const prepared = await sdk.userLedger?.prepareSubmission(
+    transferCommand,
+    keyPairSender.publicKey
+)
+
+// costEstimation is now available when running against Canton 3.4
+logger.info(prepared?.costEstimation)
+```
+
+## 0.20.0
+
+**Released on January 16th, 2026**
+
+- subscribe to ledger update events via WebSocket
+
+*it is now possible to open a persistent WebSocket connection and receive a real-time stream of ledger update events filtered by interface or template id. The stream is exposed as an async generator so it integrates naturally with `for await` loops.*
+
+``` javascript
+const stream = sdk.userLedger?.subscribeToUpdates({
+    partyId: sender!.partyId,
+    interfaceIds: [HOLDING_INTERFACE_ID],
+})
+
+for await (const update of stream!) {
+    logger.info(update, 'received ledger update')
+    if (done) break
+}
+```
+
+- subscribe to command completions via WebSocket
+
+*similarly to update subscriptions, you can now subscribe to command completion events so you can react to completed or failed commands in real time instead of polling.*
+
+``` javascript
+const stream = sdk.userLedger?.subscribeToCompletions({
+    parties: [sender!.partyId],
+    beginOffset: 0,
+})
+
+for await (const completion of stream!) {
+    logger.info(completion, 'received completion event')
+    if (done) break
+}
+```
+
+- `listWallets` now only returns local parties
+
+*previously `listWallets` could return parties that the user had been granted access to on remote validators, this was confusing and incorrect behaviour. The method now only returns parties that are locally allocated on the connected participant.*
+
+- optional input utxos for merge delegations
+
+*the merge delegation setup previously required UTXOs to be provided explicitly. Input UTXOs are now optional and will fall back to smart UTXO selection when not provided, consistent with other operations.*
+
+## 0.19.1
+
+**Released on December 29th, 2025**
+
+Version bump to align package publication. No functional changes.
+
+## 0.19.0
+
+**Released on December 29th, 2025**
+
+- **Important!: LedgerController constructor has changed to named parameters**
+
+*the `LedgerController` constructor has been refactored from positional parameters to a named parameter object. This is a breaking change if you construct `LedgerController` directly. The new signature also accepts an optional custom `fetch` implementation which is useful for routing requests through an intermediary such as the wallet gateway.*
+
+``` javascript
+// previous constructor
+const ledger = new LedgerController(
+    userId,
+    new URL('http://127.0.0.1:5001'),
+    token
+)
+
+// new constructor with named params
+const ledger = new LedgerController({
+    userId,
+    baseUrl: new URL('http://127.0.0.1:5001'),
+    token,
+    // optional: provide a custom fetch to route requests through a proxy
+    fetch: myCustomFetch,
+})
+```
+
+- get created contract by update id
+
+*a new method `getCreatedContractByUpdateId` has been added on the ledger controller. After submitting a transaction you can use the returned `updateId` to look up the contract(s) that were created as part of that transaction. Optionally you can narrow the result by providing template or interface ids.*
+
+``` javascript
+const result = await sdk.userLedger?.prepareSignExecuteAndWaitFor(
+    transferCommand,
+    keyPairSender.privateKey,
+    v4(),
+    disclosedContracts
+)
+
+const transferCid = (
+    await sdk.userLedger!.getCreatedContractByUpdateId(
+        result!.updateId,
+        {
+            interfaceIds: [TRANSFER_INSTRUCTION_INTERFACE_ID],
+        }
+    )
+).contractId!
+```
+
+- unified `createTransferInstruction` choice helper
+
+*the logic for Accept, Reject and Withdraw on a transfer instruction has been consolidated into a single `createTransferInstruction` method, reducing boilerplate when you want to exercise a choice without caring about which specific one.*
+
+``` javascript
+const [command, disclosedContracts] =
+    await sdk.tokenStandard!.createTransferInstruction(
+        transferCid,
+        'Accept' // or 'Reject' or 'Withdraw'
+    )
+
+await sdk.userLedger?.prepareSignExecuteAndWaitFor(
+    command,
+    keyPairSender.privateKey,
+    v4(),
+    disclosedContracts
+)
+```
+
+- browser support for the ledger client
+
+*the `@canton-network/core-ledger-client` package can now be imported and used directly in a browser environment. Node.js-specific modules have been removed from the main bundle so that browser-based dApps and portfolio UIs can leverage the ledger utilities without additional bundler workarounds.*
+
+- fixed decimal precision handling
+
+*decimal arithmetic is now handled using `decimal.js` to prevent floating-point precision errors when working with large or fractional CC amounts.*
 
 ## 0.18.0
 
@@ -13,7 +219,7 @@ Below are the release notes for the Wallet SDK versions, detailing new features,
 
 - merge utxos command
 
-*you can now easily perform utxos merging for you by simply calling the method \`mergeHoldingUtxos\`, this returns a series of commands that each needs to be executed individually to merge the assets. It returns a list of utxos commands because: Firstly, it supports multi-assets (so it will merge both CC and non-CC tokens) and secondly there is an upper limit of 100 inputs per transaction so to facilitate if more is present then it splices it for the client.*
+*you can now easily perform utxos merging for you by simply calling the method `mergeHoldingUtxos`, this returns a series of commands that each needs to be executed individually to merge the assets. It returns a list of utxos commands because: Firstly, it supports multi-assets (so it will merge both CC and non-CC tokens) and secondly there is an upper limit of 100 inputs per transaction so to facilitate if more is present then it splices it for the client.*
 
 ``` javascript
 const [mergeUtxoCommands, mergedDisclosedContracts] =
@@ -31,7 +237,7 @@ for (let i = 0; i < mergeUtxoCommands.length; i++) {
 
 - merge utxos delegation
 
-*instead of manually monitor and act you can set up utxos merge delegation as described at* [merge-delegation](https://docs.dev.sync.global/app_dev/token_standard/index.html#setting-up-mergedelegations) *using the new functionality like. An example of the complete setup can be found here:* [Wallet SDK example 18](https://github.com/hyperledger-labs/splice-wallet-kernel/blob/main/docs/wallet-integration-guide/examples/scripts/18-merge-delegation-proposal.ts)
+*instead of manually monitor and act you can set up utxos merge delegation as described at* [merge-delegation](https://docs.dev.sync.global/app_dev/token_standard/index.html#setting-up-mergedelegations) *using the new functionality like. An example of the complete setup can be found here:* [Wallet SDK example 18](https://github.com/canton-network/wallet-gateway/blob/main/docs/wallet-integration-guide/examples/scripts/18-merge-delegation-proposal.ts)
 
 - create party with preapproval
 
@@ -78,7 +284,7 @@ const trafficStatus =
 
 - Better automation around token metadata
 
-*the token standard controller have two new methods: \`getInstrumentById\` & \`listInstruments\`, these uses the transferRegistryUrl provided to fetch relevant data from the original source making non-CC token integration more seamless. Likewise in certain cases the instrumentAdmin has been made optional since we can use the above to fetch these.*
+*the token standard controller have two new methods: `getInstrumentById` & `listInstruments`, these uses the transferRegistryUrl provided to fetch relevant data from the original source making non-CC token integration more seamless. Likewise in certain cases the instrumentAdmin has been made optional since we can use the above to fetch these.*
 
 - test improvements of snippets
 
@@ -166,7 +372,7 @@ Due to CommonJS compatibility, the module type needs to be explicitly declared i
 
 - Handling inflight transmissions
 
-*Introduced special handling cases for \`REQUEST_ALREADY_IN_FLIGHT\` and \`SUBMISSION_ALREADY_IN_FLIGHT\`, now in those cases the SDK will retrieve the inflight submission and track that for ..AndWait functions.*
+*Introduced special handling cases for `REQUEST_ALREADY_IN_FLIGHT` and `SUBMISSION_ALREADY_IN_FLIGHT`, now in those cases the SDK will retrieve the inflight submission and track that for ..AndWait functions.*
 
 - support cjs module
 
@@ -182,9 +388,9 @@ Due to CommonJS compatibility, the module type needs to be explicitly declared i
 
 - Caching of Access Tokens
 
-*Previously a new token was retrieved from the AuthController every time a request was made, this is not a huge problem for \`unsafe\` tokens, however still unnecessary. Tokens are now kept in memory and reused and a new token is only requested upon expiry.*
+*Previously a new token was retrieved from the AuthController every time a request was made, this is not a huge problem for `unsafe` tokens, however still unnecessary. Tokens are now kept in memory and reused and a new token is only requested upon expiry.*
 
-*For this change to take effect you need to alter your token usage to use \`AccessTokenProvider\` instead, all examples are updated accordingly.*
+*For this change to take effect you need to alter your token usage to use `AccessTokenProvider` instead, all examples are updated accordingly.*
 
 ## 0.14.0
 
@@ -242,7 +448,7 @@ async waitForCompletion(
 
 - proxy delegation for feature app marker for deposits
 
-*Proxy delegation support have been added for deposits allowing attaching a featured app marker flag to an incoming deposit, this requires running the dar \`splice-util-featured-app-proxies-1.1.0.dar\` on the validator.*
+*Proxy delegation support have been added for deposits allowing attaching a featured app marker flag to an incoming deposit, this requires running the dar `splice-util-featured-app-proxies-1.1.0.dar` on the validator.*
 
 ``` javascript
 const delegateCommand = await sdk.userLedger?.createDelegateProxyCommand(
@@ -411,7 +617,7 @@ const tlsTopologyController = (
 
 - Stress tested party creation
 
-*Party creation is under heavy load on mainnet and would consistently run into: \`The server was not able to produce a timely response to your request\`. Safe guard has been added against this, when the error occurs we continuously look for the party to be available. If a timeout is required then it will have to be handled outside of the method. It is worth nothing that the party creation has no timeout on ledger.*
+*Party creation is under heavy load on mainnet and would consistently run into: `The server was not able to produce a timely response to your request`. Safe guard has been added against this, when the error occurs we continuously look for the party to be available. If a timeout is required then it will have to be handled outside of the method. It is worth nothing that the party creation has no timeout on ledger.*
 
 you can disable this by setting `expectHeavyLoad` to false
 
@@ -635,7 +841,7 @@ if (recomputeHash !== prepared!.combinedHash) {
 
 - new awaiting variation with `prepareSignExecuteAndWaitFor` & `executeSubmissionAndWaitFor`
 
-*release 0.7.0 introduced the \`waitForCompletion\`, we have now backed that into the executions*
+*release 0.7.0 introduced the `waitForCompletion`, we have now backed that into the executions*
 
 ``` javascript
 // PREVIOUS CODE EXAMPLE
@@ -712,7 +918,7 @@ const sdk = new WalletSDKImpl().configure({
     tokenStandardFactory: localNetTokenStandardDefault,
 })
 
-await sdk.connectTopology(localNetStaticConfig.LOCALNET_SCAN_PROXY_API_URL)
+await sdk.connectTopology(localNetStaticConfig.LOCALNET_APP_VALIDATOR_URL)
 
 sdk.tokenStandard?.setTransferFactoryRegistryUrl(
     localNetStaticConfig.LOCALNET_REGISTRY_API_URL
@@ -801,7 +1007,7 @@ const transferPreApprovalStatus =
 
 **Release on September 18th, 2025**
 
-- **Important!: scan api is not longer used for methods like \`connectTopology\` use scan proxy instead**
+- **Important!: scan api is not longer used for methods like `connectTopology` use scan proxy instead**
 - Added support for multi-hosting a party upon creation against multiple validators
 
 ``` javascript
@@ -1100,7 +1306,7 @@ const allUtxos = await sdk.tokenStandard?.listHoldingUtxos()
 ```
 
 - Include some small bug fixes. The most noteable are:
-  - `Contract not found` error when listing holdings ([https://github.com/hyperledger-labs/splice-wallet-kernel/issues/357](https://github.com/hyperledger-labs/splice-wallet-kernel/issues/357))
+  - `Contract not found` error when listing holdings ([https://github.com/canton-network/wallet-gateway/issues/357](https://github.com/canton-network/wallet-gateway/issues/357))
   - Requirements to have extra import (like @protobuf-ts/runtime-rpc) resolved
 
 


### PR DESCRIPTION
## Summary

Closes #570.

Regenerated `integrations/release-notes/wallet-sdk.mdx` from `canton-network/wallet-gateway@82ec39c9` (today's HEAD on `main`):

- `docs/wallet-integration-guide/src/release-notes/index.rst` → converted via `.internal/rst2mdx.py`
- Adds versions **1.1.0, 1.0.0, 0.21.1, 0.21.0, 0.20.0** (and updates earlier entries) that were missing from the previous snapshot, which had stopped at 0.18.0
- Source path in the `COPIED_START` marker repointed from `splice-wallet-kernel:...` to `wallet-gateway:...@82ec39c9` (the repo was renamed)

### Migration guide links

The 1.0.0 entry uses `:doc:` cross-references to sibling RST pages (`wallet-sdk-v1-migration-guide/...`) that have not been ported into this site. Those bullets are rewritten as GitHub blob URLs pinned to the same commit so readers can still reach the source without dead links.