### PR TITLE
PQS: close gaps with scribe repo

### DIFF
--- a/docs-main/appdev/reference/pqs-sql-reference.mdx
+++ b/docs-main/appdev/reference/pqs-sql-reference.mdx
@@ -125,6 +125,7 @@ The following functions allow you to control the temporal scope of the ledger. T
 - `validate_offset_exists(offset)`: validates that the datastore has a complete history up to and including the offset provided. Returns an error if the nominated offset is not available (too old, or too new).
 - `set_oldest(offset)`: nominates the offset of the oldest events to include in query scope. If `NULL` then it uses the oldest available. Function returns the actual offset used. If the supplied offset is beyond what is available, an error occurs.
 - `nearest_offset(time)`: a helper function to determine the offset of a given time (or interval prior to now).
+- `pruned_offset()`: returns the offset up to which the database has been pruned, or `NULL` if no pruning has occurred.
 
 ## Accessing contracts and exercises
 
@@ -134,6 +135,10 @@ Under this scope, the following table functions[^1] allow access to the ledger a
 - `creates(name, [from_offset], [to_offset])`: create events of the target template/interface views that occurred between the oldest and latest offset
 - `archives(name, [from_offset], [to_offset])`: archive events of the target template/interface views that occurred between the oldest and latest offset
 - `exercises(name, [from_offset], [to_offset])`: exercise events of the target choice that occurred between the oldest and latest offset
+
+<Note>
+After pruning, `archives()`, `exercises()`, and related summary functions (`summary_archives`, `summary_exercises`, `summary_transients`) default their `from_offset` to the pruned offset when available, avoiding unnecessary scans over pruned ranges. `creates()`, `summary_creates()`, and `summary_updates()` are not affected as they cover both active and archived contracts.
+</Note>
 
 The `name` identifier can be used with or without the package specified:
 
@@ -217,13 +222,22 @@ All functions returning contract data return the following columns:
 | `payload`               | `jsonb`                       | JSONB representation of contract data                                                                                                                  |
 | `metadata`              | `bytea`                       | Explicit contract disclosure metadata (see `stakeholder-contract-share`)                                                                               |
 | `package_name`          | `text`                        | Daml package name                                                                                                                                      |
-| `package_version`       | `text`                        | Daml package version                                                                                                                                   |
-| `package_id`            | `text`                        | Daml package ID                                                                                                                                        |
+| `package_version`       | `text`                        | Version of the representative Daml package                                                                                                             |
+| `package_id`            | `text`                        | Representative package ID. The Daml package used for decoding; guaranteed to be present on the connected Participant Node                               |
+| `creation_package_id`   | `text`                        | Original creation-time package ID from the ledger. May reference a package not present on the connected Participant Node                                |
 | `redaction_id`          | `text`                        | Redaction process reference                                                                                                                            |
 | `signatories`           | `text[]`                      | Parties consenting to the creation of the contract                                                                                                     |
 | `observers`             | `text[]`                      | Additional stakeholders whom the contract is visible to                                                                                                |
 | `witnesses`             | `text[]`                      | Parties that are notified of this event                                                                                                                |
 | `divulged_only`         | `boolean`                     | Indicates whether the contract was only divulged (`true`), or properly disclosed (`false`). Refer to `da-model-divulgence` for background information. |
+
+#### Package ID and Daml upgrades
+
+When Daml packages are upgraded, the Participant Node re-encodes contract data using the latest (representative) package version it knows about. This means:
+
+- `package_id` always references a package that is present on the connected Participant Node, suitable for decoding.
+- `creation_package_id` preserves the original package ID from the creation transaction. It may reference a package that has since been superseded and is no longer present on the Participant Node.
+- `package_version` reflects the version of the representative package, not the original creation-time package.
 
 All functions returning exercise data return the following columns:
 
