### PR TITLE
Generate Canton metrics from release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ python3 scripts/generate_all_reference_docs.py
 
 Use `--dry-run` to print the exact per-step commands without executing them.
 
+### Generate the Canton Metrics reference
+
+The Canton Metrics page is generated from the Canton release docs build rather than from protobuf files. The generator resolves the latest `DACH-NY/canton` GitHub release tag, checks out that Canton source tag under `.internal/cache/canton-metrics-reference/`, runs Canton's release bundle plus generated-include tasks, resolves the metrics RST template with the generated metric includes, converts it to MDX, and records the source release in the generated page comment.
+
+Run:
+
+```bash
+python3 scripts/generate_canton_metrics_reference.py
+```
+
+or:
+
+```bash
+npm run generate:canton-metrics-reference
+```
+
+By default this writes:
+
+- `docs-main/global-synchronizer/reference/canton-metrics.mdx`
+
+For a pinned refresh, pass `--canton-ref v3.5.1`.
+
 ### Generate the Version Compatibility Dashboard
 
 The version dashboard generator collects the public sources that are safe to automate, preserves the fields that still need a manual or owner-approved source, rewrites the dashboard config, and regenerates the published MDX snippet consumed by the version dashboard page.

--- a/docs-main/global-synchronizer/reference/canton-metrics.mdx
+++ b/docs-main/global-synchronizer/reference/canton-metrics.mdx
@@ -3,13 +3,13 @@ title: "Canton Metrics"
 description: "Canton node metrics exported for Prometheus scraping."
 ---
 
-{/* COPIED_START source="docs-website:docs/replicated/canton/3.4/participant/reference/metrics.rst" hash="9de8735e" */}
+{/* GENERATED_FROM source="DACH-NY/canton" ref="v3.5.1" path="docs-open/src/sphinx/participant/reference/metrics.rst" */}
 
 # Metrics
 
 The following sections contain the common metrics exposed for Daml services supporting a Prometheus metrics reporter.
 
