### PR TITLE
Remove inaccurate Ethereum privacy claim from m2-canton-for-ethereum-devs

### DIFF
--- a/docs-main/appdev/modules/m2-canton-for-ethereum-devs.mdx
+++ b/docs-main/appdev/modules/m2-canton-for-ethereum-devs.mdx
@@ -93,7 +93,7 @@ The `Transfer` choice in Daml doesn't mutate the existing contract. It **archive
 
 ## Privacy Model Differences
 
-**Ethereum default**: Everything public. Privacy requires additional layers (ZK-rollups, private channels).
+**Ethereum default**: Everything public.
 
 **Canton default**: Everything private. Visibility requires explicit declaration.
 


### PR DESCRIPTION
Per reviewer feedback on the [Privacy Model Differences](https://docs.canton.network/appdev/modules/m2-canton-for-ethereum-devs#privacy-model-differences) section.

The sentence *"Privacy requires additional layers (ZK-rollups, private channels)"* implied that ZK-rollups and private channels are equivalent privacy solutions for Ethereum. They are not equivalent to Canton's privacy model, and naming them in this context misrepresents the state of privacy on Ethereum.

## Change

```diff
- **Ethereum default**: Everything public. Privacy requires additional layers (ZK-rollups, private channels).
+ **Ethereum default**: Everything public.
```