@@ -242,8 +256,8 @@ All functions returning exercise data return the following columns:
 | `argument`                | `jsonb`                    | JSONB representation of the choice argument type                                                                                                                                                               |
 | `result`                  | `jsonb`                    | JSONB representation of the choice return type                                                                                                                                                                 |
 | `package_name`            | `text`                     | Daml package name                                                                                                                                                                                              |
-| `package_version`         | `text`                     | Daml package version                                                                                                                                                                                           |
-| `package_id`              | `text`                     | Daml package ID                                                                                                                                                                                                |
+| `package_version`         | `text`                     | Version of the representative Daml package                                                                                                                                                                     |
+| `package_id`              | `text`                     | Representative package ID. The Daml package used for decoding; guaranteed to be present on the connected Participant Node                                                                                       |
 | `redaction_id`            | `text`                     | Redaction process reference                                                                                                                                                                                    |
 | `signatories`             | `text[]`                   | Parties that consented to the creation of the contract that choice was exercised on                                                                                                                            |
 | `observers`               | `text[]`                   | Additional stakeholders made aware of the creation of the contract that choice was exercised on                                                                                                                |
@@ -330,6 +344,7 @@ The `transactions` view provides transaction metadata not directly exposed by th
 | `workflow_id` | `text` | Workflow ID used in command submission |
 | `trace_context` | `trace_context` | Ledger API trace context (user-defined type containing `trace_parent` and `trace_state`) |
 | `external_transaction_hash` | `bytea` | Hash of the transaction submitted by the external party |
+| `paid_traffic_cost` | `bigint` | Traffic cost paid by the submitting Participant Node (see first transactions table above for full semantics) |
 
 Join through the `*_at_ix` column to enrich contract or exercise data with transaction metadata:
 

--- a/docs-main/appdev/reference/pqs-sql-reference.mdx
+++ b/docs-main/appdev/reference/pqs-sql-reference.mdx
@@ -233,11 +233,13 @@ All functions returning contract data return the following columns:
 
 #### Package ID and Daml upgrades
 
-When Daml packages are upgraded, the Participant Node re-encodes contract data using the latest (representative) package version it knows about. This means:
+- `package_id` is the representative package ID used for decoding, guaranteed to be present on the connected Participant Node.
+- `creation_package_id` is the original package ID from the creation transaction.
+- `package_version` reflects the version of the representative package.
 
-- `package_id` always references a package that is present on the connected Participant Node, suitable for decoding.
-- `creation_package_id` preserves the original package ID from the creation transaction. It may reference a package that has since been superseded and is no longer present on the Participant Node.
-- `package_version` reflects the version of the representative package, not the original creation-time package.
+For Smart Contract Upgrades (SCU), no re-encoding occurs. The creation package is retained in the package store and remains the representative package, so `package_id` and `creation_package_id` are identical.
+
+For Major Upgrades (MUT), the Participant Node re-encodes contract data using the new package version. In this case `package_id` references the new representative package while `creation_package_id` preserves the original, which may no longer be present on the Participant Node.
 
 All functions returning exercise data return the following columns:
 

--- a/docs-main/sdks-tools/development-tools/pqs/configure.mdx
+++ b/docs-main/sdks-tools/development-tools/pqs/configure.mdx
@@ -16,7 +16,7 @@ PQS ascertains its configuration from the following sources, in order of priorit
 Consult the command `./scribe.jar pipeline --help-verbose` for further information on individual configuration items, and the conventions used to specify them in the above forms.
 </Note>
 
-PQS sets its configuration at startup. It does not perform dynamic configuration updates, so making a configuration change (such as adding a new party, new template, or new interface to filters) requires a restart.
+PQS sets its configuration at startup. It does not perform dynamic configuration updates, so making a configuration change (such as adding a new party, new template, or new interface to filters) requires a restart. Deploying new Daml packages (DARs) to the Participant Node does **not** require restarting PQS. When PQS encounters an unknown package while processing events, it fetches the missing packages from the Participant Node automatically. This may pause ingestion for up to tens of seconds.
 
 <div id="pqs-configure-warning">
 

