### PR TITLE
Clarify validator and participant terminology

### DIFF
--- a/docs-main/overview/learn/architecture.mdx
+++ b/docs-main/overview/learn/architecture.mdx
@@ -52,13 +52,13 @@ Validators are the workhorses of Canton. They:
 | **Validate transactions** | Verify authorization and correctness for their shard |
 | **Expose the Ledger API** | Provide gRPC/JSON APIs for applications |
 
-A participant is the private, self-sovereign computational and storage unit for an entity within Canton Network.
+A validator is the Canton Network role that operates a participant node. The participant node, often shortened to "participant", is the private, self-sovereign computational and storage unit for an entity within Canton Network.
 
 **Key characteristics:**
-- Each participant maintains a **localized, private view** of the ledger
-- Participants only store contracts where their hosted parties are stakeholders
-- Multiple parties can be hosted on a single participant
-- Participants can connect to multiple synchronizers
+- Each participant node maintains a **localized, private view** of the ledger
+- Participant nodes only store contracts where their hosted parties are stakeholders
+- Multiple parties can be hosted on a single participant node
+- Participant nodes can connect to multiple synchronizers
 
 ### Synchronizers
 


### PR DESCRIPTION
## Summary
- Clarify that validators operate participant nodes
- Use participant node terminology consistently in the Core Components section

## Testing
- Docs-only change; no automated tests run