### PR TITLE
Move Splice Daml nav under API Reference

### DIFF
--- a/docs-main/docs.json
+++ b/docs-main/docs.json
@@ -656,197 +656,6 @@
                   "sdks-tools/api-reference/splice-apis",
                   "sdks-tools/api-reference/splice-overview",
                   "sdks-tools/api-reference/splice-http-apis",
-                  "sdks-tools/api-reference/splice-daml-apis",
-                  "sdks-tools/api-reference/splice-daml-models",
-                  {
-                    "group": "Splice Daml Packages",
-                    "pages": [
-                      {
-                        "group": "splice-amulet",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/index",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-round",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-types",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense"
-                        ]
-                      },
-                      {
-                        "group": "splice-amulet-name-service",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/index",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed",
-                          "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans"
-                        ]
-                      },
-                      {
-                        "group": "splice-api-featured-app-v1",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/index",
-                          "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1"
-                        ]
-                      },
-                      {
-                        "group": "splice-api-featured-app-v2",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/index",
-                          "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2"
-                        ]
-                      },
-                      {
-                        "group": "splice-api-token-allocation-instruction-v1",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/index",
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1"
-                        ]
-                      },
-                      {
-                        "group": "splice-api-token-allocation-request-v1",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/index",
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1"
-                        ]
-                      },
-                      {
-                        "group": "splice-api-token-allocation-v1",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/index",
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1"
-                        ]
-                      },
-                      {
-                        "group": "splice-api-token-burn-mint-v1",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/index",
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1"
-                        ]
-                      },
-                      {
-                        "group": "splice-api-token-holding-v1",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/index",
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1"
-                        ]
-                      },
-                      {
-                        "group": "splice-api-token-metadata-v1",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/index",
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1"
-                        ]
-                      },
-                      {
-                        "group": "splice-api-token-transfer-instruction-v1",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/index",
-                          "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1"
-                        ]
-                      },
-                      {
-                        "group": "splice-dso-governance",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/index",
-                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft",
-                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice",
-                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer",
-                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate",
-                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap",
-                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules",
-                          "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding"
-                        ]
-                      },
-                      {
-                        "group": "splice-token-standard-test",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/index",
-                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry-parameters",
-                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry",
-                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-registryapi",
-                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-walletclient",
-                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-utils",
-                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokendvp",
-                          "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokentransfer"
-                        ]
-                      },
-                      {
-                        "group": "splice-token-test-trading-app",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/index",
-                          "sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp"
-                        ]
-                      },
-                      {
-                        "group": "splice-util",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-util/index",
-                          "sdks-tools/api-reference/splice-daml/splice-util/splice-util"
-                        ]
-                      },
-                      {
-                        "group": "splice-util-batched-markers",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-util-batched-markers/index",
-                          "sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy"
-                        ]
-                      },
-                      {
-                        "group": "splice-util-featured-app-proxies",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/index",
-                          "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy",
-                          "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy"
-                        ]
-                      },
-                      {
-                        "group": "splice-util-token-standard-wallet",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/index",
-                          "sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation"
-                        ]
-                      },
-                      {
-                        "group": "splice-validator-lifecycle",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/index",
-                          "sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding"
-                        ]
-                      },
-                      {
-                        "group": "splice-wallet",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-wallet/index",
-                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-buytrafficrequest",
-                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-install",
-                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-mintingdelegation",
-                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-topupstate",
-                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferoffer",
-                          "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferpreapproval"
-                        ]
-                      },
-                      {
-                        "group": "splice-wallet-payments",
-                        "pages": [
-                          "sdks-tools/api-reference/splice-daml/splice-wallet-payments/index",
-                          "sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment",
-                          "sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions"
-                        ]
-                      }
-                    ]
-                  },
                   {
                     "group": "Scan APIs",
                     "pages": [
@@ -1772,6 +1581,197 @@
           {
             "group": "Splice APIs",
             "pages": [
+              "sdks-tools/api-reference/splice-daml-apis",
+              "sdks-tools/api-reference/splice-daml-models",
+              {
+                "group": "Splice Daml Packages",
+                "pages": [
+                  {
+                    "group": "splice-amulet",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/index",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-tokenapiutils",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet-twosteptransfer",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulet",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletallocation",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletconfig",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amuletrules",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-amulettransferinstruction",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-decentralizedsynchronizer",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-expiry",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyamuletrules",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-externalpartyconfigstate",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-fees",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-issuance",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-relround",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-round",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-schedule",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-types",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet/splice-validatorlicense"
+                    ]
+                  },
+                  {
+                    "group": "splice-amulet-name-service",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/index",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans-amuletconversionratefeed",
+                      "sdks-tools/api-reference/splice-daml/splice-amulet-name-service/splice-ans"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-featured-app-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v1/splice-api-featuredapprightv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-featured-app-v2",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-featured-app-v2/splice-api-featuredapprightv2"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-allocation-instruction-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-instruction-v1/splice-api-token-allocationinstructionv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-allocation-request-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-request-v1/splice-api-token-allocationrequestv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-allocation-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-allocation-v1/splice-api-token-allocationv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-burn-mint-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-burn-mint-v1/splice-api-token-burnmintv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-holding-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-holding-v1/splice-api-token-holdingv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-metadata-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-metadata-v1/splice-api-token-metadatav1"
+                    ]
+                  },
+                  {
+                    "group": "splice-api-token-transfer-instruction-v1",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/index",
+                      "sdks-tools/api-reference/splice-daml/splice-api-token-transfer-instruction-v1/splice-api-token-transferinstructionv1"
+                    ]
+                  },
+                  {
+                    "group": "splice-dso-governance",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/index",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-cometbft",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-amuletprice",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-decentralizedsynchronizer",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dso-svstate",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsobootstrap",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-dsorules",
+                      "sdks-tools/api-reference/splice-daml/splice-dso-governance/splice-svonboarding"
+                    ]
+                  },
+                  {
+                    "group": "splice-token-standard-test",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/index",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry-parameters",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-registries-amuletregistry",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-registryapi",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-tokenstandard-walletclient",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-testing-utils",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokendvp",
+                      "sdks-tools/api-reference/splice-daml/splice-token-standard-test/splice-tests-testamulettokentransfer"
+                    ]
+                  },
+                  {
+                    "group": "splice-token-test-trading-app",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/index",
+                      "sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/splice-testing-apps-tradingapp"
+                    ]
+                  },
+                  {
+                    "group": "splice-util",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-util/index",
+                      "sdks-tools/api-reference/splice-daml/splice-util/splice-util"
+                    ]
+                  },
+                  {
+                    "group": "splice-util-batched-markers",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-util-batched-markers/index",
+                      "sdks-tools/api-reference/splice-daml/splice-util-batched-markers/splice-util-featuredapp-batchedmarkersproxy"
+                    ]
+                  },
+                  {
+                    "group": "splice-util-featured-app-proxies",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/index",
+                      "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-delegateproxy",
+                      "sdks-tools/api-reference/splice-daml/splice-util-featured-app-proxies/splice-util-featuredapp-walletuserproxy"
+                    ]
+                  },
+                  {
+                    "group": "splice-util-token-standard-wallet",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/index",
+                      "sdks-tools/api-reference/splice-daml/splice-util-token-standard-wallet/splice-util-token-wallet-mergedelegation"
+                    ]
+                  },
+                  {
+                    "group": "splice-validator-lifecycle",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/index",
+                      "sdks-tools/api-reference/splice-daml/splice-validator-lifecycle/splice-validatoronboarding"
+                    ]
+                  },
+                  {
+                    "group": "splice-wallet",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/index",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-buytrafficrequest",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-install",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-mintingdelegation",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-topupstate",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferoffer",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet/splice-wallet-transferpreapproval"
+                    ]
+                  },
+                  {
+                    "group": "splice-wallet-payments",
+                    "pages": [
+                      "sdks-tools/api-reference/splice-daml/splice-wallet-payments/index",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-payment",
+                      "sdks-tools/api-reference/splice-daml/splice-wallet-payments/splice-wallet-subscriptions"
+                    ]
+                  }
+                ]
+              },
               {
                 "group": "Scan APIs",
                 "pages": [

--- a/tests/test_api_reference_navigation.py
+++ b/tests/test_api_reference_navigation.py
@@ -7,10 +7,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def find_product(products: list[object], label: str) -> dict[str, object]:
+    return next(item for item in products if isinstance(item, dict) and item.get("product") == label)
+
+
+def find_group(items: list[object], label: str) -> dict[str, object]:
+    return next(item for item in items if isinstance(item, dict) and item.get("group") == label)
+
+
 def test_api_reference_landing_page_is_dropdown_root_and_index_page() -> None:
     docs = json.loads((REPO_ROOT / "docs-main" / "docs.json").read_text(encoding="utf-8"))
     products = docs["navigation"]["products"]
-    api_reference = next(item for item in products if item["product"] == "API Reference")
+    api_reference = find_product(products, "API Reference")
 
     assert api_reference["root"] == "api-reference"
     assert api_reference["pages"][0] == "api-reference"
@@ -21,6 +29,30 @@ def test_api_reference_landing_page_is_dropdown_root_and_index_page() -> None:
 
     frontmatter = (REPO_ROOT / "docs-main" / "api-reference.mdx").read_text(encoding="utf-8")
     assert 'sidebarTitle: "API Reference Index"' in frontmatter
+
+
+def test_splice_daml_package_nav_lives_under_api_reference_splice_apis() -> None:
+    docs = json.loads((REPO_ROOT / "docs-main" / "docs.json").read_text(encoding="utf-8"))
+    products = docs["navigation"]["products"]
+    api_reference = find_product(products, "API Reference")
+    api_splice = find_group(api_reference["pages"], "Splice APIs")
+
+    assert api_splice["pages"][:3] == [
+        "sdks-tools/api-reference/splice-daml-apis",
+        "sdks-tools/api-reference/splice-daml-models",
+        find_group(api_splice["pages"], "Splice Daml Packages"),
+    ]
+
+    sdks_tools = find_product(products, "SDKs and Tools")
+    api_overview = find_group(sdks_tools["groups"], "API Overview")
+    sdks_splice = find_group(api_overview["pages"], "Splice APIs")
+
+    assert "sdks-tools/api-reference/splice-daml-apis" not in sdks_splice["pages"]
+    assert "sdks-tools/api-reference/splice-daml-models" not in sdks_splice["pages"]
+    assert all(
+        not (isinstance(item, dict) and item.get("group") == "Splice Daml Packages")
+        for item in sdks_splice["pages"]
+    )
 
 
 def test_product_selector_has_visible_accent_line() -> None:


### PR DESCRIPTION
## Summary

Closes #565.

Moves the existing Splice Daml API overview pages and package navigation out of the `SDKs and Tools` product and into `API Reference > Splice APIs`. The underlying page paths are unchanged, so existing links continue to resolve without adding redirect churn.

## Screenshots

### Before

The live site shows a Splice Daml package page owned by `SDKs and Tools`, even though it is API reference material.

![Before: Splice Daml under SDKs and Tools](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issue-565-screenshots/issue-565/before-splice-daml-under-sdks-tools.png)

### After

The same page is now owned by `API Reference`, with breadcrumbs under `Splice APIs > Splice Daml Packages`.

![After: Splice Daml under API Reference Splice APIs](https://raw.githubusercontent.com/canton-network/cf-docs/pr-assets/cf-docs-issue-565-screenshots/issue-565/after-splice-daml-under-api-reference.png)

## Validation

- `python3 -m pytest tests/test_api_reference_navigation.py`
- `npx mintlify validate`
- `git diff --check`
- Local Mintlify preview at `http://localhost:3333/sdks-tools/api-reference/splice-daml/splice-token-test-trading-app/index` for screenshot verification
