### PR TITLE
Document Splice Grafana dashboard folder changes

### DIFF
--- a/docs-main/global-synchronizer/production-operations/splice-metrics-overview.mdx
+++ b/docs-main/global-synchronizer/production-operations/splice-metrics-overview.mdx
@@ -66,3 +66,12 @@ The validator app can be configured to run a trigger that polls the topology sta
 This trigger is disabled by default. As per the information in Adding ad-hoc configuration, add an environment variable `ADDITIONAL_CONFIG_TOPOLOGY_METRICS_EXPORT=canton.validator-apps.validator_backend.automation.topology-metrics-polling-interval = 5m` to enable the trigger with a polling interval of 5 minutes.
 
 {/* COPIED_END */}
+
+## Grafana Dashboards
+
+The release bundle includes Grafana dashboards that can be imported into a Grafana instance. These dashboards assume a Kubernetes deployment and use Prometheus native histogram queries.
+
+Dashboard folder locations depend on the Splice version:
+
+- Up to and including Splice `0.6.4`, use the `grafana-dashboards/` folder.
+- Starting with Splice `0.6.5`, Validator operators should use `validator-grafana-dashboards/`, and Super Validator operators should use `sv-grafana-dashboards/`.

--- a/docs-main/global-synchronizer/reference/configuration-reference.mdx
+++ b/docs-main/global-synchronizer/reference/configuration-reference.mdx
@@ -245,7 +245,7 @@ A 200 response indicates the validator is healthy.
 
 ### Grafana dashboards
 
-The release bundle includes Grafana dashboards under the `grafana-dashboards` folder. These dashboards assume a Kubernetes deployment and use Prometheus native histogram queries.
+The release bundle includes Grafana dashboards that assume a Kubernetes deployment and use Prometheus native histogram queries. Up to and including Splice `0.6.4`, use the `grafana-dashboards/` folder. Starting with Splice `0.6.5`, Validator operators should use `validator-grafana-dashboards/`, and Super Validator operators should use `sv-grafana-dashboards/`.
 
 ## HTTP proxy configuration
 


### PR DESCRIPTION
## Summary
- restores Grafana dashboard folder guidance on the Splice metrics overview page
- updates the existing configuration reference note with version-specific folder names
- keeps this as version guidance only; no DevNet/TestNet/MainNet tabs

Stacked on #616.

## Validation
- `git diff --check`
- `jq empty docs-main/docs.json`
- `npx mintlify validate` from `docs-main`