-For the metric types referenced below, see the relevant Prometheus documentation.
+For the metric types referenced below, see the [relevant Prometheus documentation](https://prometheus.io/docs/tutorials/understanding_metric_types/).
 
 ## Participant Metrics
 
@@ -76,6 +76,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: timer
 > - **Qualification**: Debug
 
+### daml.db-storage.internal_contract_ids_cache_size
+
+> - **Summary**: Size of the internal contract IDs cache
+> - **Description**: The number of entries in the internal contract IDs cache.
+> - **Type**: gauge
+> - **Qualification**: Debug
+
 ### daml.db-storage.write.executor.exectime
 
 > - **Summary**: Execution time metric for database tasks
@@ -114,78 +121,54 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.db.commit\*
 
 > - **Summary**: The time needed to perform the SQL query commit.
->
 > - **Description**: This metric measures the time it takes to commit an SQL transaction relating to the \<operation\>. It roughly corresponds to calling `commit()` on a DB connection.
->
 > - **Type**: timer
->
 > - **Qualification**: Debug
->
 > - **Labels**:
 >   - **name**: The operation/pool for which the metric is registered.
 
 ### daml.db.compression\*
 
 > - **Summary**: The time needed to decompress the SQL query result.
->
 > - **Description**: Some index database queries that target contracts involve a decompression step. For such queries this metric represents the time it takes to decompress contract arguments retrieved from the database.
->
 > - **Type**: timer
->
 > - **Qualification**: Debug
->
 > - **Labels**:
 >   - **name**: The operation/pool for which the metric is registered.
 
 ### daml.db.exec\*
 
 > - **Summary**: The time needed to run the SQL query and read the result.
->
 > - **Description**: This metric encompasses the time measured by `query` and `commit` metrics. Additionally it includes the time needed to obtain the DB connection, optionally roll it back and close the connection at the end.
->
 > - **Type**: timer
->
 > - **Qualification**: Debug
->
 > - **Labels**:
 >   - **name**: The operation/pool for which the metric is registered.
 
 ### daml.db.query\*
 
 > - **Summary**: The time needed to run the SQL query.
->
 > - **Description**: This metric measures the time it takes to execute a block of code (on a dedicated executor) related to the \<operation\> that can issue multiple SQL statements such that all run in a single DB transaction (either committed or aborted).
->
 > - **Type**: timer
->
 > - **Qualification**: Debug
->
 > - **Labels**:
 >   - **name**: The operation/pool for which the metric is registered.
 
 ### daml.db.translation\*
 
 > - **Summary**: The time needed to turn serialized Daml-LF values into in-memory objects.
->
 > - **Description**: Some index database queries that target contracts and transactions involve a Daml-LF translation step. For such queries this metric stands for the time it takes to turn the serialized Daml-LF values into in-memory representation.
->
 > - **Type**: timer
->
 > - **Qualification**: Debug
->
 > - **Labels**:
 >   - **name**: The operation/pool for which the metric is registered.
 
 ### daml.db.wait\*
 
 > - **Summary**: The time needed to acquire a connection to the database.
->
 > - **Description**: SQL statements are run in a dedicated executor. This metric measures the time it takes between creating the SQL statement corresponding to the \<operation\> and the point when it starts running on the dedicated executor.
->
 > - **Type**: timer
->
 > - **Qualification**: Debug
->
 > - **Labels**:
 >   - **name**: The operation/pool for which the metric is registered.
 
@@ -234,13 +217,9 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.grpc.server.requests.rejections\*
 
 > - **Summary**: Number of rejected requests due to active request limits.
->
 > - **Description**: Counts the number of requests rejected because the active request limit was reached.
->
 > - **Type**: counter
->
 > - **Qualification**: Saturation
->
 > - **Labels**:
 >   - **method**: The method / service name limited.
 >   - **service**: The API the method belongs to
@@ -372,6 +351,20 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: counter
 > - **Qualification**: Saturation
 
+### daml.participant.api.commands.taps_package_selection
+
+> - **Summary**: The time spent on package selection in a single TAPS pass.
+> - **Description**: The time spent on package selection in a single pass of the Topology-Aware Package Selection, before the command is handed to the Daml Engine for interpretation.
+> - **Type**: timer
+> - **Qualification**: Latency
+
+### daml.participant.api.commands.taps_passes
+
+> - **Summary**: The number of TAPS passes during processing of a command.
+> - **Description**: The number of Topology-Aware Package Selection passes during processing of a command.
+> - **Type**: histogram
+> - **Qualification**: Debug
+
 ### daml.participant.api.commands.valid_submissions
 
 > - **Summary**: The total number of the valid Daml commands.
@@ -411,6 +404,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 
 > - **Summary**: The time to lookup persisted contract by LF contract id.
 > - **Description**: The time to enqueue and execute the lookup for persisted contract by LF contract id.
+> - **Type**: timer
+> - **Qualification**: Debug
+
+### daml.participant.api.contract_store.re_insert_contracts
+
+> - **Summary**: The time to execute batched contract insertion in DB in case the contracts have got pruned by the time needed by the Indexer.
+> - **Description**: The time to conduct the DB operation for storing the contracts missing.
 > - **Type**: timer
 > - **Qualification**: Debug
 
@@ -491,6 +491,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: timer
 > - **Qualification**: Debug
 
+### daml.participant.api.execution.lookup_n_contract_key
+
+> - **Summary**: The time to lookup individual contract keys during interpretation.
+> - **Description**: The interpretation of a command in the ledger api server might require fetching multiple contract keys. This metric exposes the time needed to lookup individual non unique contract keys.
+> - **Type**: timer
+> - **Qualification**: Debug
+
 ### daml.participant.api.execution.retry
 
 > - **Summary**: The number of the interpretation retries.
@@ -509,6 +516,20 @@ For the metric types referenced below, see the relevant Prometheus documentation
 
 > - **Summary**: The number of Daml commands currently being interpreted.
 > - **Description**: The number of the commands that are currently being interpreted (includes executing Daml code and fetching data).
+> - **Type**: counter
+> - **Qualification**: Debug
+
+### daml.participant.api.index.achs_midstream_fallbacks
+
+> - **Summary**: The number of mid-stream fallbacks from ACHS to filter tables.
+> - **Description**: Counts the number of times the active contracts stream fell back from the ACHS to the filter tables because the ACHS validAt was bumped past the requested activeAt while streaming was in progress.
+> - **Type**: counter
+> - **Qualification**: Debug
+
+### daml.participant.api.index.achs_skips
+
+> - **Summary**: The number of times the ACHS was skipped entirely.
+> - **Description**: Counts the number of times the active contracts stream skipped the ACHS entirely because the ACHS validAt had already surpassed the requested activeAtEventSeqId before streaming started.
 > - **Type**: counter
 > - **Qualification**: Debug
 
@@ -603,6 +624,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: timer
 > - **Qualification**: Debug
 
+### daml.participant.api.index.db.lookup_non_unique_key
+
+> - **Summary**: The time spent looking up contracts using its key.
+> - **Description**: This metric exposes the time spent looking up contracts using its key in the index db. It is then used by the Daml interpreter when evaluating a command into a transaction.
+> - **Type**: timer
+> - **Qualification**: Debug
+
 ### daml.participant.api.index.db.tree_transactions_stream.translation
 
 > - **Summary**: The time needed to turn serialized Daml-LF values into in-memory objects.
@@ -631,6 +659,34 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: counter
 > - **Qualification**: Debug
 
+### daml.participant.api.indexer.achs_buffer_length
+
+> - **Summary**: The size of the queue between the indexer and the ACHS maintenance pipe.
+> - **Description**: This counter counts batches of updates queued before the ACHS maintenance pipe. When the buffer is mostly full, it indicates that ACHS maintenance is creating backpressure on the indexing pipeline.
+> - **Type**: counter
+> - **Qualification**: Debug
+
+### daml.participant.api.indexer.achs_last_populated
+
+> - **Summary**: The last event sequential id populated into the ACHS.
+> - **Description**: The last event sequential id for which activations were added to the ACHS.
+> - **Type**: gauge
+> - **Qualification**: Debug
+
+### daml.participant.api.indexer.achs_last_removed
+
+> - **Summary**: The last event sequential id for which deactivations were removed from the ACHS.
+> - **Description**: The last event sequential id for which deactivations were looked up and the corresponding activations were removed from the ACHS.
+> - **Type**: gauge
+> - **Qualification**: Debug
+
+### daml.participant.api.indexer.achs_valid_at
+
+> - **Summary**: The event sequential id at which the ACHS is valid.
+> - **Description**: The event sequential id at which the ACHS is currently valid. It may contain some deactivated events but they will anyway be removed when fetched.
+> - **Type**: gauge
+> - **Qualification**: Debug
+
 ### daml.participant.api.indexer.deactivation_distances
 
 > - **Summary**: Event sequence id distances between activations and deactivations.
@@ -641,18 +697,14 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.participant.api.indexer.events\*
 
 > - **Summary**: Number of ledger events processed.
->
 > - **Description**: Represents the total number of ledger events processed (transactions, reassignments, party allocations).
->
 > - **Type**: meter
->
 > - **Qualification**: Debug
->
 > - **Labels**:
 >   - **participant_id**: The id of the participant.
 >   - **user_id**: The user generating the events.
 >   - **event_type**: The type of ledger event processed (transaction, reassignment, party_allocation).
->   - **status**: Indicates if the event was accepted or not. Possible values accepted\|rejected.
+>   - **status**: Indicates if the event was accepted or not. Possible values accepted|rejected.
 
 ### daml.participant.api.indexer.indexer_queue_blocked
 
@@ -675,6 +727,20 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: meter
 > - **Qualification**: Debug
 
+### daml.participant.api.indexer.indexer_restart_due_to_missing_contract
+
+> - **Summary**: Number of times the Indexer needed to restart due to missing referenced contracts.
+> - **Description**: Under seldom circumstances the indexer could be forced to restart if pruning removed referenced contracts. If this happens the missing contracts will be re-inserted to the DB and indexing continues. This is part for the normal operation and should happen very rarely.
+> - **Type**: counter
+> - **Qualification**: Traffic
+
+### daml.participant.api.indexer.ingestion_blocked_by_pruning.duration
+
+> - **Summary**: The duration of ingestions DB execution is blocked by pruning.
+> - **Description**: The time that a batch of updates spends in blocked waiting for the pruning DB operation to finish.
+> - **Type**: timer
+> - **Qualification**: Debug
+
 ### daml.participant.api.indexer.ledger_end_sequential_id
 
 > - **Summary**: The sequential id of the current ledger end kept in the database.
@@ -685,13 +751,9 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.participant.api.indexer.metered_events\*
 
 > - **Summary**: Number of individual ledger events (create, exercise, archive).
->
 > - **Description**: Represents the number of individual ledger events constituting a transaction.
->
 > - **Type**: meter
->
 > - **Qualification**: Debug
->
 > - **Labels**:
 >   - **participant_id**: The id of the participant.
 >   - **user_id**: The user generating the events.
@@ -795,6 +857,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Qualification**: Debug
 
 ### daml.participant.api.services.get_update_by_offset
+
+> - **Summary**: The time to execute an index service operation.
+> - **Description**: The index service is an internal component responsible for access to the index db data. Its operations are invoked whenever a client request received over the ledger api requires access to the index db. This metric captures time statistics of such operations.
+> - **Type**: timer
+> - **Qualification**: Debug
+
+### daml.participant.api.services.get_updates_page
 
 > - **Summary**: The time to execute an index service operation.
 > - **Description**: The index service is an internal component responsible for access to the index db data. Its operations are invoked whenever a client request received over the ledger api requires access to the index db. This metric captures time statistics of such operations.
@@ -934,6 +1003,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: timer
 > - **Qualification**: Debug
 
+### daml.participant.api.services.lookup_non_unique_contract_key
+
+> - **Summary**: The time to execute an index service operation.
+> - **Description**: The index service is an internal component responsible for access to the index db data. Its operations are invoked whenever a client request received over the ledger api requires access to the index db. This metric captures time statistics of such operations.
+> - **Type**: timer
+> - **Qualification**: Debug
+
 ### daml.participant.api.services.party_entries
 
 > - **Summary**: The time to execute an index service operation.
@@ -946,6 +1022,20 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Summary**: The time to execute an index service operation.
 > - **Description**: The index service is an internal component responsible for access to the index db data. Its operations are invoked whenever a client request received over the ledger api requires access to the index db. This metric captures time statistics of such operations.
 > - **Type**: timer
+> - **Qualification**: Debug
+
+### daml.participant.api.services.pruning.contract_pruning_blocked
+
+> - **Summary**: Optimistic locking with contention might result in retries. This metric tracks if maximum amount of configured retries reached.
+> - **Description**:
+> - **Type**: counter
+> - **Qualification**: Debug
+
+### daml.participant.api.services.pruning.contract_pruning_retried
+
+> - **Summary**: Optimistic locking with contention might result in retries. This metric tracks if the operation was retried this many times.
+> - **Description**:
+> - **Type**: meter
 > - **Qualification**: Debug
 
 ### daml.participant.api.services.pruning.prune.completed
@@ -1070,7 +1160,7 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.participant.declarative_api.errors
 
 > - **Summary**: Errors for the last update
-> - **Description**: The node will attempt to apply the changes configured in the declarative config file. A positive number means that some items failed to be synchronised. A negative number means that the overall synchronisation procedure failed with an error. : 0 = everything good, -1 = config file unreadable, -2 = context could not be created, -3 = failure while applying items, -9 = exception caught.
+> - **Description**: The node will attempt to apply the changes configured in the declarative config file.     A positive number means that some items failed to be synchronised. A negative number     means that the overall synchronisation procedure failed with an error. :     0 = everything good, -1 = config file unreadable, -2 = context could not be created,     -3 = failure while applying items, -9 = exception caught.
 > - **Type**: gauge
 > - **Qualification**: Errors
 
@@ -1084,15 +1174,44 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.participant.inflight_validation_requests\*
 
 > - **Summary**: Number of requests being validated.
->
 > - **Description**: Number of requests that are currently being validated. This also covers requests submitted by other participants.
->
 > - **Type**: gauge
->
 > - **Qualification**: Saturation
->
 > - **Labels**:
 >   - **participant**: The id of the participant for which the value applies.
+
+### daml.participant.kms.session-signing-keys-fallback
+
+> - **Summary**: Number of times signing had to fall back to the long-term key, triggering a KMS call.
+> - **Description**: Session signing keys are configured to be valid for a short duration. If this duration is too small or a session key is unavailable, the signing process falls back to using the long-term key to ensure request validation succeeds. This metric counts how many times signing required a direct KMS call with the long-term key.
+> - **Type**: counter
+> - **Qualification**: Saturation
+
+### daml.participant.lsu_status\*
+
+> - **Summary**: Tracks the state of the LSU for a specific successor
+> - **Description**: The value represents the progress of LSU from the participant point of view. 0: Unset / initial 1: LSU announcement received 2: Threshold many sequencer successors known 3: Handshake with successor done 4: Topology local copy done 5: LSU is done (node ready to connect to new synchronizer)
+> - **Type**: gauge
+> - **Qualification**: Debug
+> - **Labels**:
+>   - **successor_psid**: The physical synchronizer id of the successor
+
+### daml.participant.phase\*
+
+> - **Summary**: Phase metrics measuring the time for the various command submission processing stages
+> - **Description**: Time from receipt of command to submission such as interpretation and view computation.
+> - **Type**: timer
+> - **Qualification**: Latency
+> - **Labels**:
+>   - **synchronizer**: synchronizer
+>   - **phase**: phase
+
+### daml.participant.sync.commitments.active-stakeholder-groups
+
+> - **Summary**: Record the number of stakeholder groups with active contracts on this participants
+> - **Description**: The number of stakeholder groups for which the participant has at least one active contract in the current active contract store.
+> - **Type**: gauge
+> - **Qualification**: Saturation
 
 ### daml.participant.sync.commitments.catchup-mode-enabled
 
@@ -1106,6 +1225,20 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Summary**: Measures the time that the participant node spends computing commitments.
 > - **Description**: Participant nodes compute bilateral commitments at regular intervals, i.e., reconciliation intervals. This metric exposes the time spent on each computation in milliseconds. There are two cases that the operator should pay attention to. First, fluctuations in this value are expected if the number of counter-participants or common stakeholder groups changes. However, changes with no apparent reason could indicate a bug and the operator should monitor closely. Second, it is a cause of concern if the value starts approaching or is greater than the reconciliation interval: The participant will perpetually lag behind, because it needs to compute commitments more frequently than it can manage. The operator should consider asking the synchronizer operator to increase the reconciliation interval if the increase in commitment computation is expected, or otherwise investigate the cause.
 > - **Type**: timer
+> - **Qualification**: Debug
+
+### daml.participant.sync.commitments.largest-counter-participant-latency
+
+> - **Summary**: The highest latency in micros for commitments outstanding from counter-participants for more than a threshold-number of reconciliation intervals.
+> - **Description**: Participant nodes compute bilateral commitments at regular intervals and send them. This metric is the default indicator of a counter-participant being slow.The metric exposes the highest latency of a counter-participant, measured by subtracting the highest known counter-participant latency from the most recent period processed by the participant. A counter-participant has to send a commitment at least once in order to appear here. The operator of a participant can configure a default threshold per synchronizer that the participant connects to. The smaller the threshold, the more sensitive the metric is to even small delays in receiving commitments from counter-participants. For example, for a threshold of 5 intervals and a reconciliation interval of 1 minute, the metric measures the latency of counter-participants that have sent no commitments for periods covering the last 5 minutes observed by the participant.
+> - **Type**: gauge
+> - **Qualification**: Debug
+
+### daml.participant.sync.commitments.largest-distinguished-counter-participant-latency
+
+> - **Summary**: The highest latency in micros for commitments outstanding from distinguished counter-participants for more than a threshold-number of reconciliation intervals.
+> - **Description**: Participant nodes compute bilateral commitments at regular intervals and send them. This metric indicates that a distinguished counter-participant is slow, i.e., the participant cannot confirm that its state is the same with that of a counter-participant with whom the operator has an important business relation.The metric exposes the highest latency of a counter-participant, measured by subtracting the highest known counter-participant latency from the most recent period processed by the participant. A counter-participant has to send a commitment at least once in order to appear here. The operator of a participant can configure a default threshold per synchronizer that the participant connects to. The smaller the threshold, the more sensitive the metric is to even small delays in receiving commitments from counter-participants. For example, for a threshold of 5 intervals and a reconciliation interval of 1 minute, the metric measures the latency of counter-participants that have sent no commitments for periods covering the last 5 minutes observed by the participant.
+> - **Type**: gauge
 > - **Qualification**: Debug
 
 ### daml.participant.sync.commitments.last-incoming-processed
@@ -1140,20 +1273,6 @@ For the metric types referenced below, see the relevant Prometheus documentation
 
 > - **Summary**: Measures the time between the end of a commitment period, and the time when the sequencer observes the corresponding commitment.
 > - **Description**: Participant nodes compute bilateral commitments at regular intervals. After a participant computes a commitment, it sends it for sequencing. The time between the end of a commitment interval and sequencing is measured in milliseconds. Because commitment computation is comprised within the measured time, the value is always greater than the `daml.participant.sync.commitments.compute` metric. The operator should pay attention to fluctuations of this value. An increase can be expected, e.g., because the computation time increases. However, a value increase can be a cause of concern, because it can indicate that the participant is lagging behind in processing messages and computing commitments, which is accompanied by `ACS_COMMITMENT_DEGRADATION` warnings in the participant logs. An increase can also indicate that the sequencer is slow in sequencing the commitment messages. The operator should cross-correlate with sequencing metrics such as `daml.sequencer-client.submissions.sequencing` and `daml.sequencer-client.handler.delay.` In this case, the operator should consider changing the preferred sequencer configuration.
-> - **Type**: gauge
-> - **Qualification**: Debug
-
-### daml.participant.sync.commitments.synchronizer.largest-counter-participant-latency
-
-> - **Summary**: The highest latency in micros for commitments outstanding from counter-participants for more than a threshold-number of reconciliation intervals.
-> - **Description**: Participant nodes compute bilateral commitments at regular intervals and send them. This metric is the default indicator of a counter-participant being slow.The metric exposes the highest latency of a counter-participant, measured by subtracting the highest known counter-participant latency from the most recent period processed by the participant. A counter-participant has to send a commitment at least once in order to appear here. The operator of a participant can configure a default threshold per synchronizer that the participant connects to. The smaller the threshold, the more sensitive the metric is to even small delays in receiving commitments from counter-participants. For example, for a threshold of 5 intervals and a reconciliation interval of 1 minute, the metric measures the latency of counter-participants that have sent no commitments for periods covering the last 5 minutes observed by the participant.
-> - **Type**: gauge
-> - **Qualification**: Debug
-
-### daml.participant.sync.commitments.synchronizer.largest-distinguished-counter-participant-latency
-
-> - **Summary**: The highest latency in micros for commitments outstanding from distinguished counter-participants for more than a threshold-number of reconciliation intervals.
-> - **Description**: Participant nodes compute bilateral commitments at regular intervals and send them. This metric indicates that a distinguished counter-participant is slow, i.e., the participant cannot confirm that its state is the same with that of a counter-participant with whom the operator has an important business relation.The metric exposes the highest latency of a counter-participant, measured by subtracting the highest known counter-participant latency from the most recent period processed by the participant. A counter-participant has to send a commitment at least once in order to appear here. The operator of a participant can configure a default threshold per synchronizer that the participant connects to. The smaller the threshold, the more sensitive the metric is to even small delays in receiving commitments from counter-participants. For example, for a threshold of 5 intervals and a reconciliation interval of 1 minute, the metric measures the latency of counter-participants that have sent no commitments for periods covering the last 5 minutes observed by the participant.
 > - **Type**: gauge
 > - **Qualification**: Debug
 
@@ -1304,6 +1423,27 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: gauge
 > - **Qualification**: Saturation
 
+### daml.sequencer-client.submissions.amplification
+
+> - **Summary**: Rate and timings of submission request attempts to a sequencer
+> - **Description**: This timer is started when a submission request attempt is sent to the sequencer, and completed when it is observed as sequenced. If the attempt is not observed as sequenced before the amplification patience expires, no timing will be recorded for this and the following attempts.
+> - **Type**: timer
+> - **Qualification**: Latency
+
+### daml.sequencer-client.submissions.amplified-attempts
+
+> - **Summary**: Count of send request attempts which are amplified
+> - **Description**: Counter that is incremented if a send request attempt, which did not receive a synchronous error from the sequencer, is not observed as sequenced until the amplification patience expires and a new attempt is sent.
+> - **Type**: meter
+> - **Qualification**: Errors
+
+### daml.sequencer-client.submissions.attempt-sync-errors
+
+> - **Summary**: Count of send request attempts which receive a synchronous error
+> - **Description**: Counter that is incremented if a send request attempt receives a synchronous error from the sequencer.
+> - **Type**: meter
+> - **Qualification**: Errors
+
 ### daml.sequencer-client.submissions.dropped
 
 > - **Summary**: Count of send requests that did not cause an event to be sequenced
@@ -1317,6 +1457,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Description**: Incremented on every successful send to the sequencer. Decremented when the event or an error is sequenced, or when the max-sequencing-time has elapsed.
 > - **Type**: counter
 > - **Qualification**: Debug
+
+### daml.sequencer-client.submissions.no-connection-available
+
+> - **Summary**: Count of send attempts which are skipped because no connection is available
+> - **Description**: Counter that is incremented if a send request attempt is skipped because there is no connection available.
+> - **Type**: meter
+> - **Qualification**: Errors
 
 ### daml.sequencer-client.submissions.overloaded
 
@@ -1349,7 +1496,7 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer-client.traffic-control.event-delivered-cost
 
 > - **Summary**: Cost of events that were sequenced and delivered.
-> - **Description**: Cost of events for which the sender received confirmation that they were delivered. There is an exception for aggregated submissions: the cost of aggregate events will be recorded as soon as the event is ordered and the sequencer waits to receive threshold-many events. The final event may or may not be delivered successfully depending on the result of the aggregation.
+> - **Description**: Cost of events for which the sender received confirmation that they were delivered.      There is an exception for aggregated submissions: the cost of aggregate events will be recorded      as soon as the event is ordered and the sequencer waits to receive threshold-many events.      The final event may or may not be delivered successfully depending on the result of the aggregation.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
@@ -1363,17 +1510,16 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer-client.traffic-control.event-rejected-cost
 
 > - **Summary**: Cost of events that were sequenced but no delivered successfully.
-> - **Description**: Cost of events for which the sender received confirmation that the events will not be delivered. The reason for non-delivery is labeled on the metric, if available.
+> - **Description**: Cost of events for which the sender received confirmation that the events will not be delivered.      The reason for non-delivery is labeled on the metric, if available.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
 ### daml.sequencer-client.traffic-control.submitted-event-cost
 
 > - **Summary**: Cost of event submitted from the sequencer client.
-> - **Description**: When the sequencer client sends an event to the sequencer to be sequenced, it will record on this metric the cost of the event. Note that the event may or may not end up being sequenced. So this metric may not exactly match the actual consumed traffic.
+> - **Description**: When the sequencer client sends an event to the sequencer to be sequenced,      it will record on this metric the cost of the event. Note that the event may or may not end up being sequenced.      So this metric may not exactly match the actual consumed traffic.
 > - **Type**: meter
 > - **Qualification**: Traffic
-
 ## Sequencer Metrics
 
 ### daml.cache.evicted_weight
@@ -1437,6 +1583,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Summary**: Scheduling time metric for database tasks
 > - **Description**: Every database query is scheduled using an asynchronous executor with a queue. The time a task is waiting in this queue is monitored using this metric.
 > - **Type**: timer
+> - **Qualification**: Debug
+
+### daml.db-storage.internal_contract_ids_cache_size
+
+> - **Summary**: Size of the internal contract IDs cache
+> - **Description**: The number of entries in the internal contract IDs cache.
+> - **Type**: gauge
 > - **Qualification**: Debug
 
 ### daml.db-storage.write.executor.exectime
@@ -1519,13 +1672,9 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.grpc.server.requests.rejections\*
 
 > - **Summary**: Number of rejected requests due to active request limits.
->
 > - **Description**: Counts the number of requests rejected because the active request limit was reached.
->
 > - **Type**: counter
->
 > - **Qualification**: Saturation
->
 > - **Labels**:
 >   - **method**: The method / service name limited.
 >   - **service**: The API the method belongs to
@@ -1622,6 +1771,27 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: gauge
 > - **Qualification**: Saturation
 
+### daml.sequencer-client.submissions.amplification
+
+> - **Summary**: Rate and timings of submission request attempts to a sequencer
+> - **Description**: This timer is started when a submission request attempt is sent to the sequencer, and completed when it is observed as sequenced. If the attempt is not observed as sequenced before the amplification patience expires, no timing will be recorded for this and the following attempts.
+> - **Type**: timer
+> - **Qualification**: Latency
+
+### daml.sequencer-client.submissions.amplified-attempts
+
+> - **Summary**: Count of send request attempts which are amplified
+> - **Description**: Counter that is incremented if a send request attempt, which did not receive a synchronous error from the sequencer, is not observed as sequenced until the amplification patience expires and a new attempt is sent.
+> - **Type**: meter
+> - **Qualification**: Errors
+
+### daml.sequencer-client.submissions.attempt-sync-errors
+
+> - **Summary**: Count of send request attempts which receive a synchronous error
+> - **Description**: Counter that is incremented if a send request attempt receives a synchronous error from the sequencer.
+> - **Type**: meter
+> - **Qualification**: Errors
+
 ### daml.sequencer-client.submissions.dropped
 
 > - **Summary**: Count of send requests that did not cause an event to be sequenced
@@ -1635,6 +1805,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Description**: Incremented on every successful send to the sequencer. Decremented when the event or an error is sequenced, or when the max-sequencing-time has elapsed.
 > - **Type**: counter
 > - **Qualification**: Debug
+
+### daml.sequencer-client.submissions.no-connection-available
+
+> - **Summary**: Count of send attempts which are skipped because no connection is available
+> - **Description**: Counter that is incremented if a send request attempt is skipped because there is no connection available.
+> - **Type**: meter
+> - **Qualification**: Errors
 
 ### daml.sequencer-client.submissions.overloaded
 
@@ -1667,7 +1844,7 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer-client.traffic-control.event-delivered-cost
 
 > - **Summary**: Cost of events that were sequenced and delivered.
-> - **Description**: Cost of events for which the sender received confirmation that they were delivered. There is an exception for aggregated submissions: the cost of aggregate events will be recorded as soon as the event is ordered and the sequencer waits to receive threshold-many events. The final event may or may not be delivered successfully depending on the result of the aggregation.
+> - **Description**: Cost of events for which the sender received confirmation that they were delivered.      There is an exception for aggregated submissions: the cost of aggregate events will be recorded      as soon as the event is ordered and the sequencer waits to receive threshold-many events.      The final event may or may not be delivered successfully depending on the result of the aggregation.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
@@ -1681,14 +1858,14 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer-client.traffic-control.event-rejected-cost
 
 > - **Summary**: Cost of events that were sequenced but no delivered successfully.
-> - **Description**: Cost of events for which the sender received confirmation that the events will not be delivered. The reason for non-delivery is labeled on the metric, if available.
+> - **Description**: Cost of events for which the sender received confirmation that the events will not be delivered.      The reason for non-delivery is labeled on the metric, if available.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
 ### daml.sequencer-client.traffic-control.submitted-event-cost
 
 > - **Summary**: Cost of event submitted from the sequencer client.
-> - **Description**: When the sequencer client sends an event to the sequencer to be sequenced, it will record on this metric the cost of the event. Note that the event may or may not end up being sequenced. So this metric may not exactly match the actual consumed traffic.
+> - **Description**: When the sequencer client sends an event to the sequencer to be sequenced,      it will record on this metric the cost of the event. Note that the event may or may not end up being sequenced.      So this metric may not exactly match the actual consumed traffic.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
@@ -1821,7 +1998,7 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer.bftordering.declarative_api.errors
 
 > - **Summary**: Errors for the last update
-> - **Description**: The node will attempt to apply the changes configured in the declarative config file. A positive number means that some items failed to be synchronised. A negative number means that the overall synchronisation procedure failed with an error. : 0 = everything good, -1 = config file unreadable, -2 = context could not be created, -3 = failure while applying items, -9 = exception caught.
+> - **Description**: The node will attempt to apply the changes configured in the declarative config file.     A positive number means that some items failed to be synchronised. A negative number     means that the overall synchronisation procedure failed with an error. :     0 = everything good, -1 = config file unreadable, -2 = context could not be created,     -3 = failure while applying items, -9 = exception caught.
 > - **Type**: gauge
 > - **Qualification**: Errors
 
@@ -1834,22 +2011,22 @@ For the metric types referenced below, see the relevant Prometheus documentation
 
 ### daml.sequencer.bftordering.global.ordered-batches
 
-> - **Summary**: Batches ordered
-> - **Description**: Measures the total batches ordered.
+> - **Summary**: Batches ordered since startup
+> - **Description**: Measures the total batches ordered since this node last started up.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
 ### daml.sequencer.bftordering.global.ordered-blocks
 
-> - **Summary**: Blocks ordered
-> - **Description**: Measures the total blocks ordered.
+> - **Summary**: Blocks ordered on synchronizer
+> - **Description**: Reports the number of blocks ordered on the synchronizer.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
 ### daml.sequencer.bftordering.global.ordered-requests
 
-> - **Summary**: Requests ordered
-> - **Description**: Measures the total requests ordered.
+> - **Summary**: Requests ordered since startup
+> - **Description**: Measures the total requests ordered since this node last started up.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
@@ -2044,14 +2221,10 @@ For the metric types referenced below, see the relevant Prometheus documentation
 
 ### daml.sequencer.block.acknowledgments_micros\*
 
-> - **Summary**: Acknowledgments by members in Micros
->
+> - **Summary**: Acknowledgments by members in micros
 > - **Description**:
->
 > - **Type**: gauge
->
 > - **Qualification**: Latency
->
 > - **Labels**:
 >   - **member**: The sender of the acknowledgment
 
@@ -2065,13 +2238,9 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer.block.event-bytes\*
 
 > - **Summary**: Event bytes processed by the sequencer, tagged by type.
->
 > - **Description**: Similar to events, except measured by bytes
->
 > - **Type**: meter
->
 > - **Qualification**: Traffic
->
 > - **Labels**:
 >   - **member**: The sender of the submission request
 >   - **type**: Type of request
@@ -2079,13 +2248,9 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer.block.events\*
 
 > - **Summary**: Events processed by the sequencer, tagged by type.
->
 > - **Description**: The sequencer forwards opaque, possibly encrypted payload. However, by looking at the recipient list, the type of message can still be inferred, and tagged appropriately, including the sender.
->
 > - **Type**: meter
->
 > - **Qualification**: Traffic
->
 > - **Labels**:
 >   - **member**: The sender of the submission request
 >   - **type**: Type of request
@@ -2099,17 +2264,10 @@ For the metric types referenced below, see the relevant Prometheus documentation
 
 ### daml.sequencer.block.stream-buffer-size
 
-> - **Summary**: Size of the buffer of Pekko streams after the flow, tagged by stream flow name
+> - **Summary**: Size of the buffer used by Pekko streams, tagged by stream element
 > - **Description**:
 > - **Type**: counter
 > - **Qualification**: Saturation
-
-### daml.sequencer.block.stream-element-count
-
-> - **Summary**: Number of elements passing through a Pekko streams flow, tagged by stream element
-> - **Description**:
-> - **Type**: counter
-> - **Qualification**: Traffic
 
 ### daml.sequencer.db-storage.general.executor.exectime
 
@@ -2144,6 +2302,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Summary**: Scheduling time metric for database tasks
 > - **Description**: Every database query is scheduled using an asynchronous executor with a queue. The time a task is waiting in this queue is monitored using this metric.
 > - **Type**: timer
+> - **Qualification**: Debug
+
+### daml.sequencer.db-storage.internal_contract_ids_cache_size
+
+> - **Summary**: Size of the internal contract IDs cache
+> - **Description**: The number of entries in the internal contract IDs cache.
+> - **Type**: gauge
 > - **Qualification**: Debug
 
 ### daml.sequencer.db-storage.write.executor.exectime
@@ -2191,7 +2356,7 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer.declarative_api.errors
 
 > - **Summary**: Errors for the last update
-> - **Description**: The node will attempt to apply the changes configured in the declarative config file. A positive number means that some items failed to be synchronised. A negative number means that the overall synchronisation procedure failed with an error. : 0 = everything good, -1 = config file unreadable, -2 = context could not be created, -3 = failure while applying items, -9 = exception caught.
+> - **Description**: The node will attempt to apply the changes configured in the declarative config file.     A positive number means that some items failed to be synchronised. A negative number     means that the overall synchronisation procedure failed with an error. :     0 = everything good, -1 = config file unreadable, -2 = context could not be created,     -3 = failure while applying items, -9 = exception caught.
 > - **Type**: gauge
 > - **Qualification**: Errors
 
@@ -2209,6 +2374,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: gauge
 > - **Qualification**: Debug
 
+### daml.sequencer.kms.session-signing-keys-fallback
+
+> - **Summary**: Number of times signing had to fall back to the long-term key, triggering a KMS call.
+> - **Description**: Session signing keys are configured to be valid for a short duration. If this duration is too small or a session key is unavailable, the signing process falls back to using the long-term key to ensure request validation succeeds. This metric counts how many times signing required a direct KMS call with the long-term key.
+> - **Type**: counter
+> - **Qualification**: Saturation
+
 ### daml.sequencer.last_timestamp
 
 > - **Summary**: Timestamp of the last (newest) event in the buffer
@@ -2216,12 +2388,31 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: gauge
 > - **Qualification**: Debug
 
+### daml.sequencer.lsu_contact_successor_status\*
+
+> - **Summary**: Tracks whether the sequencer was able to contact its successor.
+> - **Description**: The value represents the progress of LSU from the participant point of view. -1: No LSU ongoing 0: No successful contact yet. 1: Successor successfully contacted
+> - **Type**: gauge
+> - **Qualification**: Debug
+> - **Labels**:
+>   - **successor_psid**: The physical synchronizer id of the successor
+
 ### daml.sequencer.max-event-age
 
 > - **Summary**: Age of oldest unpruned sequencer event.
 > - **Description**: This gauge exposes the age of the oldest, unpruned sequencer event in hours as a way to quantify the pruning backlog.
 > - **Type**: gauge
 > - **Qualification**: Debug
+
+### daml.sequencer.public-api.handshakes\*
+
+> - **Summary**: The number of handshakes
+> - **Description**: Record the number of handshakes per member and status.
+> - **Type**: meter
+> - **Qualification**: Debug
+> - **Labels**:
+>   - **member**: The member performing the handshake or 'unknown'
+>   - **status**: Status of the handshake: success or failure
 
 ### daml.sequencer.public-api.processed
 
@@ -2275,7 +2466,7 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer.traffic-control.event-delivered-cost
 
 > - **Summary**: Cost of events that were sequenced and delivered.
-> - **Description**: Cost of events for which the sender received confirmation that they were delivered. There is an exception for aggregated submissions: the cost of aggregate events will be recorded as soon as the event is ordered and the sequencer waits to receive threshold-many events. The final event may or may not be delivered successfully depending on the result of the aggregation.
+> - **Description**: Cost of events for which the sender received confirmation that they were delivered.      There is an exception for aggregated submissions: the cost of aggregate events will be recorded      as soon as the event is ordered and the sequencer waits to receive threshold-many events.      The final event may or may not be delivered successfully depending on the result of the aggregation.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
@@ -2289,14 +2480,14 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer.traffic-control.event-rejected-cost
 
 > - **Summary**: Cost of events that were sequenced but no delivered successfully.
-> - **Description**: Cost of events for which the sender received confirmation that the events will not be delivered. The reason for non-delivery is labeled on the metric, if available.
+> - **Description**: Cost of events for which the sender received confirmation that the events will not be delivered.      The reason for non-delivery is labeled on the metric, if available.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
 ### daml.sequencer.traffic-control.submitted-event-cost
 
 > - **Summary**: Cost of event submitted from the sequencer client.
-> - **Description**: When the sequencer client sends an event to the sequencer to be sequenced, it will record on this metric the cost of the event. Note that the event may or may not end up being sequenced. So this metric may not exactly match the actual consumed traffic.
+> - **Description**: When the sequencer client sends an event to the sequencer to be sequenced,      it will record on this metric the cost of the event. Note that the event may or may not end up being sequenced.      So this metric may not exactly match the actual consumed traffic.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
@@ -2327,7 +2518,6 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Description**: Counter for wasted-traffic.
 > - **Type**: counter
 > - **Qualification**: Traffic
-
 ## Mediator Metrics
 
 ### daml.db-storage.general.executor.exectime
@@ -2363,6 +2553,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Summary**: Scheduling time metric for database tasks
 > - **Description**: Every database query is scheduled using an asynchronous executor with a queue. The time a task is waiting in this queue is monitored using this metric.
 > - **Type**: timer
+> - **Qualification**: Debug
+
+### daml.db-storage.internal_contract_ids_cache_size
+
+> - **Summary**: Size of the internal contract IDs cache
+> - **Description**: The number of entries in the internal contract IDs cache.
+> - **Type**: gauge
 > - **Qualification**: Debug
 
 ### daml.db-storage.write.executor.exectime
@@ -2445,13 +2642,9 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.grpc.server.requests.rejections\*
 
 > - **Summary**: Number of rejected requests due to active request limits.
->
 > - **Description**: Counts the number of requests rejected because the active request limit was reached.
->
 > - **Type**: counter
->
 > - **Qualification**: Saturation
->
 > - **Labels**:
 >   - **method**: The method / service name limited.
 >   - **service**: The API the method belongs to
@@ -2474,7 +2667,7 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.mediator.declarative_api.errors
 
 > - **Summary**: Errors for the last update
-> - **Description**: The node will attempt to apply the changes configured in the declarative config file. A positive number means that some items failed to be synchronised. A negative number means that the overall synchronisation procedure failed with an error. : 0 = everything good, -1 = config file unreadable, -2 = context could not be created, -3 = failure while applying items, -9 = exception caught.
+> - **Description**: The node will attempt to apply the changes configured in the declarative config file.     A positive number means that some items failed to be synchronised. A negative number     means that the overall synchronisation procedure failed with an error. :     0 = everything good, -1 = config file unreadable, -2 = context could not be created,     -3 = failure while applying items, -9 = exception caught.
 > - **Type**: gauge
 > - **Qualification**: Errors
 
@@ -2484,6 +2677,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Description**: This metric indicates the number of items managed through the declarative API
 > - **Type**: gauge
 > - **Qualification**: Debug
+
+### daml.mediator.kms.session-signing-keys-fallback
+
+> - **Summary**: Number of times signing had to fall back to the long-term key, triggering a KMS call.
+> - **Description**: Session signing keys are configured to be valid for a short duration. If this duration is too small or a session key is unavailable, the signing process falls back to using the long-term key to ensure request validation succeeds. This metric counts how many times signing required a direct KMS call with the long-term key.
+> - **Type**: counter
+> - **Qualification**: Saturation
 
 ### daml.mediator.max-event-age
 
@@ -2502,9 +2702,34 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.mediator.requests
 
 > - **Summary**: Total number of processed confirmation requests (approved and rejected)
-> - **Description**: This metric provides the number of processed confirmation requests since the system has been started.
+> - **Description**: This metric provides the number of processed confirmation requests since the system has been started. Requests that are rejected because they reuse the request UUID are labelled with `duplicate_reject`.
 > - **Type**: meter
 > - **Qualification**: Debug
+
+### daml.mediator.response-latency\*
+
+> - **Summary**: Individual participant response latencies
+> - **Description**: Provides the time difference between the sequencing time of the given senders response and the first response received for a particular request..
+> - **Type**: timer
+> - **Qualification**: Latency
+> - **Labels**:
+>   - **sender**: The participant who sent the response
+
+### daml.mediator.timeout-non-responsive-participants
+
+> - **Summary**: Count of participants that failed to respond for parties before timeout
+> - **Description**: This metric tracks participant non-responsiveness during confirmation request timeouts. When a mediator times out a transaction, it increments this counter once for each party that the participant hosts (with confirmation rights) but did not respond for. The metric includes labels for both the party and the participant to enable detailed analysis.
+> - **Type**: meter
+> - **Qualification**: Debug
+
+### daml.received-lsu-sequencing-test-messages\*
+
+> - **Summary**: Received testing lsu sequencing messages by sender (sequencer)
+> - **Description**: The number of received testing lsu sequencing messages by sender (sequencer)
+> - **Type**: meter
+> - **Qualification**: Debug
+> - **Labels**:
+>   - **sender**: The sequencer who sent the message
 
 ### daml.sequencer-client.handler.actual-in-flight-event-batches
 
@@ -2590,6 +2815,27 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Type**: gauge
 > - **Qualification**: Saturation
 
+### daml.sequencer-client.submissions.amplification
+
+> - **Summary**: Rate and timings of submission request attempts to a sequencer
+> - **Description**: This timer is started when a submission request attempt is sent to the sequencer, and completed when it is observed as sequenced. If the attempt is not observed as sequenced before the amplification patience expires, no timing will be recorded for this and the following attempts.
+> - **Type**: timer
+> - **Qualification**: Latency
+
+### daml.sequencer-client.submissions.amplified-attempts
+
+> - **Summary**: Count of send request attempts which are amplified
+> - **Description**: Counter that is incremented if a send request attempt, which did not receive a synchronous error from the sequencer, is not observed as sequenced until the amplification patience expires and a new attempt is sent.
+> - **Type**: meter
+> - **Qualification**: Errors
+
+### daml.sequencer-client.submissions.attempt-sync-errors
+
+> - **Summary**: Count of send request attempts which receive a synchronous error
+> - **Description**: Counter that is incremented if a send request attempt receives a synchronous error from the sequencer.
+> - **Type**: meter
+> - **Qualification**: Errors
+
 ### daml.sequencer-client.submissions.dropped
 
 > - **Summary**: Count of send requests that did not cause an event to be sequenced
@@ -2603,6 +2849,13 @@ For the metric types referenced below, see the relevant Prometheus documentation
 > - **Description**: Incremented on every successful send to the sequencer. Decremented when the event or an error is sequenced, or when the max-sequencing-time has elapsed.
 > - **Type**: counter
 > - **Qualification**: Debug
+
+### daml.sequencer-client.submissions.no-connection-available
+
+> - **Summary**: Count of send attempts which are skipped because no connection is available
+> - **Description**: Counter that is incremented if a send request attempt is skipped because there is no connection available.
+> - **Type**: meter
+> - **Qualification**: Errors
 
 ### daml.sequencer-client.submissions.overloaded
 
@@ -2635,7 +2888,7 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer-client.traffic-control.event-delivered-cost
 
 > - **Summary**: Cost of events that were sequenced and delivered.
-> - **Description**: Cost of events for which the sender received confirmation that they were delivered. There is an exception for aggregated submissions: the cost of aggregate events will be recorded as soon as the event is ordered and the sequencer waits to receive threshold-many events. The final event may or may not be delivered successfully depending on the result of the aggregation.
+> - **Description**: Cost of events for which the sender received confirmation that they were delivered.      There is an exception for aggregated submissions: the cost of aggregate events will be recorded      as soon as the event is ordered and the sequencer waits to receive threshold-many events.      The final event may or may not be delivered successfully depending on the result of the aggregation.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
@@ -2649,14 +2902,14 @@ For the metric types referenced below, see the relevant Prometheus documentation
 ### daml.sequencer-client.traffic-control.event-rejected-cost
 
 > - **Summary**: Cost of events that were sequenced but no delivered successfully.
-> - **Description**: Cost of events for which the sender received confirmation that the events will not be delivered. The reason for non-delivery is labeled on the metric, if available.
+> - **Description**: Cost of events for which the sender received confirmation that the events will not be delivered.      The reason for non-delivery is labeled on the metric, if available.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
 ### daml.sequencer-client.traffic-control.submitted-event-cost
 
 > - **Summary**: Cost of event submitted from the sequencer client.
-> - **Description**: When the sequencer client sends an event to the sequencer to be sequenced, it will record on this metric the cost of the event. Note that the event may or may not end up being sequenced. So this metric may not exactly match the actual consumed traffic.
+> - **Description**: When the sequencer client sends an event to the sequencer to be sequenced,      it will record on this metric the cost of the event. Note that the event may or may not end up being sequenced.      So this metric may not exactly match the actual consumed traffic.
 > - **Type**: meter
 > - **Qualification**: Traffic
 
@@ -2668,10 +2921,14 @@ The following metrics are exposed for all components.
 
 - **Description**: The status of the component
 - **Values**:
-  - **0**: Not healthy
-  - **1**: Healthy
+
+- **0**: Not healthy
+- **1**: Healthy
+
 - **Labels**:
-  - **component**: the name of the component being monitored
+
+- **component**: the name of the component being monitored
+
 - **Type**: Gauge
 
 ## gRPC Metrics
@@ -2679,19 +2936,19 @@ The following metrics are exposed for all components.
 The following metrics are exposed for all gRPC endpoints. These metrics have the following common labels attached:
 
 - **grpc_service_name**:
-  fully qualified name of the gRPC service (e.g. `com.daml.ledger.api.v1.ActiveContractsService`)
+fully qualified name of the gRPC service (e.g. `com.daml.ledger.api.v1.ActiveContractsService`)
 
 - **grpc_method_name**:
-  name of the gRPC method (e.g. `GetActiveContracts`)
+name of the gRPC method (e.g. `GetActiveContracts`)
 
 - **grpc_client_type**:
-  type of client connection (`unary` or `streaming`)
+type of client connection (`unary` or `streaming`)
 
 - **grpc_server_type**:
-  type of server connection (`unary` or `streaming`)
+type of server connection (`unary` or `streaming`)
 
 - **service**:
-  Canton service's name (e.g. `participant`, `sequencer`, etc.)
+Canton service's name (e.g. `participant`, `sequencer`, etc.)
 
 ### daml_grpc_server_duration_seconds
 
@@ -2717,7 +2974,9 @@ The following metrics are exposed for all gRPC endpoints. These metrics have the
 
 - **Description**: Total number of handled gRPC requests
 - **Labels**:
-  - **grpc_code**: returned gRPC status code for the call (`OK`, `CANCELLED`, `INVALID_ARGUMENT`, etc.)
+
+- **grpc_code**: returned [gRPC status code](https://grpc.github.io/grpc/core/md_doc_statuscodes.html) for the call (`OK`, `CANCELLED`, `INVALID_ARGUMENT`, etc.)
+
 - **Type**: Counter
 
 ### daml_grpc_server_messages_sent_bytes
@@ -2735,16 +2994,16 @@ The following metrics are exposed for all gRPC endpoints. These metrics have the
 The following metrics are exposed for all HTTP endpoints. These metrics have the following common labels attached:
 
 - **http_verb**:
-  HTTP verb used for a given call (e.g. `GET` or `PUT`)
+HTTP verb used for a given call (e.g. `GET` or `PUT`)
 
 - **host**:
-  fully qualified hostname of the HTTP endpoint (e.g. `example.com`)
+fully qualified hostname of the HTTP endpoint (e.g. `example.com`)
 
 - **path**:
-  path of the HTTP endpoint (e.g. `/v2/parties`)
+path of the HTTP endpoint (e.g. `/v2/parties`)
 
 - **service**:
-  Daml service's name (`json_api` for the JSON Ledger API Service)
+Daml service's name (`json_api` for the JSON Ledger API Service)
 
 ### daml_http_requests_duration_seconds
 
@@ -2755,7 +3014,9 @@ The following metrics are exposed for all HTTP endpoints. These metrics have the
 
 - **Description**: Total number of HTTP requests completed
 - **Labels**:
-  - **http_status**: returned HTTP status code for the call
+
+- **http_status**: returned [HTTP status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) for the call
+
 - **Type**: Counter
 
 ### daml_http_websocket_messages_received_total
@@ -2793,7 +3054,7 @@ The following metrics are exposed for all HTTP endpoints. These metrics have the
 The following metrics are exposed for all pruning processes. These metrics have the following labels:
 
 - **phase**:
-  The name of the pruning phase being monitored
+The name of the pruning phase being monitored
 
 ### daml_services_pruning_prune_started_total
 
@@ -2813,29 +3074,32 @@ The following metrics are exposed for the JVM, if enabled.
 
 - **Description**: Time spent in a given JVM garbage collector in milliseconds
 - **Labels**:
-  - **gc**: Garbage collector regions (eg: `G1 Old Generation`, `G1 New Generation`)
+
+- **gc**: Garbage collector regions (eg: `G1 Old Generation`, `G1 New Generation`)
+
 - **Type**: Counter
 
 ### runtime_jvm_gc_count
 
 - **Description**: The number of collections that have occurred for a given JVM garbage collector
 - **Labels**:
-  - **gc**: Garbage collector regions (eg: `G1 Old Generation`, `G1 New Generation`)
+
+- **gc**: Garbage collector regions (eg: `G1 Old Generation`, `G1 New Generation`)
+
 - **Type**: Counter
 
 ### runtime_jvm_memory_area
 
 - **Description**: JVM memory area statistics
 - **Labels**:
-  - **area**: Can be `heap` or `non_heap`
-  - **type**: Can be `committed`, `used` or `max`
+
+- **area**: Can be `heap` or `non_heap`
+- **type**: Can be `committed`, `used` or `max`
 
 ### runtime_jvm_memory_pool
 
 - **Description**: JVM memory pool statistics
 - **Labels**:
-  - **pool**: Defined pool name.
-  - **type**: Can be `committed`, `used` or `max`
 
-
-{/* COPIED_END */}
+- **pool**: Defined pool name.
+- **type**: Can be `committed`, `used` or `max`

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "generate:canton-protobuf-history": "python3 scripts/generate_canton_protobuf_history.py",
     "generate:wallet-gateway-openrpc-reference": "python3 scripts/generate_wallet_gateway_openrpc_reference.py",
     "generate:splice-mintlify-openapi": "python3 scripts/generate_splice_mintlify_openapi.py",
+    "generate:canton-metrics-reference": "python3 scripts/generate_canton_metrics_reference.py",
     "generate:external-snippets": "python3 scripts/generate_external_snippets.py",
     "validate:splice-mintlify-openapi-nav": "python3 scripts/validate_splice_mintlify_openapi_nav.py",
     "generate:typescript-bindings-reference": "python3 scripts/generate_typescript_bindings_reference.py",

--- a/scripts/generate_canton_metrics_reference.py
+++ b/scripts/generate_canton_metrics_reference.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from docs_env import ensure_repo_direnv
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CACHE_DIR = REPO_ROOT / ".internal" / "cache" / "canton-metrics-reference"
+DEFAULT_CANTON_DIR = DEFAULT_CACHE_DIR / "repos" / "canton"
+DEFAULT_OUTPUT = REPO_ROOT / "docs-main" / "global-synchronizer" / "reference" / "canton-metrics.mdx"
+DEFAULT_REMOTE = "https://github.com/DACH-NY/canton.git"
+DEFAULT_RELEASE_REPO = "DACH-NY/canton"
+METRICS_RST = Path("docs-open/src/sphinx/participant/reference/metrics.rst")
+GENERATED_INCLUDES_DIR = Path("docs-open/target/generated")
+USER_AGENT = "cf-docs-canton-metrics-reference/1.0"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the Canton Metrics MDX page from the latest Canton release docs build."
+    )
+    parser.add_argument("--release-repo", default=DEFAULT_RELEASE_REPO)
+    parser.add_argument("--remote", default=DEFAULT_REMOTE)
+    parser.add_argument(
+        "--canton-ref",
+        help="Canton git ref to generate from. Defaults to the latest GitHub release tag.",
+    )
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument(
+        "--canton-dir",
+        type=Path,
+        help="Existing or cached Canton checkout. Defaults to <cache-dir>/repos/canton.",
+    )
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--generation-command",
+        nargs="+",
+        default=["sbt", "--batch", "community-app / bundle", "docs-open / generateIncludes"],
+        help=(
+            "Command to run inside the Canton checkout before reading the metrics RST template and generated "
+            "include files. Quote each SBT task when overriding this."
+        ),
+    )
+    parser.add_argument(
+        "--skip-generation",
+        action="store_true",
+        help="Use already-generated include files in the Canton checkout.",
+    )
+    parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Delete and reclone the cached Canton checkout before generation.",
+    )
+    parser.add_argument(
+        "--skip-direnv",
+        action="store_true",
+        help="Run the Canton generation command directly instead of through direnv.",
+    )
+    return parser.parse_args()
+
+
+def run(command: list[str], *, cwd: Path | None = None, capture: bool = False) -> str:
+    kwargs: dict[str, Any] = {
+        "cwd": str(cwd) if cwd else None,
+        "check": True,
+        "text": True,
+    }
+    if capture:
+        kwargs["stdout"] = subprocess.PIPE
+        kwargs["stderr"] = subprocess.PIPE
+    completed = subprocess.run(command, **kwargs)
+    return completed.stdout.strip() if capture else ""
+
+
+def github_api_json(path: str) -> Any:
+    request = urllib.request.Request(
+        f"https://api.github.com/{path.lstrip('/')}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(request, timeout=180) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def latest_release_tag(release_repo: str) -> str:
+    gh = shutil.which("gh")
+    if gh:
+        try:
+            tag = run(
+                [
+                    gh,
+                    "release",
+                    "view",
+                    "--repo",
+                    release_repo,
+                    "--json",
+                    "tagName",
+                    "--jq",
+                    ".tagName",
+                ],
+                capture=True,
+            )
+            if tag:
+                return tag
+        except subprocess.CalledProcessError:
+            pass
+
+    payload = github_api_json(f"repos/{release_repo}/releases/latest")
+    tag = payload.get("tag_name") if isinstance(payload, dict) else None
+    if not isinstance(tag, str) or not tag:
+        raise ValueError(f"Unable to resolve latest release tag for {release_repo}")
+    return tag
+
+
+def checkout_canton_release(*, canton_dir: Path, remote: str, ref: str, force_refresh: bool) -> None:
+    if force_refresh and canton_dir.exists():
+        shutil.rmtree(canton_dir)
+    canton_dir.parent.mkdir(parents=True, exist_ok=True)
+    if not (canton_dir / ".git").exists():
+        run(["git", "clone", remote, str(canton_dir)])
+    run(["git", "fetch", "origin", "--tags", "--prune"], cwd=canton_dir)
+    run(["git", "checkout", "--detach", ref], cwd=canton_dir)
+    run(["git", "reset", "--hard", ref], cwd=canton_dir)
+    run(["git", "clean", "-ffd"], cwd=canton_dir)
+
+
+def allow_direnv(canton_dir: Path) -> None:
+    if not (canton_dir / ".envrc").exists() or not shutil.which("direnv"):
+        return
+    run(["direnv", "allow"], cwd=canton_dir)
+
+
+def run_generation(*, canton_dir: Path, command: list[str], skip_direnv: bool) -> None:
+    generated = canton_dir / GENERATED_INCLUDES_DIR
+    if generated.exists():
+        shutil.rmtree(generated)
+    generated.mkdir(parents=True, exist_ok=True)
+    if skip_direnv or not (canton_dir / ".envrc").exists() or not shutil.which("direnv"):
+        run(command, cwd=canton_dir)
+        return
+    allow_direnv(canton_dir)
+    run(["direnv", "exec", str(canton_dir), *command], cwd=canton_dir)
+
+
+def resolve_generated_includes(template: str, *, generated_dir: Path) -> str:
+    def replace(match: re.Match[str]) -> str:
+        include_name = match.group(1)
+        include_path = generated_dir / include_name
+        if not include_path.is_file():
+            raise FileNotFoundError(f"Expected generated Canton include at {include_path}")
+        return include_path.read_text(encoding="utf-8").rstrip()
+
+    return re.sub(r"^\.\. generatedinclude::\s+(\S+)\s*$", replace, template, flags=re.MULTILINE)
+
+
+def convert_inline(text: str) -> str:
+    text = re.sub(r"`([^`<]+?) <([^`>]+)>`_", r"[\1](\2)", text)
+    text = re.sub(r"``([^`]+)``", r"`\1`", text)
+    text = text.replace("<", r"\<").replace(">", r"\>")
+    return text.rstrip()
+
+
+def escape_heading(text: str) -> str:
+    return convert_inline(text).replace("*", r"\*")
+
+
+def convert_rst_to_mdx(rst: str, *, source_ref: str) -> str:
+    if "generatedinclude::" in rst:
+        raise ValueError("Metrics RST still contains generatedinclude directives; run the Canton docs generator first.")
+
+    output: list[str] = [
+        "---",
+        'title: "Canton Metrics"',
+        'description: "Canton node metrics exported for Prometheus scraping."',
+        "---",
+        "",
+        (
+            "{/* GENERATED_FROM "
+            f'source="DACH-NY/canton" ref="{source_ref}" '
+            f'path="{METRICS_RST.as_posix()}" */}}'
+        ),
+        "",
+    ]
+
+    lines = rst.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index].rstrip()
+        stripped = line.strip()
+
+        if not stripped:
+            output.append("")
+            index += 1
+            continue
+
+        if stripped == "..":
+            index += 1
+            while index < len(lines) and (not lines[index].strip() or lines[index].startswith((" ", "\t"))):
+                index += 1
+            continue
+
+        if stripped.startswith(".. "):
+            index += 1
+            continue
+
+        if index + 1 < len(lines):
+            underline = lines[index + 1].strip()
+            if underline and len(underline) >= len(stripped) and set(underline) <= {"-", "~", "^"}:
+                marker = underline[0]
+                level = {"-": "#", "~": "##", "^": "###"}[marker]
+                output.append(f"{level} {escape_heading(stripped)}")
+                output.append("")
+                index += 2
+                continue
+
+        bullet = re.match(r"^(\s*)\*\s+(.*)$", line)
+        if bullet:
+            indent = len(bullet.group(1).replace("\t", "    "))
+            nested = "  " if indent >= 8 else ""
+            output.append(f"> {nested}- {convert_inline(bullet.group(2))}")
+            index += 1
+            continue
+
+        output.append(convert_inline(stripped))
+        index += 1
+
+    content = "\n".join(output)
+    content = re.sub(r"\n{3,}", "\n\n", content)
+    return content.rstrip() + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    ensure_repo_direnv(repo_root=REPO_ROOT, script_path=Path(__file__).resolve(), argv=sys.argv[1:])
+    if args.canton_dir is None:
+        args.canton_dir = args.cache_dir / "repos" / "canton"
+
+    source_ref = args.canton_ref or latest_release_tag(args.release_repo)
+    checkout_canton_release(
+        canton_dir=args.canton_dir,
+        remote=args.remote,
+        ref=source_ref,
+        force_refresh=args.force_refresh,
+    )
+    if not args.skip_generation:
+        run_generation(canton_dir=args.canton_dir, command=args.generation_command, skip_direnv=args.skip_direnv)
+
+    metrics_rst = args.canton_dir / METRICS_RST
+    if not metrics_rst.is_file():
+        raise FileNotFoundError(f"Expected Canton metrics page template at {metrics_rst}")
+
+    resolved_rst = resolve_generated_includes(
+        metrics_rst.read_text(encoding="utf-8"),
+        generated_dir=args.canton_dir / GENERATED_INCLUDES_DIR,
+    )
+    mdx = convert_rst_to_mdx(resolved_rst, source_ref=source_ref)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(mdx, encoding="utf-8")
+    print(f"Generated {args.output} from Canton {source_ref}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_canton_metrics_reference.py
+++ b/tests/test_canton_metrics_reference.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from scripts import generate_canton_metrics_reference as generator
+
+
+class CantonMetricsReferenceTests(unittest.TestCase):
+    def test_resolve_generated_includes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            generated_dir = Path(tmp)
+            (generated_dir / "metrics.inc").write_text("daml.example\n^^^^^^^^^^^^", encoding="utf-8")
+
+            resolved = generator.resolve_generated_includes(
+                "Before\n.. generatedinclude:: metrics.inc\nAfter\n",
+                generated_dir=generated_dir,
+            )
+
+        self.assertEqual(resolved, "Before\ndaml.example\n^^^^^^^^^^^^\nAfter\n")
+
+    def test_convert_resolved_metrics_rst_to_mdx(self) -> None:
+        rst = textwrap.dedent(
+            """\
+            .. _reference-metrics:
+
+            Metrics
+            -------
+
+            For the metric types referenced below, see the `relevant Prometheus documentation <https://prometheus.io/docs/tutorials/understanding_metric_types/>`_.
+
+            Participant Metrics
+            ~~~~~~~~~~~~~~~~~~~
+
+            daml.example.metric*
+            ^^^^^^^^^^^^^^^^^^^^
+            \t* **Summary**: Example summary with ``code``.
+            \t* **Description**: The value for <operation>.
+            \t* **Type**: meter
+            \t* **Qualification**: Debug
+            \t* **Labels**:
+            \t\t* **sender**: The sequencer who sent the message
+            """
+        )
+
+        mdx = generator.convert_rst_to_mdx(rst, source_ref="v1.2.3")
+
+        self.assertIn('ref="v1.2.3"', mdx)
+        self.assertIn("# Metrics", mdx)
+        self.assertIn("[relevant Prometheus documentation](https://prometheus.io/docs/tutorials/understanding_metric_types/)", mdx)
+        self.assertIn("### daml.example.metric\\*", mdx)
+        self.assertIn("> - **Summary**: Example summary with `code`.", mdx)
+        self.assertIn(r"> - **Description**: The value for \<operation\>.", mdx)
+        self.assertIn(">   - **sender**: The sequencer who sent the message", mdx)
+
+    def test_unresolved_generatedinclude_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "generatedinclude"):
+            generator.convert_rst_to_mdx(".. generatedinclude:: metrics.inc\n", source_ref="v1.2.3")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Canton metrics generator that resolves the latest `DACH-NY/canton` release tag, clones/checks it out under `.internal/cache/canton-metrics-reference/`, runs the Canton release bundle plus `docs-open / generateIncludes`, and converts the resolved metrics RST to MDX
- add an npm alias and README workflow for refreshing `docs-main/global-synchronizer/reference/canton-metrics.mdx`
- regenerate the metrics page from Canton `v3.5.1`, including `daml.received-lsu-sequencing-test-messages`

## Validation
- `direnv exec . python3 scripts/generate_canton_metrics_reference.py --canton-ref v3.5.1`
- `direnv exec . python3 scripts/generate_canton_metrics_reference.py --skip-generation`
- `direnv exec . npm run generate:canton-metrics-reference -- --canton-ref v3.5.1 --skip-generation`
- `direnv exec . python3 -m pytest tests/test_canton_metrics_reference.py`
- `git diff --check`
- `direnv exec . bash -lc 'cd docs-main && npx mintlify validate'` fails on the pre-existing main-branch `integrations/wallet/proof-of-transfer.mdx` parse/nav issue (`integrations/wallet/proof-of-transfer` referenced in `docs.json` but the file does not exist).\n\nFixes #641