--- a/docs-main/sdks-tools/development-tools/pqs/operate.mdx
+++ b/docs-main/sdks-tools/development-tools/pqs/operate.mdx
@@ -303,6 +303,10 @@ The procedure:
 The provided target offset must be within the bounds of the contiguous history. If the target offset is outside the bounds, it raises an error.
 </Warning>
 
+<Note>
+If the database was previously pruned and the reset target offset is below the stored pruning offset, `reset_to_offset` retreats the pruning offset to the reset target. After such a reset, `pruned_offset()` returns the new target offset. If the reset target is at or above the pruning offset, the pruning state is preserved.
+</Note>
+
 ### Redacting
 
 The redaction feature enables removal of sensitive or personally identifiable information from contracts and exercises within the PQS database. This operation is particularly useful for complying with privacy regulations and data protection laws, as it enables the permanent removal of contract payloads, contract keys, choice arguments, and choice results. Note that redaction is a destructive operation and once redacted, information cannot be restored.
@@ -1019,6 +1023,8 @@ PQS' `pipeline` command is a unidirectional streaming process that heavily relie
   - `INVALID_NAME`
   - `CANNOT_COERCE`
   - `UNEXPECTED_ERROR`
+- Daml packages (retries if):
+  - A transaction references a Daml package that was not present when the pipeline started.
 
 ### Configuration
 
@@ -1038,6 +1044,29 @@ Configuring `--retry-backoff-*` settings control periodicity of retries and the 
 Configuring `--retry-counter-attempts` and `--retry-counter-duration` controls the maximum *instability* tolerance before shutting down.
 
 Configuring `--retry-counter-reset` controls the period of *stability* after which the retry counters are reset across the board.
+
+### Dynamic Daml package reload
+
+When PQS encounters a transaction referencing an unknown Daml package, it does not terminate. Instead:
+
+1. Ingestion pauses.
+2. PQS fetches new packages from the Participant Node.
+3. Type mappings are rebuilt.
+4. Ingestion resumes from the paused offset.
+
+This handles the case where new DARs are deployed to the Participant Node while PQS is running. No restart is needed.
+
+**Log messages** to look for:
+
+```
+Recoverable: unknown Daml package detected.
+```
+
+**Metric**: `app_restarts_total` with label `exception="Recoverable: unknown Daml package detected."` increments each time this occurs.
+
+<Note>
+Dynamic package reload only applies to newly deployed Daml packages. Other configuration changes (parties, templates, interfaces in filters) still require a restart.
+</Note>
 
 ### Logging
 


### PR DESCRIPTION
## Summary

Closes documentation gaps in cf-docs PQS pages, syncing content with the scribe repo docs at commit `9066c817`.

## What Changed

### `pqs-sql-reference.mdx`
- Add `paid_traffic_cost` column to the 2nd transactions view table (was only in the first)
- Update `package_id`/`package_version` descriptions to clarify representative-package semantics
- Add `creation_package_id` column to contract columns
- Add "Package ID and Daml upgrades" explanatory section
- Add `pruned_offset()` to the offset management functions list
- Add `<Note>` on post-pruning default `from_offset` behavior for `archives()`/`exercises()`
- Update exercise columns with same representative-package descriptions

### `operate.mdx`
- Add "Daml packages" to the retries category list
- Add "Dynamic Daml package reload" subsection explaining automatic package fetch on unknown packages
- Add `<Note>` on `reset_to_offset` interaction with the pruning offset

### `configure.mdx`
- Add sentence clarifying that DAR deployment does not require a PQS restart

## Follow-up

The scribe repo docs have an "Upgrade" workflow section (`docs/user/component-howtos/pqs/upgrade.rst`) covering the end-to-end DAR upgrade procedure: pre-checks, DAR upload, PQS behavior during upgrade, and post-upgrade validation. cf-docs has no equivalent page yet. Whether to add it (and in what form) is TBD.
